### PR TITLE
tree-wide: Add explicit braces around `FOREACH` body

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -7472,15 +7472,15 @@ static void zend_are_intersection_types_redundant(const zend_type left_type, con
 
 	unsigned int sum = 0;
 	const zend_type *outer_type;
-	ZEND_TYPE_LIST_FOREACH(smaller_type_list, outer_type)
+	ZEND_TYPE_LIST_FOREACH(smaller_type_list, outer_type) {
 		const zend_type *inner_type;
-		ZEND_TYPE_LIST_FOREACH(larger_type_list, inner_type)
+		ZEND_TYPE_LIST_FOREACH(larger_type_list, inner_type) {
 			if (zend_string_equals_ci(ZEND_TYPE_NAME(*inner_type), ZEND_TYPE_NAME(*outer_type))) {
 				sum++;
 				break;
 			}
-		ZEND_TYPE_LIST_FOREACH_END();
-	ZEND_TYPE_LIST_FOREACH_END();
+		} ZEND_TYPE_LIST_FOREACH_END();
+	} ZEND_TYPE_LIST_FOREACH_END();
 
 	if (sum == smaller_type_list->num_types) {
 		zend_string *smaller_type_str;
@@ -7508,14 +7508,14 @@ static void zend_is_intersection_type_redundant_by_single_type(const zend_type i
 	ZEND_ASSERT(!ZEND_TYPE_IS_INTERSECTION(single_type));
 
 	const zend_type *single_intersection_type = NULL;
-	ZEND_TYPE_FOREACH(intersection_type, single_intersection_type)
+	ZEND_TYPE_FOREACH(intersection_type, single_intersection_type) {
 		if (zend_string_equals_ci(ZEND_TYPE_NAME(*single_intersection_type), ZEND_TYPE_NAME(single_type))) {
 			zend_string *single_type_str = zend_type_to_string(single_type);
 			zend_string *complete_type = zend_type_to_string(intersection_type);
 			zend_error_noreturn(E_COMPILE_ERROR, "Type %s is redundant as it is more restrictive than type %s",
 					ZSTR_VAL(complete_type), ZSTR_VAL(single_type_str));
 		}
-	ZEND_TYPE_FOREACH_END();
+	} ZEND_TYPE_FOREACH_END();
 }
 
 /* Used by both intersection and union types prior to transforming the type list to a full zend_type */
@@ -8465,7 +8465,7 @@ static void compile_implicit_lexical_binds(
 		op_array->static_variables = zend_new_array(8);
 	}
 
-	ZEND_HASH_MAP_FOREACH_STR_KEY(&info->uses, var_name)
+	ZEND_HASH_MAP_FOREACH_STR_KEY(&info->uses, var_name) {
 		zval *value = zend_hash_add(
 			op_array->static_variables, var_name, &EG(uninitialized_zval));
 		uint32_t offset = (uint32_t)((char*)value - (char*)op_array->static_variables->arData);
@@ -8474,7 +8474,7 @@ static void compile_implicit_lexical_binds(
 		opline->op2_type = IS_CV;
 		opline->op2.var = lookup_cv(var_name);
 		opline->extended_value = offset | ZEND_BIND_IMPLICIT;
-	ZEND_HASH_FOREACH_END();
+	} ZEND_HASH_FOREACH_END();
 }
 
 static void zend_compile_closure_uses(zend_ast *ast) /* {{{ */
@@ -8514,11 +8514,11 @@ static void zend_compile_closure_uses(zend_ast *ast) /* {{{ */
 static void zend_compile_implicit_closure_uses(const closure_info *info)
 {
 	zend_string *var_name;
-	ZEND_HASH_MAP_FOREACH_STR_KEY(&info->uses, var_name)
+	ZEND_HASH_MAP_FOREACH_STR_KEY(&info->uses, var_name) {
 		zval zv;
 		ZVAL_NULL(&zv);
 		zend_compile_static_var_common(var_name, &zv, ZEND_BIND_IMPLICIT);
-	ZEND_HASH_FOREACH_END();
+	} ZEND_HASH_FOREACH_END();
 }
 
 static void add_stringable_interface(zend_class_entry *ce) {

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -1283,9 +1283,9 @@ static void add_config_entries(HashTable *hash, zval *return_value) /* {{{ */
 	zend_string *key;
 	zval *zv;
 
-	ZEND_HASH_FOREACH_KEY_VAL(hash, h, key, zv)
+	ZEND_HASH_FOREACH_KEY_VAL(hash, h, key, zv) {
 		add_config_entry(h, key, zv, return_value);
-	ZEND_HASH_FOREACH_END();
+	} ZEND_HASH_FOREACH_END();
 }
 /* }}} */
 

--- a/sapi/apache2handler/php_functions.c
+++ b/sapi/apache2handler/php_functions.c
@@ -179,10 +179,10 @@ PHP_FUNCTION(apache_request_headers)
 	ctx = SG(server_context);
 	arr = apr_table_elts(ctx->r->headers_in);
 
-	APR_ARRAY_FOREACH_OPEN(arr, key, val)
+	APR_ARRAY_FOREACH_OPEN(arr, key, val) {
 		if (!val) val = "";
 		add_assoc_string(return_value, key, val);
-	APR_ARRAY_FOREACH_CLOSE()
+	} APR_ARRAY_FOREACH_CLOSE();
 }
 /* }}} */
 
@@ -200,10 +200,10 @@ PHP_FUNCTION(apache_response_headers)
 	ctx = SG(server_context);
 	arr = apr_table_elts(ctx->r->headers_out);
 
-	APR_ARRAY_FOREACH_OPEN(arr, key, val)
+	APR_ARRAY_FOREACH_OPEN(arr, key, val) {
 		if (!val) val = "";
 		add_assoc_string(return_value, key, val);
-	APR_ARRAY_FOREACH_CLOSE()
+	} APR_ARRAY_FOREACH_CLOSE();
 }
 /* }}} */
 
@@ -411,12 +411,12 @@ PHP_MINFO_FUNCTION(apache)
 		SECTION("Apache Environment");
 		php_info_print_table_start();
 		php_info_print_table_header(2, "Variable", "Value");
-		APR_ARRAY_FOREACH_OPEN(arr, key, val)
+		APR_ARRAY_FOREACH_OPEN(arr, key, val) {
 			if (!val) {
 				val = "";
 			}
 			php_info_print_table_row(2, key, val);
-		APR_ARRAY_FOREACH_CLOSE()
+		} APR_ARRAY_FOREACH_CLOSE();
 
 		php_info_print_table_end();
 
@@ -426,21 +426,21 @@ PHP_MINFO_FUNCTION(apache)
 		php_info_print_table_row(2, "HTTP Request", ((php_struct *) SG(server_context))->r->the_request);
 
 		arr = apr_table_elts(((php_struct *) SG(server_context))->r->headers_in);
-		APR_ARRAY_FOREACH_OPEN(arr, key, val)
+		APR_ARRAY_FOREACH_OPEN(arr, key, val) {
 			if (!val) {
 				val = "";
 			}
 		        php_info_print_table_row(2, key, val);
-		APR_ARRAY_FOREACH_CLOSE()
+		} APR_ARRAY_FOREACH_CLOSE();
 
 		php_info_print_table_colspan_header(2, "HTTP Response Headers");
 		arr = apr_table_elts(((php_struct *) SG(server_context))->r->headers_out);
-		APR_ARRAY_FOREACH_OPEN(arr, key, val)
+		APR_ARRAY_FOREACH_OPEN(arr, key, val) {
 			if (!val) {
 				val = "";
 			}
 		        php_info_print_table_row(2, key, val);
-		APR_ARRAY_FOREACH_CLOSE()
+		} APR_ARRAY_FOREACH_CLOSE();
 
 		php_info_print_table_end();
 	}

--- a/sapi/apache2handler/sapi_apache2.c
+++ b/sapi/apache2handler/sapi_apache2.c
@@ -269,14 +269,14 @@ php_apache_sapi_register_variables(zval *track_vars_array)
 	char *key, *val;
 	size_t new_val_len;
 
-	APR_ARRAY_FOREACH_OPEN(arr, key, val)
+	APR_ARRAY_FOREACH_OPEN(arr, key, val) {
 		if (!val) {
 			val = "";
 		}
 		if (sapi_module.input_filter(PARSE_SERVER, key, &val, strlen(val), &new_val_len)) {
 			php_register_variable_safe(key, val, new_val_len, track_vars_array);
 		}
-	APR_ARRAY_FOREACH_CLOSE()
+	} APR_ARRAY_FOREACH_CLOSE();
 
 	if (sapi_module.input_filter(PARSE_SERVER, "PHP_SELF", &ctx->r->uri, strlen(ctx->r->uri), &new_val_len)) {
 		php_register_variable_safe("PHP_SELF", ctx->r->uri, new_val_len, track_vars_array);


### PR DESCRIPTION
Places searched with:

    .*FOREACH.*\(.+\)\s*(?!\{)\n

and then manually adjusted.