### PR TITLE
Fix GH-21770: Infinite recursion in property hook getter in opcache preloaded trait

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -27,6 +27,8 @@ PHP                                                                        NEWS
   . Fixed bug GH-21593 (Borked function JIT JMPNZ smart branch). (ilutov)
   . Fixed bug GH-21460 (COND optimization regression). (Dmitry, Arnaud)
   . Fixed faulty returns out of zend_try block in zend_jit_trace(). (ilutov)
+  . Fixed bug GH-21770 (Infinite recursion in property hook getter in opcache
+    preloaded trait). (iliaal)
 
 - OpenSSL:
   . Fix a bunch of memory leaks and crashes on edge cases. (ndossche)

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -4290,12 +4290,14 @@ static void preload_fix_trait_op_array(zend_op_array *op_array)
 	uint32_t fn_flags = op_array->fn_flags;
 	zend_function *prototype = op_array->prototype;
 	HashTable *ht = op_array->static_variables;
+	const zend_property_info *prop_info = op_array->prop_info;
 	*op_array = *orig_op_array;
 	op_array->function_name = function_name;
 	op_array->scope = scope;
 	op_array->fn_flags = fn_flags;
 	op_array->prototype = prototype;
 	op_array->static_variables = ht;
+	op_array->prop_info = prop_info;
 }
 
 static void preload_fix_trait_methods(zend_class_entry *ce)

--- a/ext/opcache/tests/gh21770.phpt
+++ b/ext/opcache/tests/gh21770.phpt
@@ -1,0 +1,25 @@
+--TEST--
+GH-21770 (Infinite recursion in property hook getter in opcache preloaded trait)
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.optimization_level=-1
+opcache.preload={PWD}/preload_gh21770.inc
+--EXTENSIONS--
+opcache
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY == 'Windows') die('skip Preloading is not supported on Windows');
+?>
+--FILE--
+<?php
+$b = new B();
+echo $b->a, "\n";
+
+$c = new C();
+$c->x = 42;
+var_dump($c->x);
+?>
+--EXPECT--
+a
+int(42)

--- a/ext/opcache/tests/preload_gh21770.inc
+++ b/ext/opcache/tests/preload_gh21770.inc
@@ -1,0 +1,20 @@
+<?php
+trait A {
+    public ?string $a = 'a' {
+        get => $this->a;
+    }
+}
+
+trait X {
+    public int $x = 0 {
+        set(int $value) => $value;
+    }
+}
+
+class B {
+    use A;
+}
+
+class C {
+    use X;
+}

--- a/ext/opcache/tests/preload_gh21770.inc
+++ b/ext/opcache/tests/preload_gh21770.inc
@@ -1,0 +1,20 @@
+<?php
+trait A {
+    public ?string $a = 'a' {
+        get => $this->a;
+    }
+}
+
+trait X {
+    public int $x = 0 {
+        set(int $value) => $this->x = $value;
+    }
+}
+
+class B {
+    use A;
+}
+
+class C {
+    use X;
+}


### PR DESCRIPTION
Fixes #21770.

`preload_fix_trait_op_array` rewrites trait-cloned op_arrays from their original after optimization and preserves a short allowlist of per-clone fields: function_name, scope, fn_flags, prototype, static_variables. For trait-cloned property hooks, `prop_info` is also per-clone. `zend_do_traits_property_binding` points it at the using class's property, and `zend_is_in_hook` relies on that identity to detect backing-store access from inside the hook. Without restoring `prop_info`, the rewrite pointed it back at the trait's property, prototypes mismatched, and reading or writing the backing store from inside the hook recursed into the hook instead.

Restoring `prop_info` alongside the other preserved fields fixes the mismatch and the runaway recursion.