### PR TITLE
Fix GH-21600: Remove xsltCleanupGlobals call in ext/xsl MSHUTDOWN.

### DIFF
--- a/ext/xsl/php_xsl.c
+++ b/ext/xsl/php_xsl.c
@@ -323,7 +323,6 @@ PHP_MSHUTDOWN_FUNCTION(xsl)
 	xsltUnregisterExtModuleFunction ((const xmlChar *) "function",
 				   (const xmlChar *) "http://php.net/xsl");
 	xsltSetGenericErrorFunc(NULL, NULL);
-	xsltCleanupGlobals();
 
 	return SUCCESS;
 }


### PR DESCRIPTION
The call to xsltCleanupGlobals() during module shutdown can cause a segfault in xmlHashFree() when freeing libxslt internal hash tables. This is the same class of shutdown cleanup issue that led to xmlCleanupParser() being removed from ext/libxml. The process is about to exit and the OS will reclaim all memory, making the explicit cleanup both unnecessary and harmful.