### PR TITLE
Fix GH-21698: memory leak in ZipArchive::addGlob on early returns.

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -675,12 +675,14 @@ int php_zip_glob(char *pattern, int pattern_len, zend_long flags, zval *return_v
 
 	/* now catch the FreeBSD style of "no matches" */
 	if (!globbuf.gl_pathc || !globbuf.gl_pathv) {
+		globfree(&globbuf);
 		return 0;
 	}
 
 	/* we assume that any glob pattern will match files from one directory only
 	   so checking the dirname of the first match should be sufficient */
 	if (ZIP_OPENBASEDIR_CHECKPATH(globbuf.gl_pathv[0])) {
+		globfree(&globbuf);
 		return -1;
 	}
 

--- a/ext/zip/tests/gh21698.phpt
+++ b/ext/zip/tests/gh21698.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-21698 (ZipArchive::addGlob memory leak when open_basedir rejects the match)
+--EXTENSIONS--
+zip
+--FILE--
+<?php
+$zipfile = __DIR__ . '/gh21698.zip';
+$zip = new ZipArchive();
+$zip->open($zipfile, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+
+ini_set('open_basedir', '/nonexistent_dir_for_gh21698');
+var_dump($zip->addGlob(__FILE__, 0, []));
+$zip->close();
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/gh21698.zip');
+?>
+--EXPECTF--
+Warning: ZipArchive::addGlob(): open_basedir restriction in effect. File(%s) is not within the allowed path(s): (%s) in %s on line %d
+bool(false)


### PR DESCRIPTION
globfree was not called on the no-matches path and on the open_basedir reject path, leaking the glob_t contents populated by a successful glob() call.