### PR TITLE
/ext/standard: Check for empty string in linkinfo()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -158,6 +158,8 @@ PHP                                                                        NEWS
     throw a ValueError. (alexandre-daubois)
   . array_change_key_case() now raises a ValueError when an invalid $case
     argument value is passed. (Girgias)
+  . linkinfo() now raises a ValueError when the argument is an empty string.
+    (Weilin Du)
 
 - Streams:
   . Added so_keepalive, tcp_keepidle, tcp_keepintvl and tcp_keepcnt stream

--- a/UPGRADING
+++ b/UPGRADING
@@ -78,6 +78,7 @@ PHP 8.6 UPGRADE NOTES
     argument value is passed.
   . array_change_key_case() now raises a ValueError when an invalid $case
     argument value is passed.
+  . linkinfo() now raises a ValueError when the $path argument is empty.
   . pathinfo() now raises a ValueError when an invalid $flag
     argument value is passed.
   . scandir() now raises a ValueError when an invalid $sorting_order

--- a/ext/standard/link.c
+++ b/ext/standard/link.c
@@ -84,7 +84,11 @@ PHP_FUNCTION(linkinfo)
 		Z_PARAM_PATH(link, link_len)
 	ZEND_PARSE_PARAMETERS_END();
 
-	// TODO Check for empty string
+	if (UNEXPECTED(link_len == 0)) {
+		php_error_docref(NULL, E_WARNING, "%s", strerror(ENOENT));
+		RETURN_LONG(Z_L(-1));
+	}
+
 	dirname = estrndup(link, link_len);
 	zend_dirname(dirname, link_len);
 

--- a/ext/standard/link.c
+++ b/ext/standard/link.c
@@ -85,8 +85,8 @@ PHP_FUNCTION(linkinfo)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (UNEXPECTED(link_len == 0)) {
-		php_error_docref(NULL, E_WARNING, "%s", strerror(ENOENT));
-		RETURN_LONG(Z_L(-1));
+		zend_argument_must_not_be_empty_error(1);
+		RETURN_THROWS();
 	}
 
 	dirname = estrndup(link, link_len);

--- a/ext/standard/tests/file/symlink_link_linkinfo_is_link_error1.phpt
+++ b/ext/standard/tests/file/symlink_link_linkinfo_is_link_error1.phpt
@@ -27,8 +27,16 @@ var_dump( symlink($filename, false) );  // false as linkname
 echo "\n*** Testing linkinfo() for error conditions ***\n";
 
 //invalid arguments
-var_dump( linkinfo('') );  // empty string as linkname
-var_dump( linkinfo(false) );  // boolean false as linkname
+try {
+    var_dump(linkinfo(''));  // empty string as linkname
+} catch (ValueError $e) {
+    echo $e->getMessage() . "\n";
+}
+try {
+    var_dump(linkinfo(false));  // boolean false as linkname
+} catch (ValueError $e) {
+    echo $e->getMessage() . "\n";
+}
 
 echo "Done\n";
 ?>
@@ -54,9 +62,6 @@ bool(false)
 
 *** Testing linkinfo() for error conditions ***
 
-Warning: linkinfo(): %s in %s on line %d
-int(-1)
-
-Warning: linkinfo(): %s in %s on line %d
-int(-1)
+linkinfo(): Argument #1 ($path) must not be empty
+linkinfo(): Argument #1 ($path) must not be empty
 Done

--- a/ext/standard/tests/file/symlink_link_linkinfo_is_link_error1.phpt
+++ b/ext/standard/tests/file/symlink_link_linkinfo_is_link_error1.phpt
@@ -61,7 +61,6 @@ Warning: symlink(): %s in %s on line %d
 bool(false)
 
 *** Testing linkinfo() for error conditions ***
-
 linkinfo(): Argument #1 ($path) must not be empty
 linkinfo(): Argument #1 ($path) must not be empty
 Done

--- a/ext/standard/tests/file/symlink_link_linkinfo_is_link_error1.phpt
+++ b/ext/standard/tests/file/symlink_link_linkinfo_is_link_error1.phpt
@@ -32,11 +32,6 @@ try {
 } catch (ValueError $e) {
     echo $e->getMessage() . "\n";
 }
-try {
-    var_dump(linkinfo(false));  // boolean false as linkname
-} catch (ValueError $e) {
-    echo $e->getMessage() . "\n";
-}
 
 echo "Done\n";
 ?>
@@ -61,6 +56,5 @@ Warning: symlink(): %s in %s on line %d
 bool(false)
 
 *** Testing linkinfo() for error conditions ***
-linkinfo(): Argument #1 ($path) must not be empty
 linkinfo(): Argument #1 ($path) must not be empty
 Done


### PR DESCRIPTION
If link_len == 0, it now emits the same warning style as the existing filesystem error path and returns -1 immediately, avoiding the later estrndup() / zend_dirname() work on an empty input as per the TODO message.