### PR TITLE
Fixing memory leak in phar_verify_signature when md_ctx is invalid

### DIFF
--- a/ext/phar/util.c
+++ b/ext/phar/util.c
@@ -1640,9 +1640,7 @@ zend_result phar_verify_signature(php_stream *fp, size_t end_of_phar, uint32_t s
 				if (md_ctx) {
 					EVP_MD_CTX_destroy(md_ctx);
 				}
-				if (key) {
-					EVP_PKEY_free(key);
-				}
+				EVP_PKEY_free(key);
 				if (error) {
 					spprintf(error, 0, "openssl signature could not be verified");
 				}

--- a/ext/phar/util.c
+++ b/ext/phar/util.c
@@ -1640,6 +1640,9 @@ zend_result phar_verify_signature(php_stream *fp, size_t end_of_phar, uint32_t s
 				if (md_ctx) {
 					EVP_MD_CTX_destroy(md_ctx);
 				}
+				if (key) {
+					EVP_PKEY_free(key);
+				}
 				if (error) {
 					spprintf(error, 0, "openssl signature could not be verified");
 				}


### PR DESCRIPTION
```
=================================================================
==2317111==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 152 byte(s) in 1 object(s) allocated from:
    #0 0x7ff9962e6f2b in malloc (/lib64/libasan.so.8+0xe6f2b) (BuildId: 25975f766867e9e604dc5a71a8befeaed3301942)
    #1 0x7ff995b38bbd in CRYPTO_malloc (/lib64/libcrypto.so.3+0x138bbd) (BuildId: b0b5c707569ba97d977637f93a8851c5a6fb9f31)
    #2 0x7ff995b38ed4 in CRYPTO_zalloc (/lib64/libcrypto.so.3+0x138ed4) (BuildId: b0b5c707569ba97d977637f93a8851c5a6fb9f31)
    #3 0x7ff995b19742 in EVP_PKEY_new (/lib64/libcrypto.so.3+0x119742) (BuildId: b0b5c707569ba97d977637f93a8851c5a6fb9f31)
    #4 0x7ff995ad65ff in decoder_construct_pkey (/lib64/libcrypto.so.3+0xd65ff) (BuildId: b0b5c707569ba97d977637f93a8851c5a6fb9f31)
    #5 0x7ff995ad5127 in decoder_process.lto_priv.0 (/lib64/libcrypto.so.3+0xd5127) (BuildId: b0b5c707569ba97d977637f93a8851c5a6fb9f31)
    #6 0x7ff995c0d45b in der2key_decode.lto_priv.0 (/lib64/libcrypto.so.3+0x20d45b) (BuildId: b0b5c707569ba97d977637f93a8851c5a6fb9f31)
    #7 0x7ff995ad5394 in decoder_process.lto_priv.0 (/lib64/libcrypto.so.3+0xd5394) (BuildId: b0b5c707569ba97d977637f93a8851c5a6fb9f31)
    #8 0x7ff995c1018c in ossl_spki2typespki_der_decode.isra.0 (/lib64/libcrypto.so.3+0x21018c) (BuildId: b0b5c707569ba97d977637f93a8851c5a6fb9f31)
    #9 0x7ff995c107a1 in pem2der_decode.lto_priv.0 (/lib64/libcrypto.so.3+0x2107a1) (BuildId: b0b5c707569ba97d977637f93a8851c5a6fb9f31)
    #10 0x7ff995ad5394 in decoder_process.lto_priv.0 (/lib64/libcrypto.so.3+0xd5394) (BuildId: b0b5c707569ba97d977637f93a8851c5a6fb9f31)
    #11 0x7ff995acfc4a in OSSL_DECODER_from_bio (/lib64/libcrypto.so.3+0xcfc4a) (BuildId: b0b5c707569ba97d977637f93a8851c5a6fb9f31)
    #12 0x7ff995b6e919 in pem_read_bio_key (/lib64/libcrypto.so.3+0x16e919) (BuildId: b0b5c707569ba97d977637f93a8851c5a6fb9f31)
    #13 0x7ff995b6ea75 in PEM_read_bio_PUBKEY_ex (/lib64/libcrypto.so.3+0x16ea75) (BuildId: b0b5c707569ba97d977637f93a8851c5a6fb9f31)
    #14 0x000000a8a2a0 in phar_verify_signature /home/jarne/ugent/mastersThesis/project/php/ext/phar/util.c:1627
    #15 0x000000a4c844 in phar_parse_pharfile /home/jarne/ugent/mastersThesis/project/php/ext/phar/phar.c:905
    #16 0x000000a558e8 in phar_open_from_fp /home/jarne/ugent/mastersThesis/project/php/ext/phar/phar.c:1771
    #17 0x000000a5330a in phar_create_or_parse_filename /home/jarne/ugent/mastersThesis/project/php/ext/phar/phar.c:1418
    #18 0x000000a530a9 in phar_open_or_create_filename /home/jarne/ugent/mastersThesis/project/php/ext/phar/phar.c:1389
    #19 0x000000a112b2 in zim_Phar___construct /home/jarne/ugent/mastersThesis/project/php/ext/phar/phar_object.c:1166
    #20 0x0000011b73f0 in ZEND_DO_FCALL_SPEC_RETVAL_UNUSED_HANDLER /home/jarne/ugent/mastersThesis/project/php/Zend/zend_vm_execute.h:1907
    #21 0x000001322c94 in execute_ex /home/jarne/ugent/mastersThesis/project/php/Zend/zend_vm_execute.h:58947
    #22 0x000001336b2f in zend_execute /home/jarne/ugent/mastersThesis/project/php/Zend/zend_vm_execute.h:64334
    #23 0x0000014db0fc in zend_execute_script /home/jarne/ugent/mastersThesis/project/php/Zend/zend.c:1934
    #24 0x000000ec6236 in php_execute_script_ex /home/jarne/ugent/mastersThesis/project/php/main/main.c:2577
    #25 0x000000ec68a3 in php_execute_script /home/jarne/ugent/mastersThesis/project/php/main/main.c:2617
    #26 0x0000014e1048 in do_cli /home/jarne/ugent/mastersThesis/project/php/sapi/cli/php_cli.c:935
    #27 0x0000014e3345 in main /home/jarne/ugent/mastersThesis/project/php/sapi/cli/php_cli.c:1310
    #28 0x7ff9956965b4 in __libc_start_call_main (/lib64/libc.so.6+0x35b4) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)
    #29 0x7ff995696667 in __libc_start_main@@GLIBC_2.34 (/lib64/libc.so.6+0x3667) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)
```

Found by a static-dynamic analyzer looking for memory bugs in error-handling paths.