### PR TITLE
phar: propagate phar_stream_flush return value from phar_stream_close

### DIFF
--- a/ext/phar/stream.c
+++ b/ext/phar/stream.c
@@ -357,11 +357,11 @@ phar_stub:
 static int phar_stream_close(php_stream *stream, int close_handle) /* {{{ */
 {
 	/* for some reasons phar needs to be flushed even if there is no write going on */
-	phar_stream_flush(stream);
+	int ret = phar_stream_flush(stream);
 
 	phar_entry_delref((phar_entry_data *)stream->abstract);
 
-	return 0;
+	return ret;
 }
 /* }}} */
 

--- a/ext/phar/tests/gh21799-stream-close-flush.phpt
+++ b/ext/phar/tests/gh21799-stream-close-flush.phpt
@@ -1,0 +1,32 @@
+--TEST--
+GH-21799: phar_stream_close propagates phar_stream_flush return value
+--EXTENSIONS--
+phar
+--INI--
+phar.readonly=0
+phar.require_hash=0
+--FILE--
+<?php
+// Regression baseline: fclose() on a phar file handle succeeds on the
+// normal code path. phar_stream_close now returns the phar_stream_flush
+// result instead of always returning 0.
+$fname = __DIR__ . '/' . basename(__FILE__, '.php') . '.phar';
+
+$phar = new Phar($fname);
+$phar->addFromString('hello.txt', 'hello');
+unset($phar);
+
+$fp = fopen('phar://' . $fname . '/hello.txt', 'rb');
+$content = fread($fp, 1024);
+$result = fclose($fp);
+
+echo $content . "\n";
+var_dump($result);
+echo "no crash\n";
+?>
+--CLEAN--
+<?php @unlink(__DIR__ . '/' . basename(__FILE__, '.clean.php') . '.phar'); ?>
+--EXPECT--
+hello
+bool(true)
+no crash


### PR DESCRIPTION
`phar_stream_close` called `phar_stream_flush` but discarded its `int` return value, always returning `0` from the stream close operation. On a write-modified phar entry, a flush failure (disk full during archive commit, etc.) was silently ignored.

Capture the flush result and return it so the stream layer receives an accurate close status.

Fixes #21799