### PR TITLE
ext/phar: always free `phar_archive_data->alias` field if present

### DIFF
--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -192,7 +192,7 @@ PHP_INI_END()
  */
 void phar_destroy_phar_data(phar_archive_data *phar) /* {{{ */
 {
-	if (phar->alias && phar->alias != phar->fname) {
+	if (phar->alias) {
 		pefree(phar->alias, phar->is_persistent);
 		phar->alias = NULL;
 	}

--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -2631,7 +2631,7 @@ PHP_METHOD(Phar, getAlias)
 
 	PHAR_ARCHIVE_OBJECT();
 
-	if (phar_obj->archive->alias && phar_obj->archive->alias != phar_obj->archive->fname) {
+	if (phar_obj->archive->alias) {
 		RETURN_STRINGL(phar_obj->archive->alias, phar_obj->archive->alias_len);
 	}
 }


### PR DESCRIPTION
This field is only ever assigned a newly allocated `char*` or `NULL`, as such it can never be equal to the `phar_archive_data->fname` field