### PR TITLE
ext/standard/tests/filters: add missing CTYPE extension requirement

### DIFF
--- a/ext/standard/tests/filters/user_filter_seek_01.phpt
+++ b/ext/standard/tests/filters/user_filter_seek_01.phpt
@@ -1,5 +1,7 @@
 --TEST--
 php_user_filter with seek method - always seekable (stateless filter)
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 


### PR DESCRIPTION
Found while running the tests on a minimal build.