### PR TITLE
Fix GH-18105: Wrong file & line on exception trace with trait default parameter

### DIFF
--- a/Zend/tests/gh18105.phpt
+++ b/Zend/tests/gh18105.phpt
@@ -1,0 +1,37 @@
+--TEST--
+GH-18105 (Wrong line & file on error trace with trait default parameter)
+--FILE--
+<?php
+
+file_put_contents(__DIR__ . '/gh18105_defs.inc', <<<'PHP'
+<?php
+class ThrowableParam {
+    public function __construct() {
+        throw new Exception('thrown here');
+    }
+}
+trait TraitInASeparateFile {
+    public function execute(ThrowableParam $param = new ThrowableParam): void {}
+}
+PHP);
+
+include __DIR__ . '/gh18105_defs.inc';
+
+class Foo {
+    use TraitInASeparateFile;
+}
+
+try {
+    (new Foo)->execute();
+} catch (Exception $e) {
+    echo basename($e->getFile()), "\n";
+    echo $e->getLine(), "\n";
+}
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/gh18105_defs.inc');
+?>
+--EXPECT--
+gh18105_defs.inc
+4

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -1099,8 +1099,14 @@ static zend_result ZEND_FASTCALL zend_ast_evaluate_inner(
 
 				zend_function *ctor = Z_OBJ_HT_P(result)->get_constructor(Z_OBJ_P(result));
 				if (ctor) {
+					zend_string *prev_filename = EG(filename_override);
+					zend_long prev_lineno = EG(lineno_override);
+					EG(filename_override) = NULL;
+					EG(lineno_override) = -1;
 					zend_call_known_function(
 						ctor, Z_OBJ_P(result), Z_OBJCE_P(result), NULL, 0, NULL, args);
+					EG(filename_override) = prev_filename;
+					EG(lineno_override) = prev_lineno;
 				}
 
 				zend_array_destroy(args);
@@ -1120,8 +1126,14 @@ static zend_result ZEND_FASTCALL zend_ast_evaluate_inner(
 
 				zend_function *ctor = Z_OBJ_HT_P(result)->get_constructor(Z_OBJ_P(result));
 				if (ctor) {
+					zend_string *prev_filename = EG(filename_override);
+					zend_long prev_lineno = EG(lineno_override);
+					EG(filename_override) = NULL;
+					EG(lineno_override) = -1;
 					zend_call_known_instance_method(
 						ctor, Z_OBJ_P(result), NULL, args_ast->children, args);
+					EG(filename_override) = prev_filename;
+					EG(lineno_override) = prev_lineno;
 				}
 
 				for (uint32_t i = 0; i < args_ast->children; i++) {


### PR DESCRIPTION
When a trait method has a default parameter using `new` (e.g., `new ThrowableParam`) and the constructor throws, the exception reports the file of the class using the trait, not the file where the throw occurs.

`zend_ast_evaluate_ex` sets `EG(filename_override)` to the scope's filename during constant expression evaluation. For trait clones, the scope points to the using class's file. When `ZEND_AST_NEW` calls the constructor and it throws, `zend_default_exception_new` picks up this stale override.

Save and clear `EG(filename_override)` before constructor calls in `zend_ast_evaluate_inner`'s `ZEND_AST_NEW` handler, restore after. The VM's normal stack frame resolution then applies during constructor execution.

Fixes #18105