### PR TITLE
replace ERR_NUM_ERRORS with PHP_OPENSSL_ERR_BUFFER_SIZE

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -218,9 +218,9 @@ void php_openssl_store_errors(void)
 	errors = OPENSSL_G(errors);
 
 	do {
-		errors->top = (errors->top + 1) % ERR_NUM_ERRORS;
+		errors->top = (errors->top + 1) % PHP_OPENSSL_ERR_BUFFER_SIZE;
 		if (errors->top == errors->bottom) {
-			errors->bottom = (errors->bottom + 1) % ERR_NUM_ERRORS;
+			errors->bottom = (errors->bottom + 1) % PHP_OPENSSL_ERR_BUFFER_SIZE;
 		}
 		errors->buffer[errors->top] = error_code;
 	} while ((error_code = ERR_get_error()));
@@ -4042,7 +4042,7 @@ PHP_FUNCTION(openssl_error_string)
 		RETURN_FALSE;
 	}
 
-	OPENSSL_G(errors)->bottom = (OPENSSL_G(errors)->bottom + 1) % ERR_NUM_ERRORS;
+	OPENSSL_G(errors)->bottom = (OPENSSL_G(errors)->bottom + 1) % PHP_OPENSSL_ERR_BUFFER_SIZE;
 	val = OPENSSL_G(errors)->buffer[OPENSSL_G(errors)->bottom];
 
 	if (val) {

--- a/ext/openssl/php_openssl.h
+++ b/ext/openssl/php_openssl.h
@@ -36,6 +36,8 @@ extern zend_module_entry openssl_module_entry;
 #define PHP_OPENSSL_API_VERSION 0x30200
 #endif
 
+#define PHP_OPENSSL_ERR_BUFFER_SIZE 16
+
 #define OPENSSL_RAW_DATA 1
 #define OPENSSL_ZERO_PADDING 2
 #define OPENSSL_DONT_ZERO_PAD_KEY 4
@@ -65,7 +67,7 @@ extern zend_module_entry openssl_module_entry;
 #endif
 
 struct php_openssl_errors {
-	int buffer[ERR_NUM_ERRORS];
+	int buffer[PHP_OPENSSL_ERR_BUFFER_SIZE];
 	int top;
 	int bottom;
 };


### PR DESCRIPTION
The [latest version of OpenSSL](https://github.com/openssl/openssl/commit/5c14539427ab2890655e6ac5cb47a65d20f0cb53) removed `ERR_NUM_ERRORS` from the public API thus we cannot rely on it anymore.


Fixes #21382 