### PR TITLE
JIT: persist the SHM op_array in trace exit_info

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -33,6 +33,9 @@ PHP                                                                        NEWS
   . Fixed opcache.protect_memory race under ZTS. (realFlowControl)
   . Fixed bug GH-23288 (Crash on restart when opcache.interned_strings_buffer
     is overridden in an individual FPM pool). (David Carlier)
+  . Fixed a tracing JIT crash when compiling a side trace for a method of a
+    class that could not be stored in the inheritance cache. (GH-21710)
+    (Arnaud, iliaal)
 
 - PDO:
   . Fixed a leak when a persistent connection failed a liveness check

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -8068,7 +8068,7 @@ static int zend_jit_defined(zend_jit_ctx *jit, const zend_op *opline, uint8_t sm
 	return 1;
 }
 
-static int zend_jit_escape_if_undef(zend_jit_ctx *jit, int var, uint32_t flags, const zend_op *opline, const zend_op_array *op_array, int8_t reg)
+static int zend_jit_escape_if_undef(zend_jit_ctx *jit, int var, uint32_t flags, const zend_op *opline, int8_t reg)
 {
 	zend_jit_addr reg_addr = ZEND_ADDR_REF_ZVAL(zend_jit_deopt_rload(jit, IR_ADDR, reg));
 	ir_ref if_def = ir_IF(jit_Z_TYPE(jit, reg_addr));
@@ -8094,7 +8094,7 @@ static int zend_jit_escape_if_undef(zend_jit_ctx *jit, int var, uint32_t flags, 
 
 	/* We can't use trace_escape() because opcode handler may be overridden by JIT */
 	zend_jit_op_array_trace_extension *jit_extension =
-		(zend_jit_op_array_trace_extension*)ZEND_FUNC_INFO(op_array);
+		(zend_jit_op_array_trace_extension*)ZEND_FUNC_INFO(jit->current_op_array);
 	size_t offset = jit_extension->offset;
 	ir_ref ref = ir_CONST_FC_FUNC(ZEND_OP_TRACE_INFO((opline - 1), offset)->orig_handler);
 	if (GCC_GLOBAL_REGS) {

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -3606,7 +3606,7 @@ static int zend_jit_trace_deoptimization(
 
 		ZEND_ASSERT(STACK_FLAGS(parent_stack, check2) == ZREG_ZVAL_COPY);
 		ZEND_ASSERT(reg != ZREG_NONE);
-		if (!zend_jit_escape_if_undef(jit, check2, flags, opline, exit_info->op_array, reg)) {
+		if (!zend_jit_escape_if_undef(jit, check2, flags, opline, reg)) {
 			return 0;
 		}
 		if (!zend_jit_restore_zval(jit, EX_NUM_TO_VAR(check2), reg)) {
@@ -7376,6 +7376,8 @@ static const void *zend_jit_trace_exit_to_vm(uint32_t trace_num, uint32_t exit_n
 	stack =  zend_jit_traces[trace_num].exit_info[exit_num].stack_size ?
 		zend_jit_traces[trace_num].stack_map + zend_jit_traces[trace_num].exit_info[exit_num].stack_offset :
 		NULL;
+
+	ctx.current_op_array = zend_jit_traces[trace_num].exit_info[exit_num].op_array;
 
 	if (!zend_jit_trace_deoptimization(&ctx,
 			&zend_jit_traces[trace_num].exit_info[exit_num],

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -145,6 +145,11 @@ static uint32_t zend_jit_trace_get_exit_point(const zend_op *to_opline, uint32_t
 	}
 	if (JIT_G(current_frame)) {
 		op_array = &JIT_G(current_frame)->func->op_array;
+		if (!(op_array->fn_flags & ZEND_ACC_IMMUTABLE)) {
+			zend_jit_op_array_trace_extension *jit_extension =
+				(zend_jit_op_array_trace_extension*)ZEND_FUNC_INFO(op_array);
+			op_array = jit_extension->op_array;
+		}
 		stack_size = op_array->last_var + op_array->T;
 		if (stack_size) {
 			stack = JIT_G(current_frame)->stack;

--- a/ext/opcache/tests/jit/gh21710.inc
+++ b/ext/opcache/tests/jit/gh21710.inc
@@ -1,0 +1,15 @@
+<?php
+if (getenv('call_user_func')) {
+    eval('class P {}');
+}
+
+class C extends P {
+    static function f($v) {
+        return $v[0];
+        if ($a) {
+            return 1;
+        } else {
+            return 2;
+        }
+    }
+}

--- a/ext/opcache/tests/jit/gh21710.phpt
+++ b/ext/opcache/tests/jit/gh21710.phpt
@@ -1,0 +1,50 @@
+--TEST--
+GH-21710: tracing JIT side-trace compile with a heap-copied linked method
+--EXTENSIONS--
+opcache
+pcntl
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.file_update_protection=0
+opcache.jit=tracing
+opcache.jit_buffer_size=64M
+--ENV--
+call_user_func=call_user_func
+--SKIPIF--
+<?php
+if (!function_exists('pcntl_fork')) die('skip pcntl_fork() not available');
+if (!(opcache_get_status()['jit']['on'] ?? false)) die('skip JIT is not available');
+?>
+--FILE--
+<?php
+$pid = pcntl_fork();
+if ($pid === 0) {
+    require __DIR__ . '/gh21710.inc';
+    for ($i = 0; $i < 1000; $i++) {
+        getenv('call_user_func')('C::f', [false]);
+    }
+    exit(0);
+}
+if ($pid === -1) {
+    echo "pcntl_fork() failed\n";
+    exit(1);
+}
+
+pcntl_waitpid($pid, $status, 0);
+
+$buf = [];
+for ($i = 0; $i < 100; $i++) {
+    $buf[] = str_repeat('a', $i * 100);
+}
+
+require __DIR__ . '/gh21710.inc';
+
+for ($i = 0; $i < 1000; $i++) {
+    getenv('call_user_func')('C::f', [true]);
+}
+
+var_dump(getenv('call_user_func')('C::f', [true]));
+?>
+--EXPECT--
+bool(true)


### PR DESCRIPTION
`zend_jit_trace_get_exit_point` stored `exit_info.op_array` from the current frame. For methods of linked classes that miss the inheritance cache, that pointer is a heap copy of the op_array header. Trace metadata lives in SHM, so a later request or process then crashes in `zend_jit_escape_if_undef`. It now stores the original from the JIT extension, as root traces already do.