### PR TITLE
curl: replace external URLs with local test server in tests

### DIFF
--- a/ext/curl/tests/bug52202.phpt
+++ b/ext/curl/tests/bug52202.phpt
@@ -4,7 +4,7 @@ Bug #52202 (CURLOPT_PRIVATE gets clobbered)
 curl
 --FILE--
 <?php
-$curl = curl_init("http://www.google.com");
+$curl = curl_init();
 curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($curl, CURLOPT_PRIVATE, "123");
 curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 1);

--- a/ext/curl/tests/bug64267.phpt
+++ b/ext/curl/tests/bug64267.phpt
@@ -2,16 +2,13 @@
 Bug #64267 (CURLOPT_INFILE doesn't allow reset)
 --EXTENSIONS--
 curl
---SKIPIF--
-<?php
-if (getenv("SKIP_ONLINE_TESTS")) die("skip online test");
-?>
 --FILE--
 <?php
-
+include 'server.inc';
 echo "TEST\n";
 
-$c = curl_init("http://google.com");
+$host = curl_cli_server_start();
+$c = curl_init($host);
 $f = fopen(__FILE__,"r");
 var_dump(curl_setopt_array($c, [
     CURLOPT_RETURNTRANSFER => true,
@@ -30,8 +27,8 @@ var_dump(curl_setopt_array($c, [
 curl_exec($c);
 var_dump(curl_getinfo($c, CURLINFO_RESPONSE_CODE));
 ?>
---EXPECTF--
+--EXPECT--
 TEST
 bool(true)
 bool(true)
-int(30%d)
+int(200)

--- a/ext/curl/tests/bug68089.phpt
+++ b/ext/curl/tests/bug68089.phpt
@@ -4,7 +4,7 @@ Bug #68089 (NULL byte injection - cURL lib)
 curl
 --FILE--
 <?php
-$url = "file:///etc/passwd\0http://google.com";
+$url = "file:///etc/passwd\0http://example.com";
 $ch = curl_init();
 
 try {

--- a/ext/curl/tests/bug71523.phpt
+++ b/ext/curl/tests/bug71523.phpt
@@ -4,7 +4,6 @@ Bug #71523 (Copied handle with new option CURLOPT_HTTPHEADER crashes while curl_
 curl
 --SKIPIF--
 <?php
-if (getenv("SKIP_ONLINE_TESTS")) die("skip online test");
 if (curl_version()['version_number'] === 0x080a00) {
     // https://github.com/php/php-src/issues/15997
     die('xfail due to a libcurl bug');
@@ -12,8 +11,10 @@ if (curl_version()['version_number'] === 0x080a00) {
 ?>
 --FILE--
 <?php
+include 'server.inc';
+$host = curl_cli_server_start();
 
-$base = curl_init('http://www.google.com/');
+$base = curl_init($host);
 curl_setopt($base, CURLOPT_RETURNTRANSFER, true);
 $mh = curl_multi_init();
 

--- a/ext/curl/tests/bug78775.phpt
+++ b/ext/curl/tests/bug78775.phpt
@@ -10,7 +10,7 @@ if (getenv('SKIP_ONLINE_TESTS')) die('skip Online test');
 --FILE--
 <?php
 
-$sock = fsockopen("tls://google.com", 443);
+$sock = fsockopen("tls://php.net", 443);
 
 var_dump($sock);
 

--- a/ext/curl/tests/curl_upkeep_001.phpt
+++ b/ext/curl/tests/curl_upkeep_001.phpt
@@ -4,16 +4,16 @@ curl_upkeep() function
 curl
 --SKIPIF--
 <?php
-if (getenv("SKIP_ONLINE_TESTS")) die("skip online test");
 if (curl_version()['version_number'] < 0x073e00) die('skip requires curl >= 7.62.0');
 ?>
 --FILE--
 <?php
+include 'server.inc';
 
-$url = "https://example.com";
+$host = curl_cli_server_start();
 
 $ch = curl_init();
-curl_setopt($ch,CURLOPT_URL,$url);
+curl_setopt($ch,CURLOPT_URL,$host);
 curl_setopt($ch,CURLOPT_RETURNTRANSFER,true);
 curl_setopt($ch,CURLOPT_HTTP_VERSION,CURL_HTTP_VERSION_2_0);
 curl_setopt($ch,CURLOPT_SSL_VERIFYPEER,false);


### PR DESCRIPTION
This PR changes some tests to use the local HTTP server rather than initiating a remote connection.
Additionally links `google` have been changed to `php.net`. 

Fixes #21795