### PR TITLE
Fix GH-21639: Protect frameless args during __toString() reentry

### DIFF
--- a/Zend/tests/gh21639.phpt
+++ b/Zend/tests/gh21639.phpt
@@ -1,0 +1,98 @@
+--TEST--
+GH-21639: Frameless calls keep volatile CV arguments alive during __toString()
+--FILE--
+<?php
+class ImplodeElement {
+    public function __toString(): string {
+        global $separator, $pieces;
+
+        $separator = null;
+        $pieces = null;
+
+        return "C";
+    }
+}
+
+$separator = str_repeat(",", 1) . " ";
+$pieces = [new ImplodeElement(), 42];
+
+var_dump(implode($separator, $pieces));
+var_dump($separator, $pieces);
+
+class ImplodeElementWithoutSeparator {
+    public function __toString(): string {
+        global $oneArgPieces;
+
+        $oneArgPieces = null;
+
+        return "D";
+    }
+}
+
+$oneArgPieces = [new ImplodeElementWithoutSeparator(), 42];
+
+var_dump(implode($oneArgPieces));
+var_dump($oneArgPieces);
+
+class InArrayNeedle {
+    public function __toString(): string {
+        global $inArrayHaystack;
+
+        $inArrayHaystack = null;
+
+        return "needle";
+    }
+}
+
+$inArrayHaystack = [new InArrayNeedle()];
+
+var_dump(in_array("needle", $inArrayHaystack));
+var_dump($inArrayHaystack);
+
+class StrtrReplacement {
+    public function __toString(): string {
+        global $strtrReplacements;
+
+        $strtrReplacements = null;
+
+        return "b";
+    }
+}
+
+$strtrReplacements = ["a" => new StrtrReplacement()];
+
+var_dump(strtr("a", $strtrReplacements));
+var_dump($strtrReplacements);
+
+class StrReplaceSubject {
+    public function __toString(): string {
+        global $strReplaceSubject;
+
+        $strReplaceSubject = null;
+
+        return "a";
+    }
+}
+
+$strReplaceSubject = [new StrReplaceSubject(), "aa"];
+
+var_dump(str_replace("a", "b", $strReplaceSubject));
+var_dump($strReplaceSubject);
+?>
+--EXPECT--
+string(5) "C, 42"
+NULL
+NULL
+string(3) "D42"
+NULL
+bool(true)
+NULL
+string(1) "b"
+NULL
+array(2) {
+  [0]=>
+  string(1) "b"
+  [1]=>
+  string(2) "bb"
+}
+NULL

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -810,6 +810,7 @@ static void executor_globals_ctor(zend_executor_globals *executor_globals) /* {{
 	ZVAL_UNDEF(&executor_globals->user_exception_handler);
 	executor_globals->in_autoload = NULL;
 	executor_globals->current_execute_data = NULL;
+	executor_globals->frameless_reentry_copies = NULL;
 	executor_globals->current_module = NULL;
 	executor_globals->exit_status = 0;
 #if XPFPA_HAVE_CW

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1673,11 +1673,6 @@ ZEND_API bool zend_frameless_protect_args_for_reentry(void)
 	return true;
 }
 
-ZEND_API void zend_frameless_schedule_reentry_cleanup(void)
-{
-	zend_atomic_bool_store_ex(&EG(vm_interrupt), true);
-}
-
 static bool zend_frameless_reentry_copies_in_use(zend_frameless_reentry_copies *copies)
 {
 	for (zend_execute_data *execute_data = EG(current_execute_data);
@@ -1689,6 +1684,34 @@ static bool zend_frameless_reentry_copies_in_use(zend_frameless_reentry_copies *
 	}
 
 	return false;
+}
+
+static void zend_frameless_free_reentry_copies(zend_frameless_reentry_copies *copies)
+{
+	for (uint32_t i = 0; i < 3; i++) {
+		if (copies->copied_args & (1u << i)) {
+			zval_ptr_dtor(&copies->args[i]);
+		}
+	}
+
+	efree(copies);
+}
+
+ZEND_API void zend_frameless_cleanup_reentry_copies_for_handler(zend_execute_data *execute_data, const zend_op *opline)
+{
+	zend_frameless_reentry_copies **next = &EG(frameless_reentry_copies);
+
+	while (*next) {
+		zend_frameless_reentry_copies *copies = *next;
+
+		if (copies->execute_data != execute_data || copies->opline != opline) {
+			next = &copies->prev;
+			continue;
+		}
+
+		*next = copies->prev;
+		zend_frameless_free_reentry_copies(copies);
+	}
 }
 
 static void zend_frameless_cleanup_reentry_copies_ex(bool force)
@@ -1704,18 +1727,7 @@ static void zend_frameless_cleanup_reentry_copies_ex(bool force)
 		}
 
 		*next = copies->prev;
-
-		for (uint32_t i = 0; i < 3; i++) {
-			if (copies->copied_args & (1u << i)) {
-				zval_ptr_dtor(&copies->args[i]);
-			}
-		}
-
-		efree(copies);
-	}
-
-	if (EG(frameless_reentry_copies)) {
-		zend_atomic_bool_store_ex(&EG(vm_interrupt), true);
+		zend_frameless_free_reentry_copies(copies);
 	}
 }
 

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1582,6 +1582,153 @@ static zend_never_inline void zend_assign_to_object_dim(zend_object *obj, zval *
 	}
 }
 
+struct _zend_frameless_reentry_copies {
+	struct _zend_frameless_reentry_copies *prev;
+	zend_execute_data *execute_data;
+	const zend_op *opline;
+	uint8_t copied_args;
+	zval args[3];
+};
+
+static zend_always_inline bool zend_frameless_arg_needs_reentry_copy(zval *zv)
+{
+	ZVAL_DEREF(zv);
+	return Z_TYPE_P(zv) == IS_ARRAY || Z_TYPE_P(zv) == IS_STRING;
+}
+
+static void zend_frameless_reentry_copy_arg(zend_frameless_reentry_copies *copies, uint32_t arg, zval *zv)
+{
+	if (!zend_frameless_arg_needs_reentry_copy(zv)) {
+		return;
+	}
+
+	ZVAL_COPY_DEREF(&copies->args[arg], zv);
+	copies->copied_args |= (1u << arg);
+}
+
+static bool zend_frameless_reentry_has_copies(zend_execute_data *execute_data, const zend_op *opline)
+{
+	for (zend_frameless_reentry_copies *copies = EG(frameless_reentry_copies);
+			copies;
+			copies = copies->prev) {
+		if (copies->execute_data == execute_data && copies->opline == opline) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+ZEND_API bool zend_frameless_protect_args_for_reentry(void)
+{
+	zend_execute_data *execute_data = EG(current_execute_data);
+	if (!execute_data) {
+		return false;
+	}
+
+	if (!EX(func) || !ZEND_USER_CODE(EX(func)->type)) {
+		return false;
+	}
+
+	const zend_op *opline = EX(opline);
+	if (!opline || !ZEND_OP_IS_FRAMELESS_ICALL(opline->opcode)) {
+		return false;
+	}
+
+	if (zend_frameless_reentry_has_copies(execute_data, opline)) {
+		return true;
+	}
+
+	uint8_t num_args = ZEND_FLF_NUM_ARGS(opline->opcode);
+	if (num_args == 0) {
+		return false;
+	}
+
+	zend_frameless_reentry_copies *copies = emalloc(sizeof(zend_frameless_reentry_copies));
+	copies->execute_data = execute_data;
+	copies->opline = opline;
+	copies->copied_args = 0;
+
+	if (opline->op1_type == IS_CV) {
+		zend_frameless_reentry_copy_arg(copies, 0,
+			zend_get_zval_ptr(opline, opline->op1_type, &opline->op1, execute_data));
+	}
+	if (num_args >= 2 && opline->op2_type == IS_CV) {
+		zend_frameless_reentry_copy_arg(copies, 1,
+			zend_get_zval_ptr(opline, opline->op2_type, &opline->op2, execute_data));
+	}
+	if (num_args >= 3 && (opline + 1)->op1_type == IS_CV) {
+		zend_frameless_reentry_copy_arg(copies, 2,
+			zend_get_zval_ptr(opline + 1, (opline + 1)->op1_type, &(opline + 1)->op1, execute_data));
+	}
+
+	if (copies->copied_args == 0) {
+		efree(copies);
+		return false;
+	}
+
+	copies->prev = EG(frameless_reentry_copies);
+	EG(frameless_reentry_copies) = copies;
+
+	return true;
+}
+
+ZEND_API void zend_frameless_schedule_reentry_cleanup(void)
+{
+	zend_atomic_bool_store_ex(&EG(vm_interrupt), true);
+}
+
+static bool zend_frameless_reentry_copies_in_use(zend_frameless_reentry_copies *copies)
+{
+	for (zend_execute_data *execute_data = EG(current_execute_data);
+			execute_data;
+			execute_data = execute_data->prev_execute_data) {
+		if (execute_data == copies->execute_data && execute_data->opline == copies->opline) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+static void zend_frameless_cleanup_reentry_copies_ex(bool force)
+{
+	zend_frameless_reentry_copies **next = &EG(frameless_reentry_copies);
+
+	while (*next) {
+		zend_frameless_reentry_copies *copies = *next;
+
+		if (!force && zend_frameless_reentry_copies_in_use(copies)) {
+			next = &copies->prev;
+			continue;
+		}
+
+		*next = copies->prev;
+
+		for (uint32_t i = 0; i < 3; i++) {
+			if (copies->copied_args & (1u << i)) {
+				zval_ptr_dtor(&copies->args[i]);
+			}
+		}
+
+		efree(copies);
+	}
+
+	if (EG(frameless_reentry_copies)) {
+		zend_atomic_bool_store_ex(&EG(vm_interrupt), true);
+	}
+}
+
+ZEND_API void zend_frameless_cleanup_reentry_copies(void)
+{
+	zend_frameless_cleanup_reentry_copies_ex(false);
+}
+
+ZEND_API void zend_frameless_cleanup_reentry_copies_force(void)
+{
+	zend_frameless_cleanup_reentry_copies_ex(true);
+}
+
 static void frameless_observed_call_copy(zend_execute_data *call, uint32_t arg, zval *zv)
 {
 	if (Z_ISUNDEF_P(zv)) {
@@ -4081,6 +4228,7 @@ ZEND_API void ZEND_FASTCALL zend_free_compiled_variables(zend_execute_data *exec
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_fcall_interrupt(zend_execute_data *call)
 {
 	zend_atomic_bool_store_ex(&EG(vm_interrupt), false);
+	zend_frameless_cleanup_reentry_copies();
 	if (zend_atomic_bool_load_ex(&EG(timed_out))) {
 		zend_timeout();
 	} else if (zend_interrupt_function) {

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1673,19 +1673,6 @@ ZEND_API bool zend_frameless_protect_args_for_reentry(void)
 	return true;
 }
 
-static bool zend_frameless_reentry_copies_in_use(zend_frameless_reentry_copies *copies)
-{
-	for (zend_execute_data *execute_data = EG(current_execute_data);
-			execute_data;
-			execute_data = execute_data->prev_execute_data) {
-		if (execute_data == copies->execute_data && execute_data->opline == copies->opline) {
-			return true;
-		}
-	}
-
-	return false;
-}
-
 static void zend_frameless_free_reentry_copies(zend_frameless_reentry_copies *copies)
 {
 	for (uint32_t i = 0; i < 3; i++) {
@@ -1714,31 +1701,16 @@ ZEND_API void zend_frameless_cleanup_reentry_copies_for_handler(zend_execute_dat
 	}
 }
 
-static void zend_frameless_cleanup_reentry_copies_ex(bool force)
+ZEND_API void zend_frameless_cleanup_reentry_copies_force(void)
 {
 	zend_frameless_reentry_copies **next = &EG(frameless_reentry_copies);
 
 	while (*next) {
 		zend_frameless_reentry_copies *copies = *next;
 
-		if (!force && zend_frameless_reentry_copies_in_use(copies)) {
-			next = &copies->prev;
-			continue;
-		}
-
 		*next = copies->prev;
 		zend_frameless_free_reentry_copies(copies);
 	}
-}
-
-ZEND_API void zend_frameless_cleanup_reentry_copies(void)
-{
-	zend_frameless_cleanup_reentry_copies_ex(false);
-}
-
-ZEND_API void zend_frameless_cleanup_reentry_copies_force(void)
-{
-	zend_frameless_cleanup_reentry_copies_ex(true);
 }
 
 static void frameless_observed_call_copy(zend_execute_data *call, uint32_t arg, zval *zv)
@@ -4240,7 +4212,6 @@ ZEND_API void ZEND_FASTCALL zend_free_compiled_variables(zend_execute_data *exec
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_fcall_interrupt(zend_execute_data *call)
 {
 	zend_atomic_bool_store_ex(&EG(vm_interrupt), false);
-	zend_frameless_cleanup_reentry_copies();
 	if (zend_atomic_bool_load_ex(&EG(timed_out))) {
 		zend_timeout();
 	} else if (zend_interrupt_function) {

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -428,6 +428,10 @@ ZEND_API zend_result zend_set_user_opcode_handler(uint8_t opcode, user_opcode_ha
 ZEND_API user_opcode_handler_t zend_get_user_opcode_handler(uint8_t opcode);
 
 ZEND_API zval *zend_get_zval_ptr(const zend_op *opline, int op_type, const znode_op *node, const zend_execute_data *execute_data);
+ZEND_API bool zend_frameless_protect_args_for_reentry(void);
+ZEND_API void zend_frameless_schedule_reentry_cleanup(void);
+ZEND_API void zend_frameless_cleanup_reentry_copies(void);
+ZEND_API void zend_frameless_cleanup_reentry_copies_force(void);
 
 ZEND_API void zend_clean_and_cache_symbol_table(zend_array *symbol_table);
 ZEND_API void ZEND_FASTCALL zend_free_compiled_variables(zend_execute_data *execute_data);

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -429,7 +429,7 @@ ZEND_API user_opcode_handler_t zend_get_user_opcode_handler(uint8_t opcode);
 
 ZEND_API zval *zend_get_zval_ptr(const zend_op *opline, int op_type, const znode_op *node, const zend_execute_data *execute_data);
 ZEND_API bool zend_frameless_protect_args_for_reentry(void);
-ZEND_API void zend_frameless_schedule_reentry_cleanup(void);
+ZEND_API void zend_frameless_cleanup_reentry_copies_for_handler(zend_execute_data *execute_data, const zend_op *opline);
 ZEND_API void zend_frameless_cleanup_reentry_copies(void);
 ZEND_API void zend_frameless_cleanup_reentry_copies_force(void);
 

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -430,7 +430,6 @@ ZEND_API user_opcode_handler_t zend_get_user_opcode_handler(uint8_t opcode);
 ZEND_API zval *zend_get_zval_ptr(const zend_op *opline, int op_type, const znode_op *node, const zend_execute_data *execute_data);
 ZEND_API bool zend_frameless_protect_args_for_reentry(void);
 ZEND_API void zend_frameless_cleanup_reentry_copies_for_handler(zend_execute_data *execute_data, const zend_op *opline);
-ZEND_API void zend_frameless_cleanup_reentry_copies(void);
 ZEND_API void zend_frameless_cleanup_reentry_copies_force(void);
 
 ZEND_API void zend_clean_and_cache_symbol_table(zend_array *symbol_table);

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -176,6 +176,7 @@ void init_executor(void) /* {{{ */
 	EG(full_tables_cleanup) = 0;
 	ZEND_ATOMIC_BOOL_INIT(&EG(vm_interrupt), false);
 	ZEND_ATOMIC_BOOL_INIT(&EG(timed_out), false);
+	EG(frameless_reentry_copies) = NULL;
 
 	EG(exception) = NULL;
 	EG(prev_exception) = NULL;
@@ -274,6 +275,8 @@ ZEND_API void zend_shutdown_executor_values(bool fast_shutdown)
 {
 	zend_string *key;
 	zval *zv;
+
+	zend_frameless_cleanup_reentry_copies_force();
 
 	EG(flags) |= EG_FLAGS_IN_RESOURCE_SHUTDOWN;
 	zend_close_rsrc_list(&EG(regular_list));
@@ -1039,6 +1042,7 @@ cleanup_args:
 		/* This flag is regularly checked while running user functions, but not internal
 		 * So see whether interrupt flag was set while the function was running... */
 		if (zend_atomic_bool_exchange_ex(&EG(vm_interrupt), false)) {
+			zend_frameless_cleanup_reentry_copies();
 			if (zend_atomic_bool_load_ex(&EG(timed_out))) {
 				zend_timeout();
 			} else if (zend_interrupt_function) {

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1042,7 +1042,6 @@ cleanup_args:
 		/* This flag is regularly checked while running user functions, but not internal
 		 * So see whether interrupt flag was set while the function was running... */
 		if (zend_atomic_bool_exchange_ex(&EG(vm_interrupt), false)) {
-			zend_frameless_cleanup_reentry_copies();
 			if (zend_atomic_bool_load_ex(&EG(timed_out))) {
 				zend_timeout();
 			} else if (zend_interrupt_function) {

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -74,6 +74,7 @@ typedef struct _zend_vm_stack *zend_vm_stack;
 typedef struct _zend_ini_entry zend_ini_entry;
 typedef struct _zend_fiber_context zend_fiber_context;
 typedef struct _zend_fiber zend_fiber;
+typedef struct _zend_frameless_reentry_copies zend_frameless_reentry_copies;
 
 typedef enum {
 	ZEND_MEMOIZE_NONE,
@@ -215,6 +216,7 @@ struct _zend_executor_globals {
 
 	zend_atomic_bool vm_interrupt;
 	zend_atomic_bool timed_out;
+	zend_frameless_reentry_copies *frameless_reentry_copies;
 
 	HashTable *in_autoload;
 

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -2558,13 +2558,10 @@ ZEND_API zend_result zend_std_cast_object_tostring(zend_object *readobj, zval *w
 			zend_class_entry *ce = readobj->ce;
 			if (ce->__tostring) {
 				zval retval;
-				bool frameless_reentry = zend_frameless_protect_args_for_reentry();
+				zend_frameless_protect_args_for_reentry();
 				GC_ADDREF(readobj);
 				zend_call_known_instance_method_with_0_params(ce->__tostring, readobj, &retval);
 				zend_object_release(readobj);
-				if (frameless_reentry) {
-					zend_frameless_schedule_reentry_cleanup();
-				}
 				if (EXPECTED(Z_TYPE(retval) == IS_STRING)) {
 					ZVAL_COPY_VALUE(writeobj, &retval);
 					return SUCCESS;

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -2558,9 +2558,13 @@ ZEND_API zend_result zend_std_cast_object_tostring(zend_object *readobj, zval *w
 			zend_class_entry *ce = readobj->ce;
 			if (ce->__tostring) {
 				zval retval;
+				bool frameless_reentry = zend_frameless_protect_args_for_reentry();
 				GC_ADDREF(readobj);
 				zend_call_known_instance_method_with_0_params(ce->__tostring, readobj, &retval);
 				zend_object_release(readobj);
+				if (frameless_reentry) {
+					zend_frameless_schedule_reentry_cleanup();
+				}
 				if (EXPECTED(Z_TYPE(retval) == IS_STRING)) {
 					ZVAL_COPY_VALUE(writeobj, &retval);
 					return SUCCESS;

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -9690,6 +9690,9 @@ ZEND_VM_HANDLER(204, ZEND_FRAMELESS_ICALL_0, UNUSED, UNUSED, SPEC(OBSERVER))
 		zend_frameless_function_0 function = (zend_frameless_function_0)ZEND_FLF_HANDLER(opline);
 		function(EX_VAR(opline->result.var));
 	}
+	if (UNEXPECTED(EG(frameless_reentry_copies))) {
+		zend_frameless_cleanup_reentry_copies_for_handler(execute_data, opline);
+	}
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -9714,6 +9717,9 @@ ZEND_VM_HANDLER(205, ZEND_FRAMELESS_ICALL_1, ANY, UNUSED, SPEC(OBSERVER))
 	{
 		zend_frameless_function_1 function = (zend_frameless_function_1)ZEND_FLF_HANDLER(opline);
 		function(result, arg1);
+	}
+	if (UNEXPECTED(EG(frameless_reentry_copies))) {
+		zend_frameless_cleanup_reentry_copies_for_handler(execute_data, opline);
 	}
 	FREE_OP1();
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -9742,6 +9748,9 @@ ZEND_VM_HANDLER(206, ZEND_FRAMELESS_ICALL_2, ANY, ANY, SPEC(OBSERVER))
 	{
 		zend_frameless_function_2 function = (zend_frameless_function_2)ZEND_FLF_HANDLER(opline);
 		function(result, arg1, arg2);
+	}
+	if (UNEXPECTED(EG(frameless_reentry_copies))) {
+		zend_frameless_cleanup_reentry_copies_for_handler(execute_data, opline);
 	}
 
 	FREE_OP1();
@@ -9778,6 +9787,9 @@ ZEND_VM_HANDLER(207, ZEND_FRAMELESS_ICALL_3, ANY, ANY, SPEC(OBSERVER))
 	{
 		zend_frameless_function_3 function = (zend_frameless_function_3)ZEND_FLF_HANDLER(opline);
 		function(result, arg1, arg2, arg3);
+	}
+	if (UNEXPECTED(EG(frameless_reentry_copies))) {
+		zend_frameless_cleanup_reentry_copies_for_handler(execute_data, opline);
 	}
 
 	FREE_OP1();

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -10410,6 +10410,7 @@ ZEND_VM_DEFINE_OP(137, ZEND_OP_DATA);
 ZEND_VM_HELPER(zend_interrupt_helper, ANY, ANY)
 {
 	zend_atomic_bool_store_ex(&EG(vm_interrupt), false);
+	zend_frameless_cleanup_reentry_copies();
 	SAVE_OPLINE();
 	if (zend_atomic_bool_load_ex(&EG(timed_out))) {
 		zend_timeout();

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -10410,8 +10410,8 @@ ZEND_VM_DEFINE_OP(137, ZEND_OP_DATA);
 ZEND_VM_HELPER(zend_interrupt_helper, ANY, ANY)
 {
 	zend_atomic_bool_store_ex(&EG(vm_interrupt), false);
-	zend_frameless_cleanup_reentry_copies();
 	SAVE_OPLINE();
+	zend_frameless_cleanup_reentry_copies();
 	if (zend_atomic_bool_load_ex(&EG(timed_out))) {
 		zend_timeout();
 	} else if (zend_interrupt_function) {

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -10423,7 +10423,6 @@ ZEND_VM_HELPER(zend_interrupt_helper, ANY, ANY)
 {
 	zend_atomic_bool_store_ex(&EG(vm_interrupt), false);
 	SAVE_OPLINE();
-	zend_frameless_cleanup_reentry_copies();
 	if (zend_atomic_bool_load_ex(&EG(timed_out))) {
 		zend_timeout();
 	} else if (zend_interrupt_function) {

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -3738,6 +3738,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FRAMELESS_ICALL_2_SPEC_HANDLER
 		zend_frameless_function_2 function = (zend_frameless_function_2)ZEND_FLF_HANDLER(opline);
 		function(result, arg1, arg2);
 	}
+	if (UNEXPECTED(EG(frameless_reentry_copies))) {
+		zend_frameless_cleanup_reentry_copies_for_handler(execute_data, opline);
+	}
 
 	FREE_OP(opline->op1_type, opline->op1.var);
 	/* Set OP1 to UNDEF in case FREE_OP(opline->op2_type, opline->op2.var) throws. */
@@ -3771,6 +3774,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FRAMELESS_ICALL_2_SPEC_OBSERVE
 	{
 		zend_frameless_function_2 function = (zend_frameless_function_2)ZEND_FLF_HANDLER(opline);
 		function(result, arg1, arg2);
+	}
+	if (UNEXPECTED(EG(frameless_reentry_copies))) {
+		zend_frameless_cleanup_reentry_copies_for_handler(execute_data, opline);
 	}
 
 	FREE_OP(opline->op1_type, opline->op1.var);
@@ -3807,6 +3813,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FRAMELESS_ICALL_3_SPEC_HANDLER
 	{
 		zend_frameless_function_3 function = (zend_frameless_function_3)ZEND_FLF_HANDLER(opline);
 		function(result, arg1, arg2, arg3);
+	}
+	if (UNEXPECTED(EG(frameless_reentry_copies))) {
+		zend_frameless_cleanup_reentry_copies_for_handler(execute_data, opline);
 	}
 
 	FREE_OP(opline->op1_type, opline->op1.var);
@@ -3847,6 +3856,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FRAMELESS_ICALL_3_SPEC_OBSERVE
 	{
 		zend_frameless_function_3 function = (zend_frameless_function_3)ZEND_FLF_HANDLER(opline);
 		function(result, arg1, arg2, arg3);
+	}
+	if (UNEXPECTED(EG(frameless_reentry_copies))) {
+		zend_frameless_cleanup_reentry_copies_for_handler(execute_data, opline);
 	}
 
 	FREE_OP(opline->op1_type, opline->op1.var);
@@ -4274,6 +4286,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FRAMELESS_ICALL_1_SPEC_UNUSED_
 		zend_frameless_function_1 function = (zend_frameless_function_1)ZEND_FLF_HANDLER(opline);
 		function(result, arg1);
 	}
+	if (UNEXPECTED(EG(frameless_reentry_copies))) {
+		zend_frameless_cleanup_reentry_copies_for_handler(execute_data, opline);
+	}
 	FREE_OP(opline->op1_type, opline->op1.var);
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -4299,6 +4314,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FRAMELESS_ICALL_1_SPEC_OBSERVE
 	{
 		zend_frameless_function_1 function = (zend_frameless_function_1)ZEND_FLF_HANDLER(opline);
 		function(result, arg1);
+	}
+	if (UNEXPECTED(EG(frameless_reentry_copies))) {
+		zend_frameless_cleanup_reentry_copies_for_handler(execute_data, opline);
 	}
 	FREE_OP(opline->op1_type, opline->op1.var);
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -38384,6 +38402,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FRAMELESS_ICALL_0_SPEC_UNUSED_
 		zend_frameless_function_0 function = (zend_frameless_function_0)ZEND_FLF_HANDLER(opline);
 		function(EX_VAR(opline->result.var));
 	}
+	if (UNEXPECTED(EG(frameless_reentry_copies))) {
+		zend_frameless_cleanup_reentry_copies_for_handler(execute_data, opline);
+	}
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -38403,6 +38424,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FRAMELESS_ICALL_0_SPEC_OBSERVE
 	{
 		zend_frameless_function_0 function = (zend_frameless_function_0)ZEND_FLF_HANDLER(opline);
 		function(EX_VAR(opline->result.var));
+	}
+	if (UNEXPECTED(EG(frameless_reentry_copies))) {
+		zend_frameless_cleanup_reentry_copies_for_handler(execute_data, opline);
 	}
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -3873,8 +3873,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_JMP_FORWARD_SPEC_H
 static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_interrupt_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS)
 {
 	zend_atomic_bool_store_ex(&EG(vm_interrupt), false);
-	zend_frameless_cleanup_reentry_copies();
 	SAVE_OPLINE();
+	zend_frameless_cleanup_reentry_copies();
 	if (zend_atomic_bool_load_ex(&EG(timed_out))) {
 		zend_timeout();
 	} else if (zend_interrupt_function) {

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -3873,6 +3873,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_JMP_FORWARD_SPEC_H
 static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_interrupt_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS)
 {
 	zend_atomic_bool_store_ex(&EG(vm_interrupt), false);
+	zend_frameless_cleanup_reentry_copies();
 	SAVE_OPLINE();
 	if (zend_atomic_bool_load_ex(&EG(timed_out))) {
 		zend_timeout();

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -3886,7 +3886,6 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_interrupt_he
 {
 	zend_atomic_bool_store_ex(&EG(vm_interrupt), false);
 	SAVE_OPLINE();
-	zend_frameless_cleanup_reentry_copies();
 	if (zend_atomic_bool_load_ex(&EG(timed_out))) {
 		zend_timeout();
 	} else if (zend_interrupt_function) {

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -17513,6 +17513,15 @@ static ir_ref jit_frameless_observer(zend_jit_ctx *jit, const zend_op *opline) {
 	return skip;
 }
 
+static void jit_frameless_cleanup_reentry_copies(zend_jit_ctx *jit, const zend_op *opline)
+{
+	ir_ref if_copies = ir_IF(ir_LOAD_A(jit_EG(frameless_reentry_copies)));
+	ir_IF_TRUE_cold(if_copies);
+	ir_CALL_2(IR_VOID, ir_CONST_ADDR((size_t)zend_frameless_cleanup_reentry_copies_for_handler),
+		jit_FP(jit), ir_CONST_ADDR((size_t)opline));
+	ir_MERGE_WITH_EMPTY_FALSE(if_copies);
+}
+
 static void jit_frameless_icall0(zend_jit_ctx *jit, const zend_op *opline)
 {
 	jit_SET_EX_OPLINE(jit, opline);
@@ -17533,6 +17542,7 @@ static void jit_frameless_icall0(zend_jit_ctx *jit, const zend_op *opline)
 		ir_MERGE_WITH(skip_observer);
 	}
 
+	jit_frameless_cleanup_reentry_copies(jit, opline);
 	zend_jit_check_exception(jit);
 }
 
@@ -17572,6 +17582,7 @@ static void jit_frameless_icall1(zend_jit_ctx *jit, const zend_op *opline, uint3
 		ir_MERGE_WITH(skip_observer);
 	}
 
+	jit_frameless_cleanup_reentry_copies(jit, opline);
 	jit_FREE_OP(jit, opline->op1_type, opline->op1, op1_info, NULL);
 	zend_jit_check_exception(jit);
 }
@@ -17626,6 +17637,7 @@ static void jit_frameless_icall2(zend_jit_ctx *jit, const zend_op *opline, uint3
 		ir_MERGE_WITH(skip_observer);
 	}
 
+	jit_frameless_cleanup_reentry_copies(jit, opline);
 	jit_FREE_OP(jit, opline->op1_type, opline->op1, op1_info, NULL);
 	/* Set OP1 to UNDEF in case FREE_OP2() throws. */
 	if ((opline->op1_type & (IS_VAR|IS_TMP_VAR)) != 0
@@ -17707,6 +17719,7 @@ static void jit_frameless_icall3(zend_jit_ctx *jit, const zend_op *opline, uint3
 		ir_MERGE_WITH(skip_observer);
 	}
 
+	jit_frameless_cleanup_reentry_copies(jit, opline);
 	jit_FREE_OP(jit, opline->op1_type, opline->op1, op1_info, NULL);
 	/* Set OP1 to UNDEF in case FREE_OP2() throws. */
 	bool op1_undef = false;

--- a/ext/pcre/tests/gh21639.phpt
+++ b/ext/pcre/tests/gh21639.phpt
@@ -1,0 +1,29 @@
+--TEST--
+GH-21639: Frameless preg_replace keeps volatile CV arguments alive during __toString()
+--EXTENSIONS--
+pcre
+--FILE--
+<?php
+class PregReplaceSubject {
+    public function __toString(): string {
+        global $pregReplaceSubject;
+
+        $pregReplaceSubject = null;
+
+        return "a";
+    }
+}
+
+$pregReplaceSubject = [new PregReplaceSubject(), "aa"];
+
+var_dump(preg_replace("/a/", "b", $pregReplaceSubject));
+var_dump($pregReplaceSubject);
+?>
+--EXPECT--
+array(2) {
+  [0]=>
+  string(1) "b"
+  [1]=>
+  string(2) "bb"
+}
+NULL


### PR DESCRIPTION
Fixes GH-21639.

Frameless internal calls borrow CV operands from the caller frame. If an argument is converted through `__toString()`, that call can re-enter userland and change those CVs while the frameless handler is still using them.

This keeps copies only when `__toString()` is entered from an active frameless opcode, and releases them at the frameless handler cleanup point. The JIT frameless path uses the same cleanup point.

Normal frameless calls only keep the cold pending-copy check after the handler.

Tests run:

```
env PATH=/opt/homebrew/opt/bison/bin:$PATH make -j8
git diff --check
sapi/cli/php run-tests.php -q Zend/tests/gh21639.phpt ext/pcre/tests/gh21639.phpt ext/standard/tests/strings/bug22224.phpt ext/standard/tests/strings/implode_variation.phpt ext/standard/tests/array/in_array_variation1.phpt ext/standard/tests/strings/strtr_basic.phpt ext/standard/tests/strings/str_replace_basic.phpt ext/pcre/tests/preg_replace.phpt
sapi/cli/php -d zend_extension=$PWD/modules/opcache.so -d opcache.enable_cli=1 -d opcache.jit=tracing -d opcache.protect_memory=1 -d opcache.jit_buffer_size=64M run-tests.php -q Zend/tests/gh21639.phpt ext/pcre/tests/gh21639.phpt Zend/tests/frameless_undefined_var.phpt
```
