### PR TITLE
phar: fix NULL dereference in Phar::webPhar() when SCRIPT_NAME is absent

### DIFF
--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -649,6 +649,9 @@ PHP_METHOD(Phar, webPhar)
 			char *testit;
 
 			testit = sapi_getenv("SCRIPT_NAME", sizeof("SCRIPT_NAME")-1);
+			if (!testit) {
+				goto finish;
+			}
 			if (!(pt = strstr(testit, basename))) {
 				efree(testit);
 				goto finish;

--- a/ext/phar/tests/gh21797.phpt
+++ b/ext/phar/tests/gh21797.phpt
@@ -1,29 +1,28 @@
 --TEST--
 GH-21797: Phar::webPhar() NULL dereference when SCRIPT_NAME absent from SAPI environment
+--CGI--
 --EXTENSIONS--
 phar
 --INI--
 phar.readonly=0
 phar.require_hash=0
+variables_order=EGPC
+register_argc_argv=0
+cgi.fix_pathinfo=0
+--ENV--
+REQUEST_METHOD=GET
+PATH_INFO=/gh21797.phar
 --FILE--
 <?php
-// The NULL dereference in the CGI/FastCGI branch of webPhar() is not
-// reachable from CLI SAPI. This test exercises the CLI code path as a
-// regression baseline and verifies the function behaves correctly when
-// called outside an HTTP context.
-
 $fname = __DIR__ . '/' . basename(__FILE__, '.php') . '.phar';
-
 $phar = new Phar($fname);
 $phar->addFromString('index.php', '<?php echo "ok\n"; ?>');
 $phar->setStub('<?php
 Phar::webPhar();
+echo "no crash\n";
 __HALT_COMPILER(); ?>');
 unset($phar);
-
-// webPhar() with no HTTP context returns silently (no request method set)
 include $fname;
-echo "no crash\n";
 ?>
 --CLEAN--
 <?php @unlink(__DIR__ . '/' . basename(__FILE__, '.clean.php') . '.phar'); ?>

--- a/ext/phar/tests/gh21797.phpt
+++ b/ext/phar/tests/gh21797.phpt
@@ -1,0 +1,31 @@
+--TEST--
+GH-21797: Phar::webPhar() NULL dereference when SCRIPT_NAME absent from SAPI environment
+--EXTENSIONS--
+phar
+--INI--
+phar.readonly=0
+phar.require_hash=0
+--FILE--
+<?php
+// The NULL dereference in the CGI/FastCGI branch of webPhar() is not
+// reachable from CLI SAPI. This test exercises the CLI code path as a
+// regression baseline and verifies the function behaves correctly when
+// called outside an HTTP context.
+
+$fname = __DIR__ . '/' . basename(__FILE__, '.php') . '.phar';
+
+$phar = new Phar($fname);
+$phar->addFromString('index.php', '<?php echo "ok\n"; ?>');
+$phar->setStub('<?php
+Phar::webPhar();
+__HALT_COMPILER(); ?>');
+unset($phar);
+
+// webPhar() with no HTTP context returns silently (no request method set)
+include $fname;
+echo "no crash\n";
+?>
+--CLEAN--
+<?php @unlink(__DIR__ . '/' . basename(__FILE__, '.clean.php') . '.phar'); ?>
+--EXPECT--
+no crash


### PR DESCRIPTION
In the CGI/FastCGI branch of `webPhar()`, `sapi_getenv("SCRIPT_NAME")` can return NULL when the upstream server doesn't forward `SCRIPT_NAME` in the FastCGI params block. The return value was passed directly to `strstr()` without a NULL check, causing a segfault.

Add a NULL guard that jumps to the `finish:` label, which is already used for the "SCRIPT_NAME doesn't match the phar basename" case. The fix matches the intent of the existing `strstr` check and requires no new cleanup.

Fixes #21797