### PR TITLE
ext/snmp: rename argument number variables

### DIFF
--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -656,7 +656,7 @@ static void php_free_objid_query(struct objid_query *objid_query, HashTable* oid
 static bool php_snmp_parse_oid(
 	zval *object, int st, struct objid_query *objid_query, zend_string *oid_str, HashTable *oid_ht,
 	zend_string *type_str, HashTable *type_ht, zend_string *value_str, HashTable *value_ht,
-	uint32_t oid_argument_offset, uint32_t type_argument_offset, uint32_t value_argument_offset
+	uint32_t oid_arg_num, uint32_t type_arg_num, uint32_t value_arg_num
 ) {
 	char *pptr;
 	uint32_t idx_type = 0, idx_value = 0;
@@ -683,7 +683,7 @@ static bool php_snmp_parse_oid(
 			ZEND_ASSERT(type_str && value_str);
 
 			if (ZSTR_LEN(type_str) != 1) {
-				zend_argument_value_error(type_argument_offset, "must be a single character");
+				zend_argument_value_error(type_arg_num, "must be a single character");
 				efree(objid_query->vars);
 				return false;
 			}
@@ -694,7 +694,7 @@ static bool php_snmp_parse_oid(
 		objid_query->count++;
 	} else if (oid_ht) { /* we got objid array */
 		if (zend_hash_num_elements(oid_ht) == 0) {
-			zend_argument_value_error(oid_argument_offset, "must not be empty when passed as an array");
+			zend_argument_value_error(oid_arg_num, "must not be empty when passed as an array");
 			return false;
 		}
 		objid_query->vars = (snmpobjarg *)safe_emalloc(sizeof(snmpobjarg), zend_hash_num_elements(oid_ht), 0);
@@ -739,14 +739,14 @@ static bool php_snmp_parse_oid(
 						char ptype = *ZSTR_VAL(type);
 						zend_string_release(type);
 						if (len != 1) {
-							zend_argument_value_error(type_argument_offset, "must be a single character");
+							zend_argument_value_error(type_arg_num, "must be a single character");
 							php_free_objid_query(objid_query, oid_ht, value_ht, st);
 							return false;
 						}
 						objid_query->vars[objid_query->count].type = ptype;
 						idx_type++;
 					} else {
-						zend_argument_value_error(type_argument_offset, "must contain a type for object ID '%s'", ZSTR_VAL(tmp));
+						zend_argument_value_error(type_arg_num, "must contain a type for object ID '%s'", ZSTR_VAL(tmp));
 						php_free_objid_query(objid_query, oid_ht, value_ht, st);
 						return false;
 					}
@@ -781,7 +781,7 @@ static bool php_snmp_parse_oid(
 						objid_query->vars[objid_query->count].value = ZSTR_VAL(tmp);
 						idx_value++;
 					} else {
-						zend_argument_value_error(value_argument_offset, "must contain a value for object ID '%s'", ZSTR_VAL(tmp));
+						zend_argument_value_error(value_arg_num, "must contain a value for object ID '%s'", ZSTR_VAL(tmp));
 						php_free_objid_query(objid_query, oid_ht, value_ht, st);
 						return false;
 					}
@@ -828,7 +828,7 @@ static bool php_snmp_parse_oid(
 /* {{{ snmp_session_init
 	allocates memory for session and session->peername, caller should free it manually using snmp_session_free() and efree()
 */
-static bool snmp_session_init(php_snmp_session **session_p, int version, zend_string *hostname, zend_string *community, zend_long timeout, zend_long retries, int hostname_argument_offset, int timeout_argument_offset)
+static bool snmp_session_init(php_snmp_session **session_p, int version, zend_string *hostname, zend_string *community, zend_long timeout, zend_long retries, int hostname_arg_num, int timeout_arg_num)
 {
 	php_snmp_session *session;
 	char *pptr, *host_ptr;
@@ -843,23 +843,23 @@ static bool snmp_session_init(php_snmp_session **session_p, int version, zend_st
 	ZEND_ASSERT(community != NULL);
 
 	if (ZSTR_LEN(hostname) >= MAX_NAME_LEN) {
-		zend_argument_value_error(hostname_argument_offset, "length must be lower than %d", MAX_NAME_LEN);
+		zend_argument_value_error(hostname_arg_num, "length must be lower than %d", MAX_NAME_LEN);
 		return false;
 	}
 
 	if (ZSTR_LEN(community) == 0) {
-		zend_argument_must_not_be_empty_error(hostname_argument_offset + 1);
+		zend_argument_must_not_be_empty_error(hostname_arg_num + 1);
 		return false;
 	}
 
-	if (timeout_argument_offset != -1) {
+	if (timeout_arg_num != -1) {
 		if (timeout < -1 || timeout > LONG_MAX) {
-			zend_argument_value_error(timeout_argument_offset, "must be between -1 and %ld", LONG_MAX);
+			zend_argument_value_error(timeout_arg_num, "must be between -1 and %ld", LONG_MAX);
 			return false;
 		}
 
 		if (retries < -1 || retries > INT_MAX) {
-			zend_argument_value_error(timeout_argument_offset + 1, "must be between -1 and %d", INT_MAX);
+			zend_argument_value_error(timeout_arg_num + 1, "must be between -1 and %d", INT_MAX);
 			return false;
 		}
 	}
@@ -890,14 +890,14 @@ static bool snmp_session_init(php_snmp_session **session_p, int version, zend_st
 				char *pport = pptr + 2;
 				tmp_port = atoi(pport);
 				if (tmp_port < 0 || tmp_port > USHRT_MAX) {
-					zend_argument_value_error(hostname_argument_offset, "remote port must be between 0 and %u", USHRT_MAX);
+					zend_argument_value_error(hostname_arg_num, "remote port must be between 0 and %u", USHRT_MAX);
 					return false;
 				}
 				remote_port = (unsigned short)tmp_port;
 			}
 			*pptr = '\0';
 		} else {
-			zend_argument_value_error(hostname_argument_offset, "has a malformed IPv6 address, closing square bracket missing");
+			zend_argument_value_error(hostname_arg_num, "has a malformed IPv6 address, closing square bracket missing");
 			return false;
 		}
 	} else { /* IPv4 address */
@@ -905,7 +905,7 @@ static bool snmp_session_init(php_snmp_session **session_p, int version, zend_st
 			char *pport = pptr + 1;
 			tmp_port = atoi(pport);
 			if (tmp_port < 0 || tmp_port > USHRT_MAX) {
-				zend_argument_value_error(hostname_argument_offset, "remote port must be between 0 and %u", USHRT_MAX);
+				zend_argument_value_error(hostname_arg_num, "remote port must be between 0 and %u", USHRT_MAX);
 				return false;
 			}
 			remote_port = (unsigned short)tmp_port;
@@ -1114,13 +1114,13 @@ static ZEND_ATTRIBUTE_NONNULL bool snmp_session_gen_sec_key(struct snmp_session 
 /* }}} */
 
 /* {{{ Set context Engine Id in the snmpv3 session */
-static bool snmp_session_set_contextEngineID(struct snmp_session *s, zend_string * contextEngineID, uint32_t contextEngineID_argument_offset)
+static bool snmp_session_set_contextEngineID(struct snmp_session *s, zend_string *contextEngineID, uint32_t context_engine_id_arg_num)
 {
 	size_t	ebuf_len = 32, eout_len = 0;
 	uint8_t	*ebuf = (uint8_t *) emalloc(ebuf_len);
 
 	if (!snmp_hex_to_binary(&ebuf, &ebuf_len, &eout_len, 1, ZSTR_VAL(contextEngineID))) {
-		zend_argument_value_error(contextEngineID_argument_offset, "must be a valid context engine ID");
+		zend_argument_value_error(context_engine_id_arg_num, "must be a valid context engine ID");
 		efree(ebuf);
 		return false;
 	}
@@ -1136,13 +1136,13 @@ static bool snmp_session_set_contextEngineID(struct snmp_session *s, zend_string
 /* }}} */
 
 /* {{{ Set all snmpv3-related security options
- * auth_protocol_argnum and contextEngineID_argument_offset are the userland
+ * auth_protocol_arg_num and context_engine_id_arg_num are the userland
  * argument numbers used for error reporting.
  */
 static ZEND_ATTRIBUTE_NONNULL_ARGS(2) bool snmp_session_set_security(struct snmp_session *session, zend_string *sec_level,
 	zend_string *auth_protocol, zend_string *auth_passphrase, zend_string *priv_protocol,
 	zend_string *priv_passphrase, zend_string *contextName, zend_string *contextEngineID,
-	uint32_t auth_protocol_argnum, uint32_t contextEngineID_argument_offset)
+	uint32_t auth_protocol_arg_num, uint32_t context_engine_id_arg_num)
 {
 
 	/* Setting the security level. */
@@ -1154,7 +1154,7 @@ static ZEND_ATTRIBUTE_NONNULL_ARGS(2) bool snmp_session_set_security(struct snmp
 	if (session->securityLevel == SNMP_SEC_LEVEL_AUTHNOPRIV || session->securityLevel == SNMP_SEC_LEVEL_AUTHPRIV) {
 
 		if (!auth_protocol) {
-			zend_argument_value_error(auth_protocol_argnum, "cannot be null when security level is \"authNoPriv\" or \"authPriv\"");
+			zend_argument_value_error(auth_protocol_arg_num, "cannot be null when security level is \"authNoPriv\" or \"authPriv\"");
 			return false;
 		}
 
@@ -1165,7 +1165,7 @@ static ZEND_ATTRIBUTE_NONNULL_ARGS(2) bool snmp_session_set_security(struct snmp
 		}
 
 		if (!auth_passphrase) {
-			zend_argument_value_error(auth_protocol_argnum + 1, "cannot be null when security level is \"authNoPriv\" or \"authPriv\"");
+			zend_argument_value_error(auth_protocol_arg_num + 1, "cannot be null when security level is \"authNoPriv\" or \"authPriv\"");
 			return false;
 		}
 
@@ -1178,7 +1178,7 @@ static ZEND_ATTRIBUTE_NONNULL_ARGS(2) bool snmp_session_set_security(struct snmp
 		if (session->securityLevel == SNMP_SEC_LEVEL_AUTHPRIV) {
 
 			if (!priv_protocol) {
-				zend_argument_value_error(auth_protocol_argnum + 2, "cannot be null when security level is \"authPriv\"");
+				zend_argument_value_error(auth_protocol_arg_num + 2, "cannot be null when security level is \"authPriv\"");
 				return false;
 			}
 
@@ -1189,7 +1189,7 @@ static ZEND_ATTRIBUTE_NONNULL_ARGS(2) bool snmp_session_set_security(struct snmp
 			}
 
 			if (!priv_passphrase) {
-				zend_argument_value_error(auth_protocol_argnum + 3, "cannot be null when security level is \"authPriv\"");
+				zend_argument_value_error(auth_protocol_arg_num + 3, "cannot be null when security level is \"authPriv\"");
 				return false;
 			}
 
@@ -1208,7 +1208,7 @@ static ZEND_ATTRIBUTE_NONNULL_ARGS(2) bool snmp_session_set_security(struct snmp
 	}
 
 	/* Setting contextEngineIS if specified */
-	if (contextEngineID && ZSTR_LEN(contextEngineID) && !snmp_session_set_contextEngineID(session, contextEngineID, contextEngineID_argument_offset)) {
+	if (contextEngineID && ZSTR_LEN(contextEngineID) && !snmp_session_set_contextEngineID(session, contextEngineID, context_engine_id_arg_num)) {
 		/* Warning message sent already, just bail out */
 		return false;
 	}
@@ -1235,8 +1235,8 @@ static void php_snmp(INTERNAL_FUNCTION_PARAMETERS, int st, int version)
 	struct objid_query objid_query;
 	php_snmp_session *session;
 	int session_less_mode = (getThis() == NULL);
-	int timeout_argument_offset = -1;
-	uint32_t oid_argument_offset = 1, type_argument_offset = 0, value_argument_offset = 0;
+	int timeout_arg_num = -1;
+	uint32_t oid_arg_num = 1, type_arg_num = 0, value_arg_num = 0;
 	php_snmp_object *snmp_object;
 	php_snmp_object glob_snmp_object;
 
@@ -1264,10 +1264,10 @@ static void php_snmp(INTERNAL_FUNCTION_PARAMETERS, int st, int version)
 					Z_PARAM_LONG(retries)
 				ZEND_PARSE_PARAMETERS_END();
 
-				timeout_argument_offset = 10;
-				oid_argument_offset = 8;
-				type_argument_offset = 9;
-				value_argument_offset = 10;
+				timeout_arg_num = 10;
+				oid_arg_num = 8;
+				type_arg_num = 9;
+				value_arg_num = 10;
 			} else {
 				/* SNMP_CMD_GET
 				 * SNMP_CMD_GETNEXT
@@ -1287,8 +1287,8 @@ static void php_snmp(INTERNAL_FUNCTION_PARAMETERS, int st, int version)
 					Z_PARAM_LONG(retries)
 				ZEND_PARSE_PARAMETERS_END();
 
-				timeout_argument_offset = 9;
-				oid_argument_offset = 8;
+				timeout_arg_num = 9;
+				oid_arg_num = 8;
 			}
 		} else {
 			if (st & SNMP_CMD_SET) {
@@ -1303,10 +1303,10 @@ static void php_snmp(INTERNAL_FUNCTION_PARAMETERS, int st, int version)
 					Z_PARAM_LONG(retries)
 				ZEND_PARSE_PARAMETERS_END();
 
-				timeout_argument_offset = 6;
-				oid_argument_offset = 3;
-				type_argument_offset = 4;
-				value_argument_offset = 5;
+				timeout_arg_num = 6;
+				oid_arg_num = 3;
+				type_arg_num = 4;
+				value_arg_num = 5;
 			} else {
 				/* SNMP_CMD_GET
 				 * SNMP_CMD_GETNEXT
@@ -1321,8 +1321,8 @@ static void php_snmp(INTERNAL_FUNCTION_PARAMETERS, int st, int version)
 					Z_PARAM_LONG(retries)
 				ZEND_PARSE_PARAMETERS_END();
 
-				timeout_argument_offset = 4;
-				oid_argument_offset = 3;
+				timeout_arg_num = 4;
+				oid_arg_num = 3;
 			}
 		}
 	} else {
@@ -1332,8 +1332,8 @@ static void php_snmp(INTERNAL_FUNCTION_PARAMETERS, int st, int version)
 				Z_PARAM_ARRAY_HT_OR_STR(type_ht, type_str)
 				Z_PARAM_ARRAY_HT_OR_STR(value_ht, value_str)
 			ZEND_PARSE_PARAMETERS_END();
-			type_argument_offset = 2;
-			value_argument_offset = 3;
+			type_arg_num = 2;
+			value_arg_num = 3;
 		} else if (st & SNMP_CMD_WALK) {
 			ZEND_PARSE_PARAMETERS_START(1, 4)
 				Z_PARAM_ARRAY_HT_OR_STR(oid_ht, oid_str)
@@ -1364,12 +1364,12 @@ static void php_snmp(INTERNAL_FUNCTION_PARAMETERS, int st, int version)
 	}
 
 	if (!php_snmp_parse_oid(getThis(), st, &objid_query, oid_str, oid_ht, type_str, type_ht, value_str, value_ht,
-			oid_argument_offset, type_argument_offset, value_argument_offset)) {
+			oid_arg_num, type_arg_num, value_arg_num)) {
 		RETURN_FALSE;
 	}
 
 	if (session_less_mode) {
-		if (!snmp_session_init(&session, version, a1, a2, timeout, retries, 1, timeout_argument_offset)) {
+		if (!snmp_session_init(&session, version, a1, a2, timeout, retries, 1, timeout_arg_num)) {
 			php_free_objid_query(&objid_query, oid_ht, value_ht, st);
 			snmp_session_free(&session);
 			RETURN_FALSE;
@@ -1732,6 +1732,8 @@ PHP_METHOD(SNMP, setSecurity)
 	php_snmp_object *snmp_object;
 	zval *object = ZEND_THIS;
 	zend_string *a1 = NULL, *a2 = NULL, *a3 = NULL, *a4 = NULL, *a5 = NULL, *a6 = NULL, *a7 = NULL;
+	uint32_t auth_protocol_arg_num = 2;
+	uint32_t context_engine_id_arg_num = 7;
 
 	snmp_object = Z_SNMP_P(object);
 	if (!snmp_object->session) {
@@ -1743,8 +1745,7 @@ PHP_METHOD(SNMP, setSecurity)
 		RETURN_THROWS();
 	}
 
-	/* authProtocol is argument #2 and contextEngineId is argument #7. */
-	if (!snmp_session_set_security(snmp_object->session, a1, a2, a3, a4, a5, a6, a7, 2, 7)) {
+	if (!snmp_session_set_security(snmp_object->session, a1, a2, a3, a4, a5, a6, a7, auth_protocol_arg_num, context_engine_id_arg_num)) {
 		/* An error has already been emitted, just bail out. */
 		RETURN_FALSE;
 	}

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -828,7 +828,7 @@ static bool php_snmp_parse_oid(
 /* {{{ snmp_session_init
 	allocates memory for session and session->peername, caller should free it manually using snmp_session_free() and efree()
 */
-static bool snmp_session_init(php_snmp_session **session_p, int version, zend_string *hostname, zend_string *community, zend_long timeout, zend_long retries, int hostname_arg_num, int timeout_arg_num)
+static bool snmp_session_init(php_snmp_session **session_p, int version, zend_string *hostname, zend_string *community, zend_long timeout, zend_long retries, uint32_t hostname_arg_num, uint32_t timeout_arg_num)
 {
 	php_snmp_session *session;
 	char *pptr, *host_ptr;
@@ -852,7 +852,7 @@ static bool snmp_session_init(php_snmp_session **session_p, int version, zend_st
 		return false;
 	}
 
-	if (timeout_arg_num != -1) {
+	if (timeout_arg_num != 0) {
 		if (timeout < -1 || timeout > LONG_MAX) {
 			zend_argument_value_error(timeout_arg_num, "must be between -1 and %ld", LONG_MAX);
 			return false;
@@ -1228,14 +1228,16 @@ static void php_snmp(INTERNAL_FUNCTION_PARAMETERS, int st, int version)
 {
 	zend_string *oid_str, *type_str = NULL, *value_str = NULL;
 	HashTable *oid_ht, *type_ht = NULL, *value_ht = NULL;
-	zend_string *a1 = NULL, *a2 = NULL, *a3 = NULL, *a4 = NULL, *a5 = NULL, *a6 = NULL, *a7 = NULL;
+	zend_string *hostname = NULL, *community_or_security_name = NULL;
+	zend_string *security_level = NULL, *auth_protocol = NULL, *auth_passphrase = NULL;
+	zend_string *privacy_protocol = NULL, *privacy_passphrase = NULL;
 	bool use_orignames = 0, suffix_keys = 0;
 	zend_long timeout = SNMP_DEFAULT_TIMEOUT;
 	zend_long retries = SNMP_DEFAULT_RETRIES;
 	struct objid_query objid_query;
 	php_snmp_session *session;
 	int session_less_mode = (getThis() == NULL);
-	int timeout_arg_num = -1;
+	uint32_t timeout_arg_num = 0;
 	uint32_t oid_arg_num = 1, type_arg_num = 0, value_arg_num = 0;
 	php_snmp_object *snmp_object;
 	php_snmp_object glob_snmp_object;
@@ -1249,13 +1251,13 @@ static void php_snmp(INTERNAL_FUNCTION_PARAMETERS, int st, int version)
 		if (version == SNMP_VERSION_3) {
 			if (st & SNMP_CMD_SET) {
 				ZEND_PARSE_PARAMETERS_START(10, 12)
-					Z_PARAM_PATH_STR(a1)
-					Z_PARAM_PATH_STR(a2)
-					Z_PARAM_STR(a3)
-					Z_PARAM_STR(a4)
-					Z_PARAM_STR(a5)
-					Z_PARAM_STR(a6)
-					Z_PARAM_STR(a7)
+					Z_PARAM_PATH_STR(hostname)
+					Z_PARAM_PATH_STR(community_or_security_name)
+					Z_PARAM_STR(security_level)
+					Z_PARAM_STR(auth_protocol)
+					Z_PARAM_STR(auth_passphrase)
+					Z_PARAM_STR(privacy_protocol)
+					Z_PARAM_STR(privacy_passphrase)
 					Z_PARAM_ARRAY_HT_OR_STR(oid_ht, oid_str)
 					Z_PARAM_ARRAY_HT_OR_STR(type_ht, type_str)
 					Z_PARAM_ARRAY_HT_OR_STR(value_ht, value_str)
@@ -1274,13 +1276,13 @@ static void php_snmp(INTERNAL_FUNCTION_PARAMETERS, int st, int version)
 				 * SNMP_CMD_WALK
 				 */
 				ZEND_PARSE_PARAMETERS_START(8, 10)
-					Z_PARAM_PATH_STR(a1)
-					Z_PARAM_PATH_STR(a2)
-					Z_PARAM_STR(a3)
-					Z_PARAM_STR(a4)
-					Z_PARAM_STR(a5)
-					Z_PARAM_STR(a6)
-					Z_PARAM_STR(a7)
+					Z_PARAM_PATH_STR(hostname)
+					Z_PARAM_PATH_STR(community_or_security_name)
+					Z_PARAM_STR(security_level)
+					Z_PARAM_STR(auth_protocol)
+					Z_PARAM_STR(auth_passphrase)
+					Z_PARAM_STR(privacy_protocol)
+					Z_PARAM_STR(privacy_passphrase)
 					Z_PARAM_ARRAY_HT_OR_STR(oid_ht, oid_str)
 					Z_PARAM_OPTIONAL
 					Z_PARAM_LONG(timeout)
@@ -1293,8 +1295,8 @@ static void php_snmp(INTERNAL_FUNCTION_PARAMETERS, int st, int version)
 		} else {
 			if (st & SNMP_CMD_SET) {
 				ZEND_PARSE_PARAMETERS_START(5, 7)
-					Z_PARAM_PATH_STR(a1)
-					Z_PARAM_PATH_STR(a2)
+					Z_PARAM_PATH_STR(hostname)
+					Z_PARAM_PATH_STR(community_or_security_name)
 					Z_PARAM_ARRAY_HT_OR_STR(oid_ht, oid_str)
 					Z_PARAM_ARRAY_HT_OR_STR(type_ht, type_str)
 					Z_PARAM_ARRAY_HT_OR_STR(value_ht, value_str)
@@ -1313,8 +1315,8 @@ static void php_snmp(INTERNAL_FUNCTION_PARAMETERS, int st, int version)
 				 * SNMP_CMD_WALK
 				 */
 				ZEND_PARSE_PARAMETERS_START(3, 5)
-					Z_PARAM_PATH_STR(a1)
-					Z_PARAM_PATH_STR(a2)
+					Z_PARAM_PATH_STR(hostname)
+					Z_PARAM_PATH_STR(community_or_security_name)
 					Z_PARAM_ARRAY_HT_OR_STR(oid_ht, oid_str)
 					Z_PARAM_OPTIONAL
 					Z_PARAM_LONG(timeout)
@@ -1369,12 +1371,12 @@ static void php_snmp(INTERNAL_FUNCTION_PARAMETERS, int st, int version)
 	}
 
 	if (session_less_mode) {
-		if (!snmp_session_init(&session, version, a1, a2, timeout, retries, 1, timeout_arg_num)) {
+		if (!snmp_session_init(&session, version, hostname, community_or_security_name, timeout, retries, 1, timeout_arg_num)) {
 			php_free_objid_query(&objid_query, oid_ht, value_ht, st);
 			snmp_session_free(&session);
 			RETURN_FALSE;
 		}
-		if (version == SNMP_VERSION_3 && !snmp_session_set_security(session, a3, a4, a5, a6, a7, NULL, NULL, 4, 0)) {
+		if (version == SNMP_VERSION_3 && !snmp_session_set_security(session, security_level, auth_protocol, auth_passphrase, privacy_protocol, privacy_passphrase, NULL, NULL, 4, 0)) {
 			php_free_objid_query(&objid_query, oid_ht, value_ht, st);
 			snmp_session_free(&session);
 			/* An error has already been emitted, just bail out. */

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -1733,7 +1733,9 @@ PHP_METHOD(SNMP, setSecurity)
 {
 	php_snmp_object *snmp_object;
 	zval *object = ZEND_THIS;
-	zend_string *a1 = NULL, *a2 = NULL, *a3 = NULL, *a4 = NULL, *a5 = NULL, *a6 = NULL, *a7 = NULL;
+	zend_string *security_level = NULL, *auth_protocol = NULL, *auth_passphrase = NULL;
+	zend_string *privacy_protocol = NULL, *privacy_passphrase = NULL;
+	zend_string *context_name = NULL, *context_engine_id = NULL;
 	uint32_t auth_protocol_arg_num = 2;
 	uint32_t context_engine_id_arg_num = 7;
 
@@ -1743,11 +1745,11 @@ PHP_METHOD(SNMP, setSecurity)
 		RETURN_THROWS();
 	}
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S|SSSSSS", &a1, &a2, &a3, &a4,&a5, &a6, &a7) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S|SSSSSS", &security_level, &auth_protocol, &auth_passphrase, &privacy_protocol, &privacy_passphrase, &context_name, &context_engine_id) == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	if (!snmp_session_set_security(snmp_object->session, a1, a2, a3, a4, a5, a6, a7, auth_protocol_arg_num, context_engine_id_arg_num)) {
+	if (!snmp_session_set_security(snmp_object->session, security_level, auth_protocol, auth_passphrase, privacy_protocol, privacy_passphrase, context_name, context_engine_id, auth_protocol_arg_num, context_engine_id_arg_num)) {
 		/* An error has already been emitted, just bail out. */
 		RETURN_FALSE;
 	}


### PR DESCRIPTION
This is a readability-only follow-up to #21319.

It renames the internal argument-number variables added for error reporting so they describe what they represent more clearly, and replaces the inline `SNMP::setSecurity()` comment with named locals at the call site.

No behavior changes are intended.

Testing:
- `git diff --check`