### PR TITLE
run tests with UTC as default date.timezone

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -304,6 +304,7 @@ function main(): void
         'zend.exception_ignore_args=0',
         'zend.exception_string_param_max_len=15',
         'short_open_tag=0',
+        'date.timezone=UTC',
     ];
 
     $no_file_cache = '-d opcache.file_cache= -d opcache.file_cache_only=0';


### PR DESCRIPTION
add date.timezone=UTC to the INI overwrites in run-tests.php.

refs: #21665