### PR TITLE
Fix GH-21691: OPcache CFG optimizer eliminates QM_ASSIGN feeding JMPZ with VAR operand

### DIFF
--- a/Zend/Optimizer/block_pass.c
+++ b/Zend/Optimizer/block_pass.c
@@ -703,7 +703,7 @@ optimize_type_check:
 					} else if (opline->op1_type == IS_TMP_VAR &&
 					           !zend_bitset_in(used_ext, VAR_NUM(opline->op1.var))) {
 						src = VAR_SOURCE(opline->op1);
-						if (src) {
+						if (src && src->op1_type != IS_VAR) {
 							if (src->opcode == ZEND_BOOL_NOT) {
 								VAR_SOURCE(opline->op1) = NULL;
 								COPY_NODE(opline->op1, src->op1);
@@ -747,7 +747,7 @@ optimize_type_check:
 					           (!zend_bitset_in(used_ext, VAR_NUM(opline->op1.var)) ||
 					            opline->result.var == opline->op1.var)) {
 						src = VAR_SOURCE(opline->op1);
-						if (src) {
+						if (src && src->op1_type != IS_VAR) {
 							if (src->opcode == ZEND_BOOL ||
 							    src->opcode == ZEND_QM_ASSIGN) {
 								VAR_SOURCE(opline->op1) = NULL;

--- a/ext/opcache/tests/gh21691.phpt
+++ b/ext/opcache/tests/gh21691.phpt
@@ -1,0 +1,42 @@
+--TEST--
+GH-21691 (OPcache CFG optimizer breaks reference returns with JMPZ/JMPZ_EX)
+--INI--
+opcache.enable_cli=1
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+class Base {
+    protected function &getData(): array {
+        $x = [];
+        return $x;
+    }
+
+    public function process(): array {
+        if ($data = &$this->getData() && !isset($data['key'])) {
+        }
+        return $data;
+    }
+
+    public function check(): bool {
+        return ($data = &$this->getData()) && count($data) > 0;
+    }
+}
+
+class Child extends Base {
+    protected function &getData(): array {
+        static $x = ['value' => 42];
+        return $x;
+    }
+}
+
+$child = new Child();
+var_dump($child->process());
+var_dump($child->check());
+?>
+--EXPECT--
+array(1) {
+  ["value"]=>
+  int(42)
+}
+bool(true)


### PR DESCRIPTION
Fixes #21691

The CFG optimizer (pass 5) removed a `QM_ASSIGN` that converted `IS_VAR` to `IS_TMP_VAR` before `JMPZ`. Since `JMPZ` has no handler for `IS_VAR` operands, this produced "Invalid opcode 43/4/0." The pattern occurs when `ASSIGN_REF` (which produces `IS_VAR`) feeds into a conditional via `QM_ASSIGN`.

Skips the `QM_ASSIGN` elimination when the source operand is `IS_VAR`.