### PR TITLE
Convert remaining K&R function declarations in libbcmath

### DIFF
--- a/ext/bcmath/libbcmath/src/add.c
+++ b/ext/bcmath/libbcmath/src/add.c
@@ -42,10 +42,7 @@
    N1 is added to N2 and the result placed into RESULT.  SCALE_MIN
    is the minimum scale for the result. */
 
-void
-bc_add (n1, n2, result, scale_min)
-     bc_num n1, n2, *result;
-     int scale_min;
+void bc_add(bc_num n1, bc_num n2, bc_num *result, int scale_min)
 {
   bc_num sum = NULL;
   int cmp_res;

--- a/ext/bcmath/libbcmath/src/compare.c
+++ b/ext/bcmath/libbcmath/src/compare.c
@@ -42,11 +42,7 @@
    than N2 and +1 if N1 is greater than N2.  If USE_SIGN is false, just
    compare the magnitudes. */
 
- int
-_bc_do_compare (n1, n2, use_sign, ignore_last)
-     bc_num n1, n2;
-     int use_sign;
-     int ignore_last;
+int _bc_do_compare(bc_num n1, bc_num n2, int use_sign, int ignore_last)
 {
   char *n1ptr, *n2ptr;
   int  count;
@@ -151,9 +147,7 @@ _bc_do_compare (n1, n2, use_sign, ignore_last)
 
 /* This is the "user callable" routine to compare numbers N1 and N2. */
 
-int
-bc_compare (n1, n2)
-     bc_num n1, n2;
+int bc_compare(bc_num n1, bc_num n2)
 {
   return _bc_do_compare (n1, n2, TRUE, FALSE);
 }

--- a/ext/bcmath/libbcmath/src/doaddsub.c
+++ b/ext/bcmath/libbcmath/src/doaddsub.c
@@ -42,10 +42,7 @@
    returned.  The signs of N1 and N2 are ignored.
    SCALE_MIN is to set the minimum scale of the result. */
 
- bc_num
-_bc_do_add (n1, n2, scale_min)
-     bc_num n1, n2;
-     int scale_min;
+bc_num _bc_do_add(bc_num n1, bc_num n2, int scale_min)
 {
   bc_num sum;
   int sum_scale, sum_digits;
@@ -134,10 +131,7 @@ _bc_do_add (n1, n2, scale_min)
    assumed to be larger than N2.  SCALE_MIN is the minimum scale
    of the result. */
 
- bc_num
-_bc_do_sub (n1, n2, scale_min)
-     bc_num n1, n2;
-     int scale_min;
+bc_num _bc_do_sub(bc_num n1, bc_num n2, int scale_min)
 {
   bc_num diff;
   int diff_scale, diff_len;

--- a/ext/bcmath/libbcmath/src/init.c
+++ b/ext/bcmath/libbcmath/src/init.c
@@ -39,9 +39,7 @@
 
 /* new_num allocates a number and sets fields to known values. */
 
-bc_num
-_bc_new_num_ex (length, scale, persistent)
-     int length, scale, persistent;
+bc_num _bc_new_num_ex(int length, int scale, int persistent)
 {
   bc_num temp;
   /* PHP Change:  malloc() -> pemalloc(), removed free_list code */
@@ -61,10 +59,7 @@ _bc_new_num_ex (length, scale, persistent)
 /* "Frees" a bc_num NUM.  Actually decreases reference count and only
    frees the storage if reference count is zero. */
 
-void
-_bc_free_num_ex (num, persistent)
-    bc_num *num;
-    int persistent;
+void _bc_free_num_ex(bc_num *num, int persistent)
 {
   if (*num == NULL) return;
   (*num)->n_refs--;

--- a/ext/bcmath/libbcmath/src/int2num.c
+++ b/ext/bcmath/libbcmath/src/int2num.c
@@ -40,10 +40,7 @@
 
 /* Convert an integer VAL to a bc number NUM. */
 
-void
-bc_int2num (num, val)
-     bc_num *num;
-     int val;
+void bc_int2num(bc_num *num, int val)
 {
   char buffer[30];
   char *bptr, *vptr;

--- a/ext/bcmath/libbcmath/src/nearzero.c
+++ b/ext/bcmath/libbcmath/src/nearzero.c
@@ -41,10 +41,7 @@
    Specifically, all but the last digit is 0 and the last digit is 1.
    Last digit is defined by scale. */
 
-char
-bc_is_near_zero (num, scale)
-     bc_num num;
-     int scale;
+char bc_is_near_zero(bc_num num, int scale)
 {
   int  count;
   char *nptr;

--- a/ext/bcmath/libbcmath/src/neg.c
+++ b/ext/bcmath/libbcmath/src/neg.c
@@ -39,9 +39,7 @@
 
 /* In some places we need to check if the number is negative. */
 
-char
-bc_is_neg (num)
-     bc_num num;
+char bc_is_neg(bc_num num)
 {
   return num->n_sign == MINUS;
 }

--- a/ext/bcmath/libbcmath/src/num2long.c
+++ b/ext/bcmath/libbcmath/src/num2long.c
@@ -42,9 +42,7 @@
    a long, this function returns a zero.  This can be detected by checking
    the NUM for zero after having a zero returned. */
 
-long
-bc_num2long (num)
-     bc_num num;
+long bc_num2long(bc_num num)
 {
   long val;
   char *nptr;

--- a/ext/bcmath/libbcmath/src/num2str.c
+++ b/ext/bcmath/libbcmath/src/num2str.c
@@ -39,10 +39,7 @@
 
 /* Convert a numbers to a string.  Base 10 only.*/
 
-zend_string
-*bc_num2str_ex (num, scale)
-      bc_num num;
-	  int scale;
+zend_string *bc_num2str_ex(bc_num num, int scale)
 {
 	zend_string *str;
 	char *sptr;

--- a/ext/bcmath/libbcmath/src/rmzero.c
+++ b/ext/bcmath/libbcmath/src/rmzero.c
@@ -41,9 +41,7 @@
    _bc_rm_leading_zeros just moves the data "value" pointer to the
    correct place and adjusts the length. */
 
- void
-_bc_rm_leading_zeros (num)
-     bc_num num;
+void _bc_rm_leading_zeros(bc_num num)
 {
   /* We can move n_value to point to the first non zero digit! */
   while (*num->n_value == 0 && num->n_len > 1) {

--- a/ext/bcmath/libbcmath/src/sub.c
+++ b/ext/bcmath/libbcmath/src/sub.c
@@ -42,10 +42,7 @@
    N2 is subtracted from N1 and the result placed in RESULT.  SCALE_MIN
    is the minimum scale for the result. */
 
-void
-bc_sub (n1, n2, result, scale_min)
-     bc_num n1, n2, *result;
-     int scale_min;
+void bc_sub(bc_num n1, bc_num n2, bc_num *result, int scale_min)
 {
   bc_num diff = NULL;
   int cmp_res;


### PR DESCRIPTION
These are already converted in 8.3. Backport minimal changes to 8.2, as the latest version of Clang on macOS has stopped supporting the K&R syntax.

Context: https://github.com/php/php-src/actions/runs/23963588819/job/69898753663