### PR TITLE
Fix GH-21548: Dom\XMLDocument::C14N() emits duplicate xmlns declarati…

### DIFF
--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -2132,7 +2132,7 @@ static void dom_relink_ns_decls_element(HashTable *links, xmlNodePtr node)
 
 				ns->_private = attr;
 				if (attr->prev) {
-					attr->prev = attr->next;
+					attr->prev->next = attr->next;
 				} else {
 					node->properties = attr->next;
 				}

--- a/ext/dom/tests/modern/xml/gh21548.phpt
+++ b/ext/dom/tests/modern/xml/gh21548.phpt
@@ -1,0 +1,17 @@
+--TEST--
+GH-21548 (Dom\XMLDocument::C14N() emits duplicate xmlns declarations after setAttributeNS())
+--CREDITS--
+Toon Verwerft (veewee)
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+$doc = Dom\XMLDocument::createFromString('<root xmlns="urn:a" attr="val"/>');
+$doc->documentElement->setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns:ns1", "urn:a");
+
+echo $doc->C14N() . PHP_EOL;
+
+?>
+--EXPECT--
+<root xmlns="urn:a" xmlns:ns1="urn:a" attr="val"></root>


### PR DESCRIPTION
…ons after setAttributeNS().

The xmlns attribute unlinking code in dom_relink_ns_decls_element was clobbering attr->prev instead of updating the predecessor's next pointer, leaving non-first xmlns attributes reachable in the properties list. C14N then output them both as nsDef entries and as attributes.