### PR TITLE
Fix GH-21538: declare(encoding=...) ignored because Zend multibyte feature is turned off by settings for ASCII or UTF-8

### DIFF
--- a/Zend/tests/declare/bug69092.2.phpt
+++ b/Zend/tests/declare/bug69092.2.phpt
@@ -13,6 +13,4 @@ function foo() {
 echo "Bye"
 ?>
 --EXPECTF--
-Warning: declare(encoding=...) ignored because Zend multibyte feature is turned off by settings in %s on line %d
-
 Fatal error: Encoding declaration pragma must be the very first statement in the script in %s on line %d

--- a/Zend/tests/declare/gh21538.phpt
+++ b/Zend/tests/declare/gh21538.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-21538 (declare(encoding=...) warning with zend.multibyte=0 should be skipped for UTF-8 and ASCII)
+--INI--
+zend.multibyte=0
+--FILE--
+<?php
+eval("declare(encoding='UTF-8');");
+eval("declare(encoding='ASCII');");
+eval("declare(encoding='ISO-8859-1');");
+echo "Done\n";
+?>
+--EXPECTF--
+Warning: declare(encoding=...) ignored because Zend multibyte feature is turned off by settings in %s on line %d
+Done

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -7187,6 +7187,14 @@ static void zend_compile_try(const zend_ast *ast) /* {{{ */
 }
 /* }}} */
 
+static bool zend_encoding_declaration_can_be_ignored_without_warning(const zend_string *encoding_name)
+{
+	return zend_string_equals_literal_ci(encoding_name, "UTF-8")
+		|| zend_string_equals_literal_ci(encoding_name, "UTF8")
+		|| zend_string_equals_literal_ci(encoding_name, "ASCII")
+		|| zend_string_equals_literal_ci(encoding_name, "US-ASCII");
+}
+
 /* Encoding declarations must already be handled during parsing */
 bool zend_handle_encoding_declaration(zend_ast *ast) /* {{{ */
 {
@@ -7229,8 +7237,14 @@ bool zend_handle_encoding_declaration(zend_ast *ast) /* {{{ */
 
 				zend_string_release_ex(encoding_name, 0);
 			} else {
-				zend_error(E_COMPILE_WARNING, "declare(encoding=...) ignored because "
-					"Zend multibyte feature is turned off by settings");
+				zend_string *encoding_name = zval_get_string(zend_ast_get_zval(value_ast));
+
+				if (!zend_encoding_declaration_can_be_ignored_without_warning(encoding_name)) {
+					zend_error(E_COMPILE_WARNING, "declare(encoding=...) ignored because "
+						"Zend multibyte feature is turned off by settings");
+				}
+
+				zend_string_release_ex(encoding_name, 0);
 			}
 		}
 	}


### PR DESCRIPTION
Fix #21538

AFAIK warnings should be suppressed in those case, since ASCII and UTF-8 do not require multibyte which makes the warning useless. So I add a helper function that treats UTF-8, UTF8, ASCII, and US-ASCII as safe to silently ignore the warnings when multibyte is disabled: