### PR TITLE
phar: reject extractTo() when destination parent escapes via symlink

### DIFF
--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -4282,6 +4282,34 @@ static zend_result phar_extract_file(bool overwrite, phar_entry_info *entry, cha
 		return SUCCESS;
 	}
 
+	const char *last_sep = zend_memrchr(fullpath + dest_len + 1, '/', len - dest_len - 1);
+	if (last_sep) {
+		char parent_path[MAXPATHLEN];
+		char resolved[MAXPATHLEN];
+		char resolved_dest[MAXPATHLEN];
+		size_t parent_len = last_sep - fullpath;
+		ZEND_ASSERT(parent_len < MAXPATHLEN);
+		if (!VCWD_REALPATH(dest, resolved_dest)) {
+			spprintf(error, 4096, "Cannot extract \"%s\", could not resolve destination directory", entry->filename);
+			efree(fullpath);
+			return FAILURE;
+		}
+		memcpy(parent_path, fullpath, parent_len);
+		parent_path[parent_len] = '\0';
+		if (!VCWD_REALPATH(parent_path, resolved)) {
+			spprintf(error, 4096, "Cannot extract \"%s\", could not resolve parent directory", entry->filename);
+			efree(fullpath);
+			return FAILURE;
+		}
+		size_t resolved_dest_len = strlen(resolved_dest);
+		if (strncmp(resolved, resolved_dest, resolved_dest_len) != 0 ||
+				(!IS_SLASH(resolved[resolved_dest_len]) && resolved[resolved_dest_len] != '\0')) {
+			spprintf(error, 4096, "Cannot extract \"%s\", symlink traversal detected", entry->filename);
+			efree(fullpath);
+			return FAILURE;
+		}
+	}
+
 	fp = php_stream_open_wrapper(fullpath, "w+b", REPORT_ERRORS, NULL);
 
 	if (!fp) {

--- a/ext/phar/tests/gh-ss008-extractto-symlink.phpt
+++ b/ext/phar/tests/gh-ss008-extractto-symlink.phpt
@@ -1,0 +1,59 @@
+--TEST--
+extractTo: symlink traversal via pre-existing symlink in destination directory
+--EXTENSIONS--
+phar
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY === 'Windows') {
+    if (false === include __DIR__ . '/../../standard/tests/file/windows_links/common.inc') {
+        die('skip windows_links/common.inc is not available');
+    }
+    skipIfSeCreateSymbolicLinkPrivilegeIsDisabled(__FILE__);
+}
+?>
+--INI--
+phar.readonly=0
+--FILE--
+<?php
+$pharFile = __DIR__ . '/gh_ss008.phar';
+$dest     = __DIR__ . '/gh_ss008_dest';
+$target   = __DIR__ . '/gh_ss008_target';
+
+@mkdir($dest, 0777, true);
+@mkdir($target, 0777, true);
+
+$p = new Phar($pharFile);
+$p->addFromString('subdir/evil.txt', 'should not arrive');
+unset($p);
+
+symlink($target, $dest . '/subdir');
+
+try {
+    $phar = new Phar($pharFile);
+    $phar->extractTo($dest, null, true);
+    echo "EXTRACTED (unexpected)\n";
+} catch (PharException $e) {
+    echo "Caught PharException: " . $e->getMessage() . "\n";
+}
+
+if (file_exists($target . '/evil.txt')) {
+    echo "FAIL: target was written\n";
+} else {
+    echo "OK: target not written\n";
+}
+?>
+--CLEAN--
+<?php
+$pharFile = __DIR__ . '/gh_ss008.phar';
+$dest     = __DIR__ . '/gh_ss008_dest';
+$target   = __DIR__ . '/gh_ss008_target';
+
+@unlink($dest . '/subdir');
+@unlink($target . '/evil.txt');
+@rmdir($dest);
+@rmdir($target);
+@unlink($pharFile);
+?>
+--EXPECTF--
+Caught PharException: %s
+OK: target not written


### PR DESCRIPTION
Fixes destination-side symlink traversal in `Phar::extractTo()`.

`extractTo()` builds the target path as `dest + "/" + entry_path`. `CWD_EXPAND` validates the entry path against `..` traversal but doesn't resolve symlinks. A pre-existing symlink in the destination (e.g., `/dest/subdir -> /etc`) causes the extracted file to land outside the intended root.

After creating the parent directory, resolve it with `VCWD_REALPATH` and verify it stays under `dest`. Return `FAILURE` if it escapes so the caller throws a `PharException`.

The test skips on Windows only when `SeCreateSymbolicLinkPrivilege` is absent. Without it, `symlink()` returns false without error, so no symlink exists in the destination, `extractTo()` succeeds, and the test outputs `EXTRACTED (unexpected)` instead of the `PharException` that `--EXPECTF--` requires.