### PR TITLE
use `zend_string_equals*` APIs for string comparisons

### DIFF
--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -563,7 +563,7 @@ ZEND_API zend_result zend_check_property_access(const zend_object *zobj, zend_st
 			if (!(property_info->flags & ZEND_ACC_PRIVATE)) {
 				/* we we're looking for a private prop but found a non private one of the same name */
 				return FAILURE;
-			} else if (!zend_string_equals(prop_info_name, property_info->name)) {
+			} else if (strcmp(ZSTR_VAL(prop_info_name)+1, ZSTR_VAL(property_info->name)+1)) {
 				/* we we're looking for a private prop but found a private one of the same name but another class */
 				return FAILURE;
 			}

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -563,7 +563,7 @@ ZEND_API zend_result zend_check_property_access(const zend_object *zobj, zend_st
 			if (!(property_info->flags & ZEND_ACC_PRIVATE)) {
 				/* we we're looking for a private prop but found a non private one of the same name */
 				return FAILURE;
-			} else if (strcmp(ZSTR_VAL(prop_info_name)+1, ZSTR_VAL(property_info->name)+1)) {
+			} else if (!zend_string_equals(prop_info_name, property_info->name)) {
 				/* we we're looking for a private prop but found a private one of the same name but another class */
 				return FAILURE;
 			}

--- a/ext/openssl/openssl_pwhash.c
+++ b/ext/openssl/openssl_pwhash.c
@@ -331,7 +331,7 @@ PHP_FUNCTION(openssl_password_hash)
 		Z_PARAM_ARRAY_HT(options)
 	ZEND_PARSE_PARAMETERS_END();
 
-	if (strcmp(ZSTR_VAL(algo), "argon2i") && strcmp(ZSTR_VAL(algo), "argon2id")) {
+	if (!zend_string_equals_literal(algo, "argon2i") && !zend_string_equals_literal(algo, "argon2id")) {
 		zend_argument_value_error(1, "must be a valid password openssl hashing algorithm");
 		RETURN_THROWS();
 	}
@@ -357,7 +357,7 @@ PHP_FUNCTION(openssl_password_verify)
 		Z_PARAM_STR(digest)
 	ZEND_PARSE_PARAMETERS_END();
 
-	if (strcmp(ZSTR_VAL(algo), "argon2i") && strcmp(ZSTR_VAL(algo), "argon2id")) {
+	if (!zend_string_equals_literal(algo, "argon2i") && !zend_string_equals_literal(algo, "argon2id")) {
 		zend_argument_value_error(1, "must be a valid password openssl hashing algorithm");
 		RETURN_THROWS();
 	}

--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -255,10 +255,10 @@ static encodePtr find_encoder_by_type_name(sdlPtr sdl, const char *type)
 
 	if (sdl && sdl->encoders) {
 		encodePtr enc;
+		size_t type_len = strlen(type);
 
 		ZEND_HASH_FOREACH_PTR(sdl->encoders, enc)  {
 			if (type[0] == '{') {
-				size_t type_len = strlen(type);
 				if (enc->details.clark_notation
 					&& zend_string_equals_cstr(enc->details.clark_notation, type, type_len)) {
 					return enc;

--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -252,7 +252,6 @@ void whiteSpace_collapse(xmlChar* str)
 
 static encodePtr find_encoder_by_type_name(sdlPtr sdl, const char *type)
 {
-
 	if (sdl && sdl->encoders) {
 		encodePtr enc;
 		size_t type_len = strlen(type);

--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -252,13 +252,13 @@ void whiteSpace_collapse(xmlChar* str)
 
 static encodePtr find_encoder_by_type_name(sdlPtr sdl, const char *type)
 {
-	size_t type_len = strlen(type);
 
 	if (sdl && sdl->encoders) {
 		encodePtr enc;
 
 		ZEND_HASH_FOREACH_PTR(sdl->encoders, enc)  {
 			if (type[0] == '{') {
+				size_t type_len = strlen(type);
 				if (enc->details.clark_notation
 					&& zend_string_equals_cstr(enc->details.clark_notation, type, type_len)) {
 					return enc;

--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -252,13 +252,15 @@ void whiteSpace_collapse(xmlChar* str)
 
 static encodePtr find_encoder_by_type_name(sdlPtr sdl, const char *type)
 {
+	size_t type_len = strlen(type);
+
 	if (sdl && sdl->encoders) {
 		encodePtr enc;
 
 		ZEND_HASH_FOREACH_PTR(sdl->encoders, enc)  {
 			if (type[0] == '{') {
 				if (enc->details.clark_notation
-					&& strcmp(ZSTR_VAL(enc->details.clark_notation), type) == 0) {
+					&& zend_string_equals_cstr(enc->details.clark_notation, type, type_len)) {
 					return enc;
 				}
 			} else {

--- a/ext/soap/php_http.c
+++ b/ext/soap/php_http.c
@@ -327,7 +327,7 @@ static bool in_domain(const zend_string *host, const zend_string *domain)
 {
 	if (ZSTR_VAL(domain)[0] == '.') {
 		if (ZSTR_LEN(host) > ZSTR_LEN(domain)) {
-			return strcmp(ZSTR_VAL(host)+ZSTR_LEN(host)-ZSTR_LEN(domain), ZSTR_VAL(domain)) == 0;
+			return zend_string_equals_cstr(domain, ZSTR_VAL(host) + ZSTR_LEN(host) - ZSTR_LEN(domain), ZSTR_LEN(domain));
 		} else {
 			return false;
 		}


### PR DESCRIPTION
use the zend_string APIs `zend_string_equals*` which are clearer, and can also do some pointer comparisons if the strings are interned for any reason.