### PR TITLE
ext/ldap: Enable ldap_set_rebind_proc() on Windows

### DIFF
--- a/ext/ldap/config.w32
+++ b/ext/ldap/config.w32
@@ -24,7 +24,7 @@ if (PHP_LDAP != "no") {
 		AC_DEFINE('HAVE_LDAP_WHOAMI_S', 1);
 		AC_DEFINE('HAVE_LDAP_REFRESH_S', 1);
 		AC_DEFINE('HAVE_LDAP_EXTENDED_OPERATION', 1);
-
+		AC_DEFINE('HAVE_3ARG_SETREBINDPROC', 1);
 	} else {
 		WARNING("ldap not enabled; libraries and headers not found");
 	}


### PR DESCRIPTION
Windows uses OpenLDAP which provides ldap_set_rebind_proc() with a 3-arg-signature:
https://github.com/winlibs/openldap