### PR TITLE
Disable ASLR during benchmarking for target process only

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -1012,10 +1012,6 @@ jobs:
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
           fetch-depth: 0
-      # ASLR can cause a lot of noise due to missed sse opportunities for memcpy
-      # and other operations, so we disable it during benchmarking.
-      - name: Disable ASLR
-        run: echo 0 | sudo tee /proc/sys/kernel/randomize_va_space
       - name: apt
         run: |
           set -x

--- a/benchmark/benchmark.php
+++ b/benchmark/benchmark.php
@@ -109,12 +109,16 @@ function runValgrindPhpCgiCommand(
 ): array {
     global $phpCgi;
 
+    // ASLR can cause a lot of noise due to missed sse opportunities for memcpy and other operations
+    $aslrDisable = checkPersonalityAslrDisablePermission();
+
     $profileOut = __DIR__ . "/profiles/callgrind.out.$name";
     if ($jit) {
         $profileOut .= '.jit';
     }
 
     $process = runCommand([
+        ...($aslrDisable ? ['setarch', '--addr-no-randomize'] : []),
         'valgrind',
         '--tool=callgrind',
         '--dump-instr=yes',

--- a/benchmark/benchmark.php
+++ b/benchmark/benchmark.php
@@ -109,7 +109,7 @@ function runValgrindPhpCgiCommand(
 ): array {
     global $phpCgi;
 
-    // ASLR can cause a lot of noise due to missed sse opportunities for memcpy and other operations
+    // ASLR can cause a lot of noise due to missed SSE opportunities for memcpy and other operations
     $aslrDisable = checkPersonalityAslrDisablePermission();
 
     $profileOut = __DIR__ . "/profiles/callgrind.out.$name";

--- a/benchmark/shared.php
+++ b/benchmark/shared.php
@@ -72,3 +72,16 @@ function cloneRepo(string $path, string $url) {
     }
     runCommand(['git', 'clone', '-q', '--end-of-options', $url, $repo], dirname($path));
 }
+
+function checkPersonalityAslrDisablePermission(): bool {
+    $processResult = runCommand(['sh', '-c', 'setarch --addr-no-randomize sh -c \'cat /proc/self/personality\' || true'], null, false);
+
+    $n = hexdec($processResult->stdout);
+    if (($n & 0x4_00_00) === 0) {
+        fwrite(STDOUT, 'Unable to disable ASLR: ' . trim($processResult->stderr) . "\n");
+
+        return false;
+    }
+
+    return true;
+}


### PR DESCRIPTION
It is better to disable ASLR for target process only than globally.

The current script works also when run locally and it emits a warning when the ASLR cannot be disabled (like in unprivileged Docker).