### PR TITLE
[ext/session] Validate session.cookie_samesite against allowed values

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -733,6 +733,23 @@ static PHP_INI_MH(OnUpdateSessionStr)
 	return OnUpdateStr(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
 }
 
+static PHP_INI_MH(OnUpdateSessionSameSite)
+{
+	SESSION_CHECK_ACTIVE_STATE;
+	SESSION_CHECK_OUTPUT_STATE;
+
+	if (new_value && ZSTR_LEN(new_value) > 0
+		&& !zend_string_equals_literal_ci(new_value, "Strict")
+		&& !zend_string_equals_literal_ci(new_value, "Lax")
+		&& !zend_string_equals_literal_ci(new_value, "None")) {
+		php_error_docref(NULL, E_WARNING,
+			"session.cookie_samesite must be \"Strict\", \"Lax\", \"None\", or \"\"");
+		return FAILURE;
+	}
+
+	return OnUpdateStr(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
+}
+
 static PHP_INI_MH(OnUpdateSessionBool)
 {
 	SESSION_CHECK_ACTIVE_STATE;
@@ -904,7 +921,7 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_BOOLEAN("session.cookie_secure",      "0",         PHP_INI_ALL,    OnUpdateSessionBool,          cookie_secure,      php_ps_globals, ps_globals)
 	STD_PHP_INI_BOOLEAN("session.cookie_partitioned", "0",         PHP_INI_ALL,    OnUpdateSessionBool,          cookie_partitioned, php_ps_globals, ps_globals)
 	STD_PHP_INI_BOOLEAN("session.cookie_httponly",    "0",         PHP_INI_ALL,    OnUpdateSessionBool,          cookie_httponly,    php_ps_globals, ps_globals)
-	STD_PHP_INI_ENTRY("session.cookie_samesite",      "",          PHP_INI_ALL,    OnUpdateSessionStr,           cookie_samesite,    php_ps_globals, ps_globals)
+	STD_PHP_INI_ENTRY("session.cookie_samesite",      "",          PHP_INI_ALL,    OnUpdateSessionSameSite,      cookie_samesite,    php_ps_globals, ps_globals)
 	STD_PHP_INI_BOOLEAN("session.use_cookies",        "1",         PHP_INI_ALL,    OnUpdateSessionBool,          use_cookies,        php_ps_globals, ps_globals)
 	STD_PHP_INI_BOOLEAN("session.use_only_cookies",   "1",         PHP_INI_ALL,    OnUpdateUseOnlyCookies,       use_only_cookies,   php_ps_globals, ps_globals)
 	STD_PHP_INI_BOOLEAN("session.use_strict_mode",    "0",         PHP_INI_ALL,    OnUpdateSessionBool,          use_strict_mode,    php_ps_globals, ps_globals)

--- a/ext/session/tests/session_cookie_samesite_validation.phpt
+++ b/ext/session/tests/session_cookie_samesite_validation.phpt
@@ -1,0 +1,31 @@
+--TEST--
+session.cookie_samesite only accepts Strict, Lax, None, or empty string
+--EXTENSIONS--
+session
+--SKIPIF--
+<?php include('skipif.inc'); ?>
+--FILE--
+<?php
+ob_start();
+ini_set('session.cookie_samesite', 'Invalid');
+ini_set('session.cookie_samesite', "Strict\r\nX-Injected: evil");
+$after_invalid = ini_get('session.cookie_samesite');
+
+$r_strict = ini_set('session.cookie_samesite', 'Strict') !== false;
+$r_lax    = ini_set('session.cookie_samesite', 'Lax')    !== false;
+$r_none   = ini_set('session.cookie_samesite', 'None')   !== false;
+$r_empty  = ini_set('session.cookie_samesite', '')       !== false;
+echo ob_get_clean();
+
+var_dump($after_invalid);
+var_dump($r_strict, $r_lax, $r_none, $r_empty);
+?>
+--EXPECTF--
+Warning: ini_set(): session.cookie_samesite must be "Strict", "Lax", "None", or "" in %s on line %d
+
+Warning: ini_set(): session.cookie_samesite must be "Strict", "Lax", "None", or "" in %s on line %d
+string(0) ""
+bool(true)
+bool(true)
+bool(true)
+bool(true)


### PR DESCRIPTION
## Summary

- Adds `OnUpdateSessionSameSite()` INI handler that enforces the SameSite whitelist (`Strict`, `Lax`, `None`, or empty string)
- Rejects any other value with `E_WARNING` and returns `FAILURE`, preventing arbitrary strings (including CRLF sequences) from being appended verbatim into the `Set-Cookie` header
- `php_setcookie()` in `ext/standard/head.c` has a `/* Should check value of SameSite? */` TODO comment for the same gap — this addresses it at the INI layer
- `session.cookie_path` and `session.cookie_domain` already have equivalent validation in `php_setcookie()` at call time; `session.cookie_partitioned` is a boolean INI entry requiring no string validation

## Test plan

- [ ] `ext/session/tests/session_cookie_samesite_validation.phpt` — verifies invalid and CRLF-containing values are rejected, and that `Strict`/`Lax`/`None`/`""` are all accepted