### PR TITLE
Decrease zend.max_allowed_stack_size in stack_limit_015.phpt

### DIFF
--- a/Zend/tests/stack_limit/stack_limit_015.phpt
+++ b/Zend/tests/stack_limit/stack_limit_015.phpt
@@ -9,7 +9,7 @@ if (!function_exists('zend_test_zend_call_stack_get')) die("skip zend_test_zend_
 --EXTENSIONS--
 zend_test
 --INI--
-zend.max_allowed_stack_size=128K
+zend.max_allowed_stack_size=64K
 --FILE--
 <?php
 


### PR DESCRIPTION
With the stack size of 128K the compile-time stack guard does not fire on 32bit Windows tests, reducing it to 64K.

Fixes #17929.