### PR TITLE
phar: free EVP_PKEY on EVP_MD_CTX_create/EVP_VerifyInit failure in phar_verify_signature

### DIFF
--- a/ext/phar/tests/phar-openssl-verify-evp-pkey-leak.phpt
+++ b/ext/phar/tests/phar-openssl-verify-evp-pkey-leak.phpt
@@ -1,0 +1,34 @@
+--TEST--
+phar: EVP_PKEY freed on EVP_MD_CTX_create/EVP_VerifyInit failure in phar_verify_signature
+--EXTENSIONS--
+phar
+--SKIPIF--
+<?php
+if (!in_array('OpenSSL', Phar::getSupportedSignatures())) {
+    die('skip OpenSSL signature support required');
+}
+?>
+--INI--
+phar.require_hash=1
+phar.readonly=0
+--FILE--
+<?php
+// Exercise phar_verify_signature for all three OpenSSL digest types.
+// Under ASAN, a missing EVP_PKEY_free on the EVP_MD_CTX_create/EVP_VerifyInit
+// failure branch would produce a leak report.
+
+$dir = __DIR__ . '/files/';
+
+$p = new Phar($dir . 'openssl.phar');
+var_dump($p->getSignature()['hash_type']);
+
+$p = new Phar($dir . 'openssl256.phar');
+var_dump($p->getSignature()['hash_type']);
+
+$p = new Phar($dir . 'openssl512.phar');
+var_dump($p->getSignature()['hash_type']);
+?>
+--EXPECT--
+string(7) "OpenSSL"
+string(14) "OpenSSL_SHA256"
+string(14) "OpenSSL_SHA512"

--- a/ext/phar/util.c
+++ b/ext/phar/util.c
@@ -1640,6 +1640,7 @@ zend_result phar_verify_signature(php_stream *fp, size_t end_of_phar, uint32_t s
 				if (md_ctx) {
 					EVP_MD_CTX_destroy(md_ctx);
 				}
+				EVP_PKEY_free(key);
 				if (error) {
 					spprintf(error, 0, "openssl signature could not be verified");
 				}


### PR DESCRIPTION
In `phar_verify_signature`, `PEM_read_bio_PUBKEY` allocates `EVP_PKEY *key`. When `EVP_MD_CTX_create()` returns NULL or `EVP_VerifyInit()` fails, the early return freed `md_ctx` but did not call `EVP_PKEY_free(key)`, leaking the object in OpenSSL's heap.

The existing `failure:` label (reached on bad signature or `EVP_VerifyUpdate` errors) already calls both `EVP_PKEY_free` and `EVP_MD_CTX_destroy`. The fix adds `EVP_PKEY_free(key)` to the earlier exit branch, mirroring the symmetric fix in `phar_create_signature` from GH-19563 (f5a3a642c61).

ASAN catches the leak when `EVP_VerifyInit` fails, in FIPS-mode deployments with SHA-1 disabled.