### PR TITLE
[ext/standard] Specialize array_sum()/array_product() for long arrays

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -292,6 +292,8 @@ PHP 8.6 UPGRADE NOTES
 - Standard:
   . Improved performance of array_fill_keys().
   . Improved performance of array_map() with multiple arrays passed.
+  . Improved performance of array_sum() and array_product() for
+    integer-only arrays.
   . Improved performance of array_unshift().
   . Improved performance of array_walk().
   . Improved performance of intval('+0b...', 2) and intval('0b...', 2).

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -6355,7 +6355,7 @@ static zend_always_inline void php_array_binop_apply(
 }
 
 /* Wrapper for array_sum and array_product */
-static void php_array_binop(INTERNAL_FUNCTION_PARAMETERS, const char *op_name, binary_op_type op, zend_long initial)
+static zend_always_inline void php_array_binop(INTERNAL_FUNCTION_PARAMETERS, const char *op_name, binary_op_type op, zend_long initial)
 {
 	HashTable *input;
 

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -6371,69 +6371,35 @@ static void php_array_binop(INTERNAL_FUNCTION_PARAMETERS, const char *op_name, b
 
 	if (op == add_function) {
 		zval *entry;
-		if (HT_IS_PACKED(input)) {
-			ZEND_HASH_PACKED_FOREACH_VAL(input, entry) {
-				if (EXPECTED(Z_TYPE_P(entry) == IS_LONG) && EXPECTED(Z_TYPE_P(return_value) == IS_LONG)) {
-					fast_long_add_function(return_value, return_value, entry);
-					continue;
-				}
-				php_array_binop_apply(return_value, entry, op_name, op);
-			} ZEND_HASH_FOREACH_END();
-		} else {
-			ZEND_HASH_MAP_FOREACH_VAL(input, entry) {
-				if (EXPECTED(Z_TYPE_P(entry) == IS_LONG) && EXPECTED(Z_TYPE_P(return_value) == IS_LONG)) {
-					fast_long_add_function(return_value, return_value, entry);
-					continue;
-				}
-				php_array_binop_apply(return_value, entry, op_name, op);
-			} ZEND_HASH_FOREACH_END();
-		}
+		ZEND_HASH_FOREACH_VAL(input, entry) {
+			if (EXPECTED(Z_TYPE_P(entry) == IS_LONG) && EXPECTED(Z_TYPE_P(return_value) == IS_LONG)) {
+				fast_long_add_function(return_value, return_value, entry);
+				continue;
+			}
+			php_array_binop_apply(return_value, entry, op_name, op);
+		} ZEND_HASH_FOREACH_END();
 	} else if (op == mul_function) {
 		zval *entry;
-		if (HT_IS_PACKED(input)) {
-			ZEND_HASH_PACKED_FOREACH_VAL(input, entry) {
-				if (EXPECTED(Z_TYPE_P(entry) == IS_LONG) && EXPECTED(Z_TYPE_P(return_value) == IS_LONG)) {
-					zend_long lval;
-					double dval;
-					int overflow;
-					ZEND_SIGNED_MULTIPLY_LONG(Z_LVAL_P(return_value), Z_LVAL_P(entry), lval, dval, overflow);
-					if (UNEXPECTED(overflow)) {
-						ZVAL_DOUBLE(return_value, dval);
-					} else {
-						Z_LVAL_P(return_value) = lval;
-					}
-					continue;
+		ZEND_HASH_FOREACH_VAL(input, entry) {
+			if (EXPECTED(Z_TYPE_P(entry) == IS_LONG) && EXPECTED(Z_TYPE_P(return_value) == IS_LONG)) {
+				zend_long lval;
+				double dval;
+				int overflow;
+				ZEND_SIGNED_MULTIPLY_LONG(Z_LVAL_P(return_value), Z_LVAL_P(entry), lval, dval, overflow);
+				if (UNEXPECTED(overflow)) {
+					ZVAL_DOUBLE(return_value, dval);
+				} else {
+					Z_LVAL_P(return_value) = lval;
 				}
-				php_array_binop_apply(return_value, entry, op_name, op);
-			} ZEND_HASH_FOREACH_END();
-		} else {
-			ZEND_HASH_MAP_FOREACH_VAL(input, entry) {
-				if (EXPECTED(Z_TYPE_P(entry) == IS_LONG) && EXPECTED(Z_TYPE_P(return_value) == IS_LONG)) {
-					zend_long lval;
-					double dval;
-					int overflow;
-					ZEND_SIGNED_MULTIPLY_LONG(Z_LVAL_P(return_value), Z_LVAL_P(entry), lval, dval, overflow);
-					if (UNEXPECTED(overflow)) {
-						ZVAL_DOUBLE(return_value, dval);
-					} else {
-						Z_LVAL_P(return_value) = lval;
-					}
-					continue;
-				}
-				php_array_binop_apply(return_value, entry, op_name, op);
-			} ZEND_HASH_FOREACH_END();
-		}
+				continue;
+			}
+			php_array_binop_apply(return_value, entry, op_name, op);
+		} ZEND_HASH_FOREACH_END();
 	} else {
 		zval *entry;
-		if (HT_IS_PACKED(input)) {
-			ZEND_HASH_PACKED_FOREACH_VAL(input, entry) {
-				php_array_binop_apply(return_value, entry, op_name, op);
-			} ZEND_HASH_FOREACH_END();
-		} else {
-			ZEND_HASH_MAP_FOREACH_VAL(input, entry) {
-				php_array_binop_apply(return_value, entry, op_name, op);
-			} ZEND_HASH_FOREACH_END();
-		}
+		ZEND_HASH_FOREACH_VAL(input, entry) {
+			php_array_binop_apply(return_value, entry, op_name, op);
+		} ZEND_HASH_FOREACH_END();
 	}
 }
 

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -6314,11 +6314,50 @@ PHP_FUNCTION(array_rand)
 }
 /* }}} */
 
+/* Apply a single array_sum/array_product step to return_value. */
+static zend_always_inline void php_array_binop_apply(
+		zval *return_value, zval *entry, const char *op_name, binary_op_type op)
+{
+	/* For objects we try to cast them to a numeric type */
+	if (Z_TYPE_P(entry) == IS_OBJECT) {
+		zval dst;
+		zend_result status = Z_OBJ_HT_P(entry)->cast_object(Z_OBJ_P(entry), &dst, _IS_NUMBER);
+
+		/* Do not type error for BC */
+		if (status == FAILURE || (Z_TYPE(dst) != IS_LONG && Z_TYPE(dst) != IS_DOUBLE)) {
+			php_error_docref(NULL, E_WARNING, "%s is not supported on type %s",
+				op_name, zend_zval_type_name(entry));
+			return;
+		}
+		op(return_value, return_value, &dst);
+		return;
+	}
+
+	zend_result status = op(return_value, return_value, entry);
+	if (status == FAILURE) {
+		ZEND_ASSERT(EG(exception));
+		zend_clear_exception();
+		/* BC resources: previously resources were cast to int */
+		if (Z_TYPE_P(entry) == IS_RESOURCE) {
+			zval tmp;
+			ZVAL_LONG(&tmp, Z_RES_HANDLE_P(entry));
+			op(return_value, return_value, &tmp);
+		}
+		/* BC non numeric strings: previously were cast to 0 */
+		else if (Z_TYPE_P(entry) == IS_STRING) {
+			zval tmp;
+			ZVAL_LONG(&tmp, 0);
+			op(return_value, return_value, &tmp);
+		}
+		php_error_docref(NULL, E_WARNING, "%s is not supported on type %s",
+			op_name, zend_zval_type_name(entry));
+	}
+}
+
 /* Wrapper for array_sum and array_product */
 static void php_array_binop(INTERNAL_FUNCTION_PARAMETERS, const char *op_name, binary_op_type op, zend_long initial)
 {
 	HashTable *input;
-	zval *entry;
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
 		Z_PARAM_ARRAY_HT(input)
@@ -6329,42 +6368,73 @@ static void php_array_binop(INTERNAL_FUNCTION_PARAMETERS, const char *op_name, b
 	}
 
 	ZVAL_LONG(return_value, initial);
-	ZEND_HASH_FOREACH_VAL(input, entry) {
-		/* For objects we try to cast them to a numeric type */
-		if (Z_TYPE_P(entry) == IS_OBJECT) {
-			zval dst;
-			zend_result status = Z_OBJ_HT_P(entry)->cast_object(Z_OBJ_P(entry), &dst, _IS_NUMBER);
 
-			/* Do not type error for BC */
-			if (status == FAILURE || (Z_TYPE(dst) != IS_LONG && Z_TYPE(dst) != IS_DOUBLE)) {
-				php_error_docref(NULL, E_WARNING, "%s is not supported on type %s",
-					op_name, zend_zval_type_name(entry));
-				continue;
-			}
-			op(return_value, return_value, &dst);
-			continue;
+	if (op == add_function) {
+		zval *entry;
+		if (HT_IS_PACKED(input)) {
+			ZEND_HASH_PACKED_FOREACH_VAL(input, entry) {
+				if (EXPECTED(Z_TYPE_P(entry) == IS_LONG) && EXPECTED(Z_TYPE_P(return_value) == IS_LONG)) {
+					fast_long_add_function(return_value, return_value, entry);
+					continue;
+				}
+				php_array_binop_apply(return_value, entry, op_name, op);
+			} ZEND_HASH_FOREACH_END();
+		} else {
+			ZEND_HASH_MAP_FOREACH_VAL(input, entry) {
+				if (EXPECTED(Z_TYPE_P(entry) == IS_LONG) && EXPECTED(Z_TYPE_P(return_value) == IS_LONG)) {
+					fast_long_add_function(return_value, return_value, entry);
+					continue;
+				}
+				php_array_binop_apply(return_value, entry, op_name, op);
+			} ZEND_HASH_FOREACH_END();
 		}
-
-		zend_result status = op(return_value, return_value, entry);
-		if (status == FAILURE) {
-			ZEND_ASSERT(EG(exception));
-			zend_clear_exception();
-			/* BC resources: previously resources were cast to int */
-			if (Z_TYPE_P(entry) == IS_RESOURCE) {
-				zval tmp;
-				ZVAL_LONG(&tmp, Z_RES_HANDLE_P(entry));
-				op(return_value, return_value, &tmp);
-			}
-			/* BC non numeric strings: previously were cast to 0 */
-			else if (Z_TYPE_P(entry) == IS_STRING) {
-				zval tmp;
-				ZVAL_LONG(&tmp, 0);
-				op(return_value, return_value, &tmp);
-			}
-			php_error_docref(NULL, E_WARNING, "%s is not supported on type %s",
-				op_name, zend_zval_type_name(entry));
+	} else if (op == mul_function) {
+		zval *entry;
+		if (HT_IS_PACKED(input)) {
+			ZEND_HASH_PACKED_FOREACH_VAL(input, entry) {
+				if (EXPECTED(Z_TYPE_P(entry) == IS_LONG) && EXPECTED(Z_TYPE_P(return_value) == IS_LONG)) {
+					zend_long lval;
+					double dval;
+					int overflow;
+					ZEND_SIGNED_MULTIPLY_LONG(Z_LVAL_P(return_value), Z_LVAL_P(entry), lval, dval, overflow);
+					if (UNEXPECTED(overflow)) {
+						ZVAL_DOUBLE(return_value, dval);
+					} else {
+						Z_LVAL_P(return_value) = lval;
+					}
+					continue;
+				}
+				php_array_binop_apply(return_value, entry, op_name, op);
+			} ZEND_HASH_FOREACH_END();
+		} else {
+			ZEND_HASH_MAP_FOREACH_VAL(input, entry) {
+				if (EXPECTED(Z_TYPE_P(entry) == IS_LONG) && EXPECTED(Z_TYPE_P(return_value) == IS_LONG)) {
+					zend_long lval;
+					double dval;
+					int overflow;
+					ZEND_SIGNED_MULTIPLY_LONG(Z_LVAL_P(return_value), Z_LVAL_P(entry), lval, dval, overflow);
+					if (UNEXPECTED(overflow)) {
+						ZVAL_DOUBLE(return_value, dval);
+					} else {
+						Z_LVAL_P(return_value) = lval;
+					}
+					continue;
+				}
+				php_array_binop_apply(return_value, entry, op_name, op);
+			} ZEND_HASH_FOREACH_END();
 		}
-	} ZEND_HASH_FOREACH_END();
+	} else {
+		zval *entry;
+		if (HT_IS_PACKED(input)) {
+			ZEND_HASH_PACKED_FOREACH_VAL(input, entry) {
+				php_array_binop_apply(return_value, entry, op_name, op);
+			} ZEND_HASH_FOREACH_END();
+		} else {
+			ZEND_HASH_MAP_FOREACH_VAL(input, entry) {
+				php_array_binop_apply(return_value, entry, op_name, op);
+			} ZEND_HASH_FOREACH_END();
+		}
+	}
 }
 
 /* {{{ Returns the sum of the array entries */

--- a/ext/standard/tests/array/array_product_packed_long_overflow.phpt
+++ b/ext/standard/tests/array/array_product_packed_long_overflow.phpt
@@ -1,0 +1,22 @@
+--TEST--
+array_product() packed long overflow continues in double mode
+--FILE--
+<?php
+
+$tests = [
+    [[PHP_INT_MAX, 2, 3], ((float) PHP_INT_MAX * 2) * 3],
+    [[PHP_INT_MIN, -1, 2], ((float) PHP_INT_MIN * -1) * 2],
+];
+
+foreach ($tests as [$input, $expected]) {
+    $result = array_product($input);
+    var_dump(is_float($result));
+    var_dump($result === $expected);
+}
+
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/ext/standard/tests/array/array_sum_packed_long_overflow.phpt
+++ b/ext/standard/tests/array/array_sum_packed_long_overflow.phpt
@@ -1,0 +1,22 @@
+--TEST--
+array_sum() packed long overflow continues in double mode
+--FILE--
+<?php
+
+$tests = [
+    [[PHP_INT_MAX, 1, 4096], ((float) PHP_INT_MAX + 1) + 4096],
+    [[PHP_INT_MIN, -1, -4096], ((float) PHP_INT_MIN - 1) - 4096],
+];
+
+foreach ($tests as [$input, $expected]) {
+    $result = array_sum($input);
+    var_dump(is_float($result));
+    var_dump($result === $expected);
+}
+
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/ext/standard/tests/array/array_sum_product_integration.phpt
+++ b/ext/standard/tests/array/array_sum_product_integration.phpt
@@ -1,0 +1,32 @@
+--TEST--
+array_sum()/array_product(): PHP 8.3 nested-array warning and array_column() integration
+--FILE--
+<?php
+
+echo "-- array_column() + array_sum()/array_product() integration --\n";
+$products = [
+    ['name' => 'Pen',   'price' => 3],
+    ['name' => 'Paper', 'price' => 5],
+];
+$prices = array_column($products, 'price');
+var_dump($prices === [3, 5]);
+var_dump(array_sum($prices) === 8);
+var_dump(array_product($prices) === 15);
+
+echo "-- PHP 8.3: nested array emits warning and is skipped --\n";
+var_dump(array_sum([1, [2], 3]));
+var_dump(array_product([2, [3], 4]));
+
+?>
+--EXPECTF--
+-- array_column() + array_sum()/array_product() integration --
+bool(true)
+bool(true)
+bool(true)
+-- PHP 8.3: nested array emits warning and is skipped --
+
+Warning: array_sum(): Addition is not supported on type array in %s on line %d
+int(4)
+
+Warning: array_product(): Multiplication is not supported on type array in %s on line %d
+int(8)


### PR DESCRIPTION
## Summary

`array_sum()` and `array_product()` currently dispatch through
`add_function()` / `mul_function()` for every element.

This change adds a specialized fast path for arrays when both the
accumulator and current element are `IS_LONG`, inlining overflow-aware
arithmetic via `fast_long_add_function()` and `ZEND_SIGNED_MULTIPLY_LONG()` --
the same engine helpers that `add_function_fast()` dispatches to internally.
The fast path applies to both packed and hash arrays.

When those conditions are not met (overflow, non-`IS_LONG` entry, object,
resource, string, etc.), execution falls back to the existing generic path
through `php_array_binop_apply()`, preserving current behavior and warnings.

This follows the pattern of recent array function optimizations
(#18157, #18158, #18180).

## Benchmark

Apple M1, release build (`-O2 -DNDEBUG`), median of 7 runs. Each benchmark
processes roughly 20M elements total (`n * iterations` held constant), so the
timings are intended to reflect per-element cost. Benchmark script posted as
a comment below.

| Case | Baseline | Patched | Speedup |
|:--|--:|--:|--:|
| `array_sum`, packed long (n=10000) | 42.24 ms | 12.99 ms | 3.25x |
| `array_product`, packed small long (0-9 cycled, n=10000) | 144.63 ms | 19.39 ms | 7.46x |
| `array_product(range(1, 100))` (packed) | 82.94 ms | 58.66 ms | 1.41x |
| `array_sum`, hash long (n=10000) | 41.95 ms | 12.90 ms | 3.25x |
| `array_product`, hash small long (0-9 cycled, n=10000) | 69.90 ms | 19.40 ms | 3.60x |

Packed/hash float arrays and mixed `IS_LONG` / `IS_DOUBLE` arrays stay
approximately neutral.

Broader fast paths (including `IS_DOUBLE` accumulators) were prototyped
but dropped: `add_function_fast()` already inlines the `double+double` case,
so the wins were marginal, and the extra type-dispatch branch caused
regressions on mixed and pure-float workloads. The `IS_LONG` + `IS_LONG`
variant was the only one with a consistent win and no regressions.

## Testing

- Full `ext/standard/tests/array/` suite: `856/856` passing on debug, ZTS, and release builds.
- Added regression tests:
  - `array_sum_packed_long_overflow.phpt`
  - `array_product_packed_long_overflow.phpt`
  - `array_sum_product_integration.phpt`

All three new tests also pass on current master without the patch, so they
lock in existing semantics rather than implementation details.
