### PR TITLE
Fix GH-21730: Mt19937::__debugInfo() leaks state HashTable when the serialize callback fails

### DIFF
--- a/ext/random/engine_mt19937.c
+++ b/ext/random/engine_mt19937.c
@@ -392,11 +392,11 @@ PHP_METHOD(Random_Engine_Mt19937, __debugInfo)
 
 	if (engine->engine.algo->serialize) {
 		array_init(&t);
+		zend_hash_str_add(Z_ARR_P(return_value), "__states", strlen("__states"), &t);
 		if (!engine->engine.algo->serialize(engine->engine.state, Z_ARRVAL(t))) {
 			zend_throw_exception(NULL, "Engine serialize failed", 0);
 			RETURN_THROWS();
 		}
-		zend_hash_str_add(Z_ARR_P(return_value), "__states", strlen("__states"), &t);
 	}
 }
 /* }}} */


### PR DESCRIPTION
Fixes #21730.

`Mt19937::__debugInfo()` allocates a temporary HashTable with `array_init(&t)` and then calls the engine's `serialize` callback. If the callback returns false, the method throws "Engine serialize failed" and hits `RETURN_THROWS()` before inserting `t`, so the HashTable leaks. `PcgOneseq128XslRr64` and `Xoshiro256StarStar` alias the same method and share the leak.

Niels Dossche fixed the same pattern in `__serialize()` via #20383 (720e0069829). That cleanup didn't touch `__debugInfo()`. The fix here is identical: insert `t` into the return value before calling the callback, so `RETURN_THROWS()` unwinds it cleanly on failure.

The leak path is latent in stock PHP because the three built-in `serialize` callbacks all return `true`, so no user code reaches it today. Fixing for symmetry with #20383 and to keep the pattern from regressing if a future engine grows a failing serialize path. Verified under valgrind with a forced-failure patch: zero definitely-lost bytes.