### PR TITLE
gen_stub: Conditionally include zend_attributes.h to arginfo based on usage

### DIFF
--- a/Zend/zend_attributes_arginfo.h
+++ b/Zend/zend_attributes_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit zend_attributes.stub.php instead.
  * Stub hash: dc2b1de9f4d91162f0e9ab236272f79019c5b5ab */
 
+#include "zend_attributes.h"
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Attribute___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "Attribute::TARGET_ALL")
 ZEND_END_ARG_INFO()

--- a/Zend/zend_builtin_functions_arginfo.h
+++ b/Zend/zend_builtin_functions_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit zend_builtin_functions.stub.php instead.
  * Stub hash: 5d7145b7bc305bb50b45e75c02740206148223b1 */
 
+#include "zend_attributes.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_clone, 0, 1, IS_OBJECT, 0)
 	ZEND_ARG_TYPE_INFO(0, object, IS_OBJECT, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, withProperties, IS_ARRAY, 0, "[]")

--- a/Zend/zend_constants_arginfo.h
+++ b/Zend/zend_constants_arginfo.h
@@ -1,6 +1,9 @@
 /* This is a generated file, edit zend_constants.stub.php instead.
  * Stub hash: 569ccba4e0a93a9ce49c81c76955413188df390e */
 
+#include "zend_attributes.h"
+#include "zend_constants.h"
+
 static void register_zend_constants_symbols(int module_number)
 {
 	REGISTER_LONG_CONSTANT("E_ERROR", E_ERROR, CONST_PERSISTENT);

--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -230,6 +230,57 @@ class Context {
     public array $parsedFiles = [];
 }
 
+// Headers the generated arginfo file needs to be self-contained, each with the
+// preprocessor condition and minimum PHP version its code is guarded by
+class HeaderDependencies {
+    /** @var array<string, list<array{?string, ?int}>> */
+    private array $headers = [];
+
+    public function add(string $header, ?string $cond = null, ?int $minPhpVersionId = null): void {
+        $this->headers[$header][] = [$cond, $minPhpVersionId];
+    }
+
+    public function generateCode(): string {
+        ksort($this->headers);
+
+        $code = "";
+        foreach ($this->headers as $header => $guards) {
+            $conds = [];
+            $minPhpVersionId = null;
+
+            foreach ($guards as [$cond, $versionId]) {
+                // An unconditional use overrides any guarded ones
+                if ($cond === null) {
+                    $conds = null;
+                } elseif ($conds !== null) {
+                    $conds[$cond] = $cond;
+                }
+
+                if ($versionId !== null && ($minPhpVersionId === null || $versionId < $minPhpVersionId)) {
+                    $minPhpVersionId = $versionId;
+                }
+            }
+
+            $include = "#include \"$header\"\n";
+
+            if ($conds) {
+                $cond = count($conds) === 1
+                    ? reset($conds)
+                    : implode(" || ", array_map(static fn (string $cond): string => "($cond)", $conds));
+                $include = "#if $cond\n" . $include . "#endif\n";
+            }
+
+            if ($minPhpVersionId !== null) {
+                $include = "#if (PHP_VERSION_ID >= $minPhpVersionId)\n" . $include . "#endif\n";
+            }
+
+            $code .= $include;
+        }
+
+        return $code;
+    }
+}
+
 class ArrayType extends SimpleType {
 
     public function __construct(
@@ -2649,7 +2700,7 @@ class ConstInfo extends VariableLike
     }
 
     /** @param array<string, ConstInfo> $allConstInfos */
-    public function getDeclaration(array $allConstInfos): string
+    public function getDeclaration(array $allConstInfos, HeaderDependencies $headerDependencies): string
     {
         $type = $this->phpDocType ?? $this->type;
         $simpleType = $type?->tryToSimpleType();
@@ -2672,15 +2723,17 @@ class ConstInfo extends VariableLike
         if ($this->name instanceof ClassConstName) {
             $code = $this->getClassConstDeclaration($value);
         } else {
-            $code = $this->getGlobalConstDeclaration($value);
+            $code = $this->getGlobalConstDeclaration($value, $headerDependencies);
         }
         $code .= $this->getValueAssertion($value);
 
         return $code;
     }
 
-    private function getGlobalConstDeclaration(EvaluatedValue $value): string
+    private function getGlobalConstDeclaration(EvaluatedValue $value, HeaderDependencies $headerDependencies): string
     {
+        $headerDependencies->add("zend_constants.h", $this->cond);
+
         $constName = str_replace('\\', '\\\\', $this->name->__toString());
         $constValue = $value->value;
         $cExpr = $value->getCExpr();
@@ -3226,7 +3279,9 @@ class EnumCaseInfo {
     ) {}
 
     /** @param array<string, ConstInfo> $allConstInfos */
-    public function getDeclaration(array $allConstInfos): string {
+    public function getDeclaration(array $allConstInfos, HeaderDependencies $headerDependencies, ?string $cond = null, ?int $minPhpVersionId = null): string {
+        $headerDependencies->add("zend_enum.h", $cond, $minPhpVersionId);
+
         $escapedName = addslashes($this->name->case);
         if ($this->value === null) {
             return "\n\tzend_enum_add_case_cstr(class_entry, \"$escapedName\", NULL);\n";
@@ -3305,7 +3360,13 @@ class AttributeInfo {
      * @param array<string, string> &$declaredStrings Map of string content to
      *   the name of a zend_string already created with that content
      */
-    public function generateCode(string $invocation, string $nameSuffix, array $allConstInfos, ?int $phpVersionIdMinimumCompatibility, array &$declaredStrings = []): string {
+    public function generateCode(string $invocation, string $nameSuffix, array $allConstInfos, ?int $phpVersionIdMinimumCompatibility, HeaderDependencies $headerDependencies, ?string $cond = null, array &$declaredStrings = []): string {
+        $headerDependencies->add(
+            "zend_attributes.h",
+            $cond,
+            $phpVersionIdMinimumCompatibility !== null && $phpVersionIdMinimumCompatibility < PHP_80_VERSION_ID ? PHP_80_VERSION_ID : null
+        );
+
         $escapedAttributeName = strtr($this->class, '\\', '_');
         [$stringInit, $nameCode, $stringRelease] = StringBuilder::getString(
             "attribute_name_{$escapedAttributeName}_$nameSuffix",
@@ -3419,7 +3480,7 @@ class ClassInfo {
     ) {}
 
     /** @param array<string, ConstInfo> $allConstInfos */
-    public function getRegistration(array $allConstInfos): string
+    public function getRegistration(array $allConstInfos, HeaderDependencies $headerDependencies): string
     {
         $params = [];
         foreach ($this->extends as $extends) {
@@ -3459,6 +3520,7 @@ class ClassInfo {
             $name = addslashes((string) $this->name);
             $backingType = $this->enumBackingType
                 ? $this->enumBackingType->toTypeCode() : "IS_UNDEF";
+            $headerDependencies->add("zend_enum.h", $this->cond, $php81MinimumCompatibility ? null : PHP_81_VERSION_ID);
             $code .= "\tzend_class_entry *class_entry = zend_register_internal_enum(\"$name\", $backingType, $classMethods);\n";
             if (!$flags->isEmpty()) {
                 $code .= $this->getFlagsByPhpVersion()->generateVersionDependentFlagCode("\tclass_entry->ce_flags = %s;\n", $this->phpVersionIdMinimumCompatibility);
@@ -3546,11 +3608,11 @@ class ClassInfo {
         $code .= generateCodeWithConditions(
             $this->constInfos,
             '',
-            static fn (ConstInfo $const): string => $const->getDeclaration($allConstInfos)
+            static fn (ConstInfo $const): string => $const->getDeclaration($allConstInfos, $headerDependencies)
         );
 
         foreach ($this->enumCaseInfos as $enumCase) {
-            $code .= $enumCase->getDeclaration($allConstInfos);
+            $code .= $enumCase->getDeclaration($allConstInfos, $headerDependencies, $this->cond, $php81MinimumCompatibility ? null : PHP_81_VERSION_ID);
         }
 
         foreach ($this->propertyInfos as $property) {
@@ -3576,6 +3638,8 @@ class ClassInfo {
                     "class_{$escapedName}_$key",
                     $allConstInfos,
                     $this->phpVersionIdMinimumCompatibility,
+                    $headerDependencies,
+                    $this->cond,
                     $declaredStrings
                 );
             }
@@ -3583,19 +3647,19 @@ class ClassInfo {
             $code .= $php80CondEnd;
         }
 
-        if ($attributeInitializationCode = generateConstantAttributeInitialization($this->constInfos, $allConstInfos, $this->phpVersionIdMinimumCompatibility, $this->cond, $declaredStrings)) {
+        if ($attributeInitializationCode = generateConstantAttributeInitialization($this->constInfos, $allConstInfos, $this->phpVersionIdMinimumCompatibility, $headerDependencies, $this->cond, $declaredStrings)) {
             $code .= $php80CondStart;
             $code .= "\n" . $attributeInitializationCode;
             $code .= $php80CondEnd;
         }
 
-        if ($attributeInitializationCode = generatePropertyAttributeInitialization($this->propertyInfos, $allConstInfos, $this->phpVersionIdMinimumCompatibility, $declaredStrings)) {
+        if ($attributeInitializationCode = generatePropertyAttributeInitialization($this->propertyInfos, $allConstInfos, $this->phpVersionIdMinimumCompatibility, $headerDependencies, $this->cond, $declaredStrings)) {
             $code .= $php80CondStart;
             $code .= "\n" . $attributeInitializationCode;
             $code .= $php80CondEnd;
         }
 
-        if ($attributeInitializationCode = generateFunctionAttributeInitialization($this->funcInfos, $allConstInfos, $this->phpVersionIdMinimumCompatibility, $this->cond, $declaredStrings)) {
+        if ($attributeInitializationCode = generateFunctionAttributeInitialization($this->funcInfos, $allConstInfos, $this->phpVersionIdMinimumCompatibility, $headerDependencies, $this->cond, $declaredStrings)) {
             $code .= $php80CondStart;
             $code .= "\n" . $attributeInitializationCode;
             $code .= $php80CondEnd;
@@ -4562,11 +4626,11 @@ class FileInfo {
     }
 
     /** @param array<string, ConstInfo> $allConstInfos */
-    public function generateClassEntryCode(array $allConstInfos): string {
+    public function generateClassEntryCode(array $allConstInfos, HeaderDependencies $headerDependencies): string {
         $code = "";
 
         foreach ($this->classInfos as $class) {
-            $code .= "\n" . $class->getRegistration($allConstInfos);
+            $code .= "\n" . $class->getRegistration($allConstInfos, $headerDependencies);
         }
 
         return $code;
@@ -4599,6 +4663,7 @@ class FileInfo {
         array $allConstInfos,
         string $stubHash
     ): array {
+        $headerDependencies = new HeaderDependencies();
         $code = "";
 
         $generatedFuncInfos = [];
@@ -4662,8 +4727,8 @@ class FileInfo {
 
         if ($this->generateClassEntries) {
             $declaredStrings = [];
-            $attributeInitializationCode = generateFunctionAttributeInitialization($this->funcInfos, $allConstInfos, $this->getMinimumPhpVersionIdCompatibility(), null, $declaredStrings);
-            $attributeInitializationCode .= generateGlobalConstantAttributeInitialization($this->constInfos, $allConstInfos, $this->getMinimumPhpVersionIdCompatibility(), null, $declaredStrings);
+            $attributeInitializationCode = generateFunctionAttributeInitialization($this->funcInfos, $allConstInfos, $this->getMinimumPhpVersionIdCompatibility(), $headerDependencies, null, $declaredStrings);
+            $attributeInitializationCode .= generateGlobalConstantAttributeInitialization($this->constInfos, $allConstInfos, $this->getMinimumPhpVersionIdCompatibility(), $headerDependencies, null, $declaredStrings);
             if ($attributeInitializationCode) {
                 if (!$php80MinimumCompatibility) {
                     $attributeInitializationCode = "\n#if (PHP_VERSION_ID >= " . PHP_80_VERSION_ID . ")" . $attributeInitializationCode . "#endif\n";
@@ -4677,7 +4742,7 @@ class FileInfo {
                 $code .= generateCodeWithConditions(
                     $this->constInfos,
                     '',
-                    static fn (ConstInfo $constInfo): string => $constInfo->getDeclaration($allConstInfos)
+                    static fn (ConstInfo $constInfo): string => $constInfo->getDeclaration($allConstInfos, $headerDependencies)
                 );
 
                 if ($attributeInitializationCode !== "" && $this->constInfos) {
@@ -4688,7 +4753,7 @@ class FileInfo {
                 $code .= "}\n";
             }
 
-            $code .= $this->generateClassEntryCode($allConstInfos);
+            $code .= $this->generateClassEntryCode($allConstInfos, $headerDependencies);
         }
 
         $hasDeclFile = false;
@@ -4705,9 +4770,12 @@ class FileInfo {
                 . "#endif /* {$headerName} */\n";
         }
 
+        $includeCode = $headerDependencies->generateCode();
+
         $code = "/* This is a generated file, edit {$stubFilenameWithoutExtension}.stub.php instead.\n"
             . " * Stub hash: $stubHash"
             . ($hasDeclFile ? "\n * Has decl header: yes */\n" : " */\n")
+            . ($includeCode !== "" ? "\n" . $includeCode : "")
             . $code;
 
         return [$code, $declCode];
@@ -5378,11 +5446,11 @@ function generateFunctionEntries(?Name $className, array $funcInfos, ?string $co
  * @param array<string, string> &$declaredStrings Map of string content to
  *   the name of a zend_string already created with that content
  */
-function generateFunctionAttributeInitialization(iterable $funcInfos, array $allConstInfos, ?int $phpVersionIdMinimumCompatibility, ?string $parentCond = null, array &$declaredStrings = []): string {
+function generateFunctionAttributeInitialization(iterable $funcInfos, array $allConstInfos, ?int $phpVersionIdMinimumCompatibility, HeaderDependencies $headerDependencies, ?string $parentCond = null, array &$declaredStrings = []): string {
     return generateCodeWithConditions(
         $funcInfos,
         "",
-        static function (FuncInfo $funcInfo) use ($allConstInfos, $phpVersionIdMinimumCompatibility, &$declaredStrings) {
+        static function (FuncInfo $funcInfo) use ($allConstInfos, $phpVersionIdMinimumCompatibility, $headerDependencies, $parentCond, &$declaredStrings) {
             $code = null;
 
             if ($funcInfo->name instanceof MethodName) {
@@ -5406,6 +5474,8 @@ function generateFunctionAttributeInitialization(iterable $funcInfos, array $all
                     "func_" . $funcInfo->name->getNameForAttributes() . "_$key",
                     $allConstInfos,
                     $phpVersionIdMinimumCompatibility,
+                    $headerDependencies,
+                    $funcInfo->cond ?? $parentCond,
                     $useDeclared
                 );
             }
@@ -5417,6 +5487,8 @@ function generateFunctionAttributeInitialization(iterable $funcInfos, array $all
                         "func_{$funcInfo->name->getNameForAttributes()}_arg{$index}_$key",
                         $allConstInfos,
                         $phpVersionIdMinimumCompatibility,
+                        $headerDependencies,
+                        $funcInfo->cond ?? $parentCond,
                         $useDeclared
                     );
                 }
@@ -5438,6 +5510,7 @@ function generateGlobalConstantAttributeInitialization(
     iterable $constInfos,
     array $allConstInfos,
     ?int $phpVersionIdMinimumCompatibility,
+    HeaderDependencies $headerDependencies,
     ?string $parentCond = null,
     array &$declaredStrings = []
 ): string {
@@ -5448,7 +5521,7 @@ function generateGlobalConstantAttributeInitialization(
     $code = generateCodeWithConditions(
         $constInfos,
         "",
-        static function (ConstInfo $constInfo) use ($allConstInfos, $isConditional, &$declaredStrings) {
+        static function (ConstInfo $constInfo) use ($allConstInfos, $isConditional, $headerDependencies, $parentCond, &$declaredStrings) {
             $code = "";
 
             if ($constInfo->attributes === []) {
@@ -5477,6 +5550,8 @@ function generateGlobalConstantAttributeInitialization(
                     $constVarName . "_$key",
                     $allConstInfos,
                     PHP_85_VERSION_ID,
+                    $headerDependencies,
+                    $constInfo->cond ?? $parentCond,
                     $useDeclared
                 );
             }
@@ -5501,13 +5576,14 @@ function generateConstantAttributeInitialization(
     iterable $constInfos,
     array $allConstInfos,
     ?int $phpVersionIdMinimumCompatibility,
+    HeaderDependencies $headerDependencies,
     ?string $parentCond = null,
     array &$declaredStrings = []
 ): string {
     return generateCodeWithConditions(
         $constInfos,
         "",
-        static function (ConstInfo $constInfo) use ($allConstInfos, $phpVersionIdMinimumCompatibility, &$declaredStrings) {
+        static function (ConstInfo $constInfo) use ($allConstInfos, $phpVersionIdMinimumCompatibility, $headerDependencies, $parentCond, &$declaredStrings) {
             $code = null;
 
             // Make sure we don't try and use strings that might only be
@@ -5524,6 +5600,8 @@ function generateConstantAttributeInitialization(
                     "const_" . $constInfo->name->getDeclarationName() . "_$key",
                     $allConstInfos,
                     $phpVersionIdMinimumCompatibility,
+                    $headerDependencies,
+                    $constInfo->cond ?? $parentCond,
                     $useDeclared
                 );
             }
@@ -5544,6 +5622,8 @@ function generatePropertyAttributeInitialization(
     iterable $propertyInfos,
     array $allConstInfos,
     ?int $phpVersionIdMinimumCompatibility,
+    HeaderDependencies $headerDependencies,
+    ?string $cond,
     array &$declaredStrings
 ): string {
     $code = "";
@@ -5554,6 +5634,8 @@ function generatePropertyAttributeInitialization(
                 "property_" . $propertyInfo->name->getDeclarationName() . "_" . $key,
                 $allConstInfos,
                 $phpVersionIdMinimumCompatibility,
+                $headerDependencies,
+                $cond,
                 $declaredStrings
             );
         }

--- a/ext/calendar/calendar_arginfo.h
+++ b/ext/calendar/calendar_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit calendar.stub.php instead.
  * Stub hash: f45116785b01842f56ff923a54f65ab839b3dd61 */
 
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_cal_days_in_month, 0, 3, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, calendar, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, month, IS_LONG, 0)

--- a/ext/com_dotnet/com_extension_arginfo.h
+++ b/ext/com_dotnet/com_extension_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit com_extension.stub.php instead.
  * Stub hash: 9b2eea541946c291eb002ee98997f3dcad8bdfce */
 
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_variant_set, 0, 2, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(0, variant, variant, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)

--- a/ext/curl/curl_arginfo.h
+++ b/ext/curl/curl_arginfo.h
@@ -1,6 +1,9 @@
 /* This is a generated file, edit curl.stub.php instead.
  * Stub hash: 5da31d6790f9db408cac4aed3f81f7affb2849a6 */
 
+#include "zend_attributes.h"
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_curl_close, 0, 1, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(0, handle, CurlHandle, 0)
 ZEND_END_ARG_INFO()

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -44,7 +44,6 @@
 # pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-#include "zend_attributes.h"
 #include "curl_arginfo.h"
 
 ZEND_DECLARE_MODULE_GLOBALS(curl)

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -19,7 +19,6 @@
 #include "ext/standard/php_versioning.h"
 #include "php_date.h"
 #include "php_time.h"
-#include "zend_attributes.h"
 #include "zend_interfaces.h"
 #include "zend_exceptions.h"
 #include "lib/timelib.h"

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -1,6 +1,9 @@
 /* This is a generated file, edit php_date.stub.php instead.
  * Stub hash: 8556e1b5f05ae9f78200f05f01d9f8e815cba49d */
 
+#include "zend_attributes.h"
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_strtotime, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, baseTimestamp, IS_LONG, 1, "null")

--- a/ext/dba/dba_arginfo.h
+++ b/ext/dba/dba_arginfo.h
@@ -1,6 +1,10 @@
 /* This is a generated file, edit dba.stub.php instead.
  * Stub hash: d7ff53b73d3921c41ffd8279ea724bcd3a6d8542 */
 
+#if defined(DBA_LMDB)
+#include "zend_constants.h"
+#endif
+
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_dba_popen, 0, 2, Dba\\Connection, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, path, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, mode, IS_STRING, 0)

--- a/ext/dl_test/dl_test_arginfo.h
+++ b/ext/dl_test/dl_test_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit dl_test.stub.php instead.
  * Stub hash: 3c47a0da41b4548eb68c4124bd54cbac22f60c01 */
 
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_dl_test_test1, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -20,8 +20,6 @@
 
 #include "php.h"
 #if defined(HAVE_LIBXML) && defined(HAVE_DOM)
-#include "zend_enum.h"
-#include "zend_attributes.h"
 #include "php_dom.h"
 #include "obj_map.h"
 #include "nodelist.h"

--- a/ext/dom/php_dom_arginfo.h
+++ b/ext/dom/php_dom_arginfo.h
@@ -2,6 +2,10 @@
  * Stub hash: 8d7713834c924709155ed7acc554c9efc55e96c1
  * Has decl header: yes */
 
+#include "zend_attributes.h"
+#include "zend_constants.h"
+#include "zend_enum.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_dom_import_simplexml, 0, 1, DOMAttr|DOMElement, 0)
 	ZEND_ARG_TYPE_INFO(0, node, IS_OBJECT, 0)
 ZEND_END_ARG_INFO()

--- a/ext/enchant/enchant.c
+++ b/ext/enchant/enchant.c
@@ -20,7 +20,6 @@
 #include "php.h"
 #include "php_ini.h"
 #include "ext/standard/info.h"
-#include "Zend/zend_attributes.h"
 #include "Zend/zend_exceptions.h"
 #include <enchant.h>
 #include "php_enchant.h"

--- a/ext/enchant/enchant_arginfo.h
+++ b/ext/enchant/enchant_arginfo.h
@@ -1,6 +1,9 @@
 /* This is a generated file, edit enchant.stub.php instead.
  * Stub hash: 31974eb901477da53ede7476953d461d32f772ba */
 
+#include "zend_attributes.h"
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_enchant_broker_init, 0, 0, EnchantBroker, MAY_BE_FALSE)
 ZEND_END_ARG_INFO()
 

--- a/ext/exif/exif_arginfo.h
+++ b/ext/exif/exif_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit exif.stub.php instead.
  * Stub hash: 633b2db018fa1453845a854a6361f11f107f4653 */
 
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_exif_tagname, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
 ZEND_END_ARG_INFO()

--- a/ext/fileinfo/fileinfo.c
+++ b/ext/fileinfo/fileinfo.c
@@ -29,7 +29,6 @@
 #include "php_ini.h"
 #include "ext/standard/info.h"
 #include "ext/standard/file.h" /* needed for context stuff */
-#include "Zend/zend_attributes.h"
 #include "Zend/zend_exceptions.h"
 #include "php_fileinfo.h"
 #include "fileinfo_arginfo.h"

--- a/ext/fileinfo/fileinfo_arginfo.h
+++ b/ext/fileinfo/fileinfo_arginfo.h
@@ -1,6 +1,9 @@
 /* This is a generated file, edit fileinfo.stub.php instead.
  * Stub hash: 311d1049e32af017b44e260a00f13830714b1e96 */
 
+#include "zend_attributes.h"
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_finfo_open, 0, 0, finfo, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "FILEINFO_NONE")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, magic_database, IS_STRING, 1, "null")

--- a/ext/filter/filter.c
+++ b/ext/filter/filter.c
@@ -25,7 +25,6 @@
 
 ZEND_DECLARE_MODULE_GLOBALS(filter)
 
-#include "zend_attributes.h"
 #include "filter_private.h"
 #include "filter_arginfo.h"
 #include "zend_exceptions.h"

--- a/ext/filter/filter_arginfo.h
+++ b/ext/filter/filter_arginfo.h
@@ -1,6 +1,9 @@
 /* This is a generated file, edit filter.stub.php instead.
  * Stub hash: bd421586fdc068c456415b597d718787eb140517 */
 
+#include "zend_attributes.h"
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_filter_has_var, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, input_type, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, var_name, IS_STRING, 0)

--- a/ext/ftp/ftp_arginfo.h
+++ b/ext/ftp/ftp_arginfo.h
@@ -1,6 +1,9 @@
 /* This is a generated file, edit ftp.stub.php instead.
  * Stub hash: 29606d7114a0698b8ae231173a624b17c196ffec */
 
+#include "zend_attributes.h"
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ftp_connect, 0, 1, FTP\\Connection, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, hostname, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, port, IS_LONG, 0, "21")

--- a/ext/ftp/php_ftp.c
+++ b/ext/ftp/php_ftp.c
@@ -27,7 +27,6 @@
 
 #include "ext/standard/info.h"
 #include "ext/standard/file.h"
-#include "Zend/zend_attributes.h"
 #include "Zend/zend_exceptions.h"
 
 #include "php_ftp.h"

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -32,7 +32,6 @@
 #include "ext/standard/info.h"
 #include "php_open_temporary_file.h"
 #include "php_memory_streams.h"
-#include "zend_attributes.h"
 #include "zend_object_handlers.h"
 
 #ifdef HAVE_SYS_WAIT_H

--- a/ext/gd/gd_arginfo.h
+++ b/ext/gd/gd_arginfo.h
@@ -1,6 +1,9 @@
 /* This is a generated file, edit gd.stub.php instead.
  * Stub hash: 21f8a978b8e54da880315dd9dfeecaf0f7d5593b */
 
+#include "zend_attributes.h"
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_gd_info, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/gmp/gmp_arginfo.h
+++ b/ext/gmp/gmp_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit gmp.stub.php instead.
  * Stub hash: 743a4be1078abfa29294336564126ace8c194cbe */
 
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_gmp_init, 0, 1, GMP, 0)
 	ZEND_ARG_TYPE_MASK(0, num, MAY_BE_LONG|MAY_BE_STRING, NULL)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, base, IS_LONG, 0, "0")

--- a/ext/hash/hash_arginfo.h
+++ b/ext/hash/hash_arginfo.h
@@ -1,6 +1,9 @@
 /* This is a generated file, edit hash.stub.php instead.
  * Stub hash: b0fe91da9b0469b44a9647b774b9b00498592e30 */
 
+#include "zend_attributes.h"
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_hash, 0, 2, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, algo, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)

--- a/ext/iconv/iconv_arginfo.h
+++ b/ext/iconv/iconv_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit iconv.stub.php instead.
  * Stub hash: 4367fa431d3e4814e42d9aa514c10cae1d842d8f */
 
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_iconv_strlen, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, encoding, IS_STRING, 1, "null")

--- a/ext/intl/collator/collator_arginfo.h
+++ b/ext/intl/collator/collator_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit collator.stub.php instead.
  * Stub hash: cbe3c5f4c35d93f90c3e7164bdfc4e2fefc88c83 */
 
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Collator___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, locale, IS_STRING, 0)
 ZEND_END_ARG_INFO()

--- a/ext/intl/common/common_arginfo.h
+++ b/ext/intl/common/common_arginfo.h
@@ -1,6 +1,9 @@
 /* This is a generated file, edit common.stub.php instead.
  * Stub hash: 9ed8bfc955a557c02171ec12b4634c60c6fb513e */
 
+#include "zend_attributes.h"
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_IntlIterator_current, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/intl/formatter/formatter_arginfo.h
+++ b/ext/intl/formatter/formatter_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit formatter.stub.php instead.
  * Stub hash: d886941aa76837aed1da08845dbaff9442107203 */
 
+#include "zend_attributes.h"
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_NumberFormatter___construct, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, locale, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, style, IS_LONG, 0)

--- a/ext/intl/php_intl.c
+++ b/ext/intl/php_intl.c
@@ -75,7 +75,6 @@
 
 #include "php_ini.h"
 
-#include "zend_attributes.h"
 
 #include "php_intl_arginfo.h"
 

--- a/ext/intl/php_intl_arginfo.h
+++ b/ext/intl/php_intl_arginfo.h
@@ -1,6 +1,9 @@
 /* This is a generated file, edit php_intl.stub.php instead.
  * Stub hash: f94e7c9cc372878f1f8bd0e948092ea72076e687 */
 
+#include "zend_attributes.h"
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_intlcal_create_instance, 0, 0, IntlCalendar, 1)
 	ZEND_ARG_OBJ_TYPE_MASK(0, timezone, IntlTimeZone|DateTimeZone, MAY_BE_STRING|MAY_BE_NULL, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, locale, IS_STRING, 1, "null")

--- a/ext/json/json_arginfo.h
+++ b/ext/json/json_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit json.stub.php instead.
  * Stub hash: 0ceb50047401c4b9e878c09cc518eacc274f7fff */
 
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_json_encode, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -26,7 +26,6 @@
 
 #include "php.h"
 #include "php_ini.h"
-#include "Zend/zend_attributes.h"
 
 #include <stddef.h>
 

--- a/ext/ldap/ldap_arginfo.h
+++ b/ext/ldap/ldap_arginfo.h
@@ -1,6 +1,9 @@
 /* This is a generated file, edit ldap.stub.php instead.
  * Stub hash: 0dde8fd813f43640dee842c03365d7431858a56d */
 
+#include "zend_attributes.h"
+#include "zend_constants.h"
+
 #if defined(HAVE_ORALDAP)
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_connect, 0, 0, LDAP\\Connection, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, uri, IS_STRING, 1, "null")

--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -20,7 +20,6 @@
 #include "php.h"
 #include "SAPI.h"
 
-#include "zend_attributes.h"
 #include "zend_variables.h"
 #include "ext/standard/info.h"
 #include "ext/standard/file.h"

--- a/ext/libxml/libxml_arginfo.h
+++ b/ext/libxml/libxml_arginfo.h
@@ -1,6 +1,9 @@
 /* This is a generated file, edit libxml.stub.php instead.
  * Stub hash: 6dceb619736a3de55b84609a9e3aeb13405bbfde */
 
+#include "zend_attributes.h"
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_libxml_set_streams_context, 0, 1, IS_VOID, 0)
 	ZEND_ARG_INFO(0, context)
 ZEND_END_ARG_INFO()

--- a/ext/mbstring/mbstring_arginfo.h
+++ b/ext/mbstring/mbstring_arginfo.h
@@ -1,6 +1,11 @@
 /* This is a generated file, edit mbstring.stub.php instead.
  * Stub hash: f02c317efd6814f902ea75c9d222893713546845 */
 
+#if defined(HAVE_MBREGEX)
+#include "zend_attributes.h"
+#endif
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mb_language, 0, 0, MAY_BE_STRING|MAY_BE_BOOL)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, language, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()

--- a/ext/mysqli/mysqli.c
+++ b/ext/mysqli/mysqli.c
@@ -26,7 +26,6 @@
 #include "php_mysqli.h"
 #include "php_mysqli_structs.h"
 #include "mysqli_priv.h"
-#include "zend_attributes.h"
 #include "zend_exceptions.h"
 #include "ext/spl/spl_exceptions.h"
 #include "zend_interfaces.h"

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1,6 +1,9 @@
 /* This is a generated file, edit mysqli.stub.php instead.
  * Stub hash: f5327d48b275a5358b740232281478c83bb8a3db */
 
+#include "zend_attributes.h"
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
 	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()

--- a/ext/odbc/odbc_arginfo.h
+++ b/ext/odbc/odbc_arginfo.h
@@ -1,6 +1,9 @@
 /* This is a generated file, edit odbc.stub.php instead.
  * Stub hash: f9ba28767b256dbcea087a65aa4bb5f5b509d6f3 */
 
+#include "zend_attributes.h"
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_odbc_close_all, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -22,7 +22,6 @@
 
 #include "php.h"
 #include "php_globals.h"
-#include "zend_attributes.h"
 
 #include "ext/standard/info.h"
 #include "Zend/zend_interfaces.h"

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -26,7 +26,6 @@
 #include "php_ini.h"
 #include "php_openssl.h"
 #include "php_openssl_backend.h"
-#include "zend_attributes.h"
 #include "zend_exceptions.h"
 
 /* PHP Includes */

--- a/ext/openssl/openssl_arginfo.h
+++ b/ext/openssl/openssl_arginfo.h
@@ -1,6 +1,9 @@
 /* This is a generated file, edit openssl.stub.php instead.
  * Stub hash: 7cad995b734d69f98d489edb97a7878a4ea8f47e */
 
+#include "zend_attributes.h"
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_openssl_x509_export_to_file, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, certificate, OpenSSLCertificate, MAY_BE_STRING, NULL)
 	ZEND_ARG_TYPE_INFO(0, output_filename, IS_STRING, 0)

--- a/ext/openssl/openssl_pwhash_arginfo.h
+++ b/ext/openssl/openssl_pwhash_arginfo.h
@@ -1,6 +1,10 @@
 /* This is a generated file, edit openssl_pwhash.stub.php instead.
  * Stub hash: 23ee957ba4945be3a21db58051e548729c3ff44e */
 
+#if defined(HAVE_OPENSSL_ARGON2)
+#include "zend_constants.h"
+#endif
+
 static void register_openssl_pwhash_symbols(int module_number)
 {
 #if defined(HAVE_OPENSSL_ARGON2)

--- a/ext/pcntl/pcntl_arginfo.h
+++ b/ext/pcntl/pcntl_arginfo.h
@@ -2,6 +2,9 @@
  * Stub hash: ec6306e93fad6d127ff880fc01736ac287619cf7
  * Has decl header: yes */
 
+#include "zend_constants.h"
+#include "zend_enum.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcntl_fork, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/pcre/php_pcre_arginfo.h
+++ b/ext/pcre/php_pcre_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit php_pcre.stub.php instead.
  * Stub hash: 63de1d37ab303e1d6af7c96eaeeba09d7f35d116 */
 
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_preg_match, 0, 2, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, pattern, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, subject, IS_STRING, 0)

--- a/ext/pdo/pdo_dbh_arginfo.h
+++ b/ext/pdo/pdo_dbh_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit pdo_dbh.stub.php instead.
  * Stub hash: 006be61b2c519e7d9ca997a7f12135eb3e0f3500 */
 
+#include "zend_attributes.h"
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_PDO___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, dsn, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, username, IS_STRING, 1, "null")

--- a/ext/pdo_odbc/pdo_odbc_arginfo.h
+++ b/ext/pdo_odbc/pdo_odbc_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit pdo_odbc.stub.php instead.
  * Stub hash: 9136c911494c9e3462c49b3e58f4bcc15ebb2a9c */
 
+#include "zend_constants.h"
+
 static void register_pdo_odbc_symbols(int module_number)
 {
 	REGISTER_STRING_CONSTANT("PDO_ODBC_TYPE", PDO_ODBC_TYPE, CONST_PERSISTENT);

--- a/ext/pdo_pgsql/pdo_pgsql_arginfo.h
+++ b/ext/pdo_pgsql/pdo_pgsql_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit pdo_pgsql.stub.php instead.
  * Stub hash: 3f62627e74ad08de8e95c9862e3d209ae63d971a */
 
+#include "zend_attributes.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Pdo_Pgsql_escapeIdentifier, 0, 1, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, input, IS_STRING, 0)
 ZEND_END_ARG_INFO()

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -35,7 +35,6 @@
 #include "php_pgsql.h"
 #include "php_globals.h"
 #include "zend_exceptions.h"
-#include "zend_attributes.h"
 #include "zend_interfaces.h"
 #include "php_network.h"
 

--- a/ext/pgsql/pgsql_arginfo.h
+++ b/ext/pgsql/pgsql_arginfo.h
@@ -1,6 +1,9 @@
 /* This is a generated file, edit pgsql.stub.php instead.
  * Stub hash: fa7cd778f4e791b15ffc8f1786384332449bda5a */
 
+#include "zend_attributes.h"
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_pg_connect, 0, 1, PgSql\\Connection, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, connection_string, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")

--- a/ext/posix/posix_arginfo.h
+++ b/ext/posix/posix_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit posix.stub.php instead.
  * Stub hash: 25e0aa769d72988ebca07fff96c8ed1fcb6b7d5e */
 
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_posix_kill, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, process_id, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, signal, IS_LONG, 0)

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -25,8 +25,6 @@
 
 #include "php.h"
 
-#include "Zend/zend_attributes.h"
-#include "Zend/zend_enum.h"
 #include "Zend/zend_exceptions.h"
 
 #include "php_random.h"

--- a/ext/random/random_arginfo.h
+++ b/ext/random/random_arginfo.h
@@ -2,6 +2,10 @@
  * Stub hash: 245fb5b66e540814c8595a06182886aee3e32f2c
  * Has decl header: yes */
 
+#include "zend_attributes.h"
+#include "zend_constants.h"
+#include "zend_enum.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_lcg_value, 0, 0, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/readline/readline_arginfo.h
+++ b/ext/readline/readline_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit readline.stub.php instead.
  * Stub hash: 848e798481f62ee09cfd8cc3dfa6b0814cfdd979 */
 
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_readline, 0, 0, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, prompt, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()

--- a/ext/reflection/php_reflection_arginfo.h
+++ b/ext/reflection/php_reflection_arginfo.h
@@ -2,6 +2,9 @@
  * Stub hash: c4dcc2653f826c2c437065faec4bf77772ef88b1
  * Has decl header: yes */
 
+#include "zend_attributes.h"
+#include "zend_enum.h"
+
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Reflection_getModifierNames, 0, 1, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, modifiers, IS_LONG, 0)
 ZEND_END_ARG_INFO()

--- a/ext/session/session_arginfo.h
+++ b/ext/session/session_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit session.stub.php instead.
  * Stub hash: 5109ef5c81733a112fe20d2626b8572d0969973c */
 
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_session_name, 0, 0, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, name, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()

--- a/ext/shmop/shmop.c
+++ b/ext/shmop/shmop.c
@@ -19,7 +19,6 @@
 
 #include "php.h"
 #include "php_shmop.h"
-#include "Zend/zend_attributes.h"
 
 #include "shmop_arginfo.h"
 

--- a/ext/shmop/shmop_arginfo.h
+++ b/ext/shmop/shmop_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit shmop.stub.php instead.
  * Stub hash: e7f250077b6721539caee96afe4ed392396018f9 */
 
+#include "zend_attributes.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_shmop_open, 0, 4, Shmop, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, key, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, mode, IS_STRING, 0)

--- a/ext/snmp/snmp_arginfo.h
+++ b/ext/snmp/snmp_arginfo.h
@@ -2,6 +2,9 @@
  * Stub hash: 9916f5e1d4db267e7f5d6709adf90decc9dc7f0a
  * Has decl header: yes */
 
+#include "zend_constants.h"
+#include "zend_enum.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_snmpget, 0, 3, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, hostname, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, community, IS_STRING, 0)

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -19,7 +19,6 @@
 #endif
 #include "php_soap.h"
 #include "ext/session/php_session.h"
-#include "zend_attributes.h"
 #include "soap_arginfo.h"
 #include "zend_exceptions.h"
 #include "zend_interfaces.h"

--- a/ext/soap/soap_arginfo.h
+++ b/ext/soap/soap_arginfo.h
@@ -1,6 +1,9 @@
 /* This is a generated file, edit soap.stub.php instead.
  * Stub hash: 14c74a5d6f547837f536920d5abb741e2b6e4373 */
 
+#include "zend_attributes.h"
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_use_soap_error_handler, 0, 0, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, enable, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()

--- a/ext/sockets/sockets_arginfo.h
+++ b/ext/sockets/sockets_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit sockets.stub.php instead.
  * Stub hash: aceee39bed5332f7f26d5d768976c4d5ab96ab3c */
 
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_socket_select, 0, 4, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(1, read, IS_ARRAY, 1)
 	ZEND_ARG_TYPE_INFO(1, write, IS_ARRAY, 1)

--- a/ext/sodium/libsodium.c
+++ b/ext/sodium/libsodium.c
@@ -19,7 +19,6 @@
 #include "php.h"
 #include "ext/standard/info.h"
 #include "php_libsodium.h"
-#include "zend_attributes.h"
 #include "zend_exceptions.h"
 
 #include <sodium.h>

--- a/ext/sodium/libsodium_arginfo.h
+++ b/ext/sodium/libsodium_arginfo.h
@@ -1,6 +1,9 @@
 /* This is a generated file, edit libsodium.stub.php instead.
  * Stub hash: 7b337a297ae333dd8d0c232979b770332c9e7eb6 */
 
+#include "zend_attributes.h"
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_aead_aes256gcm_is_available, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/sodium/sodium_pwhash_arginfo.h
+++ b/ext/sodium/sodium_pwhash_arginfo.h
@@ -1,6 +1,10 @@
 /* This is a generated file, edit sodium_pwhash.stub.php instead.
  * Stub hash: d1e804ceea5e18fc5a4eca50b318d98387b2a470 */
 
+#if SODIUM_LIBRARY_VERSION_MAJOR > 9 || (SODIUM_LIBRARY_VERSION_MAJOR == 9 && SODIUM_LIBRARY_VERSION_MINOR >= 6)
+#include "zend_constants.h"
+#endif
+
 static void register_sodium_pwhash_symbols(int module_number)
 {
 #if SODIUM_LIBRARY_VERSION_MAJOR > 9 || (SODIUM_LIBRARY_VERSION_MAJOR == 9 && SODIUM_LIBRARY_VERSION_MINOR >= 6)

--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -17,7 +17,6 @@
 #endif
 
 #include "php_spl.h"
-#include "zend_attributes.h"
 #include "php_spl_arginfo.h"
 #include "zend_autoload.h"
 #include "zend_exceptions.h"

--- a/ext/spl/php_spl_arginfo.h
+++ b/ext/spl/php_spl_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit php_spl.stub.php instead.
  * Stub hash: 5f9f72a101d08dc67472461115b90534d4805ddc */
 
+#include "zend_attributes.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_implements, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, object_or_class)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, autoload, _IS_BOOL, 0, "true")

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -18,7 +18,6 @@
 
 #include "php.h"
 #include "ext/standard/php_var.h"
-#include "zend_attributes.h"
 #include "zend_smart_str.h"
 #include "zend_interfaces.h"
 #include "zend_exceptions.h"

--- a/ext/spl/spl_array_arginfo.h
+++ b/ext/spl/spl_array_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit spl_array.stub.php instead.
  * Stub hash: c50ad88a1603d7805b7b77b60bd9c9bf0aa0a008 */
 
+#include "zend_attributes.h"
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ArrayObject___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_MASK(0, array, MAY_BE_ARRAY|MAY_BE_OBJECT, "[]")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -22,7 +22,6 @@
 #include "ext/standard/flock_compat.h"
 #include "ext/standard/scanf.h"
 #include "ext/standard/php_string.h" /* For php_basename() */
-#include "zend_attributes.h"
 #include "zend_exceptions.h"
 #include "zend_interfaces.h"
 

--- a/ext/spl/spl_directory_arginfo.h
+++ b/ext/spl/spl_directory_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit spl_directory.stub.php instead.
  * Stub hash: 3313c7bc6d9691a01903e6625630863e2b1e1bf7 */
 
+#include "zend_attributes.h"
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SplFileInfo___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 ZEND_END_ARG_INFO()

--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -20,7 +20,6 @@
 #include "php.h"
 #include "zend_interfaces.h"
 #include "zend_exceptions.h"
-#include "zend_attributes.h"
 
 #include "spl_fixedarray_arginfo.h"
 #include "spl_fixedarray.h"

--- a/ext/spl/spl_fixedarray_arginfo.h
+++ b/ext/spl/spl_fixedarray_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit spl_fixedarray.stub.php instead.
  * Stub hash: 0c838fed60b29671fe04e63315ab662d8cb16f0c */
 
+#include "zend_attributes.h"
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SplFixedArray___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, size, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()

--- a/ext/spl/spl_observer.c
+++ b/ext/spl/spl_observer.c
@@ -23,7 +23,6 @@
 #include "zend_smart_str.h"
 #include "zend_interfaces.h"
 #include "zend_exceptions.h"
-#include "zend_attributes.h"
 
 #include "php_spl.h" /* For php_spl_object_hash() */
 #include "spl_observer.h"

--- a/ext/spl/spl_observer_arginfo.h
+++ b/ext/spl/spl_observer_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit spl_observer.stub.php instead.
  * Stub hash: 9dfd8bcf8946cbee550c9a46da07c424c3505408 */
 
+#include "zend_attributes.h"
+
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_SplObserver_update, 0, 1, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(0, subject, SplSubject, 0)
 ZEND_END_ARG_INFO()

--- a/ext/sqlite3/sqlite3_arginfo.h
+++ b/ext/sqlite3/sqlite3_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit sqlite3.stub.php instead.
  * Stub hash: 247f02e9b12b901b36bb863cf2a8e73b3d97a191 */
 
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE")

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -31,8 +31,6 @@
 #include "ext/standard/info.h"
 #include "ext/session/php_session.h"
 #include "zend_exceptions.h"
-#include "zend_attributes.h"
-#include "zend_enum.h"
 #include "zend_ini.h"
 #include "zend_operators.h"
 #include "ext/standard/php_dns.h"

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -2,6 +2,10 @@
  * Stub hash: 4feeab72edf6b7440af99a60e1401492828f141e
  * Has decl header: yes */
 
+#include "zend_attributes.h"
+#include "zend_constants.h"
+#include "zend_enum.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
 ZEND_END_ARG_INFO()

--- a/ext/standard/dir_arginfo.h
+++ b/ext/standard/dir_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit dir.stub.php instead.
  * Stub hash: e21d382cd4001001874c49d8c5244efb57613910 */
 
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Directory_close, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -92,7 +92,6 @@ php_file_globals file_globals;
 # include <fnmatch.h>
 #endif
 
-#include "zend_attributes.h"
 #include "file_arginfo.h"
 
 /* }}} */

--- a/ext/standard/file_arginfo.h
+++ b/ext/standard/file_arginfo.h
@@ -1,6 +1,9 @@
 /* This is a generated file, edit file.stub.php instead.
  * Stub hash: 0c62c6fb217a87010a9e2e63d4b104cde0138655 */
 
+#include "zend_attributes.h"
+#include "zend_constants.h"
+
 static void register_file_symbols(int module_number)
 {
 	REGISTER_LONG_CONSTANT("SEEK_SET", SEEK_SET, CONST_PERSISTENT);

--- a/ext/standard/io_poll_arginfo.h
+++ b/ext/standard/io_poll_arginfo.h
@@ -2,6 +2,8 @@
  * Stub hash: 2f52b00fd6dfc62291e0dd288ffd68547b29bdaa
  * Has decl header: yes */
 
+#include "zend_enum.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Io_Poll_Backend_getAvailableBackends, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/standard/password_arginfo.h
+++ b/ext/standard/password_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit password.stub.php instead.
  * Stub hash: f61df8d477588718e0eb1b055e5a3e138e6bcad3 */
 
+#include "zend_constants.h"
+
 static void register_password_symbols(int module_number)
 {
 	REGISTER_STRING_CONSTANT("PASSWORD_DEFAULT", "2y", CONST_PERSISTENT);

--- a/ext/standard/user_filters_arginfo.h
+++ b/ext/standard/user_filters_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit user_filters.stub.php instead.
  * Stub hash: 01be6d52377ecd1940c14e3d508df28a70456c58 */
 
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_php_user_filter_filter, 0, 4, IS_LONG, 0)
 	ZEND_ARG_INFO(0, in)
 	ZEND_ARG_INFO(0, out)

--- a/ext/sysvmsg/sysvmsg_arginfo.h
+++ b/ext/sysvmsg/sysvmsg_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit sysvmsg.stub.php instead.
  * Stub hash: ed5b1e4e5dda6a65ce336fc4daa975520c354f17 */
 
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_msg_get_queue, 0, 1, SysvMessageQueue, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, key, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, permissions, IS_LONG, 0, "0666")

--- a/ext/tidy/tidy_arginfo.h
+++ b/ext/tidy/tidy_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit tidy.stub.php instead.
  * Stub hash: 7a1ba6bc8ec95e846ec89060b30f54d2c32486ef */
 
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_tidy_parse_string, 0, 1, tidy, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 	ZEND_ARG_TYPE_MASK(0, config, MAY_BE_ARRAY|MAY_BE_STRING|MAY_BE_NULL, "null")

--- a/ext/tokenizer/tokenizer_arginfo.h
+++ b/ext/tokenizer/tokenizer_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit tokenizer.stub.php instead.
  * Stub hash: a89f03303f8a7d254509ae2bc46a36bb79a3c900 */
 
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_token_get_all, 0, 1, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, code, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")

--- a/ext/tokenizer/tokenizer_data_arginfo.h
+++ b/ext/tokenizer/tokenizer_data_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit tokenizer_data.stub.php instead.
  * Stub hash: c5235344b7c651d27c2c33c90696a418a9c96837 */
 
+#include "zend_constants.h"
+
 static void register_tokenizer_data_symbols(int module_number)
 {
 	REGISTER_LONG_CONSTANT("T_LNUMBER", T_LNUMBER, CONST_PERSISTENT);

--- a/ext/uri/php_uri.c
+++ b/ext/uri/php_uri.c
@@ -19,8 +19,6 @@
 #include "php.h"
 #include "Zend/zend_interfaces.h"
 #include "Zend/zend_exceptions.h"
-#include "Zend/zend_attributes.h"
-#include "Zend/zend_enum.h"
 #include "ext/standard/info.h"
 
 #include "php_uri.h"

--- a/ext/uri/php_uri_arginfo.h
+++ b/ext/uri/php_uri_arginfo.h
@@ -2,6 +2,9 @@
  * Stub hash: 9e087e3aefdab5662892e7fad9de87857aa63057
  * Has decl header: yes */
 
+#include "zend_attributes.h"
+#include "zend_enum.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_Uri_WhatWg_url_percent_encode, 0, 2, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, input, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO(0, mode, Uri\\WhatWg\\\125rlPercentEncodingMode, 0)

--- a/ext/xml/xml.c
+++ b/ext/xml/xml.c
@@ -21,7 +21,6 @@
 #include "php.h"
 
 #include "zend_variables.h"
-#include "zend_attributes.h"
 #include "ext/standard/info.h"
 #include "ext/standard/html.h" /* For php_next_utf8_char() */
 

--- a/ext/xml/xml_arginfo.h
+++ b/ext/xml/xml_arginfo.h
@@ -1,6 +1,9 @@
 /* This is a generated file, edit xml.stub.php instead.
  * Stub hash: c7838fb209d601be280dfdebfd135906afa36e8c */
 
+#include "zend_attributes.h"
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_xml_parser_create, 0, 0, XMLParser, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, encoding, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()

--- a/ext/xsl/php_xsl_arginfo.h
+++ b/ext/xsl/php_xsl_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit php_xsl.stub.php instead.
  * Stub hash: cb1005b601e72e8d36d0f6aa5d08872f5c7ea2e6 */
 
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_XSLTProcessor_importStylesheet, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, stylesheet, IS_OBJECT, 0)
 ZEND_END_ARG_INFO()

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -2,6 +2,12 @@
  * Stub hash: 4d728e740122add9d4c91f5c1abb5f5017690636
  * Has decl header: yes */
 
+#include "zend_attributes.h"
+#include "zend_constants.h"
+#if (PHP_VERSION_ID >= 80100)
+#include "zend_enum.h"
+#endif
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_trigger_bailout, 0, 0, IS_NEVER, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/zend_test/test_legacy_arginfo.h
+++ b/ext/zend_test/test_legacy_arginfo.h
@@ -2,6 +2,11 @@
  * Stub hash: 4d728e740122add9d4c91f5c1abb5f5017690636
  * Has decl header: yes */
 
+#include "zend_constants.h"
+#if (PHP_VERSION_ID >= 80100)
+#include "zend_enum.h"
+#endif
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_zend_trigger_bailout, 0, 0, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -23,7 +23,6 @@
 #include "ext/standard/php_string.h" /* For php_basename() */
 #include "ext/pcre/php_pcre.h"
 #include "ext/standard/php_filestat.h"
-#include "zend_attributes.h"
 #include "zend_interfaces.h"
 #include "zend_exceptions.h"
 #include "php_zip.h"

--- a/ext/zip/php_zip_arginfo.h
+++ b/ext/zip/php_zip_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit php_zip.stub.php instead.
  * Stub hash: 8f2b42d73dd8ff8729ddeff8396fa6d563eb13cb */
 
+#include "zend_attributes.h"
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_zip_open, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 ZEND_END_ARG_INFO()

--- a/ext/zlib/zlib_arginfo.h
+++ b/ext/zlib/zlib_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit zlib.stub.php instead.
  * Stub hash: 4c5bea6d9f290c244c7bb27c77fe8007d43a40db */
 
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_ob_gzhandler, 0, 2, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)

--- a/main/main_arginfo.h
+++ b/main/main_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit main.stub.php instead.
  * Stub hash: 22b4c7412680888c122886bccd21e3d38953ce33 */
 
+#include "zend_constants.h"
+
 static void register_main_symbols(int module_number)
 {
 	REGISTER_STRING_CONSTANT("PHP_VERSION", PHP_VERSION, CONST_PERSISTENT);

--- a/main/streams/stream_errors_arginfo.h
+++ b/main/streams/stream_errors_arginfo.h
@@ -2,6 +2,8 @@
  * Stub hash: d3087b608996f81bf0dd19c25792feec9744e768
  * Has decl header: yes */
 
+#include "zend_enum.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_StreamException_getErrors, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 

--- a/main/streams/userspace_arginfo.h
+++ b/main/streams/userspace_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit userspace.stub.php instead.
  * Stub hash: 9198095c858c95fcb31252ddfa24fe04787d0460 */
 
+#include "zend_constants.h"
+
 static void register_userspace_symbols(int module_number)
 {
 	REGISTER_LONG_CONSTANT("STREAM_USE_PATH", USE_PATH, CONST_PERSISTENT);

--- a/sapi/phpdbg/phpdbg_arginfo.h
+++ b/sapi/phpdbg/phpdbg_arginfo.h
@@ -1,6 +1,8 @@
 /* This is a generated file, edit phpdbg.stub.php instead.
  * Stub hash: 08e29f02953f23bfce6ce04f435227b4e5e61545 */
 
+#include "zend_constants.h"
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phpdbg_break_next, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
 


### PR DESCRIPTION
Conditionally include zend_attributes.h only when attributes are actually used.

Currently, zend_attributes.h must be explicitly included in C source files even when only common attributes (e.g. #[\Deprecated]) are needed. This introduces unnecessary coupling between extensions and attribute internals.

This change removes the requirement to manually include the header for common attributes, reducing boilerplate and avoiding unnecessary dependencies.

It does not affect behavior or runtime — only improves developer ergonomics and compilation dependencies.