### PR TITLE
ext/zip: use php_globfree wrapper in addGlob early returns

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -636,14 +636,14 @@ int php_zip_glob(char *pattern, int pattern_len, zend_long flags, zval *return_v
 
 	/* now catch the FreeBSD style of "no matches" */
 	if (!globbuf.gl_pathc || !globbuf.gl_pathv) {
-		globfree(&globbuf);
+		php_globfree(&globbuf);
 		return 0;
 	}
 
 	/* we assume that any glob pattern will match files from one directory only
 	   so checking the dirname of the first match should be sufficient */
 	if (ZIP_OPENBASEDIR_CHECKPATH(globbuf.gl_pathv[0])) {
-		globfree(&globbuf);
+		php_globfree(&globbuf);
 		return -1;
 	}
 


### PR DESCRIPTION
Master fails to build on ALPINE_X64_ASAN_DEBUG_ZTS, LINUX_X64_ASAN_DEBUG_ZTS, LINUX_X64_RELEASE_NTS, MACOS_ARM64_DEBUG_NTS, and FREEBSD_NTS with:

```
ext/zip/php_zip.c:679:17: error: implicit declaration of function 'globfree'; did you mean 'php_globfree'? [-Werror=implicit-function-declaration]
```

GH-21702 added two `globfree(&globbuf)` calls at `ext/zip/php_zip.c:679` and `:686` for the no-match and open_basedir reject paths. I switched both to `php_globfree()`, matching the existing call at line 715 and the `main/php_glob.h` convention.

Two-line change. Fixes the build on affected platforms without touching behavior.