### PR TITLE
ext/intl: Add spoofchecker files unconditionally on Windows

### DIFF
--- a/ext/intl/config.w32
+++ b/ext/intl/config.w32
@@ -92,13 +92,11 @@ if (PHP_INTL != "no") {
 				resourcebundle_iterator.cpp",
 				"intl");
 
-		if (CHECK_HEADER("unicode/uspoof.h", "CFLAGS_INTL")) {
-			ADD_SOURCES(configure_module_dirname + "/spoofchecker", "\
-					spoofchecker_class.cpp \
-					spoofchecker_create.cpp \
-					spoofchecker_main.cpp",
-					"intl");
-		}
+		ADD_SOURCES(configure_module_dirname + "/spoofchecker", "\
+				spoofchecker_class.cpp \
+				spoofchecker_create.cpp \
+				spoofchecker_main.cpp",
+				"intl");
 
 		ADD_SOURCES(configure_module_dirname + "/transliterator", "\
 				transliterator_class.cpp \


### PR DESCRIPTION
This check was once relevant for ICU versions < 4.2 which lack the unicode/uspoof.h header file.

See: 6f6d60821e25c1b978c8b3f8e3e3d8128e277f06