### PR TITLE
Zend: Introduce inline helpers for raw C-string concatenation

### DIFF
--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -22,7 +22,13 @@
 #include "zend_gc.h"
 #include "zend_alloc.h"
 
+#include "zend_errors.h"
+
 BEGIN_EXTERN_C()
+
+ZEND_API ZEND_COLD ZEND_NORETURN void zend_error_noreturn(int type, const char *format, ...) ZEND_ATTRIBUTE_FORMAT(printf, 2, 3);
+
+#include "zend_multiply.h"
 
 typedef void (*zend_string_copy_storage_func_t)(void);
 typedef zend_string *(ZEND_FASTCALL *zend_new_interned_string_func_t)(zend_string *str);
@@ -329,6 +335,48 @@ static zend_always_inline zend_string *zend_string_safe_realloc(zend_string *s, 
 		GC_DELREF(s);
 	}
 	return ret;
+}
+
+static zend_always_inline char *zend_cstr_append_char(const char *str, size_t len, char c) {
+	char *res = (char *)safe_emalloc(len, 1, 2);
+	if (len > 0) {
+		memcpy(res, str, len);
+	}
+	res[len] = c;
+	res[len + 1] = '\0';
+	return res;
+}
+
+static zend_always_inline char *zend_cstr_concat(const char *s1, size_t len1, const char *s2, size_t len2) {
+	size_t size = zend_safe_address_guarded(1, len1, len2);
+	size = zend_safe_address_guarded(1, size, 1);
+	char *res = (char *)emalloc(size);
+	if (len1 > 0) {
+		memcpy(res, s1, len1);
+	}
+	if (len2 > 0) {
+		memcpy(res + len1, s2, len2);
+	}
+	res[len1 + len2] = '\0';
+	return res;
+}
+
+static zend_always_inline char *zend_cstr_concat3(const char *s1, size_t len1, const char *s2, size_t len2, const char *s3, size_t len3) {
+	size_t size = zend_safe_address_guarded(1, len1, len2);
+	size = zend_safe_address_guarded(1, size, len3);
+	size = zend_safe_address_guarded(1, size, 1);
+	char *res = (char *)emalloc(size);
+	if (len1 > 0) {
+		memcpy(res, s1, len1);
+	}
+	if (len2 > 0) {
+		memcpy(res + len1, s2, len2);
+	}
+	if (len3 > 0) {
+		memcpy(res + len1 + len2, s3, len3);
+	}
+	res[len1 + len2 + len3] = '\0';
+	return res;
 }
 
 static zend_always_inline void zend_string_free(zend_string *s)


### PR DESCRIPTION
This PR introduces three new `zend_always_inline` helpers to `Zend/zend_string.h` for concatenating raw C strings (`char *`), which is discussed before in #21597.
- `zend_str_append_char_to_raw`
- `zend_str_concat_to_raw`
- `zend_str_concat3_to_raw`

Now, several places in the codebase has manual `emalloc` + `memcpy` + `\0` boilerplate to generate temporary `char *`. This manual approach is verbose, and harder to read. In some cases when we actually need a `zend_string` instead of `char *`, we already has some refactors (https://github.com/php/php-src/pull/21564 and https://github.com/php/php-src/pull/21567) by using `zend_string_concat*` API, but when it comes to `char *`, the API forces a 24-byte struct allocation, which is immediately discarded, and will unnecessarily lower performance. In order to solve this, I think we can introduce three APIs focusing on dealing with `chars *` refactoring. 

Below are some examples:

**Appending a single character (e.g., in [ext/pdo_pgsql/pgsql_driver.c](https://github.com/php/php-src/pull/21597#issuecomment-4177847775))**

Before:
```c
char *zquery = emalloc(ZSTR_LEN(tmp) + 2);
memcpy(zquery, ZSTR_VAL(tmp), ZSTR_LEN(tmp));
zquery[ZSTR_LEN(tmp)] = '\n';
zquery[ZSTR_LEN(tmp) + 1] = '\0';
```
After:
```
char *zquery = zend_str_append_char_to_raw(ZSTR_VAL(tmp), ZSTR_LEN(tmp), '\n');
```

**Concatenating 3 strings (e.g., [php_fsockopen_format_host_port in ext/standard/fsock.c](https://github.com/php/php-src/blob/f4a2e339e331ca5758722b50c20140bd0bc943f0/ext/standard/fsock.c#L26-L46))**

Before:
```c
char *result = emalloc(total_len + 1); 
if (prefix_len > 0) {
    memcpy(result, prefix, prefix_len);
}
memcpy(result + prefix_len, host, host_len);
memcpy(result + prefix_len + host_len, portbuf, portlen);
result[total_len] = '\0';
*message = result;
```
After:
```
*message = zend_str_concat3_to_raw(prefix, prefix_len, host, host_len, portbuf, portlen);
```

p.s. I would like to add tests in a separate PR in the future, this PR is just for API itself. (Until I have time to figure out how the test suite works in core development XD)