### PR TITLE
phar: restore is_link handler in phar_intercept_functions_shutdown

### DIFF
--- a/ext/phar/func_interceptors.c
+++ b/ext/phar/func_interceptors.c
@@ -932,6 +932,7 @@ void phar_intercept_functions_shutdown(void)
 	PHAR_RELEASE(fopen);
 	PHAR_RELEASE(file_get_contents);
 	PHAR_RELEASE(is_file);
+	PHAR_RELEASE(is_link);
 	PHAR_RELEASE(is_dir);
 	PHAR_RELEASE(opendir);
 	PHAR_RELEASE(file_exists);

--- a/ext/phar/tests/phar-is-link-intercept.phpt
+++ b/ext/phar/tests/phar-is-link-intercept.phpt
@@ -12,17 +12,18 @@ $phar = new Phar($fname);
 $phar->addFromString('file.txt', 'hello');
 $phar->setStub('<?php
 Phar::interceptFileFuncs();
-// relative path resolves via phar intercept
-var_dump(is_link("file.txt"));       // false: regular entry, not a symlink
-var_dump(is_link("nonexistent.txt")); // false: missing entry
-// absolute phar:// path bypasses the relative-path intercept, goes to orig_is_link
-var_dump(is_link("phar://" . __FILE__ . "/file.txt")); // false: phar entries are never OS symlinks
+echo "regular entry (not a symlink): ";
+var_dump(is_link("file.txt"));
+echo "missing entry: ";
+var_dump(is_link("nonexistent.txt"));
+echo "absolute phar:// path (bypasses intercept): ";
+var_dump(is_link("phar://" . __FILE__ . "/file.txt"));
 __HALT_COMPILER(); ?>');
 include $fname;
 ?>
 --CLEAN--
 <?php @unlink(__DIR__ . '/' . basename(__FILE__, '.clean.php') . '.phar'); ?>
 --EXPECT--
-bool(false)
-bool(false)
-bool(false)
+regular entry (not a symlink): bool(false)
+missing entry: bool(false)
+absolute phar:// path (bypasses intercept): bool(false)

--- a/ext/phar/tests/phar-is-link-intercept.phpt
+++ b/ext/phar/tests/phar-is-link-intercept.phpt
@@ -2,8 +2,6 @@
 phar: is_link() intercept correctly delegates for non-symlink phar entries
 --EXTENSIONS--
 phar
---SKIPIF--
-<?php if (defined('PHP_WINDOWS_VERSION_MAJOR')) die("skip"); ?>
 --INI--
 phar.readonly=0
 phar.require_hash=0

--- a/ext/phar/tests/phar-is-link-intercept.phpt
+++ b/ext/phar/tests/phar-is-link-intercept.phpt
@@ -1,0 +1,30 @@
+--TEST--
+phar: is_link() intercept correctly delegates for non-symlink phar entries
+--EXTENSIONS--
+phar
+--SKIPIF--
+<?php if (defined('PHP_WINDOWS_VERSION_MAJOR')) die("skip"); ?>
+--INI--
+phar.readonly=0
+phar.require_hash=0
+--FILE--
+<?php
+$fname = __DIR__ . '/' . basename(__FILE__, '.php') . '.phar';
+$phar = new Phar($fname);
+$phar->addFromString('file.txt', 'hello');
+$phar->setStub('<?php
+Phar::interceptFileFuncs();
+// relative path resolves via phar intercept
+var_dump(is_link("file.txt"));       // false: regular entry, not a symlink
+var_dump(is_link("nonexistent.txt")); // false: missing entry
+// absolute phar:// path bypasses the relative-path intercept, goes to orig_is_link
+var_dump(is_link("phar://" . __FILE__ . "/file.txt")); // false: phar entries are never OS symlinks
+__HALT_COMPILER(); ?>');
+include $fname;
+?>
+--CLEAN--
+<?php @unlink(__DIR__ . '/' . basename(__FILE__, '.clean.php') . '.phar'); ?>
+--EXPECT--
+bool(false)
+bool(false)
+bool(false)


### PR DESCRIPTION
`phar_intercept_functions_init` (MINIT) hooks 22 built-in functions via `PHAR_INTERCEPT`, including `is_link`. `phar_intercept_functions_shutdown` (MSHUTDOWN) restores all of them via `PHAR_RELEASE`, except `is_link`, which was simply absent from the list.

In a persistent SAPI, if the module is reloaded, the second MINIT picks up `PHP_FN(phar_is_link)` as the original handler for `is_link` and stores it in `orig_is_link`. Any subsequent `is_link()` call then recurses infinitely. In practice this only bites on module reload in Apache/FPM workers; in CLI the process exits at MSHUTDOWN so the stale handler is never observable.

Added `PHAR_RELEASE(is_link)` between `is_file` and `is_dir` to match init order.