### PR TITLE
sapi/phpdbg: refactor phpdbg_load_module_or_extension()

### DIFF
--- a/sapi/phpdbg/phpdbg_prompt.c
+++ b/sapi/phpdbg/phpdbg_prompt.c
@@ -1196,7 +1196,7 @@ static const char *phpdbg_load_module_or_extension(zend_string **path, const cha
 		phpdbg_error("extension_dir ini setting contains a nul byte");
 		return NULL;
 	}
-	if (strchr(ZSTR_VAL(*path), '/') != NULL || strchr(ZSTR_VAL(*path), DEFAULT_SLASH) != NULL) {
+	if (memchr(ZSTR_VAL(*path), '/', ZSTR_LEN(*path)) != NULL || memchr(ZSTR_VAL(*path), '/', ZSTR_LEN(*path)) != NULL) {
 		/* path is fine */
 	} else if (extension_dir && ZSTR_LEN(extension_dir) > 0) {
 		zend_string *libpath;


### PR DESCRIPTION
- Accept a zend_string* to be able to use the zend_string_concat APIs
- Make the function static as it's not exported in a header and only used inside this file
As a follow-up to https://github.com/php/php-src/pull/21146