### PR TITLE
Move gcovr options to config file

### DIFF
--- a/build/Makefile.gcov
+++ b/build/Makefile.gcov
@@ -16,23 +16,6 @@ LCOV_EXCLUDES = \
 	'$(top_srcdir)/parse_date.re' \
 	'$(top_srcdir)/parse_iso_intervals.re'
 
-GCOVR_EXCLUDES = \
-	'ext/bcmath/libbcmath/.*' \
-	'ext/date/lib/.*' \
-	'ext/fileinfo/libmagic/.*' \
-	'ext/gd/libgd/.*' \
-	'ext/hash/sha3/.*' \
-	'ext/lexbor/lexbor/.*' \
-	'ext/mbstring/libmbfl/.*' \
-	'ext/opcache/jit/ir/.*' \
-	'ext/pcre/pcre2lib/.*' \
-	'ext/uri/uriparser/.*'
-
-# These patterns have implicit ^/$ anchors.
-GCOVR_EXCLUDE_LINES_BY_PATTERNS = \
-	'.*\b(ZEND_PARSE_PARAMETERS_(START|END|NONE)|Z_PARAM_).*' \
-	'\s*(default:\s*)?ZEND_UNREACHABLE\(\);\s*'
-
 lcov: lcov-html
 
 php_lcov.info:
@@ -56,15 +39,11 @@ gcovr-html:
 	@echo "Generating gcovr HTML"
 	@rm -rf gcovr_html/
 	@mkdir gcovr_html
-	gcovr -sr . -o gcovr_html/index.html --html --html-details --exclude-unreachable-branches --exclude-throw-branches \
-		$(foreach pattern, $(GCOVR_EXCLUDE_LINES_BY_PATTERNS), --exclude-lines-by-pattern $(pattern)) \
-		$(foreach lib, $(GCOVR_EXCLUDES), -e $(lib))
+	gcovr -r . -o gcovr_html/index.html --html --html-details
 
 gcovr-xml:
 	@echo "Generating gcovr XML"
 	@rm -f gcovr.xml
-	gcovr -sr . -o gcovr.xml --xml --exclude-unreachable-branches --exclude-throw-branches \
-		$(foreach pattern, $(GCOVR_EXCLUDE_LINES_BY_PATTERNS), --exclude-lines-by-pattern $(pattern)) \
-		$(foreach lib, $(GCOVR_EXCLUDES), -e $(lib))
+	gcovr -r . -o gcovr.xml --xml
 
 .PHONY: gcovr-html lcov-html php_lcov.info

--- a/gcovr.cfg
+++ b/gcovr.cfg
@@ -1,0 +1,19 @@
+print-summary = yes
+
+exclude-throw-branches = yes
+exclude-unreachable-branches = yes
+
+exclude = ext/bcmath/libbcmath/.*
+exclude = ext/date/lib/.*
+exclude = ext/fileinfo/libmagic/.*
+exclude = ext/gd/libgd/.*
+exclude = ext/hash/sha3/.*
+exclude = ext/lexbor/lexbor/.*
+exclude = ext/mbstring/libmbfl/.*
+exclude = ext/opcache/jit/ir/.*
+exclude = ext/pcre/pcre2lib/.*
+exclude = ext/uri/uriparser/.*
+
+# These patterns have implicit ^/$ anchors.
+exclude-lines-by-pattern = .*\b(ZEND_PARSE_PARAMETERS_(START|END|NONE)|Z_PARAM_).*
+exclude-lines-by-pattern = \s*(default:\s*)?ZEND_UNREACHABLE\(\);\s*


### PR DESCRIPTION
Having these in the make file is very annoying, because it requires rebuilding from scratch and rerunning tests just to see if some flag is effective.

Note: gcovr config files are marked as experiemental:

https://gcovr.com/en/latest/guide/configuration.html

However, they've been experimental for ~4 years and it's unlikely it'll go anywhere. Even if, we use this for internal purposes only.