### PR TITLE
Fix GH-21776: use-after-free in zend_std_read_property magic __isset

### DIFF
--- a/Zend/tests/gh21776.phpt
+++ b/Zend/tests/gh21776.phpt
@@ -1,0 +1,16 @@
+--TEST--
+GH-21776 (Heap use-after-free in zend_object_is_lazy via magic __isset)
+--FILE--
+<?php
+class C {
+    function __isset($x) {
+        $GLOBALS['o'] = 0;
+        return true;
+    }
+}
+$o = new C;
+$o->a ?? 0;
+echo "OK\n";
+?>
+--EXPECT--
+OK

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -743,6 +743,7 @@ ZEND_API zval *zend_std_read_property(zend_object *zobj, zend_string *name, int 
 	uintptr_t property_offset;
 	const zend_property_info *prop_info = NULL;
 	uint32_t *guard = NULL;
+	bool release_zobj = false;
 
 #if DEBUG_OBJECT_HANDLERS
 	fprintf(stderr, "Read object #%d property: %s\n", zobj->handle, ZSTR_VAL(name));
@@ -937,7 +938,7 @@ try_again:
 			if (zobj->ce->__get && !((*guard) & IN_GET)) {
 				goto call_getter;
 			}
-			OBJ_RELEASE(zobj);
+			release_zobj = true;
 		} else if (zobj->ce->__get && !((*guard) & IN_GET)) {
 			goto call_getter_addref;
 		}
@@ -986,7 +987,7 @@ uninit_error:
 			zend_object *instance = zend_lazy_object_init(zobj);
 			if (!instance) {
 				retval = &EG(uninitialized_zval);
-				goto exit;
+				goto release_zobj_exit;
 			}
 
 			if (UNEXPECTED(guard && (instance->ce->ce_flags & ZEND_ACC_USE_GUARDS))) {
@@ -999,11 +1000,12 @@ uninit_error:
 					(*guard) |= guard_type;
 					retval = zend_std_read_property(instance, name, type, cache_slot, rv);
 					(*guard) &= ~guard_type;
-					return retval;
+					goto release_zobj_exit;
 				}
 			}
 
-			return zend_std_read_property(instance, name, type, cache_slot, rv);
+			retval = zend_std_read_property(instance, name, type, cache_slot, rv);
+			goto release_zobj_exit;
 		}
 	}
 	if (type != BP_VAR_IS) {
@@ -1015,6 +1017,10 @@ uninit_error:
 	}
 	retval = &EG(uninitialized_zval);
 
+release_zobj_exit:
+	if (release_zobj) {
+		OBJ_RELEASE(zobj);
+	}
 exit:
 	return retval;
 }


### PR DESCRIPTION
Fixes #21776.

When `__isset` drops the last non-temp reference to `$this` (e.g.
`$GLOBALS['o'] = 0`), the `OBJ_RELEASE(zobj)` after the `__isset`
call freed the object before `zend_std_read_property` reached the
shared `uninit_error` check at `zend_lazy_object_must_init(zobj)`.
ASAN reports a heap-use-after-free.

Defer the release via a local flag so `zobj` stays alive through the
lazy-init check and the recursive read on the initialized instance.
Route the two `return`s inside the lazy block through `exit:` so the
deferred release runs on those paths too.