### PR TITLE
ext/{pdo_pgsql,pgsql}: Enable HAVE_PG_RESULT_MEMORY_SIZE

### DIFF
--- a/ext/pdo_pgsql/config.w32
+++ b/ext/pdo_pgsql/config.w32
@@ -7,6 +7,7 @@ if (PHP_PDO_PGSQL != "no") {
 			CHECK_HEADER("libpq-fe.h", "CFLAGS_PDO_PGSQL", PHP_PDO_PGSQL + "\\include;" + PHP_PHP_BUILD + "\\include\\pgsql;" + PHP_PHP_BUILD + "\\include\\libpq;")) {
 		EXTENSION("pdo_pgsql", "pdo_pgsql.c pgsql_driver.c pgsql_statement.c pgsql_sql_parser.c");
 
+		AC_DEFINE('HAVE_PG_RESULT_MEMORY_SIZE', 1, "Define to 1 if libpq has the 'PQresultMemorySize' function (PostgreSQL 12 or later).");
 		AC_DEFINE('HAVE_PDO_PGSQL', 1, "Define to 1 if the PHP extension 'pdo_pgsql' is available.");
 
 		ADD_EXTENSION_DEP('pdo_pgsql', 'pdo');

--- a/ext/pgsql/config.w32
+++ b/ext/pgsql/config.w32
@@ -6,6 +6,7 @@ if (PHP_PGSQL != "no") {
 	if (CHECK_LIB("libpq.lib", "pgsql", PHP_PGSQL) &&
 		CHECK_HEADER("libpq-fe.h", "CFLAGS_PGSQL", PHP_PGSQL + "\\include;" + PHP_PHP_BUILD + "\\include\\pgsql;" + PHP_PHP_BUILD + "\\include\\libpq;" + PHP_PGSQL)) {
 		EXTENSION("pgsql", "pgsql.c", PHP_PGSQL_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
+		AC_DEFINE('HAVE_PG_RESULT_MEMORY_SIZE', 1, "Define to 1 if libpq has the 'PQresultMemorySize' function (PostgreSQL 12 or later).");
 		AC_DEFINE('HAVE_PGSQL', 1, "Define to 1 if the PHP extension 'pgsql' is available.");
 		ADD_FLAG("CFLAGS_PGSQL", "/D PGSQL_EXPORTS");
 		ADD_EXTENSION_DEP('pgsql', 'pcre');


### PR DESCRIPTION
PQresultMemorySize is available since libpq 12.
On Windows libpq 16.2 is used at time of writing:
https://github.com/winlibs/postgresql