### PR TITLE
Fixing memory leak in openssl_x509_parse when str_serial creation fails

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -2169,6 +2169,7 @@ PHP_FUNCTION(openssl_x509_parse)
 	str_serial = i2s_ASN1_INTEGER(NULL, asn1_serial);
 	/* Can return NULL on error or memory allocation failure */
 	if (!str_serial) {
+		OPENSSL_free(hex_serial);
 		php_openssl_store_errors();
 		goto err;
 	}


### PR DESCRIPTION
```
=================================================================
==2207270==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 18 byte(s) in 1 object(s) allocated from:
    #0 0x7fe8a80e6f2b in malloc (/lib64/libasan.so.8+0xe6f2b) (BuildId: 25975f766867e9e604dc5a71a8befeaed3301942)
    #1 0x7fe8a7938bbd in CRYPTO_malloc (/lib64/libcrypto.so.3+0x138bbd) (BuildId: b0b5c707569ba97d977637f93a8851c5a6fb9f31)
    #2 0x7fe8a78397eb in BN_bn2hex (/lib64/libcrypto.so.3+0x397eb) (BuildId: b0b5c707569ba97d977637f93a8851c5a6fb9f31)
    #3 0x0000004f0d58 in zif_openssl_x509_parse /home/jarne/ugent/mastersThesis/project/php/ext/openssl/openssl.c:2161
    #4 0x0000011b2b6b in ZEND_DO_ICALL_SPEC_RETVAL_USED_HANDLER /home/jarne/ugent/mastersThesis/project/php/Zend/zend_vm_execute.h:1351
    #5 0x0000013221e4 in execute_ex /home/jarne/ugent/mastersThesis/project/php/Zend/zend_vm_execute.h:58907
    #6 0x0000013362cf in zend_execute /home/jarne/ugent/mastersThesis/project/php/Zend/zend_vm_execute.h:64334
    #7 0x0000014da89c in zend_execute_script /home/jarne/ugent/mastersThesis/project/php/Zend/zend.c:1934
    #8 0x000000ec59d6 in php_execute_script_ex /home/jarne/ugent/mastersThesis/project/php/main/main.c:2577
    #9 0x000000ec6043 in php_execute_script /home/jarne/ugent/mastersThesis/project/php/main/main.c:2617
    #10 0x0000014e07e8 in do_cli /home/jarne/ugent/mastersThesis/project/php/sapi/cli/php_cli.c:935
    #11 0x0000014e2ae5 in main /home/jarne/ugent/mastersThesis/project/php/sapi/cli/php_cli.c:1310
    #12 0x7fe8a74965b4 in __libc_start_call_main (/lib64/libc.so.6+0x35b4) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)
    #13 0x7fe8a7496667 in __libc_start_main@@GLIBC_2.34 (/lib64/libc.so.6+0x3667) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)
    #14 0x000000405e34 in _start (/home/jarne/ugent/mastersThesis/project/php/sapi/cli/php+0x405e34) (BuildId: fe380cbbad341808ca7d70d56a9f08f8d34910dd)
```

Found by a static-dynamic analyzer looking for memory bugs in error-handling paths.