### PR TITLE
CONTRIBUTING.md: Update branch status

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -356,18 +356,18 @@ Having said that, here are the organizational rules:
    `--enable-zts` switch to ensure your code handles TSRM correctly and doesn't
    break for those who need that.
 
-The master branch is an active development branch for PHP 8.6, which is open for
-backwards incompatible changes and major internal API changes.
+The master branch is an active development branch for the newest version of PHP,
+which is open for backwards incompatible changes and major internal API changes.
 
-For PHP-X.Y branches, they are used to release the PHP X.Y.x series. Please see
+For PHP-X.Y branches, they are used to release the PHP X.Y.z series. Please see
 the [supported versions page](https://www.php.net/supported-versions.php) to get
 the status of each version.
 
-If a version is described as "Active support" it, the corresponding branch is a
+If a version is described as "Active support", the corresponding branch is a
 current stable version and is open for bugfixes only. If a version is described
-as "Security fixes only" it, the corresponding branch is an old stable version
-and is open for security fixes only. If a version is described as "End of life"
-it, the corresponding branch is closed.
+as "Security fixes only", the corresponding branch is an old stable version
+and is open for security fixes only. If a version is described as "End of life",
+the corresponding branch is closed.
 
 Note that PHP-X.Y.Z branches are used for the release managers for tagging the
 releases, hence they are closed to the general public

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -370,7 +370,7 @@ and is open for security fixes only. If a version is described as "End of life",
 the corresponding branch is closed.
 
 Note that PHP-X.Y.Z branches are used for the release managers for tagging the
-releases, hence they are closed to the general public
+releases, hence they are closed to the general public.
 
 The next few rules are more of a technical nature:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -363,9 +363,9 @@ Currently, we have the following branches in use:
 | master    | Active development branch for PHP 8.6, which is open for backwards incompatible changes and major internal API changes. |
 | PHP-8.5   | Is used to release the PHP 8.5.x series. This is a current stable version and is open for bugfixes only. |
 | PHP-8.4   | Is used to release the PHP 8.4.x series. This is a current stable version and is open for bugfixes only. |
-| PHP-8.3   | Is used to release the PHP 8.3.x series. This is a current stable version and is open for bugfixes only. |
+| PHP-8.3   | Is used to release the PHP 8.3.x series. This is an old stable version and is open for security fixes only. |
 | PHP-8.2   | Is used to release the PHP 8.2.x series. This is an old stable version and is open for security fixes only. |
-| PHP-8.1   | Is used to release the PHP 8.1.x series. This is an old stable version and is open for security fixes only. |
+| PHP-8.1   | This branch is closed. |
 | PHP-8.0   | This branch is closed. |
 | PHP-7.4   | This branch is closed. |
 | PHP-7.3   | This branch is closed. |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -356,8 +356,18 @@ Having said that, here are the organizational rules:
    `--enable-zts` switch to ensure your code handles TSRM correctly and doesn't
    break for those who need that.
 
-For an up-to-date list of branches and their purposes, please see the
-[supported versions page](https://www.php.net/supported-versions.php).
+The master branch is an active development branch for PHP 8.6, which is open for
+backwards incompatible changes and major internal API changes.
+
+For PHP-X.Y branches, they are used to release the PHP X.Y.x series. Please see
+the [supported versions page](https://www.php.net/supported-versions.php) to get
+the status of each version.
+
+If a version is described as "Active support" it, the corresponding branch is a
+current stable version and is open for bugfixes only. If a version is described
+as "Security fixes only" it, the corresponding branch is an old stable version
+and is open for security fixes only. If a version is described as "End of life"
+it, the corresponding branch is closed.
 
 Note that PHP-X.Y.Z branches are used for the release managers for tagging the
 releases, hence they are closed to the general public

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -356,30 +356,11 @@ Having said that, here are the organizational rules:
    `--enable-zts` switch to ensure your code handles TSRM correctly and doesn't
    break for those who need that.
 
-Currently, we have the following branches in use:
+For an up-to-date list of branches and their purposes, please see the
+[supported versions page](https://www.php.net/supported-versions.php).
 
-| Branch    |           |
-| --------- | --------- |
-| master    | Active development branch for PHP 8.6, which is open for backwards incompatible changes and major internal API changes. |
-| PHP-8.5   | Is used to release the PHP 8.5.x series. This is a current stable version and is open for bugfixes only. |
-| PHP-8.4   | Is used to release the PHP 8.4.x series. This is a current stable version and is open for bugfixes only. |
-| PHP-8.3   | Is used to release the PHP 8.3.x series. This is an old stable version and is open for security fixes only. |
-| PHP-8.2   | Is used to release the PHP 8.2.x series. This is an old stable version and is open for security fixes only. |
-| PHP-8.1   | This branch is closed. |
-| PHP-8.0   | This branch is closed. |
-| PHP-7.4   | This branch is closed. |
-| PHP-7.3   | This branch is closed. |
-| PHP-7.2   | This branch is closed. |
-| PHP-7.1   | This branch is closed. |
-| PHP-7.0   | This branch is closed. |
-| PHP-5.6   | This branch is closed. |
-| PHP-5.5   | This branch is closed. |
-| PHP-5.4   | This branch is closed. |
-| PHP-5.3   | This branch is closed. |
-| PHP-5.2   | This branch is closed. |
-| PHP-5.1   | This branch is closed. |
-| PHP-4.4   | This branch is closed. |
-| PHP-X.Y.Z | These branches are used for the release managers for tagging the releases, hence they are closed to the general public. |
+Note that PHP-X.Y.Z branches are used for the release managers for tagging the
+releases, hence they are closed to the general public
 
 The next few rules are more of a technical nature:
 


### PR DESCRIPTION
as per https://www.php.net/supported-versions.php, 8.1 is no longer supported and 8.3 is now secruity-only.