### PR TITLE
Fix GH-21699: callable resolution must fail if error handler threw during self/parent/static deprecations

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,8 @@ PHP                                                                        NEWS
   . Fixed bug GH-21478 (Forward property operations to real instance for
     initialized lazy proxies). (iliaal)
   . Fixed bug GH-21605 (Missing addref for Countable::count()). (ilutov)
+  . Fixed bug GH-21699 (Assertion failure in shutdown_executor when resolving
+    self::/parent::/static:: callables if the error handler throws).
 
 - Curl:
   . Add support for brotli and zstd on Windows. (Shivam Mathur)

--- a/Zend/tests/gh16799.phpt
+++ b/Zend/tests/gh16799.phpt
@@ -15,7 +15,12 @@ Test::test();
 --EXPECTF--
 Fatal error: Uncaught Exception: Use of "static" in callables is deprecated in %s:%d
 Stack trace:
-#0 %s(%d): {closure:%s:%d}(8192, 'Use of "static"...', %s, %d)
+#0 %s(%d): {closure:%s}(8192, 'Use of "static"%s', '%s', %d)
 #1 %s(%d): Test::test()
 #2 {main}
+
+Next TypeError: call_user_func(): Argument #1 ($callback) must be a valid callback, (null) in %s:%d
+Stack trace:
+#0 %s(%d): Test::test()
+#1 {main}
   thrown in %s on line %d

--- a/Zend/tests/gh_21699.phpt
+++ b/Zend/tests/gh_21699.phpt
@@ -1,0 +1,31 @@
+--TEST--
+GH-21699: Assertion failure in shutdown_executor when error handler throws during self:: callable resolution
+--FILE--
+<?php
+set_error_handler(function () {
+    throw new Exception;
+});
+class bar {
+    public static function __callstatic($fusion, $b)
+    {
+    }
+    public function test()
+    {
+        call_user_func('self::y');
+    }
+}
+$x = new bar;
+$x->test();
+?>
+--EXPECTF--
+Fatal error: Uncaught Exception in %s:%d
+Stack trace:
+#0 %s(%d): {closure:%s}(%d, 'Use of "self" i%s', '%s', %d)
+#1 %s(%d): bar->test()
+#2 {main}
+
+Next TypeError: call_user_func(): Argument #1 ($callback) must be a valid callback, (null) in %s:%d
+Stack trace:
+#0 %s(%d): bar->test()
+#1 {main}
+  thrown in %s on line %d

--- a/Zend/tests/gh_21699_parent.phpt
+++ b/Zend/tests/gh_21699_parent.phpt
@@ -1,0 +1,32 @@
+--TEST--
+GH-21699 (parent::): no shutdown_executor trampoline assertion when error handler throws during parent:: callable resolution
+--FILE--
+<?php
+set_error_handler(function () {
+    throw new Exception;
+});
+class Base {
+    public static function __callStatic($name, $args)
+    {
+    }
+}
+class Child extends Base {
+    public function test()
+    {
+        call_user_func('parent::missing');
+    }
+}
+(new Child)->test();
+?>
+--EXPECTF--
+Fatal error: Uncaught Exception in %s:%d
+Stack trace:
+#0 %s(%d): {closure:%s}(%d, 'Use of "parent"%s', '%s', %d)
+#1 %s(%d): Child->test()
+#2 {main}
+
+Next TypeError: call_user_func(): Argument #1 ($callback) must be a valid callback, (null) in %s:%d
+Stack trace:
+#0 %s(%d): Child->test()
+#1 {main}
+  thrown in %s on line %d

--- a/Zend/tests/gh_21699_static.phpt
+++ b/Zend/tests/gh_21699_static.phpt
@@ -1,0 +1,31 @@
+--TEST--
+GH-21699 (static::): no shutdown_executor trampoline assertion when error handler throws during static:: callable resolution
+--FILE--
+<?php
+set_error_handler(function () {
+    throw new Exception;
+});
+class bar {
+    public static function __callstatic($fusion, $b)
+    {
+    }
+    public function test()
+    {
+        call_user_func('static::y');
+    }
+}
+$x = new bar;
+$x->test();
+?>
+--EXPECTF--
+Fatal error: Uncaught Exception in %s:%d
+Stack trace:
+#0 %s(%d): {closure:%s}(%d, 'Use of "static"%s', '%s', %d)
+#1 %s(%d): bar->test()
+#2 {main}
+
+Next TypeError: call_user_func(): Argument #1 ($callback) must be a valid callback, (null) in %s:%d
+Stack trace:
+#0 %s(%d): bar->test()
+#1 {main}
+  thrown in %s on line %d

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -3849,6 +3849,10 @@ static bool zend_is_callable_check_class(zend_string *name, zend_class_entry *sc
 		if (error) zend_spprintf(error, 0, "class \"%.*s\" not found", (int)name_len, ZSTR_VAL(name));
 	}
 	ZSTR_ALLOCA_FREE(lcname, use_heap);
+	/* User error handlers may throw from deprecations above; do not report callable as valid. */
+	if (UNEXPECTED(EG(exception))) {
+		return false;
+	}
 	return ret;
 }
 /* }}} */


### PR DESCRIPTION
This pull request addresses a bug (GH-21699) where an assertion failure could occur in `shutdown_executor` if an error handler throws an exception during the resolution of `self::`, `parent::`, or `static::` callables. The fix ensures that if an exception is thrown by a user-defined error handler during callable resolution, the callable is not incorrectly reported as valid. The PR also adds comprehensive tests to cover these scenarios.

Bug fix for callable resolution:

* Updated `zend_is_callable_check_class` in `Zend/zend_API.c` to check for exceptions after error handlers run, preventing invalid callables from being reported as valid if an exception was thrown.

Tests for error handler behavior:

* Added `Zend/tests/gh_21699.phpt` to test `self::` callable resolution when the error handler throws.
* Added `Zend/tests/gh_21699_parent.phpt` to test `parent::` callable resolution with throwing error handler.
* Added `Zend/tests/gh_21699_static.phpt` to test `static::` callable resolution with throwing error handler.

Documentation:

* Updated `NEWS` to document the bug fix for assertion failures in `shutdown_executor` during callable resolution with throwing error handlers.