### PR TITLE
use `IS_SLASH` in various places instead of string comparing

### DIFF
--- a/ext/mysqlnd/mysqlnd_debug.c
+++ b/ext/mysqlnd/mysqlnd_debug.c
@@ -511,7 +511,7 @@ MYSQLND_METHOD(mysqlnd_debug, set_mode)(MYSQLND_DEBUG * self, const char * const
 				if (i + 1 < mode_len && mode[i+1] == ',') {
 					unsigned int j = i + 2;
 #ifdef PHP_WIN32
-					if (i+4 < mode_len && mode[i+3] == ':' && (mode[i+4] == '\\' || mode[i+4] == '/')) {
+					if (i+4 < mode_len && mode[i+3] == ':' && IS_SLASH(mode[i+4])) {
 						j = i + 5;
 					}
 #endif

--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -1530,7 +1530,7 @@ phar_spl_fileinfo:
 
 			str_key = fname + base_len;
 
-			if (*str_key == '/' || *str_key == '\\') {
+			if (IS_SLASH(*str_key)) {
 				str_key++;
 				str_key_len--;
 			}
@@ -3565,7 +3565,7 @@ static void phar_add_file(phar_archive_data **pphar, zend_string *file_name, con
 	) {
 		size_t prefix_len = (ZSTR_VAL(file_name)[0] == '/') + sizeof(".phar")-1;
 		char next_char = ZSTR_VAL(file_name)[prefix_len];
-		if (next_char == '/' || next_char == '\\' || next_char == '\0') {
+		if (IS_SLASH(next_char) || next_char == '\0') {
 			zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Cannot create any files in magic \".phar\" directory");
 			return;
 		}

--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -3565,7 +3565,7 @@ static void phar_add_file(phar_archive_data **pphar, zend_string *file_name, con
 	) {
 		size_t prefix_len = (ZSTR_VAL(file_name)[0] == '/') + sizeof(".phar")-1;
 		char next_char = ZSTR_VAL(file_name)[prefix_len];
-		if (IS_SLASH(next_char) || next_char == '\0') {
+		if (next_char == '/' || next_char == '\\' || next_char == '\0') {
 			zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Cannot create any files in magic \".phar\" directory");
 			return;
 		}

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -1342,7 +1342,7 @@ PHP_FUNCTION(str_decrement)
 static bool _is_basename_start(const char *start, const char *pos)
 {
 	if (pos - start >= 1
-	    && !IS_SLASH(*(pos-1))) {
+		&& !IS_SLASH(*(pos-1))) {
 		if (pos - start == 1) {
 			return true;
 		} else if (IS_SLASH(*(pos-2))) {

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -1342,11 +1342,10 @@ PHP_FUNCTION(str_decrement)
 static bool _is_basename_start(const char *start, const char *pos)
 {
 	if (pos - start >= 1
-	    && *(pos-1) != '/'
-	    && *(pos-1) != '\\') {
+	    && !IS_SLASH(*(pos-1))) {
 		if (pos - start == 1) {
 			return true;
-		} else if (*(pos-2) == '/' || *(pos-2) == '\\') {
+		} else if (IS_SLASH(*(pos-2))) {
 			return true;
 		} else if (*(pos-2) == ':'
 			&& _is_basename_start(start, pos - 2)) {
@@ -1369,8 +1368,7 @@ PHPAPI zend_string *php_basename(const char *s, size_t len, const char *suffix, 
 		/* Strip trailing slashes */
 		while (basename_end >= s
 #ifdef PHP_WIN32
-			&& (*basename_end == '/'
-				|| *basename_end == '\\'
+			&& (IS_SLASH(*basename_end)
 				|| (*basename_end == ':'
 					&& _is_basename_start(s, basename_end)))) {
 #else
@@ -1387,8 +1385,7 @@ PHPAPI zend_string *php_basename(const char *s, size_t len, const char *suffix, 
 		basename_end++;
 		while (basename_start > s
 #ifdef PHP_WIN32
-			&& *(basename_start-1) != '/'
-			&& *(basename_start-1) != '\\') {
+			&& !IS_SLASH(*(basename_start-1))) {
 
 			if (*(basename_start-1) == ':' &&
 				_is_basename_start(s, basename_start - 1)) {
@@ -1414,7 +1411,7 @@ PHPAPI zend_string *php_basename(const char *s, size_t len, const char *suffix, 
 					goto quit_loop;
 				case 1:
 #ifdef PHP_WIN32
-					if (*s == '/' || *s == '\\') {
+					if (IS_SLASH(*s)) {
 #else
 					if (*s == '/') {
 #endif

--- a/main/php_ini.c
+++ b/main/php_ini.c
@@ -274,7 +274,7 @@ static void php_ini_parser_cb(zval *arg1, zval *arg2, zval *arg3, int callback_t
 
 				if (key && key_len > 0) {
 					/* Strip any trailing slashes */
-					while (key_len > 0 && (key[key_len - 1] == '/' || key[key_len - 1] == '\\')) {
+					while (key_len > 0 && IS_SLASH(key[key_len - 1])) {
 						key_len--;
 						key[key_len] = 0;
 					}

--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -1250,7 +1250,10 @@ static void init_request_info(fcgi_request *request)
 			 */
 			if (script_path_translated &&
 				(script_path_translated_len = strlen(script_path_translated)) > 0 &&
-				(IS_SLASH(script_path_translated[script_path_translated_len-1]) ||
+				(script_path_translated[script_path_translated_len-1] == '/' ||
+#ifdef PHP_WIN32
+				script_path_translated[script_path_translated_len-1] == '\\' ||
+#endif
 				(real_path = tsrm_realpath(script_path_translated, NULL)) == NULL)
 			) {
 				char *pt = estrndup(script_path_translated, script_path_translated_len);

--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -1250,10 +1250,7 @@ static void init_request_info(fcgi_request *request)
 			 */
 			if (script_path_translated &&
 				(script_path_translated_len = strlen(script_path_translated)) > 0 &&
-				(script_path_translated[script_path_translated_len-1] == '/' ||
-#ifdef PHP_WIN32
-				script_path_translated[script_path_translated_len-1] == '\\' ||
-#endif
+				(IS_SLASH(script_path_translated[script_path_translated_len-1]) ||
 				(real_path = tsrm_realpath(script_path_translated, NULL)) == NULL)
 			) {
 				char *pt = estrndup(script_path_translated, script_path_translated_len);


### PR DESCRIPTION
we have a defined `IS_SLASH` function:
```
#define IS_SLASH(c)	((c) == '/' || (c) == '\\')
```
So to make things more legible we can use `IS_SLASH(XXX)` instead of `XXX == '\\' || XXX == '/'`

I search all occasions by this command:
```
rg -n "'/'.*'\\'|'\\'.*'/'|== '/' \|\| .*== '\\'|!= '/' && .*!= '\\'|== '\\' \|\| .*== '/'|!= '\\' && .*!= '/'"
```
and manually remove some improper occasions :)