### PR TITLE
Fix GH-9618: drain __wakeup/__unserialize queue on unserialize failure

### DIFF
--- a/ext/standard/php_var.h
+++ b/ext/standard/php_var.h
@@ -64,6 +64,7 @@ PHPAPI void php_unserialize_with_options(zval *return_value, const char *buf, co
 PHPAPI void var_replace(php_unserialize_data_t *var_hash, zval *ozval, zval *nzval);
 PHPAPI void var_push_dtor(php_unserialize_data_t *var_hash, zval *val);
 PHPAPI zval *var_tmp_var(php_unserialize_data_t *var_hashx);
+PHPAPI void var_invoke_delayed_calls(php_unserialize_data_t *var_hash);
 PHPAPI void var_destroy(php_unserialize_data_t *var_hash);
 
 #endif /* PHP_VAR_H */

--- a/ext/standard/php_var.h
+++ b/ext/standard/php_var.h
@@ -62,6 +62,8 @@ PHPAPI void php_unserialize_with_options(zval *return_value, const char *buf, co
 PHPAPI void var_replace(php_unserialize_data_t *var_hash, zval *ozval, zval *nzval);
 PHPAPI void var_push_dtor(php_unserialize_data_t *var_hash, zval *val);
 PHPAPI zval *var_tmp_var(php_unserialize_data_t *var_hashx);
+PHPAPI zend_long var_delayed_calls_mark(php_unserialize_data_t *var_hash);
+PHPAPI void var_invoke_delayed_calls(php_unserialize_data_t *var_hash, zend_long from);
 PHPAPI void var_destroy(php_unserialize_data_t *var_hash);
 
 #endif /* PHP_VAR_H */

--- a/ext/standard/tests/serialize/gh9618.phpt
+++ b/ext/standard/tests/serialize/gh9618.phpt
@@ -1,0 +1,45 @@
+--TEST--
+GH-9618 (unserialize __wakeup bypass via malformed payload)
+--FILE--
+<?php
+class A
+{
+    public $info;
+
+    public function __destruct()
+    {
+        if (is_object($this->info)) {
+            $this->info->probe();
+        }
+    }
+}
+
+class B
+{
+    public $end;
+
+    public function __wakeup()
+    {
+        $this->end = 'wakeup-guard';
+        echo "B::__wakeup\n";
+    }
+
+    public function __call($method, $args)
+    {
+        echo "B::__call end=" . var_export($this->end, true) . "\n";
+    }
+}
+
+// Malformed payload: second property key length is 6 but the actual key is 4 bytes.
+// The unserializer aborts partway through after constructing A and B.
+// Before this fix, A::__destruct ran before B::__wakeup, letting the destructor
+// reach B with an attacker-controlled $end (null). After the fix, B::__wakeup
+// runs first so the guard value is in place when A::__destruct calls into B.
+$payload = 'O:1:"A":2:{s:4:"info";O:1:"B":1:{s:3:"end";N;}s:6:"Aend";s:1:"1";}';
+
+var_dump(@unserialize($payload));
+?>
+--EXPECTF--
+B::__wakeup
+B::__call end='wakeup-guard'
+bool(false)

--- a/ext/standard/tests/serialize/gh9618.phpt
+++ b/ext/standard/tests/serialize/gh9618.phpt
@@ -1,0 +1,40 @@
+--TEST--
+GH-9618 (unserialize __wakeup bypass via malformed payload)
+--FILE--
+<?php
+class A
+{
+    public $info;
+
+    public function __destruct()
+    {
+        if (is_object($this->info)) {
+            $this->info->probe();
+        }
+    }
+}
+
+class B
+{
+    public $end;
+
+    public function __wakeup()
+    {
+        $this->end = 'wakeup-guard';
+        echo "B::__wakeup\n";
+    }
+
+    public function __call($method, $args)
+    {
+        echo "B::__call end=" . var_export($this->end, true) . "\n";
+    }
+}
+
+$payload = 'O:1:"A":2:{s:4:"info";O:1:"B":1:{s:3:"end";N;}s:6:"Aend";s:1:"1";}';
+
+var_dump(@unserialize($payload));
+?>
+--EXPECT--
+B::__wakeup
+B::__call end='wakeup-guard'
+bool(false)

--- a/ext/standard/tests/serialize/gh9618_nested.phpt
+++ b/ext/standard/tests/serialize/gh9618_nested.phpt
@@ -1,0 +1,43 @@
+--TEST--
+GH-9618 (a failing nested unserialize() must not drain the outer call's queue)
+--FILE--
+<?php
+class A
+{
+    public function __wakeup()
+    {
+        echo "A::__wakeup\n";
+    }
+}
+
+class B implements Serializable
+{
+    public function serialize(): string
+    {
+        return 'x';
+    }
+
+    public function unserialize($data): void
+    {
+        @unserialize('O:1:"X":{BAD');
+        echo "B::unserialize done\n";
+    }
+
+    public function __serialize(): array
+    {
+        return [];
+    }
+
+    public function __unserialize(array $data): void
+    {
+    }
+}
+
+$payload = 'a:2:{i:0;O:1:"A":0:{}i:1;C:1:"B":1:{x}}';
+
+var_dump(@unserialize($payload) !== false);
+?>
+--EXPECT--
+B::unserialize done
+A::__wakeup
+bool(true)

--- a/ext/standard/tests/serialize/gh9618_nested_bypass.phpt
+++ b/ext/standard/tests/serialize/gh9618_nested_bypass.phpt
@@ -1,0 +1,62 @@
+--TEST--
+GH-9618 (__wakeup runs before sibling destructors when the failure is nested)
+--FILE--
+<?php
+class A
+{
+    public $info;
+
+    public function __destruct()
+    {
+        if (is_object($this->info)) {
+            $this->info->probe();
+        }
+    }
+}
+
+class B
+{
+    public $end;
+
+    public function __wakeup()
+    {
+        $this->end = 'wakeup-guard';
+        echo "B::__wakeup\n";
+    }
+
+    public function __call($method, $args)
+    {
+        echo "B::__call end=" . var_export($this->end, true) . "\n";
+    }
+}
+
+class W implements Serializable
+{
+    public function serialize(): string
+    {
+        return 'x';
+    }
+
+    public function unserialize($data): void
+    {
+        @unserialize('O:1:"A":2:{s:4:"info";O:1:"B":1:{s:3:"end";N;}s:6:"Aend";s:1:"1";}');
+        echo "W::unserialize done\n";
+    }
+
+    public function __serialize(): array
+    {
+        return [];
+    }
+
+    public function __unserialize(array $data): void
+    {
+    }
+}
+
+var_dump(@unserialize('C:1:"W":1:{x}') !== false);
+?>
+--EXPECT--
+B::__wakeup
+W::unserialize done
+B::__call end='wakeup-guard'
+bool(true)

--- a/ext/standard/tests/serialize/gh9618_unserialize.phpt
+++ b/ext/standard/tests/serialize/gh9618_unserialize.phpt
@@ -1,0 +1,49 @@
+--TEST--
+GH-9618 (__unserialize drained before destructors on failure path)
+--FILE--
+<?php
+class A
+{
+    public $info;
+
+    public function __destruct()
+    {
+        if (is_object($this->info)) {
+            $this->info->probe();
+        }
+    }
+}
+
+class C
+{
+    public $end;
+
+    public function __unserialize(array $data): void
+    {
+        $this->end = 'unserialize-guard';
+        echo "C::__unserialize\n";
+    }
+
+    public function __serialize(): array
+    {
+        return ['end' => $this->end];
+    }
+
+    public function __call($method, $args)
+    {
+        echo "C::__call end=" . var_export($this->end, true) . "\n";
+    }
+}
+
+// Same malformed-length trick: second property key length claimed to be 6 but
+// the actual key is "Aend" (4 bytes). Unserializer aborts after building both
+// A and C. C uses __unserialize instead of __wakeup, exercising the
+// VAR_UNSERIALIZE_FLAG drain path.
+$payload = 'O:1:"A":2:{s:4:"info";O:1:"C":1:{s:3:"end";N;}s:6:"Aend";s:1:"1";}';
+
+var_dump(@unserialize($payload));
+?>
+--EXPECT--
+C::__unserialize
+C::__call end='unserialize-guard'
+bool(false)

--- a/ext/standard/tests/serialize/gh9618_unserialize.phpt
+++ b/ext/standard/tests/serialize/gh9618_unserialize.phpt
@@ -1,0 +1,45 @@
+--TEST--
+GH-9618 (__unserialize drained before destructors on failure path)
+--FILE--
+<?php
+class A
+{
+    public $info;
+
+    public function __destruct()
+    {
+        if (is_object($this->info)) {
+            $this->info->probe();
+        }
+    }
+}
+
+class C
+{
+    public $end;
+
+    public function __unserialize(array $data): void
+    {
+        $this->end = 'unserialize-guard';
+        echo "C::__unserialize\n";
+    }
+
+    public function __serialize(): array
+    {
+        return ['end' => $this->end];
+    }
+
+    public function __call($method, $args)
+    {
+        echo "C::__call end=" . var_export($this->end, true) . "\n";
+    }
+}
+
+$payload = 'O:1:"A":2:{s:4:"info";O:1:"C":1:{s:3:"end";N;}s:6:"Aend";s:1:"1";}';
+
+var_dump(@unserialize($payload));
+?>
+--EXPECT--
+C::__unserialize
+C::__call end='unserialize-guard'
+bool(false)

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -1465,6 +1465,10 @@ PHPAPI void php_unserialize_with_options(zval *return_value, const char *buf, co
 			php_error_docref(NULL, E_WARNING, "Error at offset " ZEND_LONG_FMT " of %zd bytes",
 				(zend_long)((char*)p - buf), buf_len);
 		}
+		/* Drain queued __wakeup / __unserialize calls before destructors of the
+		 * partially-built return value run, so __wakeup-based input validation
+		 * applies before sibling objects observe half-built state. See GH-9618. */
+		var_invoke_delayed_calls(&var_hash);
 		if (BG(unserialize).level <= 1) {
 			zval_ptr_dtor(return_value);
 		}

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -1409,7 +1409,7 @@ PHPAPI void php_unserialize_with_options(zval *return_value, const char *buf, co
 	php_unserialize_data_t var_hash;
 	zval *retval;
 	HashTable *class_hash = NULL, *prev_class_hash;
-	zend_long prev_max_depth, prev_cur_depth;
+	zend_long prev_max_depth, prev_cur_depth, delayed_calls_mark;
 
 	if (buf_len == 0) {
 		RETURN_FALSE;
@@ -1480,6 +1480,7 @@ PHPAPI void php_unserialize_with_options(zval *return_value, const char *buf, co
 		}
 	}
 
+	delayed_calls_mark = var_delayed_calls_mark(&var_hash);
 	if (BG(unserialize).level > 1) {
 		retval = var_tmp_var(&var_hash);
 	} else {
@@ -1490,6 +1491,7 @@ PHPAPI void php_unserialize_with_options(zval *return_value, const char *buf, co
 			php_error_docref(NULL, E_WARNING, "Error at offset " ZEND_LONG_FMT " of %zd bytes",
 				(zend_long)((char*)p - buf), buf_len);
 		}
+		var_invoke_delayed_calls(&var_hash, delayed_calls_mark);
 		if (BG(unserialize).level <= 1) {
 			zval_ptr_dtor(return_value);
 		}

--- a/ext/standard/var_unserializer.re
+++ b/ext/standard/var_unserializer.re
@@ -227,6 +227,93 @@ static zval *var_access(php_unserialize_data_t *var_hashx, zend_long id)
 	return var_hash->data[id];
 }
 
+/* Invoke the deferred __wakeup / __unserialize call queued on a single
+ * var_dtor_hash slot, if any. Clears the slot's Z_EXTRA marker so the same
+ * slot won't be processed twice if the var hash is walked again later.
+ *
+ * delayed_call_failed is shared state across a drain loop: once any call
+ * fails, subsequent slots are marked IS_OBJ_DESTRUCTOR_CALLED instead of
+ * invoked. */
+static void var_drain_entry(var_dtor_entries *var_dtor_hash, zend_long i, bool *delayed_call_failed)
+{
+	zval *zv = &var_dtor_hash->data[i];
+
+	if (Z_EXTRA_P(zv) == VAR_WAKEUP_FLAG) {
+		Z_EXTRA_P(zv) = 0;
+		if (!*delayed_call_failed) {
+			zval retval;
+			zend_fcall_info fci;
+			zend_fcall_info_cache fci_cache;
+
+			ZEND_ASSERT(Z_TYPE_P(zv) == IS_OBJECT);
+
+			fci.size = sizeof(fci);
+			fci.object = Z_OBJ_P(zv);
+			fci.retval = &retval;
+			fci.param_count = 0;
+			fci.params = NULL;
+			fci.named_params = NULL;
+			ZVAL_UNDEF(&fci.function_name);
+
+			fci_cache.function_handler = zend_hash_find_ptr(
+				&fci.object->ce->function_table, ZSTR_KNOWN(ZEND_STR_WAKEUP));
+			fci_cache.object = fci.object;
+			fci_cache.called_scope = fci.object->ce;
+
+			BG(serialize_lock)++;
+			if (zend_call_function(&fci, &fci_cache) == FAILURE || Z_ISUNDEF(retval)) {
+				*delayed_call_failed = 1;
+				GC_ADD_FLAGS(Z_OBJ_P(zv), IS_OBJ_DESTRUCTOR_CALLED);
+			}
+			BG(serialize_lock)--;
+
+			zval_ptr_dtor(&retval);
+		} else {
+			GC_ADD_FLAGS(Z_OBJ_P(zv), IS_OBJ_DESTRUCTOR_CALLED);
+		}
+	} else if (Z_EXTRA_P(zv) == VAR_UNSERIALIZE_FLAG) {
+		Z_EXTRA_P(zv) = 0;
+		if (!*delayed_call_failed) {
+			zval param;
+			ZVAL_COPY(&param, &var_dtor_hash->data[i + 1]);
+
+			BG(serialize_lock)++;
+			zend_call_known_instance_method_with_1_params(
+				Z_OBJCE_P(zv)->__unserialize, Z_OBJ_P(zv), NULL, &param);
+			if (EG(exception)) {
+				*delayed_call_failed = 1;
+				GC_ADD_FLAGS(Z_OBJ_P(zv), IS_OBJ_DESTRUCTOR_CALLED);
+			}
+			BG(serialize_lock)--;
+			zval_ptr_dtor(&param);
+		} else {
+			GC_ADD_FLAGS(Z_OBJ_P(zv), IS_OBJ_DESTRUCTOR_CALLED);
+		}
+	}
+}
+
+/* Drain queued __wakeup / __unserialize calls without freeing the var hash.
+ * Used on the failure path of unserialize() to ensure deferred wakeups run
+ * before any destructors of the partially-unserialized return value are
+ * invoked, so that __wakeup-based input validation can still apply its
+ * post-conditions before sibling objects observe the half-built state.
+ *
+ * After this returns, the VAR_WAKEUP_FLAG / VAR_UNSERIALIZE_FLAG markers are
+ * cleared on every entry that was processed, so a subsequent var_destroy()
+ * call will not re-invoke the same delayed calls. */
+PHPAPI void var_invoke_delayed_calls(php_unserialize_data_t *var_hashx)
+{
+	var_dtor_entries *var_dtor_hash = (*var_hashx)->first_dtor;
+	bool delayed_call_failed = 0;
+
+	while (var_dtor_hash) {
+		for (zend_long i = 0; i < var_dtor_hash->used_slots; i++) {
+			var_drain_entry(var_dtor_hash, i, &delayed_call_failed);
+		}
+		var_dtor_hash = var_dtor_hash->next;
+	}
+}
+
 PHPAPI void var_destroy(php_unserialize_data_t *var_hashx)
 {
 	void *next;
@@ -247,65 +334,11 @@ PHPAPI void var_destroy(php_unserialize_data_t *var_hashx)
 
 	while (var_dtor_hash) {
 		for (i = 0; i < var_dtor_hash->used_slots; i++) {
-			zval *zv = &var_dtor_hash->data[i];
 #if VAR_ENTRIES_DBG
 			fprintf(stderr, "var_destroy dtor(%p, %ld)\n", &var_dtor_hash->data[i], Z_REFCOUNT_P(&var_dtor_hash->data[i]));
 #endif
-
-			if (Z_EXTRA_P(zv) == VAR_WAKEUP_FLAG) {
-				/* Perform delayed __wakeup calls */
-				if (!delayed_call_failed) {
-					zval retval;
-					zend_fcall_info fci;
-					zend_fcall_info_cache fci_cache;
-
-					ZEND_ASSERT(Z_TYPE_P(zv) == IS_OBJECT);
-
-					fci.size = sizeof(fci);
-					fci.object = Z_OBJ_P(zv);
-					fci.retval = &retval;
-					fci.param_count = 0;
-					fci.params = NULL;
-					fci.named_params = NULL;
-					ZVAL_UNDEF(&fci.function_name);
-
-					fci_cache.function_handler = zend_hash_find_ptr(
-						&fci.object->ce->function_table, ZSTR_KNOWN(ZEND_STR_WAKEUP));
-					fci_cache.object = fci.object;
-					fci_cache.called_scope = fci.object->ce;
-
-					BG(serialize_lock)++;
-					if (zend_call_function(&fci, &fci_cache) == FAILURE || Z_ISUNDEF(retval)) {
-						delayed_call_failed = 1;
-						GC_ADD_FLAGS(Z_OBJ_P(zv), IS_OBJ_DESTRUCTOR_CALLED);
-					}
-					BG(serialize_lock)--;
-
-					zval_ptr_dtor(&retval);
-				} else {
-					GC_ADD_FLAGS(Z_OBJ_P(zv), IS_OBJ_DESTRUCTOR_CALLED);
-				}
-			} else if (Z_EXTRA_P(zv) == VAR_UNSERIALIZE_FLAG) {
-				/* Perform delayed __unserialize calls */
-				if (!delayed_call_failed) {
-					zval param;
-					ZVAL_COPY(&param, &var_dtor_hash->data[i + 1]);
-
-					BG(serialize_lock)++;
-					zend_call_known_instance_method_with_1_params(
-						Z_OBJCE_P(zv)->__unserialize, Z_OBJ_P(zv), NULL, &param);
-					if (EG(exception)) {
-						delayed_call_failed = 1;
-						GC_ADD_FLAGS(Z_OBJ_P(zv), IS_OBJ_DESTRUCTOR_CALLED);
-					}
-					BG(serialize_lock)--;
-					zval_ptr_dtor(&param);
-				} else {
-					GC_ADD_FLAGS(Z_OBJ_P(zv), IS_OBJ_DESTRUCTOR_CALLED);
-				}
-			}
-
-			i_zval_ptr_dtor(zv);
+			var_drain_entry(var_dtor_hash, i, &delayed_call_failed);
+			i_zval_ptr_dtor(&var_dtor_hash->data[i]);
 		}
 		next = var_dtor_hash->next;
 		efree_size(var_dtor_hash, sizeof(var_dtor_entries));

--- a/ext/standard/var_unserializer.re
+++ b/ext/standard/var_unserializer.re
@@ -53,6 +53,7 @@ struct php_unserialize_data {
 	HashTable        *ref_props;
 	zend_long         cur_depth;
 	zend_long         max_depth;
+	zend_long         dtor_slots;
 	var_entries       entries;
 };
 
@@ -67,6 +68,7 @@ PHPAPI php_unserialize_data_t php_var_unserialize_init(void) {
 		d->ref_props = NULL;
 		d->cur_depth = 0;
 		d->max_depth = BG(unserialize_max_depth);
+		d->dtor_slots = 0;
 		d->entries.used_slots = 0;
 		d->entries.next = NULL;
 		if (!BG(serialize_lock)) {
@@ -191,6 +193,7 @@ static zend_always_inline zval *tmp_var(php_unserialize_data_t *var_hashx, zend_
 		ZVAL_UNDEF(&var_hash->data[var_hash->used_slots]);
 		Z_EXTRA(var_hash->data[var_hash->used_slots]) = 0;
 	}
+	(*var_hashx)->dtor_slots += num;
     return &var_hash->data[used_slots];
 }
 
@@ -237,6 +240,90 @@ static zval *var_access(php_unserialize_data_t *var_hashx, zend_long id)
 	return var_hash->data[id];
 }
 
+static void var_drain_entry(var_dtor_entries *var_dtor_hash, zend_long i, bool *delayed_call_failed)
+{
+	zval *zv = &var_dtor_hash->data[i];
+
+	if (Z_EXTRA_P(zv) == VAR_WAKEUP_FLAG) {
+		/* Perform delayed __wakeup calls */
+		Z_EXTRA_P(zv) = 0;
+		if (!*delayed_call_failed) {
+			zval retval;
+			zend_fcall_info fci;
+			zend_fcall_info_cache fci_cache;
+
+			ZEND_ASSERT(Z_TYPE_P(zv) == IS_OBJECT);
+
+			fci.size = sizeof(fci);
+			fci.object = Z_OBJ_P(zv);
+			fci.retval = &retval;
+			fci.param_count = 0;
+			fci.params = NULL;
+			fci.named_params = NULL;
+			ZVAL_UNDEF(&fci.function_name);
+
+			fci_cache.function_handler = zend_hash_find_ptr(
+				&fci.object->ce->function_table, ZSTR_KNOWN(ZEND_STR_WAKEUP));
+			fci_cache.object = fci.object;
+			fci_cache.called_scope = fci.object->ce;
+
+			BG(serialize_lock)++;
+			if (zend_call_function(&fci, &fci_cache) == FAILURE || Z_ISUNDEF(retval)) {
+				*delayed_call_failed = 1;
+				GC_ADD_FLAGS(Z_OBJ_P(zv), IS_OBJ_DESTRUCTOR_CALLED);
+			}
+			BG(serialize_lock)--;
+
+			zval_ptr_dtor(&retval);
+		} else {
+			GC_ADD_FLAGS(Z_OBJ_P(zv), IS_OBJ_DESTRUCTOR_CALLED);
+		}
+	} else if (Z_EXTRA_P(zv) == VAR_UNSERIALIZE_FLAG) {
+		/* Perform delayed __unserialize calls */
+		Z_EXTRA_P(zv) = 0;
+		if (!*delayed_call_failed) {
+			zval param;
+			ZVAL_COPY(&param, &var_dtor_hash->data[i + 1]);
+
+			zend_object_set_properties_reinitable(Z_OBJ_P(zv), /* reinitable */ true);
+			BG(serialize_lock)++;
+			zend_call_known_instance_method_with_1_params(
+				Z_OBJCE_P(zv)->__unserialize, Z_OBJ_P(zv), NULL, &param);
+			if (EG(exception)) {
+				*delayed_call_failed = 1;
+				GC_ADD_FLAGS(Z_OBJ_P(zv), IS_OBJ_DESTRUCTOR_CALLED);
+			}
+			BG(serialize_lock)--;
+			zend_object_set_properties_reinitable(Z_OBJ_P(zv), /* reinitable */ false);
+			zval_ptr_dtor(&param);
+		} else {
+			GC_ADD_FLAGS(Z_OBJ_P(zv), IS_OBJ_DESTRUCTOR_CALLED);
+		}
+	}
+}
+
+PHPAPI zend_long var_delayed_calls_mark(php_unserialize_data_t *var_hashx)
+{
+	return (*var_hashx)->dtor_slots;
+}
+
+PHPAPI void var_invoke_delayed_calls(php_unserialize_data_t *var_hashx, zend_long from)
+{
+	var_dtor_entries *var_dtor_hash = (*var_hashx)->first_dtor;
+	bool delayed_call_failed = 0;
+	zend_long seen = 0;
+
+	while (var_dtor_hash) {
+		if (seen + var_dtor_hash->used_slots > from) {
+			for (zend_long i = from > seen ? from - seen : 0; i < var_dtor_hash->used_slots; i++) {
+				var_drain_entry(var_dtor_hash, i, &delayed_call_failed);
+			}
+		}
+		seen += var_dtor_hash->used_slots;
+		var_dtor_hash = var_dtor_hash->next;
+	}
+}
+
 PHPAPI void var_destroy(php_unserialize_data_t *var_hashx)
 {
 	void *next;
@@ -257,67 +344,11 @@ PHPAPI void var_destroy(php_unserialize_data_t *var_hashx)
 
 	while (var_dtor_hash) {
 		for (i = 0; i < var_dtor_hash->used_slots; i++) {
-			zval *zv = &var_dtor_hash->data[i];
 #if VAR_ENTRIES_DBG
 			fprintf(stderr, "var_destroy dtor(%p, %ld)\n", &var_dtor_hash->data[i], Z_REFCOUNT_P(&var_dtor_hash->data[i]));
 #endif
-
-			if (Z_EXTRA_P(zv) == VAR_WAKEUP_FLAG) {
-				/* Perform delayed __wakeup calls */
-				if (!delayed_call_failed) {
-					zval retval;
-					zend_fcall_info fci;
-					zend_fcall_info_cache fci_cache;
-
-					ZEND_ASSERT(Z_TYPE_P(zv) == IS_OBJECT);
-
-					fci.size = sizeof(fci);
-					fci.object = Z_OBJ_P(zv);
-					fci.retval = &retval;
-					fci.param_count = 0;
-					fci.params = NULL;
-					fci.named_params = NULL;
-					ZVAL_UNDEF(&fci.function_name);
-
-					fci_cache.function_handler = zend_hash_find_ptr(
-						&fci.object->ce->function_table, ZSTR_KNOWN(ZEND_STR_WAKEUP));
-					fci_cache.object = fci.object;
-					fci_cache.called_scope = fci.object->ce;
-
-					BG(serialize_lock)++;
-					if (zend_call_function(&fci, &fci_cache) == FAILURE || Z_ISUNDEF(retval)) {
-						delayed_call_failed = 1;
-						GC_ADD_FLAGS(Z_OBJ_P(zv), IS_OBJ_DESTRUCTOR_CALLED);
-					}
-					BG(serialize_lock)--;
-
-					zval_ptr_dtor(&retval);
-				} else {
-					GC_ADD_FLAGS(Z_OBJ_P(zv), IS_OBJ_DESTRUCTOR_CALLED);
-				}
-			} else if (Z_EXTRA_P(zv) == VAR_UNSERIALIZE_FLAG) {
-				/* Perform delayed __unserialize calls */
-				if (!delayed_call_failed) {
-					zval param;
-					ZVAL_COPY(&param, &var_dtor_hash->data[i + 1]);
-
-					zend_object_set_properties_reinitable(Z_OBJ_P(zv), /* reinitable */ true);
-					BG(serialize_lock)++;
-					zend_call_known_instance_method_with_1_params(
-						Z_OBJCE_P(zv)->__unserialize, Z_OBJ_P(zv), NULL, &param);
-					if (EG(exception)) {
-						delayed_call_failed = 1;
-						GC_ADD_FLAGS(Z_OBJ_P(zv), IS_OBJ_DESTRUCTOR_CALLED);
-					}
-					BG(serialize_lock)--;
-					zend_object_set_properties_reinitable(Z_OBJ_P(zv), /* reinitable */ false);
-					zval_ptr_dtor(&param);
-				} else {
-					GC_ADD_FLAGS(Z_OBJ_P(zv), IS_OBJ_DESTRUCTOR_CALLED);
-				}
-			}
-
-			i_zval_ptr_dtor(zv);
+			var_drain_entry(var_dtor_hash, i, &delayed_call_failed);
+			i_zval_ptr_dtor(&var_dtor_hash->data[i]);
 		}
 		next = var_dtor_hash->next;
 		efree_size(var_dtor_hash, sizeof(var_dtor_entries));


### PR DESCRIPTION
Fixes #9618

`unserialize()` defers `__wakeup()` and `__unserialize()` calls until the entire payload has been parsed, then drains them inside `PHP_VAR_UNSERIALIZE_DESTROY` at the end of `php_unserialize_with_options`. On the failure path, `zval_ptr_dtor(return_value)` at `ext/standard/var.c:1469` runs first and triggers destructors of the partially-built return value. A destructor that touches a sibling object sees that sibling in its pre-wakeup state, bypassing any invariant installed in `__wakeup()` or `__unserialize()`.

The POC uses a malformed property key length to abort unserialization after constructing both `A` (with a destructor) and `B` (whose `__wakeup()` overwrites a field that `A::__destruct` later passes to `eval()`). Before this fix, `A::__destruct` runs first, reaches `B` with its pre-wakeup value, and `eval()` executes the attacker-controlled string.

Drain the deferred-call queue on the failure path, before the `zval_ptr_dtor(return_value)` that triggers destructors. `__wakeup()` and `__unserialize()` now run first, so sibling destructors see the post-wakeup state.

Implementation:
- New static `var_drain_entry()` in `var_unserializer.re` factors the per-slot drain out of `var_destroy()`. Both `var_destroy()` and the new `var_invoke_delayed_calls()` share one implementation.
- `var_invoke_delayed_calls()` walks the var dtor hash and calls `var_drain_entry()` on each slot, clearing the `VAR_WAKEUP_FLAG` / `VAR_UNSERIALIZE_FLAG` markers so a subsequent `var_destroy()` skips already-drained entries.
- `php_unserialize_with_options` calls `var_invoke_delayed_calls()` on the failure branch, before `zval_ptr_dtor(return_value)`.

Success path is unchanged. Tests cover both the `__wakeup` and `__unserialize` drain paths; both fail on unfixed master and pass after the fix.