### PR TITLE
Fix GH-21731: Random\Engine\Xoshiro256StarStar::__unserialize() accepts all-zero state

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -31,6 +31,10 @@ PHP                                                                        NEWS
 - OpenSSL:
   . Fix a bunch of memory leaks and crashes on edge cases. (ndossche)
 
+- Random:
+  . Fixed bug GH-21731 (Random\Engine\Xoshiro256StarStar::__unserialize()
+    accepts all-zero state). (iliaal)
+
 - SPL:
   . Fixed bug GH-21499 (RecursiveArrayIterator getChildren UAF after parent
     free). (Girgias)

--- a/ext/random/engine_xoshiro256starstar.c
+++ b/ext/random/engine_xoshiro256starstar.c
@@ -151,6 +151,10 @@ static bool unserialize(void *state, HashTable *data)
 		}
 	}
 
+	if (UNEXPECTED(s->state[0] == 0 && s->state[1] == 0 && s->state[2] == 0 && s->state[3] == 0)) {
+		return false;
+	}
+
 	return true;
 }
 

--- a/ext/random/tests/02_engine/xoshiro256starstar_unserialize_zero_state.phpt
+++ b/ext/random/tests/02_engine/xoshiro256starstar_unserialize_zero_state.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-21731: Xoshiro256StarStar::__unserialize() must reject the all-zero state
+--FILE--
+<?php
+
+try {
+    var_dump(unserialize('O:32:"Random\Engine\Xoshiro256StarStar":2:{i:0;a:0:{}i:1;a:4:{i:0;s:16:"0000000000000000";i:1;s:16:"0000000000000000";i:2;s:16:"0000000000000000";i:3;s:16:"0000000000000000";}}'));
+} catch (\Exception $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+Invalid serialization data for Random\Engine\Xoshiro256StarStar object


### PR DESCRIPTION
Fixes #21731.

`Random\Engine\Xoshiro256StarStar::__construct()` rejects a seed that would leave the internal state all zero, because xoshiro256** with zero state returns `0` on every call forever. The `unserialize` callback didn't check the same invariant. A caller feeding a crafted serialized payload through `__unserialize()` ended up with a live engine that returned 0 from every operation.

Match the constructor: reject the all-zero state from `unserialize` too. The Mt19937-aliased `__unserialize()` wrapper maps the `false` return into the standard "Invalid serialization data for ... object" exception, so the wrapper needs no changes.