### PR TITLE
ext/phar: refactor _phar_archive_data.fname field to be a zend_string*

### DIFF
--- a/ext/phar/dirstream.c
+++ b/ext/phar/dirstream.c
@@ -447,7 +447,7 @@ int phar_wrapper_mkdir(php_stream_wrapper *wrapper, const char *url_from, int mo
 
 	void *had_been_added = zend_hash_add_mem(&phar->manifest, entry.filename, &entry, sizeof(phar_entry_info));
 	if (!had_been_added) {
-		php_stream_wrapper_log_error(wrapper, options, "phar error: cannot create directory \"%s\" in phar \"%s\", adding to manifest failed", ZSTR_VAL(entry.filename), phar->fname);
+		php_stream_wrapper_log_error(wrapper, options, "phar error: cannot create directory \"%s\" in phar \"%s\", adding to manifest failed", ZSTR_VAL(entry.filename), ZSTR_VAL(phar->fname));
 		zend_string_efree(entry.filename);
 		return 0;
 	}
@@ -455,7 +455,7 @@ int phar_wrapper_mkdir(php_stream_wrapper *wrapper, const char *url_from, int mo
 	phar_flush(phar, &error);
 
 	if (error) {
-		php_stream_wrapper_log_error(wrapper, options, "phar error: cannot create directory \"%s\" in phar \"%s\", %s", ZSTR_VAL(entry.filename), phar->fname, error);
+		php_stream_wrapper_log_error(wrapper, options, "phar error: cannot create directory \"%s\" in phar \"%s\", %s", ZSTR_VAL(entry.filename), ZSTR_VAL(phar->fname), error);
 		zend_hash_del(&phar->manifest, entry.filename);
 		efree(error);
 		return 0;
@@ -576,7 +576,7 @@ int phar_wrapper_rmdir(php_stream_wrapper *wrapper, const char *url, int options
 		phar_flush(phar, &error);
 
 		if (error) {
-			php_stream_wrapper_log_error(wrapper, options, "phar error: cannot remove directory \"%s\" in phar \"%s\", %s", ZSTR_VAL(entry->filename), phar->fname, error);
+			php_stream_wrapper_log_error(wrapper, options, "phar error: cannot remove directory \"%s\" in phar \"%s\", %s", ZSTR_VAL(entry->filename), ZSTR_VAL(phar->fname), error);
 			php_url_free(resource);
 			efree(error);
 			return 0;

--- a/ext/phar/func_interceptors.c
+++ b/ext/phar/func_interceptors.c
@@ -483,7 +483,7 @@ static void phar_file_stat(const char *filename, size_t filename_length, int typ
 			goto skip_phar;
 		}
 
-		if (PHAR_G(last_phar) && ZSTR_LEN(fname) - 7 >= PHAR_G(last_phar_name_len) && !memcmp(ZSTR_VAL(fname) + 7, PHAR_G(last_phar_name), PHAR_G(last_phar_name_len))) {
+		if (PHAR_G(last_phar) && ZSTR_LEN(fname) - 7 >= ZSTR_LEN(PHAR_G(last_phar_name)) && !memcmp(ZSTR_VAL(fname) + 7, ZSTR_VAL(PHAR_G(last_phar_name)), ZSTR_LEN(PHAR_G(last_phar_name)))) {
 			/* fopen within phar, if :// is not in the url, then prepend phar://<archive>/ */
 			phar = PHAR_G(last_phar);
 			goto splitted;

--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -198,7 +198,7 @@ void phar_destroy_phar_data(phar_archive_data *phar) /* {{{ */
 	}
 
 	if (phar->fname) {
-		pefree(phar->fname, phar->is_persistent);
+		zend_string_release_ex(phar->fname, phar->is_persistent);
 		phar->fname = NULL;
 	}
 
@@ -249,7 +249,7 @@ bool phar_archive_delref(phar_archive_data *phar) /* {{{ */
 
 	if (--phar->refcount < 0) {
 		if (PHAR_G(request_done)
-		|| zend_hash_str_del(&(PHAR_G(phar_fname_map)), phar->fname, phar->fname_len) != SUCCESS) {
+		|| zend_hash_del(&(PHAR_G(phar_fname_map)), phar->fname) != SUCCESS) {
 			phar_destroy_phar_data(phar);
 		}
 		return true;
@@ -279,7 +279,7 @@ bool phar_archive_delref(phar_archive_data *phar) /* {{{ */
 		}
 
 		if (remove_fname_cache) {
-			if (zend_hash_str_del(&(PHAR_G(phar_fname_map)), phar->fname, phar->fname_len) != SUCCESS) {
+			if (zend_hash_del(&(PHAR_G(phar_fname_map)), phar->fname) != SUCCESS) {
 				phar_destroy_phar_data(phar);
 			}
 			return true;
@@ -505,8 +505,7 @@ static zend_result phar_open_parsed_phar(char *fname, size_t fname_len, char *al
 	}
 #endif
 	if (SUCCESS == phar_get_archive(&phar, fname, fname_len, alias, alias_len, error)
-		&& ((alias && fname_len == phar->fname_len
-		&& !strncmp(fname, phar->fname, fname_len)) || !alias)
+		&& ((alias && zend_string_equals_cstr(phar->fname, fname, fname_len)) || !alias)
 	) {
 #ifdef PHP_WIN32
 		if (fname != save_fname) {
@@ -1111,11 +1110,13 @@ static zend_result phar_parse_pharfile(php_stream *fp, char *fname, size_t fname
 		zend_get_hash_value, NULL, mydata->is_persistent);
 	zend_hash_init(&mydata->virtual_dirs, manifest_count * 2,
 		zend_get_hash_value, NULL, mydata->is_persistent);
-	mydata->fname = pestrndup(fname, fname_len, mydata->is_persistent);
+	mydata->fname = zend_string_init(fname, fname_len, mydata->is_persistent);
+	if (mydata->is_persistent) {
+		GC_MAKE_PERSISTENT_LOCAL(mydata->fname);
+	}
 #ifdef PHP_WIN32
-	phar_unixify_path_separators(mydata->fname, fname_len);
+	phar_unixify_path_separators(ZSTR_VAL(mydata->fname), ZSTR_LEN(mydata->fname));
 #endif
-	mydata->fname_len = fname_len;
 	offset = halt_offset + manifest_len + 4;
 	memset(&entry, 0, sizeof(phar_entry_info));
 	entry.phar = mydata;
@@ -1230,22 +1231,22 @@ static zend_result phar_parse_pharfile(php_stream *fp, char *fname, size_t fname
 	snprintf(mydata->version, sizeof(mydata->version), "%u.%u.%u", manifest_ver >> 12, (manifest_ver >> 8) & 0xF, (manifest_ver >> 4) & 0xF);
 	mydata->halt_offset = halt_offset;
 	mydata->flags = manifest_flags;
-	endbuffer = strrchr(mydata->fname, '/');
+	endbuffer = strrchr(ZSTR_VAL(mydata->fname), '/');
 
 	if (endbuffer) {
-		mydata->ext = memchr(endbuffer, '.', (mydata->fname + fname_len) - endbuffer);
+		mydata->ext = memchr(endbuffer, '.', (ZSTR_VAL(mydata->fname) + ZSTR_LEN(mydata->fname)) - endbuffer);
 		if (mydata->ext == endbuffer) {
-			mydata->ext = memchr(endbuffer + 1, '.', (mydata->fname + fname_len) - endbuffer - 1);
+			mydata->ext = memchr(endbuffer + 1, '.', (ZSTR_VAL(mydata->fname) + ZSTR_LEN(mydata->fname)) - endbuffer - 1);
 		}
 		if (mydata->ext) {
-			mydata->ext_len = (mydata->fname + mydata->fname_len) - mydata->ext;
+			mydata->ext_len = (ZSTR_VAL(mydata->fname) + ZSTR_LEN(mydata->fname)) - mydata->ext;
 		}
 	}
 
 	mydata->alias = alias ?
 		pestrndup(alias, alias_len, mydata->is_persistent) :
-		pestrndup(mydata->fname, fname_len, mydata->is_persistent);
-	mydata->alias_len = alias ? alias_len : fname_len;
+		pestrndup(ZSTR_VAL(mydata->fname), ZSTR_LEN(mydata->fname), mydata->is_persistent);
+	mydata->alias_len = alias ? alias_len : ZSTR_LEN(mydata->fname);
 	mydata->sig_flags = sig_flags;
 	mydata->fp = fp;
 	mydata->sig_len = sig_len;
@@ -1284,12 +1285,12 @@ static zend_result phar_parse_pharfile(php_stream *fp, char *fname, size_t fname
 	}
 
 	if (mydata->is_persistent) {
-		str = zend_string_init_interned(mydata->fname, fname_len, 1);
+		str = zend_string_init_interned(ZSTR_VAL(mydata->fname), ZSTR_LEN(mydata->fname), true);
+		zend_hash_add_ptr(&(PHAR_G(phar_fname_map)), str, mydata);
+		zend_string_release(str);
 	} else {
-		str = zend_string_init(mydata->fname, fname_len, 0);
+		zend_hash_add_ptr(&(PHAR_G(phar_fname_map)), mydata->fname, mydata);
 	}
-	zend_hash_add_ptr(&(PHAR_G(phar_fname_map)), str, mydata);
-	zend_string_release(str);
 	efree(savebuf);
 
 	if (pphar) {
@@ -1418,24 +1419,25 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 7, 8) zend_result phar_create_or_parse_filename(c
 
 	/* set up our manifest */
 	phar_archive_data *mydata = ecalloc(1, sizeof(phar_archive_data));
-	mydata->fname = expand_filepath(fname, NULL);
-	if (mydata->fname == NULL) {
+	/* TODO: prevent reallocation via a new expand_filepath() API? */
+	char *new_fname = expand_filepath(fname, NULL);
+	if (new_fname == NULL) {
 		efree(mydata);
 		return FAILURE;
 	}
-	fname_len = strlen(mydata->fname);
+	size_t new_fname_len = strlen(new_fname);
 #ifdef PHP_WIN32
-	phar_unixify_path_separators(mydata->fname, fname_len);
+	phar_unixify_path_separators(new_fname, new_fname_len);
 #endif
-	p = strrchr(mydata->fname, '/');
+	p = strrchr(new_fname, '/');
 
 	if (p) {
-		mydata->ext = memchr(p, '.', (mydata->fname + fname_len) - p);
+		mydata->ext = memchr(p, '.', (new_fname + new_fname_len) - p);
 		if (mydata->ext == p) {
-			mydata->ext = memchr(p + 1, '.', (mydata->fname + fname_len) - p - 1);
+			mydata->ext = memchr(p + 1, '.', (new_fname + new_fname_len) - p - 1);
 		}
 		if (mydata->ext) {
-			mydata->ext_len = (mydata->fname + fname_len) - mydata->ext;
+			mydata->ext_len = (new_fname + new_fname_len) - mydata->ext;
 		}
 	}
 
@@ -1445,14 +1447,15 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 7, 8) zend_result phar_create_or_parse_filename(c
 		zend_get_hash_value, NULL, 0);
 	zend_hash_init(&mydata->virtual_dirs, sizeof(char *),
 		zend_get_hash_value, NULL, mydata->is_persistent);
-	mydata->fname_len = fname_len;
+	mydata->fname = zend_string_init(new_fname, new_fname_len, false);
+	efree(new_fname);
 	snprintf(mydata->version, sizeof(mydata->version), "%s", PHP_PHAR_API_VERSION);
 	mydata->is_temporary_alias = alias ? 0 : 1;
 	mydata->fp = NULL;
 	mydata->is_writeable = 1;
 	mydata->is_brandnew = 1;
 	phar_request_initialize();
-	zend_hash_str_add_ptr(&(PHAR_G(phar_fname_map)), mydata->fname, fname_len, mydata);
+	zend_hash_add_ptr(&(PHAR_G(phar_fname_map)), mydata->fname, mydata);
 
 	if (is_data) {
 		alias = NULL;
@@ -1464,9 +1467,9 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 7, 8) zend_result phar_create_or_parse_filename(c
 		if (alias) {
 			const phar_archive_data *fd_ptr = zend_hash_str_find_ptr(&(PHAR_G(phar_alias_map)), alias, alias_len);
 			if (fd_ptr && SUCCESS != phar_free_alias(fd_ptr)) {
-				spprintf(error, 4096, "phar error: phar \"%s\" cannot set alias \"%s\", already in use by another phar archive", mydata->fname, alias);
+				spprintf(error, 4096, "phar error: phar \"%s\" cannot set alias \"%s\", already in use by another phar archive", ZSTR_VAL(mydata->fname), alias);
 
-				zend_hash_str_del(&(PHAR_G(phar_fname_map)), mydata->fname, fname_len);
+				zend_hash_del(&(PHAR_G(phar_fname_map)), mydata->fname);
 
 				*pphar = NULL;
 
@@ -1475,8 +1478,8 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 7, 8) zend_result phar_create_or_parse_filename(c
 		}
 
 		ZEND_ASSERT(!mydata->is_persistent);
-		mydata->alias = alias ? estrndup(alias, alias_len) : estrndup(mydata->fname, fname_len);
-		mydata->alias_len = alias ? alias_len : fname_len;
+		mydata->alias = alias ? estrndup(alias, alias_len) : estrndup(ZSTR_VAL(mydata->fname), ZSTR_LEN(mydata->fname));
+		mydata->alias_len = alias ? alias_len : ZSTR_LEN(mydata->fname);
 	}
 
 	if (alias_len && alias) {
@@ -1485,7 +1488,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 7, 8) zend_result phar_create_or_parse_filename(c
 				spprintf(error, 0, "archive \"%s\" cannot be associated with alias \"%s\", already in use", fname, alias);
 			}
 
-			zend_hash_str_del(&(PHAR_G(phar_fname_map)), mydata->fname, fname_len);
+			zend_hash_del(&(PHAR_G(phar_fname_map)), mydata->fname);
 
 			*pphar = NULL;
 
@@ -2318,14 +2321,14 @@ ZEND_ATTRIBUTE_NONNULL zend_result phar_postprocess_file(phar_entry_data *idata,
 
 		if (!stream) {
 			spprintf(error, 0, "phar error: unable to open zip-based phar archive \"%s\" to verify local file header for file \"%s\"",
-				idata->phar->fname, ZSTR_VAL(entry->filename));
+				ZSTR_VAL(idata->phar->fname), ZSTR_VAL(entry->filename));
 			return FAILURE;
 		}
 		php_stream_seek(stream, entry->header_offset, SEEK_SET);
 
 		if (sizeof(local) != php_stream_read(stream, (char *) &local, sizeof(local))) {
 			spprintf(error, 0, "phar error: internal corruption of zip-based phar \"%s\" (cannot read local file header for file \"%s\")",
-				idata->phar->fname, ZSTR_VAL(entry->filename));
+				ZSTR_VAL(idata->phar->fname), ZSTR_VAL(entry->filename));
 			return FAILURE;
 		}
 
@@ -2339,7 +2342,7 @@ ZEND_ATTRIBUTE_NONNULL zend_result phar_postprocess_file(phar_entry_data *idata,
 			if (sizeof(desc) != php_stream_read(stream,
 							    (char *) &desc, sizeof(desc))) {
 				spprintf(error, 0, "phar error: internal corruption of zip-based phar \"%s\" (cannot read local data descriptor for file \"%s\")",
-					idata->phar->fname, ZSTR_VAL(entry->filename));
+					ZSTR_VAL(idata->phar->fname), ZSTR_VAL(entry->filename));
 				return FAILURE;
 			}
 			if (desc.signature[0] == 'P' && desc.signature[1] == 'K') {
@@ -2352,7 +2355,7 @@ ZEND_ATTRIBUTE_NONNULL zend_result phar_postprocess_file(phar_entry_data *idata,
 		/* verify local header */
 		if (ZSTR_LEN(entry->filename) != PHAR_ZIP_16(local.filename_len) || entry->crc32 != PHAR_ZIP_32(local.crc32) || entry->uncompressed_filesize != PHAR_ZIP_32(local.uncompsize) || entry->compressed_filesize != PHAR_ZIP_32(local.compsize)) {
 			spprintf(error, 0, "phar error: internal corruption of zip-based phar \"%s\" (local header of file \"%s\" does not match central directory)",
-				idata->phar->fname, ZSTR_VAL(entry->filename));
+				ZSTR_VAL(idata->phar->fname), ZSTR_VAL(entry->filename));
 			return FAILURE;
 		}
 
@@ -2381,7 +2384,7 @@ ZEND_ATTRIBUTE_NONNULL zend_result phar_postprocess_file(phar_entry_data *idata,
 		return SUCCESS;
 	} else {
 		spprintf(error, 0, "phar error: internal corruption of phar \"%s\" (crc32 mismatch on file \"%s\")",
-			idata->phar->fname, ZSTR_VAL(entry->filename));
+			ZSTR_VAL(idata->phar->fname), ZSTR_VAL(entry->filename));
 		return FAILURE;
 	}
 }
@@ -2493,7 +2496,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_flush_ex(phar_archive_data *phar, zen
 	php_stream *shared_cfp = NULL;
 
 	if (phar->is_persistent) {
-		spprintf(error, 0, "internal error: attempt to flush cached zip-based phar \"%s\"", phar->fname);
+		spprintf(error, 0, "internal error: attempt to flush cached zip-based phar \"%s\"", ZSTR_VAL(phar->fname));
 		return EOF;
 	}
 
@@ -2522,7 +2525,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_flush_ex(phar_archive_data *phar, zen
 		must_close_old_file = false;
 		php_stream_rewind(oldfile);
 	} else {
-		oldfile = php_stream_open_wrapper(phar->fname, "rb", 0, NULL);
+		oldfile = php_stream_open_wrapper(ZSTR_VAL(phar->fname), "rb", 0, NULL);
 		must_close_old_file = oldfile != NULL;
 	}
 	newfile = php_stream_fopen_tmpfile();
@@ -2542,7 +2545,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_flush_ex(phar_archive_data *phar, zen
 				php_stream_close(oldfile);
 			}
 			php_stream_close(newfile);
-			spprintf(error, 0, "illegal stub for phar \"%s\" (__HALT_COMPILER(); is missing)", phar->fname);
+			spprintf(error, 0, "illegal stub for phar \"%s\" (__HALT_COMPILER(); is missing)", ZSTR_VAL(phar->fname));
 			return EOF;
 		}
 
@@ -2558,7 +2561,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_flush_ex(phar_archive_data *phar, zen
 				php_stream_close(oldfile);
 			}
 			php_stream_close(newfile);
-			spprintf(error, 0, "unable to create stub from string in new phar \"%s\"", phar->fname);
+			spprintf(error, 0, "unable to create stub from string in new phar \"%s\"", ZSTR_VAL(phar->fname));
 			return EOF;
 		}
 		phar->halt_offset = len + end_sequence_len;
@@ -2580,9 +2583,9 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_flush_ex(phar_archive_data *phar, zen
 			}
 			php_stream_close(newfile);
 			if (new_stub) {
-				spprintf(error, 0, "unable to create stub in new phar \"%s\"", phar->fname);
+				spprintf(error, 0, "unable to create stub in new phar \"%s\"", ZSTR_VAL(phar->fname));
 			} else {
-				spprintf(error, 0, "unable to copy stub of old phar to new phar \"%s\"", phar->fname);
+				spprintf(error, 0, "unable to copy stub of old phar to new phar \"%s\"", ZSTR_VAL(phar->fname));
 			}
 			if (new_stub) {
 				zend_string_free(new_stub);
@@ -2680,7 +2683,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_flush_ex(phar_archive_data *phar, zen
 				php_stream_close(oldfile);
 			}
 			php_stream_close(newfile);
-			spprintf(error, 0, "unable to seek to start of file \"%s\" while creating new phar \"%s\"", ZSTR_VAL(entry->filename), phar->fname);
+			spprintf(error, 0, "unable to seek to start of file \"%s\" while creating new phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(phar->fname));
 			return EOF;
 		}
 		newcrc32 = php_crc32_bulk_init();
@@ -2701,7 +2704,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_flush_ex(phar_archive_data *phar, zen
 			spprintf(error, 0, "unable to %s compress file \"%s\" to new phar \"%s\"",
 				entry->flags & PHAR_ENT_COMPRESSED_GZ ? "gzip" : "bzip2",
 				ZSTR_VAL(entry->filename),
-				phar->fname);
+				ZSTR_VAL(phar->fname));
 			return EOF;
 		}
 
@@ -2732,7 +2735,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_flush_ex(phar_archive_data *phar, zen
 			}
 			php_stream_close(newfile);
 			spprintf(error, 0, "unable to seek to start of file \"%s\" while creating new phar \"%s\"",
-				ZSTR_VAL(entry->filename), phar->fname);
+				ZSTR_VAL(entry->filename), ZSTR_VAL(phar->fname));
 			goto cleanup;
 		}
 		php_stream_filter_append((&entry->cfp->writefilters), filter);
@@ -2743,7 +2746,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_flush_ex(phar_archive_data *phar, zen
 			}
 			php_stream_close(newfile);
 			spprintf(error, 0, "unable to copy compressed file contents of file \"%s\" while creating new phar \"%s\"",
-				ZSTR_VAL(entry->filename), phar->fname);
+				ZSTR_VAL(entry->filename), ZSTR_VAL(phar->fname));
 			goto cleanup;
 		}
 		php_stream_filter_flush(filter, 1);
@@ -2803,7 +2806,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_flush_ex(phar_archive_data *phar, zen
 		php_stream_close(newfile);
 		phar->alias_len = restore_alias_len;
 
-		spprintf(error, 0, "unable to write manifest header of new phar \"%s\"", phar->fname);
+		spprintf(error, 0, "unable to write manifest header of new phar \"%s\"", ZSTR_VAL(phar->fname));
 
 		goto cleanup;
 	}
@@ -2822,7 +2825,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_flush_ex(phar_archive_data *phar, zen
 		php_stream_close(newfile);
 		phar->alias_len = restore_alias_len;
 
-		spprintf(error, 0, "unable to write manifest meta-data of new phar \"%s\"", phar->fname);
+		spprintf(error, 0, "unable to write manifest meta-data of new phar \"%s\"", ZSTR_VAL(phar->fname));
 
 		goto cleanup;
 	}
@@ -2854,9 +2857,9 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_flush_ex(phar_archive_data *phar, zen
 			}
 			php_stream_close(newfile);
 			if (entry->is_dir) {
-				spprintf(error, 0, "unable to write filename of directory \"%s\" to manifest of new phar \"%s\"", ZSTR_VAL(entry->filename), phar->fname);
+				spprintf(error, 0, "unable to write filename of directory \"%s\" to manifest of new phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(phar->fname));
 			} else {
-				spprintf(error, 0, "unable to write filename of file \"%s\" to manifest of new phar \"%s\"", ZSTR_VAL(entry->filename), phar->fname);
+				spprintf(error, 0, "unable to write filename of file \"%s\" to manifest of new phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(phar->fname));
 			}
 			goto cleanup;
 		}
@@ -2888,7 +2891,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_flush_ex(phar_archive_data *phar, zen
 
 			php_stream_close(newfile);
 
-			spprintf(error, 0, "unable to write temporary manifest of file \"%s\" to manifest of new phar \"%s\"", ZSTR_VAL(entry->filename), phar->fname);
+			spprintf(error, 0, "unable to write temporary manifest of file \"%s\" to manifest of new phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(phar->fname));
 
 			goto cleanup;
 		}
@@ -2925,7 +2928,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_flush_ex(phar_archive_data *phar, zen
 					php_stream_close(oldfile);
 				}
 				php_stream_close(newfile);
-				spprintf(error, 0, "unable to seek to start of file \"%s\" while creating new phar \"%s\"", ZSTR_VAL(entry->filename), phar->fname);
+				spprintf(error, 0, "unable to seek to start of file \"%s\" while creating new phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(phar->fname));
 				goto cleanup;
 			}
 		}
@@ -2935,7 +2938,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_flush_ex(phar_archive_data *phar, zen
 				php_stream_close(oldfile);
 			}
 			php_stream_close(newfile);
-			spprintf(error, 0, "unable to seek to start of file \"%s\" while creating new phar \"%s\"", ZSTR_VAL(entry->filename), phar->fname);
+			spprintf(error, 0, "unable to seek to start of file \"%s\" while creating new phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(phar->fname));
 			goto cleanup;
 		}
 
@@ -2949,7 +2952,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_flush_ex(phar_archive_data *phar, zen
 
 			php_stream_close(newfile);
 
-			spprintf(error, 0, "unable to write contents of file \"%s\" to new phar \"%s\"", ZSTR_VAL(entry->filename), phar->fname);
+			spprintf(error, 0, "unable to write contents of file \"%s\" to new phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(phar->fname));
 
 			goto cleanup;
 		}
@@ -3053,10 +3056,10 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_flush_ex(phar_archive_data *phar, zen
 		/* deferred flush */
 		phar->fp = newfile;
 	} else {
-		phar->fp = php_stream_open_wrapper(phar->fname, "w+b", IGNORE_URL|STREAM_MUST_SEEK|REPORT_ERRORS, NULL);
+		phar->fp = php_stream_open_wrapper(ZSTR_VAL(phar->fname), "w+b", IGNORE_URL|STREAM_MUST_SEEK|REPORT_ERRORS, NULL);
 		if (!phar->fp) {
 			phar->fp = newfile;
-			spprintf(error, 4096, "unable to open new phar \"%s\" for writing", phar->fname);
+			spprintf(error, 4096, "unable to open new phar \"%s\" for writing", ZSTR_VAL(phar->fname));
 			return EOF;
 		}
 
@@ -3070,7 +3073,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_flush_ex(phar_archive_data *phar, zen
 			zend_array_destroy(Z_ARR(filterparams));
 
 			if (!filter) {
-				spprintf(error, 4096, "unable to compress all contents of phar \"%s\" using zlib, PHP versions older than 5.2.6 have a buggy zlib", phar->fname);
+				spprintf(error, 4096, "unable to compress all contents of phar \"%s\" using zlib, PHP versions older than 5.2.6 have a buggy zlib", ZSTR_VAL(phar->fname));
 				return EOF;
 			}
 
@@ -3098,7 +3101,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_flush_ex(phar_archive_data *phar, zen
 	}
 
 	if (-1 == php_stream_seek(phar->fp, phar->halt_offset, SEEK_SET)) {
-		spprintf(error, 0, "unable to seek to __HALT_COMPILER(); in new phar \"%s\"", phar->fname);
+		spprintf(error, 0, "unable to seek to __HALT_COMPILER(); in new phar \"%s\"", ZSTR_VAL(phar->fname));
 		return EOF;
 	}
 

--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -192,7 +192,7 @@ PHP_INI_END()
  */
 void phar_destroy_phar_data(phar_archive_data *phar) /* {{{ */
 {
-	if (phar->alias && phar->alias != phar->fname) {
+	if (phar->alias) {
 		pefree(phar->alias, phar->is_persistent);
 		phar->alias = NULL;
 	}

--- a/ext/phar/phar_internal.h
+++ b/ext/phar/phar_internal.h
@@ -146,8 +146,7 @@ ZEND_BEGIN_MODULE_GLOBALS(phar)
 	char        *openssl_privatekey;
 	uint32_t    openssl_privatekey_len;
 	/* phar_get_archive cache */
-	const char  *last_phar_name;
-	uint32_t    last_phar_name_len;
+	const zend_string *last_phar_name;
 	uint32_t    last_alias_len;
 	const char* last_alias;
 	phar_archive_data* last_phar;
@@ -243,8 +242,7 @@ typedef struct _phar_entry_info {
 
 /* information about a phar file (the archive itself) */
 struct _phar_archive_data {
-	char                     *fname;
-	uint32_t                 fname_len;
+	zend_string             *fname;
 	/* The ext field stores the location of the file extension from the fname field, and thus should never be freed. */
 	uint32_t                 ext_len;
 	const char               *ext;
@@ -380,21 +378,20 @@ static inline bool phar_validate_alias(const char *alias, size_t alias_len) /* {
 
 static inline void phar_set_inode(phar_entry_info *entry) /* {{{ */
 {
-	char tmp[MAXPATHLEN];
-	size_t tmp_len;
-	size_t len1, len2;
-
-	tmp_len = MIN(MAXPATHLEN, ZSTR_LEN(entry->filename) + entry->phar->fname_len);
-
-	len1 = MIN(entry->phar->fname_len, tmp_len);
 	if (entry->phar->fname) {
-		memcpy(tmp, entry->phar->fname, len1);
+		char tmp[MAXPATHLEN];
+		size_t tmp_len = MIN(MAXPATHLEN, ZSTR_LEN(entry->filename) + ZSTR_LEN(entry->phar->fname));
+
+		size_t len1 = MIN(ZSTR_LEN(entry->phar->fname), tmp_len);
+		memcpy(tmp, ZSTR_VAL(entry->phar->fname), len1);
+
+		size_t len2 = MIN(tmp_len - len1, ZSTR_LEN(entry->filename));
+		memcpy(tmp + len1, entry->filename, len2);
+
+		entry->inode = (unsigned short) zend_hash_func(tmp, tmp_len);
+	} else {
+		entry->inode = (unsigned short) zend_string_hash_func(entry->filename);
 	}
-
-	len2 = MIN(tmp_len - len1, ZSTR_LEN(entry->filename));
-	memcpy(tmp + len1, entry->filename, len2);
-
-	entry->inode = (unsigned short) zend_hash_func(tmp, tmp_len);
 }
 /* }}} */
 

--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -1178,14 +1178,14 @@ PHP_METHOD(Phar, __construct)
 	if (entry) {
 		file_name_for_recursive_director_iterator_constructor = zend_string_concat3(
 			ZEND_STRL("phar://"),
-			phar_data->fname, phar_data->fname_len,
+			ZSTR_VAL(phar_data->fname), ZSTR_LEN(phar_data->fname),
 			ZSTR_VAL(entry), ZSTR_LEN(entry)
 		);
 		zend_string_release_ex(entry, false);
 	} else {
 		file_name_for_recursive_director_iterator_constructor = zend_string_concat2(
 			ZEND_STRL("phar://"),
-			phar_data->fname, phar_data->fname_len
+			ZSTR_VAL(phar_data->fname), ZSTR_LEN(phar_data->fname)
 		);
 	}
 
@@ -1255,25 +1255,25 @@ PHP_METHOD(Phar, getSupportedCompression)
 /* {{{ Completely remove a phar archive from memory and disk */
 PHP_METHOD(Phar, unlinkArchive)
 {
-	char *fname, *error;
-	size_t fname_len;
+	char *error;
+	zend_string *fname;
 	phar_archive_data *phar;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "p", &fname, &fname_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "P", &fname) == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	if (!fname_len) {
+	if (ZSTR_LEN(fname) == 0) {
 		zend_throw_exception_ex(phar_ce_PharException, 0, "Unknown phar archive \"\"");
 		RETURN_THROWS();
 	}
 
-	if (FAILURE == phar_open_from_filename(fname, fname_len, NULL, 0, REPORT_ERRORS, &phar, &error)) {
+	if (FAILURE == phar_open_from_filename(ZSTR_VAL(fname), ZSTR_LEN(fname), NULL, 0, REPORT_ERRORS, &phar, &error)) {
 		if (error) {
-			zend_throw_exception_ex(phar_ce_PharException, 0, "Unknown phar archive \"%s\": %s", fname, error);
+			zend_throw_exception_ex(phar_ce_PharException, 0, "Unknown phar archive \"%s\": %s", ZSTR_VAL(fname), error);
 			efree(error);
 		} else {
-			zend_throw_exception_ex(phar_ce_PharException, 0, "Unknown phar archive \"%s\"", fname);
+			zend_throw_exception_ex(phar_ce_PharException, 0, "Unknown phar archive \"%s\"", ZSTR_VAL(fname));
 		}
 		RETURN_THROWS();
 	}
@@ -1282,9 +1282,9 @@ PHP_METHOD(Phar, unlinkArchive)
 	if (zend_file_name && zend_string_starts_with_literal_ci(zend_file_name, "phar://")) {
 		zend_string *arch = phar_split_fname(ZSTR_VAL(zend_file_name), ZSTR_LEN(zend_file_name), NULL, 2, 0);
 		if (arch) {
-			if (ZSTR_LEN(arch) == fname_len && !memcmp(ZSTR_VAL(arch), fname, ZSTR_LEN(arch))) {
+			if (zend_string_equals(arch, fname)) {
 				zend_string_release_ex(arch, false);
-				zend_throw_exception_ex(phar_ce_PharException, 0, "phar archive \"%s\" cannot be unlinked from within itself", fname);
+				zend_throw_exception_ex(phar_ce_PharException, 0, "phar archive \"%s\" cannot be unlinked from within itself", ZSTR_VAL(fname));
 				RETURN_THROWS();
 			}
 			zend_string_release_ex(arch, false);
@@ -1292,16 +1292,16 @@ PHP_METHOD(Phar, unlinkArchive)
 	}
 
 	if (phar->is_persistent) {
-		zend_throw_exception_ex(phar_ce_PharException, 0, "phar archive \"%s\" is in phar.cache_list, cannot unlinkArchive()", fname);
+		zend_throw_exception_ex(phar_ce_PharException, 0, "phar archive \"%s\" is in phar.cache_list, cannot unlinkArchive()", ZSTR_VAL(fname));
 		RETURN_THROWS();
 	}
 
 	if (phar->refcount) {
-		zend_throw_exception_ex(phar_ce_PharException, 0, "phar archive \"%s\" has open file handles or objects.  fclose() all file handles, and unset() all objects prior to calling unlinkArchive()", fname);
+		zend_throw_exception_ex(phar_ce_PharException, 0, "phar archive \"%s\" has open file handles or objects.  fclose() all file handles, and unset() all objects prior to calling unlinkArchive()", ZSTR_VAL(fname));
 		RETURN_THROWS();
 	}
 
-	fname = estrndup(phar->fname, phar->fname_len);
+	fname = zend_string_copy(phar->fname);
 
 	/* invalidate phar cache */
 	PHAR_G(last_phar) = NULL;
@@ -1309,8 +1309,8 @@ PHP_METHOD(Phar, unlinkArchive)
 	PHAR_G(last_phar_name) = NULL;
 
 	phar_archive_delref(phar);
-	unlink(fname);
-	efree(fname);
+	unlink(ZSTR_VAL(fname));
+	zend_string_release(fname);
 	RETURN_TRUE;
 }
 /* }}} */
@@ -1635,7 +1635,7 @@ after_open_fp:
 		return ZEND_HASH_APPLY_KEEP;
 	}
 
-	data = phar_build_entry_data(phar_obj->archive->fname, phar_obj->archive->fname_len, str_key, str_key_len, &error, value);
+	data = phar_build_entry_data(ZSTR_VAL(phar_obj->archive->fname), ZSTR_LEN(phar_obj->archive->fname), str_key, str_key_len, &error, value);
 	if (!data) {
 		zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Entry %s cannot be created: %s", str_key, error);
 		efree(error);
@@ -1770,7 +1770,7 @@ PHP_METHOD(Phar, buildFromDirectory)
 		if (apply_reg) {
 			zval_ptr_dtor(&regexiter);
 		}
-		zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" unable to create temporary file", phar_obj->archive->fname);
+		zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" unable to create temporary file", ZSTR_VAL(phar_obj->archive->fname));
 		RETURN_THROWS();
 	}
 
@@ -1780,7 +1780,7 @@ PHP_METHOD(Phar, buildFromDirectory)
 			zval_ptr_dtor(&regexiter);
 		}
 		php_stream_close(pass.fp);
-		zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", phar_obj->archive->fname);
+		zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", ZSTR_VAL(phar_obj->archive->fname));
 		RETURN_THROWS();
 	}
 
@@ -1838,7 +1838,7 @@ PHP_METHOD(Phar, buildFromIterator)
 	}
 
 	if (phar_obj->archive->is_persistent && FAILURE == phar_copy_on_write(&(phar_obj->archive))) {
-		zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", phar_obj->archive->fname);
+		zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", ZSTR_VAL(phar_obj->archive->fname));
 		RETURN_THROWS();
 	}
 
@@ -1851,7 +1851,7 @@ PHP_METHOD(Phar, buildFromIterator)
 	pass.count = 0;
 	pass.fp = php_stream_fopen_tmpfile();
 	if (pass.fp == NULL) {
-		zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\": unable to create temporary file", phar_obj->archive->fname);
+		zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\": unable to create temporary file", ZSTR_VAL(phar_obj->archive->fname));
 		RETURN_THROWS();
 	}
 
@@ -1920,11 +1920,11 @@ static zend_result phar_copy_file_contents(phar_entry_info *entry, php_stream *f
 	if (FAILURE == phar_open_entry_fp(entry, &error, true)) {
 		if (error) {
 			zend_throw_exception_ex(spl_ce_UnexpectedValueException, 0,
-				"Cannot convert phar archive \"%s\", unable to open entry \"%s\" contents: %s", entry->phar->fname, ZSTR_VAL(entry->filename), error);
+				"Cannot convert phar archive \"%s\", unable to open entry \"%s\" contents: %s", ZSTR_VAL(entry->phar->fname), ZSTR_VAL(entry->filename), error);
 			efree(error);
 		} else {
 			zend_throw_exception_ex(spl_ce_UnexpectedValueException, 0,
-				"Cannot convert phar archive \"%s\", unable to open entry \"%s\" contents", entry->phar->fname, ZSTR_VAL(entry->filename));
+				"Cannot convert phar archive \"%s\", unable to open entry \"%s\" contents", ZSTR_VAL(entry->phar->fname), ZSTR_VAL(entry->filename));
 		}
 		return FAILURE;
 	}
@@ -1934,7 +1934,7 @@ static zend_result phar_copy_file_contents(phar_entry_info *entry, php_stream *f
 	offset = php_stream_tell(fp);
 	if (SUCCESS != php_stream_copy_to_stream_ex(phar_get_efp(entry, false), fp, entry->uncompressed_filesize, NULL)) {
 		zend_throw_exception_ex(spl_ce_UnexpectedValueException, 0,
-			"Cannot convert phar archive \"%s\", unable to copy entry \"%s\" contents", entry->phar->fname, ZSTR_VAL(entry->filename));
+			"Cannot convert phar archive \"%s\", unable to copy entry \"%s\" contents", ZSTR_VAL(entry->phar->fname), ZSTR_VAL(entry->filename));
 		return FAILURE;
 	}
 
@@ -1948,15 +1948,14 @@ static zend_result phar_copy_file_contents(phar_entry_info *entry, php_stream *f
 static zend_object *phar_rename_archive(phar_archive_data **sphar, char *ext) /* {{{ */
 {
 	phar_archive_data *phar = *sphar;
-	char *oldpath = NULL;
 	char *basename = NULL, *basepath = NULL;
-	char *newname = NULL, *newpath = NULL;
+	char *newname = NULL;
 	zval ret, arg1;
 	zend_class_entry *ce;
 	char *error = NULL;
 	const char *pcr_error;
 	size_t ext_len = ext ? strlen(ext) : 0;
-	size_t new_len, phar_ext_len;
+	size_t phar_ext_len;
 	phar_archive_data *pphar = NULL;
 	php_stream_statbuf ssb;
 
@@ -2028,24 +2027,26 @@ static zend_object *phar_rename_archive(phar_archive_data **sphar, char *ext) /*
 	} else if (phar_path_check(&ext, &ext_len, &pcr_error) > pcr_is_ok) {
 
 		if (phar->is_data) {
-			zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "data phar converted from \"%s\" has invalid extension %s", phar->fname, ext);
+			zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "data phar converted from \"%s\" has invalid extension %s", ZSTR_VAL(phar->fname), ext);
 		} else {
-			zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "phar converted from \"%s\" has invalid extension %s", phar->fname, ext);
+			zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "phar converted from \"%s\" has invalid extension %s", ZSTR_VAL(phar->fname), ext);
 		}
 		return NULL;
 	}
 
 
-	oldpath = estrndup(phar->fname, phar->fname_len);
+	zend_string *old_path = zend_string_copy(phar->fname);
 
-	const char *old_name = zend_memrchr(phar->fname, '/', phar->fname_len);
+	const char *old_name = zend_memrchr(ZSTR_VAL(phar->fname), '/', ZSTR_LEN(phar->fname));
+	size_t old_name_len;
 	if (old_name) {
 		++old_name;
+		old_name_len = strlen(old_name);
 	} else {
-		old_name = phar->fname;
+		old_name = ZSTR_VAL(phar->fname);
+		old_name_len = ZSTR_LEN(phar->fname);
 	}
 
-	size_t old_name_len = strlen(old_name);
 	/* Copy the old name to create base for the new name */
 	basename = estrndup(old_name, old_name_len);
 
@@ -2081,21 +2082,21 @@ static zend_object *phar_rename_archive(phar_archive_data **sphar, char *ext) /*
 	spprintf(&newname, 0, "%s.%s", basename, ext);
 	efree(basename);
 
-	basepath = estrndup(oldpath, (strlen(oldpath) - old_name_len));
-	new_len = spprintf(&newpath, 0, "%s%s", basepath, newname);
-	phar->fname_len = new_len;
+	basepath = estrndup(ZSTR_VAL(old_path), (ZSTR_LEN(old_path) - old_name_len));
+
+	zend_string *newpath = strpprintf(0, "%s%s", basepath, newname);
+	phar->ext = ZSTR_VAL(newpath) + ZSTR_LEN(newpath) - strlen(ext) - 1;
 	phar->fname = newpath;
-	phar->ext = newpath + phar->fname_len - strlen(ext) - 1;
 	efree(basepath);
 	efree(newname);
 
-	if (PHAR_G(manifest_cached) && NULL != (pphar = zend_hash_str_find_ptr(&cached_phars, newpath, phar->fname_len))) {
-		zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Unable to add newly converted phar \"%s\" to the list of phars, new phar name is in phar.cache_list", phar->fname);
+	if (PHAR_G(manifest_cached) && NULL != (pphar = zend_hash_find_ptr(&cached_phars, newpath))) {
+		zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Unable to add newly converted phar \"%s\" to the list of phars, new phar name is in phar.cache_list", ZSTR_VAL(phar->fname));
 		goto err_oldpath;
 	}
 
-	if (NULL != (pphar = zend_hash_str_find_ptr(&(PHAR_G(phar_fname_map)), newpath, phar->fname_len))) {
-		if (pphar->fname_len == phar->fname_len && !memcmp(pphar->fname, phar->fname, phar->fname_len)) {
+	if (NULL != (pphar = zend_hash_find_ptr(&(PHAR_G(phar_fname_map)), newpath))) {
+		if (zend_string_equals(pphar->fname, phar->fname)) {
 			if (!zend_hash_num_elements(&phar->manifest)) {
 				pphar->is_tar = phar->is_tar;
 				pphar->is_zip = phar->is_zip;
@@ -2110,22 +2111,22 @@ static zend_object *phar_rename_archive(phar_archive_data **sphar, char *ext) /*
 				phar = pphar;
 				/* NOTE: this phar is now reused, so the refcount must be increased. */
 				phar->refcount++;
-				newpath = oldpath;
+				newpath = old_path;
 				goto its_ok;
 			}
 		}
 
-		zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Unable to add newly converted phar \"%s\" to the list of phars, a phar with that name already exists", phar->fname);
+		zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Unable to add newly converted phar \"%s\" to the list of phars, a phar with that name already exists", ZSTR_VAL(phar->fname));
 		goto err_oldpath;
 	}
 its_ok:
-	if (SUCCESS == php_stream_stat_path(newpath, &ssb)) {
-		zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "phar \"%s\" exists and must be unlinked prior to conversion", newpath);
+	if (SUCCESS == php_stream_stat_path(ZSTR_VAL(newpath), &ssb)) {
+		zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "phar \"%s\" exists and must be unlinked prior to conversion", ZSTR_VAL(newpath));
 		goto err_reused_oldpath;
 	}
 	if (!phar->is_data) {
-		if (SUCCESS != phar_detect_phar_fname_ext(newpath, phar->fname_len, &(phar->ext), &ext_len, 1, 1, true)) {
-			zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "phar \"%s\" has invalid extension %s", phar->fname, ext);
+		if (SUCCESS != phar_detect_phar_fname_ext(ZSTR_VAL(newpath), ZSTR_LEN(newpath), &(phar->ext), &ext_len, 1, 1, true)) {
+			zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "phar \"%s\" has invalid extension %s", ZSTR_VAL(phar->fname), ext);
 			goto err_reused_oldpath;
 		}
 		phar->ext_len = ext_len;
@@ -2138,17 +2139,17 @@ its_ok:
 				phar->alias = NULL;
 				phar->alias_len = 0;
 			} else {
-				phar->alias = pestrndup(newpath, strlen(newpath), phar->is_persistent);
-				phar->alias_len = strlen(newpath);
+				phar->alias = pestrndup(ZSTR_VAL(newpath), ZSTR_LEN(newpath), phar->is_persistent);
+				phar->alias_len = ZSTR_LEN(newpath);
 				phar->is_temporary_alias = 1;
-				zend_hash_str_update_ptr(&(PHAR_G(phar_alias_map)), newpath, phar->fname_len, phar);
+				zend_hash_update_ptr(&(PHAR_G(phar_alias_map)), newpath, phar);
 			}
 		}
 
 	} else {
 
-		if (SUCCESS != phar_detect_phar_fname_ext(newpath, phar->fname_len, &(phar->ext), &ext_len, 0, 1, true)) {
-			zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "data phar \"%s\" has invalid extension %s", phar->fname, ext);
+		if (SUCCESS != phar_detect_phar_fname_ext(ZSTR_VAL(newpath), ZSTR_LEN(newpath), &(phar->ext), &ext_len, 0, 1, true)) {
+			zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "data phar \"%s\" has invalid extension %s", ZSTR_VAL(phar->fname), ext);
 			goto err_reused_oldpath;
 		}
 		phar->ext_len = ext_len;
@@ -2160,22 +2161,22 @@ its_ok:
 		}
 	}
 
-	if ((!pphar || phar == pphar) && NULL == zend_hash_str_update_ptr(&(PHAR_G(phar_fname_map)), newpath, phar->fname_len, phar)) {
-		zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Unable to add newly converted phar \"%s\" to the list of phars", phar->fname);
+	if ((!pphar || phar == pphar) && NULL == zend_hash_update_ptr(&(PHAR_G(phar_fname_map)), newpath, phar)) {
+		zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Unable to add newly converted phar \"%s\" to the list of phars", ZSTR_VAL(phar->fname));
 		goto err_oldpath;
 	}
 
 	phar_flush_ex(phar, NULL, true, &error);
 
 	if (error) {
-		zend_hash_str_del(&(PHAR_G(phar_fname_map)), newpath, phar->fname_len);
+		zend_hash_del(&(PHAR_G(phar_fname_map)), newpath);
 		*sphar = NULL;
 		zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "%s", error);
 		efree(error);
 		goto err_oldpath;
 	}
 
-	efree(oldpath);
+	zend_string_release(old_path);
 
 	if (phar->is_data) {
 		ce = phar_ce_data;
@@ -2183,9 +2184,8 @@ its_ok:
 		ce = phar_ce_archive;
 	}
 
-	ZVAL_STRINGL(&arg1, phar->fname, phar->fname_len);
+	ZVAL_STR(&arg1, phar->fname);
 	zend_result result = object_init_with_constructor(&ret, ce, 1, &arg1, NULL);
-	zval_ptr_dtor_str(&arg1);
 	if (SUCCESS != result) {
 		return NULL;
 	}
@@ -2198,7 +2198,7 @@ err_reused_oldpath:
 	}
 	/* fallthrough */
 err_oldpath:
-	efree(oldpath);
+	zend_string_release(old_path);
 	return NULL;
 }
 /* }}} */
@@ -2246,7 +2246,6 @@ static zend_object *phar_convert_to_other(phar_archive_data *source, int convert
 
 	phar->fp = tmp_fp;
 	phar->fname = source->fname;
-	phar->fname_len = source->fname_len;
 	phar->is_temporary_alias = source->is_temporary_alias;
 	phar->alias = source->alias;
 
@@ -2316,7 +2315,7 @@ no_copy:
 			if (phar->fname != source->fname) {
 				/* Depending on when phar_rename_archive() errors, the new filename
 				 * may have already been assigned or it may still be the old one. */
-				efree(phar->fname);
+				zend_string_release(phar->fname);
 			}
 			efree(phar);
 		}
@@ -2578,7 +2577,7 @@ PHP_METHOD(Phar, isWritable)
 		RETURN_FALSE;
 	}
 
-	if (SUCCESS != php_stream_stat_path(phar_obj->archive->fname, &ssb)) {
+	if (SUCCESS != php_stream_stat_path(ZSTR_VAL(phar_obj->archive->fname), &ssb)) {
 		/* assume it works if the file doesn't exist yet */
 		RETURN_BOOL(phar_obj->archive->is_brandnew);
 	}
@@ -2607,7 +2606,7 @@ PHP_METHOD(Phar, delete)
 	}
 
 	if (phar_obj->archive->is_persistent && FAILURE == phar_copy_on_write(&(phar_obj->archive))) {
-		zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", phar_obj->archive->fname);
+		zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", ZSTR_VAL(phar_obj->archive->fname));
 		RETURN_THROWS();
 	}
 	if (NULL != (entry = zend_hash_find_ptr(&phar_obj->archive->manifest, file_name))) {
@@ -2655,7 +2654,7 @@ PHP_METHOD(Phar, getPath)
 
 	PHAR_ARCHIVE_OBJECT();
 
-	RETURN_STRINGL(phar_obj->archive->fname, phar_obj->archive->fname_len);
+	RETURN_STR_COPY(phar_obj->archive->fname);
 }
 /* }}} */
 
@@ -2703,16 +2702,16 @@ PHP_METHOD(Phar, setAlias)
 	}
 	if (NULL != (fd_ptr = zend_hash_find_ptr(&(PHAR_G(phar_alias_map)), new_alias))) {
 		if (SUCCESS != phar_free_alias(fd_ptr)) {
-			zend_throw_exception_ex(phar_ce_PharException, 0, "alias \"%s\" is already used for archive \"%s\" and cannot be used for other archives", ZSTR_VAL(new_alias), fd_ptr->fname);
+			zend_throw_exception_ex(phar_ce_PharException, 0, "alias \"%s\" is already used for archive \"%s\" and cannot be used for other archives", ZSTR_VAL(new_alias), ZSTR_VAL(fd_ptr->fname));
 			RETURN_THROWS();
 		}
 	} else if (!phar_validate_alias(ZSTR_VAL(new_alias), ZSTR_LEN(new_alias))) {
 		zend_throw_exception_ex(spl_ce_UnexpectedValueException, 0,
-			"Invalid alias \"%s\" specified for phar \"%s\"", ZSTR_VAL(new_alias), phar_obj->archive->fname);
+			"Invalid alias \"%s\" specified for phar \"%s\"", ZSTR_VAL(new_alias), ZSTR_VAL(phar_obj->archive->fname));
 		RETURN_THROWS();
 	}
 	if (phar_obj->archive->is_persistent && FAILURE == phar_copy_on_write(&(phar_obj->archive))) {
-		zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", phar_obj->archive->fname);
+		zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", ZSTR_VAL(phar_obj->archive->fname));
 		RETURN_THROWS();
 	}
 	if (phar_obj->archive->alias_len && NULL != (fd_ptr = zend_hash_str_find_ptr(&(PHAR_G(phar_alias_map)), phar_obj->archive->alias, phar_obj->archive->alias_len))) {
@@ -2857,7 +2856,7 @@ PHP_METHOD(Phar, setStub)
 
 		if ((php_stream_from_zval_no_verify(stream, zstub)) != NULL) {
 			if (phar_obj->archive->is_persistent && FAILURE == phar_copy_on_write(&(phar_obj->archive))) {
-				zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", phar_obj->archive->fname);
+				zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", ZSTR_VAL(phar_obj->archive->fname));
 				RETURN_THROWS();
 			}
 
@@ -2869,7 +2868,7 @@ PHP_METHOD(Phar, setStub)
 			}
 
 			if (stub_file_content == NULL) {
-				zend_throw_exception_ex(phar_ce_PharException, 0, "unable to read resource to copy stub to new phar \"%s\"", phar_obj->archive->fname);
+				zend_throw_exception_ex(phar_ce_PharException, 0, "unable to read resource to copy stub to new phar \"%s\"", ZSTR_VAL(phar_obj->archive->fname));
 				RETURN_THROWS();
 			}
 
@@ -2887,7 +2886,7 @@ PHP_METHOD(Phar, setStub)
 		}
 	} else if (zend_parse_parameters(ZEND_NUM_ARGS(), "S", &stub) == SUCCESS) {
 		if (phar_obj->archive->is_persistent && FAILURE == phar_copy_on_write(&(phar_obj->archive))) {
-			zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", phar_obj->archive->fname);
+			zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", ZSTR_VAL(phar_obj->archive->fname));
 			RETURN_THROWS();
 		}
 		phar_flush_ex(phar_obj->archive, stub, /* is_default_stub */ false, &error);
@@ -2968,7 +2967,7 @@ PHP_METHOD(Phar, setDefaultStub)
 	}
 
 	if (phar_obj->archive->is_persistent && FAILURE == phar_copy_on_write(&(phar_obj->archive))) {
-		zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", phar_obj->archive->fname);
+		zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", ZSTR_VAL(phar_obj->archive->fname));
 		RETURN_THROWS();
 	}
 	phar_flush_ex(phar_obj->archive, stub, /* is_default_stub */ true, &error);
@@ -3019,7 +3018,7 @@ PHP_METHOD(Phar, setSignatureAlgorithm)
 		case PHAR_SIG_OPENSSL_SHA256:
 		case PHAR_SIG_OPENSSL_SHA512:
 			if (phar_obj->archive->is_persistent && FAILURE == phar_copy_on_write(&(phar_obj->archive))) {
-				zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", phar_obj->archive->fname);
+				zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", ZSTR_VAL(phar_obj->archive->fname));
 				RETURN_THROWS();
 			}
 			phar_obj->archive->sig_flags = (uint32_t)algo;
@@ -3329,7 +3328,7 @@ PHP_METHOD(Phar, compressFiles)
 	}
 
 	if (phar_obj->archive->is_persistent && FAILURE == phar_copy_on_write(&(phar_obj->archive))) {
-		zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", phar_obj->archive->fname);
+		zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", ZSTR_VAL(phar_obj->archive->fname));
 		RETURN_THROWS();
 	}
 	pharobj_set_compression(&phar_obj->archive->manifest, flags);
@@ -3368,7 +3367,7 @@ PHP_METHOD(Phar, decompressFiles)
 		RETURN_TRUE;
 	} else {
 		if (phar_obj->archive->is_persistent && FAILURE == phar_copy_on_write(&(phar_obj->archive))) {
-			zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", phar_obj->archive->fname);
+			zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", ZSTR_VAL(phar_obj->archive->fname));
 			RETURN_THROWS();
 		}
 		pharobj_set_compression(&phar_obj->archive->manifest, PHAR_ENT_COMPRESSED_NONE);
@@ -3410,28 +3409,28 @@ PHP_METHOD(Phar, copy)
 	if (zend_string_starts_with_literal(old_file, ".phar")) {
 		/* can't copy a meta file */
 		zend_throw_exception_ex(spl_ce_UnexpectedValueException, 0,
-			"file \"%s\" cannot be copied to file \"%s\", cannot copy Phar meta-file in %s", ZSTR_VAL(old_file), ZSTR_VAL(new_file), phar_obj->archive->fname);
+			"file \"%s\" cannot be copied to file \"%s\", cannot copy Phar meta-file in %s", ZSTR_VAL(old_file), ZSTR_VAL(new_file), ZSTR_VAL(phar_obj->archive->fname));
 		RETURN_THROWS();
 	}
 
 	if (zend_string_starts_with_literal(new_file, ".phar")) {
 		/* can't copy a meta file */
 		zend_throw_exception_ex(spl_ce_UnexpectedValueException, 0,
-			"file \"%s\" cannot be copied to file \"%s\", cannot copy to Phar meta-file in %s", ZSTR_VAL(old_file), ZSTR_VAL(new_file), phar_obj->archive->fname);
+			"file \"%s\" cannot be copied to file \"%s\", cannot copy to Phar meta-file in %s", ZSTR_VAL(old_file), ZSTR_VAL(new_file), ZSTR_VAL(phar_obj->archive->fname));
 		RETURN_THROWS();
 	}
 
 	phar_entry_info *oldentry = zend_hash_find_ptr(&phar_obj->archive->manifest, old_file);
 	if (!oldentry || oldentry->is_deleted) {
 		zend_throw_exception_ex(spl_ce_UnexpectedValueException, 0,
-			"file \"%s\" cannot be copied to file \"%s\", file does not exist in %s", ZSTR_VAL(old_file), ZSTR_VAL(new_file), phar_obj->archive->fname);
+			"file \"%s\" cannot be copied to file \"%s\", file does not exist in %s", ZSTR_VAL(old_file), ZSTR_VAL(new_file), ZSTR_VAL(phar_obj->archive->fname));
 		RETURN_THROWS();
 	}
 
 	const phar_entry_info *temp = zend_hash_find_ptr(&phar_obj->archive->manifest, new_file);
 	if (temp && !temp->is_deleted) {
 		zend_throw_exception_ex(spl_ce_UnexpectedValueException, 0,
-			"file \"%s\" cannot be copied to file \"%s\", file must not already exist in phar %s", ZSTR_VAL(old_file), ZSTR_VAL(new_file), phar_obj->archive->fname);
+			"file \"%s\" cannot be copied to file \"%s\", file must not already exist in phar %s", ZSTR_VAL(old_file), ZSTR_VAL(new_file), ZSTR_VAL(phar_obj->archive->fname));
 		RETURN_THROWS();
 	}
 
@@ -3439,13 +3438,13 @@ PHP_METHOD(Phar, copy)
 	char *tmp_new_file = ZSTR_VAL(new_file);
 	if (phar_path_check(&tmp_new_file, &tmp_len, &pcr_error) > pcr_is_ok) {
 		zend_throw_exception_ex(spl_ce_UnexpectedValueException, 0,
-				"file \"%s\" contains invalid characters %s, cannot be copied from \"%s\" in phar %s", ZSTR_VAL(new_file), pcr_error, ZSTR_VAL(old_file), phar_obj->archive->fname);
+				"file \"%s\" contains invalid characters %s, cannot be copied from \"%s\" in phar %s", ZSTR_VAL(new_file), pcr_error, ZSTR_VAL(old_file), ZSTR_VAL(phar_obj->archive->fname));
 		RETURN_THROWS();
 	}
 
 	if (phar_obj->archive->is_persistent) {
 		if (FAILURE == phar_copy_on_write(&(phar_obj->archive))) {
-			zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", phar_obj->archive->fname);
+			zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", ZSTR_VAL(phar_obj->archive->fname));
 			RETURN_THROWS();
 		}
 		/* re-populate with copied-on-write entry */
@@ -3535,12 +3534,12 @@ PHP_METHOD(Phar, offsetGet)
 		}
 
 		if (zend_string_equals_literal(file_name, ".phar/stub.php")) {
-			zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Cannot get stub \".phar/stub.php\" directly in phar \"%s\", use getStub", phar_obj->archive->fname);
+			zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Cannot get stub \".phar/stub.php\" directly in phar \"%s\", use getStub", ZSTR_VAL(phar_obj->archive->fname));
 			RETURN_THROWS();
 		}
 
 		if (zend_string_equals_literal(file_name, ".phar/alias.txt")) {
-			zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Cannot get alias \".phar/alias.txt\" directly in phar \"%s\", use getAlias", phar_obj->archive->fname);
+			zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Cannot get alias \".phar/alias.txt\" directly in phar \"%s\", use getAlias", ZSTR_VAL(phar_obj->archive->fname));
 			RETURN_THROWS();
 		}
 
@@ -3549,7 +3548,7 @@ PHP_METHOD(Phar, offsetGet)
 			RETURN_THROWS();
 		}
 
-		zend_string *sfname = strpprintf(0, "phar://%s/%s", phar_obj->archive->fname, ZSTR_VAL(file_name));
+		zend_string *sfname = strpprintf(0, "phar://%s/%s", ZSTR_VAL(phar_obj->archive->fname), ZSTR_VAL(file_name));
 		zval zfname;
 		ZVAL_NEW_STR(&zfname, sfname);
 
@@ -3598,7 +3597,7 @@ static void phar_add_file(phar_archive_data **pphar, zend_string *file_name, con
 	}
 #endif
 
-	phar_entry_data *data = phar_get_or_create_entry_data((*pphar)->fname, (*pphar)->fname_len, filename, filename_len, "w+b", 0, &error, true, time(NULL));
+	phar_entry_data *data = phar_get_or_create_entry_data(ZSTR_VAL((*pphar)->fname), ZSTR_LEN((*pphar)->fname), filename, filename_len, "w+b", 0, &error, true, time(NULL));
 	if (!data) {
 		if (error) {
 			zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Entry %s does not exist and cannot be created: %s", filename, error);
@@ -3671,8 +3670,13 @@ finish: ;
 static void phar_mkdir(phar_archive_data **pphar, zend_string *dir_name)
 {
 	char *error;
-	phar_entry_data *data = phar_get_or_create_entry_data((*pphar)->fname, (*pphar)->fname_len, ZSTR_VAL(dir_name), ZSTR_LEN(dir_name), "w+b", 2, &error, true, time(NULL));
 
+	phar_entry_data *data = phar_get_or_create_entry_data(
+		ZSTR_VAL((*pphar)->fname), ZSTR_LEN((*pphar)->fname),
+		ZSTR_VAL(dir_name), ZSTR_LEN(dir_name),
+		"w+b", 2, &error, true,
+		time(NULL)
+	);
 	if (!data) {
 		if (error) {
 			zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Directory %s does not exist and cannot be created: %s", ZSTR_VAL(dir_name), error);
@@ -3722,12 +3726,12 @@ PHP_METHOD(Phar, offsetSet)
 	}
 
 	if (zend_string_equals_literal(file_name, ".phar/stub.php")) {
-		zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Cannot set stub \".phar/stub.php\" directly in phar \"%s\", use setStub", phar_obj->archive->fname);
+		zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Cannot set stub \".phar/stub.php\" directly in phar \"%s\", use setStub", ZSTR_VAL(phar_obj->archive->fname));
 		RETURN_THROWS();
 	}
 
 	if (zend_string_equals_literal(file_name, ".phar/alias.txt")) {
-		zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Cannot set alias \".phar/alias.txt\" directly in phar \"%s\", use setAlias", phar_obj->archive->fname);
+		zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Cannot set alias \".phar/alias.txt\" directly in phar \"%s\", use setAlias", ZSTR_VAL(phar_obj->archive->fname));
 		RETURN_THROWS();
 	}
 
@@ -3767,7 +3771,7 @@ PHP_METHOD(Phar, offsetUnset)
 
 			if (phar_obj->archive->is_persistent) {
 				if (FAILURE == phar_copy_on_write(&(phar_obj->archive))) {
-					zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", phar_obj->archive->fname);
+					zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", ZSTR_VAL(phar_obj->archive->fname));
 					RETURN_THROWS();
 				}
 				/* re-populate entry after copy on write */
@@ -3876,9 +3880,9 @@ PHP_METHOD(Phar, getStub)
 			if (phar_obj->archive->fp && !phar_obj->archive->is_brandnew && !(stub->flags & PHAR_ENT_COMPRESSION_MASK)) {
 				fp = phar_obj->archive->fp;
 			} else {
-				fp = php_stream_open_wrapper(phar_obj->archive->fname, "rb", 0, NULL);
+				fp = php_stream_open_wrapper(ZSTR_VAL(phar_obj->archive->fname), "rb", 0, NULL);
 				if (!fp) {
-					zend_throw_exception_ex(spl_ce_UnexpectedValueException, 0, "phar error: unable to open phar \"%s\"", phar_obj->archive->fname);
+					zend_throw_exception_ex(spl_ce_UnexpectedValueException, 0, "phar error: unable to open phar \"%s\"", ZSTR_VAL(phar_obj->archive->fname));
 					RETURN_THROWS();
 				}
 				if (stub->flags & PHAR_ENT_COMPRESSION_MASK) {
@@ -3890,7 +3894,7 @@ PHP_METHOD(Phar, getStub)
 						filter = NULL;
 					}
 					if (!filter) {
-						zend_throw_exception_ex(spl_ce_UnexpectedValueException, 0, "phar error: unable to read stub of phar \"%s\" (cannot create %s filter)", phar_obj->archive->fname, phar_decompress_filter(stub, true));
+						zend_throw_exception_ex(spl_ce_UnexpectedValueException, 0, "phar error: unable to read stub of phar \"%s\" (cannot create %s filter)", ZSTR_VAL(phar_obj->archive->fname), phar_decompress_filter(stub, true));
 						RETURN_THROWS();
 					}
 					php_stream_filter_append(&fp->readfilters, filter);
@@ -3915,7 +3919,7 @@ PHP_METHOD(Phar, getStub)
 	if (phar_obj->archive->fp && !phar_obj->archive->is_brandnew) {
 		fp = phar_obj->archive->fp;
 	} else {
-		fp = php_stream_open_wrapper(phar_obj->archive->fname, "rb", 0, NULL);
+		fp = php_stream_open_wrapper(ZSTR_VAL(phar_obj->archive->fname), "rb", 0, NULL);
 	}
 
 	if (!fp)  {
@@ -4033,7 +4037,7 @@ PHP_METHOD(Phar, setMetadata)
 	}
 
 	if (phar_obj->archive->is_persistent && FAILURE == phar_copy_on_write(&(phar_obj->archive))) {
-		zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", phar_obj->archive->fname);
+		zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", ZSTR_VAL(phar_obj->archive->fname));
 		RETURN_THROWS();
 	}
 
@@ -4313,11 +4317,11 @@ PHP_METHOD(Phar, extractTo)
 
 	PHAR_ARCHIVE_OBJECT();
 
-	fp = php_stream_open_wrapper(phar_obj->archive->fname, "rb", IGNORE_URL|STREAM_MUST_SEEK, NULL);
+	fp = php_stream_open_wrapper(ZSTR_VAL(phar_obj->archive->fname), "rb", IGNORE_URL|STREAM_MUST_SEEK, NULL);
 
 	if (!fp) {
 		zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0,
-			"Invalid argument, %s cannot be found", phar_obj->archive->fname);
+			"Invalid argument, %s cannot be found", ZSTR_VAL(phar_obj->archive->fname));
 		RETURN_THROWS();
 	}
 
@@ -4362,13 +4366,13 @@ PHP_METHOD(Phar, extractTo)
 			switch (extract_helper(phar_obj->archive, Z_STR_P(zval_file), path_to, overwrite, &error)) {
 				case -1:
 					zend_throw_exception_ex(phar_ce_PharException, 0, "Extraction from phar \"%s\" failed: %s",
-						phar_obj->archive->fname, error);
+						ZSTR_VAL(phar_obj->archive->fname), error);
 					efree(error);
 					RETURN_THROWS();
 				case 0:
 					zend_throw_exception_ex(phar_ce_PharException, 0,
 						"phar error: attempted to extract non-existent file or directory \"%s\" from phar \"%s\"",
-						ZSTR_VAL(Z_STR_P(zval_file)), phar_obj->archive->fname);
+						ZSTR_VAL(Z_STR_P(zval_file)), ZSTR_VAL(phar_obj->archive->fname));
 					RETURN_THROWS();
 			}
 		} ZEND_HASH_FOREACH_END();
@@ -4378,12 +4382,12 @@ PHP_METHOD(Phar, extractTo)
 	ret = extract_helper(phar_obj->archive, filename, path_to, overwrite, &error);
 	if (-1 == ret) {
 		zend_throw_exception_ex(phar_ce_PharException, 0, "Extraction from phar \"%s\" failed: %s",
-			phar_obj->archive->fname, error);
+			ZSTR_VAL(phar_obj->archive->fname), error);
 		efree(error);
 	} else if (0 == ret && NULL != filename) {
 		zend_throw_exception_ex(phar_ce_PharException, 0,
 			"phar error: attempted to extract non-existent file or directory \"%s\" from phar \"%s\"",
-			ZSTR_VAL(filename), phar_obj->archive->fname);
+			ZSTR_VAL(filename), ZSTR_VAL(phar_obj->archive->fname));
 	} else {
 		RETURN_TRUE;
 	}
@@ -4612,7 +4616,7 @@ PHP_METHOD(PharFileInfo, chmod)
 	}
 
 	if (PHAR_G(readonly) && !entry_obj->entry->phar->is_data) {
-		zend_throw_exception_ex(phar_ce_PharException, 0, "Cannot modify permissions for file \"%s\" in phar \"%s\", write operations are prohibited", ZSTR_VAL(entry_obj->entry->filename), entry_obj->entry->phar->fname);
+		zend_throw_exception_ex(phar_ce_PharException, 0, "Cannot modify permissions for file \"%s\" in phar \"%s\", write operations are prohibited", ZSTR_VAL(entry_obj->entry->filename), ZSTR_VAL(entry_obj->entry->phar->fname));
 		RETURN_THROWS();
 	}
 
@@ -4620,7 +4624,7 @@ PHP_METHOD(PharFileInfo, chmod)
 		phar_archive_data *phar = entry_obj->entry->phar;
 
 		if (FAILURE == phar_copy_on_write(&phar)) {
-			zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", phar->fname);
+			zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", ZSTR_VAL(phar->fname));
 			RETURN_THROWS();
 		}
 		/* re-populate after copy-on-write */
@@ -4713,7 +4717,7 @@ PHP_METHOD(PharFileInfo, setMetadata)
 		phar_archive_data *phar = entry_obj->entry->phar;
 
 		if (FAILURE == phar_copy_on_write(&phar)) {
-			zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", phar->fname);
+			zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", ZSTR_VAL(phar->fname));
 			RETURN_THROWS();
 		}
 		/* re-populate after copy-on-write */
@@ -4761,7 +4765,7 @@ PHP_METHOD(PharFileInfo, delMetadata)
 			phar_archive_data *phar = entry_obj->entry->phar;
 
 			if (FAILURE == phar_copy_on_write(&phar)) {
-				zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", phar->fname);
+				zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", ZSTR_VAL(phar->fname));
 				RETURN_THROWS();
 			}
 			/* re-populate after copy-on-write */
@@ -4801,7 +4805,7 @@ PHP_METHOD(PharFileInfo, getContent)
 
 	if (entry_obj->entry->is_dir) {
 		zend_throw_exception_ex(spl_ce_BadMethodCallException, 0,
-			"phar error: Cannot retrieve contents, \"%s\" in phar \"%s\" is a directory", ZSTR_VAL(entry_obj->entry->filename), entry_obj->entry->phar->fname);
+			"phar error: Cannot retrieve contents, \"%s\" in phar \"%s\" is a directory", ZSTR_VAL(entry_obj->entry->filename), ZSTR_VAL(entry_obj->entry->phar->fname));
 		RETURN_THROWS();
 	}
 
@@ -4813,7 +4817,7 @@ PHP_METHOD(PharFileInfo, getContent)
 
 	if (SUCCESS != phar_open_entry_fp(link, &error, false)) {
 		zend_throw_exception_ex(spl_ce_BadMethodCallException, 0,
-			"phar error: Cannot retrieve contents, \"%s\" in phar \"%s\": %s", ZSTR_VAL(entry_obj->entry->filename), entry_obj->entry->phar->fname, error);
+			"phar error: Cannot retrieve contents, \"%s\" in phar \"%s\": %s", ZSTR_VAL(entry_obj->entry->filename), ZSTR_VAL(entry_obj->entry->phar->fname), error);
 		efree(error);
 		RETURN_THROWS();
 	}
@@ -4821,7 +4825,7 @@ PHP_METHOD(PharFileInfo, getContent)
 	php_stream *fp = phar_get_efp(link, false);
 	if (!fp) {
 		zend_throw_exception_ex(spl_ce_BadMethodCallException, 0,
-			"phar error: Cannot retrieve contents of \"%s\" in phar \"%s\"", ZSTR_VAL(entry_obj->entry->filename), entry_obj->entry->phar->fname);
+			"phar error: Cannot retrieve contents of \"%s\" in phar \"%s\"", ZSTR_VAL(entry_obj->entry->filename), ZSTR_VAL(entry_obj->entry->phar->fname));
 		RETURN_THROWS();
 	}
 
@@ -4875,7 +4879,7 @@ PHP_METHOD(PharFileInfo, compress)
 		phar_archive_data *phar = entry_obj->entry->phar;
 
 		if (FAILURE == phar_copy_on_write(&phar)) {
-			zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", phar->fname);
+			zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", ZSTR_VAL(phar->fname));
 			RETURN_THROWS();
 		}
 		/* re-populate after copy-on-write */
@@ -4897,7 +4901,7 @@ PHP_METHOD(PharFileInfo, compress)
 				/* decompress this file indirectly */
 				if (SUCCESS != phar_open_entry_fp(entry_obj->entry, &error, true)) {
 					zend_throw_exception_ex(spl_ce_BadMethodCallException, 0,
-						"phar error: Cannot decompress bzip2-compressed file \"%s\" in phar \"%s\" in order to compress with gzip: %s", ZSTR_VAL(entry_obj->entry->filename), entry_obj->entry->phar->fname, error);
+						"phar error: Cannot decompress bzip2-compressed file \"%s\" in phar \"%s\" in order to compress with gzip: %s", ZSTR_VAL(entry_obj->entry->filename), ZSTR_VAL(entry_obj->entry->phar->fname), error);
 					efree(error);
 					RETURN_THROWS();
 				}
@@ -4928,7 +4932,7 @@ PHP_METHOD(PharFileInfo, compress)
 				/* decompress this file indirectly */
 				if (SUCCESS != phar_open_entry_fp(entry_obj->entry, &error, true)) {
 					zend_throw_exception_ex(spl_ce_BadMethodCallException, 0,
-						"phar error: Cannot decompress gzip-compressed file \"%s\" in phar \"%s\" in order to compress with bzip2: %s", ZSTR_VAL(entry_obj->entry->filename), entry_obj->entry->phar->fname, error);
+						"phar error: Cannot decompress gzip-compressed file \"%s\" in phar \"%s\" in order to compress with bzip2: %s", ZSTR_VAL(entry_obj->entry->filename), ZSTR_VAL(entry_obj->entry->phar->fname), error);
 					efree(error);
 					RETURN_THROWS();
 				}
@@ -5010,7 +5014,7 @@ PHP_METHOD(PharFileInfo, decompress)
 		phar_archive_data *phar = entry_obj->entry->phar;
 
 		if (FAILURE == phar_copy_on_write(&phar)) {
-			zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", phar->fname);
+			zend_throw_exception_ex(phar_ce_PharException, 0, "phar \"%s\" is persistent, unable to copy on write", ZSTR_VAL(phar->fname));
 			RETURN_THROWS();
 		}
 		/* re-populate after copy-on-write */
@@ -5031,7 +5035,7 @@ PHP_METHOD(PharFileInfo, decompress)
 	/* decompress this file indirectly */
 	if (SUCCESS != phar_open_entry_fp(entry_obj->entry, &error, true)) {
 		zend_throw_exception_ex(spl_ce_BadMethodCallException, 0,
-			"Phar error: Cannot decompress %s-compressed file \"%s\" in phar \"%s\": %s", compression_type, ZSTR_VAL(entry_obj->entry->filename), entry_obj->entry->phar->fname, error);
+			"Phar error: Cannot decompress %s-compressed file \"%s\" in phar \"%s\": %s", compression_type, ZSTR_VAL(entry_obj->entry->filename), ZSTR_VAL(entry_obj->entry->phar->fname), error);
 		efree(error);
 		RETURN_THROWS();
 	}

--- a/ext/phar/stream.c
+++ b/ext/phar/stream.c
@@ -227,7 +227,7 @@ static php_stream * phar_wrapper_open_url(php_stream_wrapper *wrapper, const cha
 			}
 		}
 		if (opened_path) {
-			*opened_path = zend_strpprintf_unchecked(MAXPATHLEN, "phar://%s/%S", idata->phar->fname, idata->internal_file->filename);
+			*opened_path = zend_strpprintf_unchecked(MAXPATHLEN, "phar://%S/%S", idata->phar->fname, idata->internal_file->filename);
 		}
 		return fpf;
 	} else {
@@ -245,7 +245,7 @@ static php_stream * phar_wrapper_open_url(php_stream_wrapper *wrapper, const cha
 				}
 				efree(internal_file);
 				if (opened_path) {
-					*opened_path = strpprintf(MAXPATHLEN, "%s", phar->fname);
+					*opened_path = zend_string_copy(phar->fname);
 				}
 				php_url_free(resource);
 				goto phar_stub;
@@ -281,7 +281,7 @@ static php_stream * phar_wrapper_open_url(php_stream_wrapper *wrapper, const cha
 				++(entry->fp_refcount);
 				php_url_free(resource);
 				if (opened_path) {
-					*opened_path = strpprintf(MAXPATHLEN, "%s", phar->fname);
+					*opened_path = zend_string_copy(phar->fname);
 				}
 				efree(internal_file);
 				goto phar_stub;
@@ -303,7 +303,7 @@ idata_error:
 	}
 	php_url_free(resource);
 #ifdef MBO_0
-		fprintf(stderr, "Pharname:   %s\n", idata->phar->fname);
+		fprintf(stderr, "Pharname:   %s\n", ZSTR_VAL(idata->phar->fname));
 		fprintf(stderr, "Filename:   %s\n", internal_file);
 		fprintf(stderr, "Entry:      %s\n", ZSTR_VAL(idata->internal_file->filename));
 		fprintf(stderr, "Size:       %u\n", idata->internal_file->uncompressed_filesize);
@@ -336,7 +336,7 @@ idata_error:
 		}
 	}
 	if (opened_path) {
-		*opened_path = zend_strpprintf_unchecked(MAXPATHLEN, "phar://%s/%S", idata->phar->fname, idata->internal_file->filename);
+		*opened_path = zend_strpprintf_unchecked(MAXPATHLEN, "phar://%S/%S", idata->phar->fname, idata->internal_file->filename);
 	}
 	efree(internal_file);
 phar_stub:
@@ -443,7 +443,7 @@ static ssize_t phar_stream_write(php_stream *stream, const char *buf, size_t cou
 
 	php_stream_seek(data->fp, data->position + data->zero, SEEK_SET);
 	if (count != php_stream_write(data->fp, buf, count)) {
-		php_stream_wrapper_log_error(stream->wrapper, stream->flags, "phar error: Could not write %zu characters to \"%s\" in phar \"%s\"", count, ZSTR_VAL(data->internal_file->filename), data->phar->fname);
+		php_stream_wrapper_log_error(stream->wrapper, stream->flags, "phar error: Could not write %zu characters to \"%s\" in phar \"%s\"", count, ZSTR_VAL(data->internal_file->filename), ZSTR_VAL(data->phar->fname));
 		return -1;
 	}
 	data->position = php_stream_tell(data->fp) - data->zero;

--- a/ext/phar/tar.c
+++ b/ext/phar/tar.c
@@ -626,27 +626,29 @@ next:
 		return FAILURE;
 	}
 
-	myphar->fname = pestrndup(fname, fname_len, myphar->is_persistent);
+	myphar->fname = zend_string_init(fname, fname_len, myphar->is_persistent);
+	if (myphar->is_persistent) {
+		GC_MAKE_PERSISTENT_LOCAL(myphar->fname);
+	}
 #ifdef PHP_WIN32
-	phar_unixify_path_separators(myphar->fname, fname_len);
+	phar_unixify_path_separators(ZSTR_VAL(myphar->fname), ZSTR_LEN(myphar->fname));
 #endif
-	myphar->fname_len = fname_len;
 	myphar->fp = fp;
-	p = strrchr(myphar->fname, '/');
+	p = strrchr(ZSTR_VAL(myphar->fname), '/');
 
 	if (p) {
-		myphar->ext = memchr(p, '.', (myphar->fname + fname_len) - p);
+		myphar->ext = memchr(p, '.', (ZSTR_VAL(myphar->fname) + ZSTR_LEN(myphar->fname)) - p);
 		if (myphar->ext == p) {
-			myphar->ext = memchr(p + 1, '.', (myphar->fname + fname_len) - p - 1);
+			myphar->ext = memchr(p + 1, '.', (ZSTR_VAL(myphar->fname) + ZSTR_LEN(myphar->fname)) - p - 1);
 		}
 		if (myphar->ext) {
-			myphar->ext_len = (myphar->fname + fname_len) - myphar->ext;
+			myphar->ext_len = (ZSTR_VAL(myphar->fname) + ZSTR_LEN(myphar->fname)) - myphar->ext;
 		}
 	}
 
 	phar_request_initialize();
 
-	if (NULL == (actual = zend_hash_str_add_ptr(&(PHAR_G(phar_fname_map)), myphar->fname, fname_len, myphar))) {
+	if (NULL == (actual = zend_hash_add_ptr(&(PHAR_G(phar_fname_map)), myphar->fname, myphar))) {
 		if (error) {
 			spprintf(error, 4096, "phar error: Unable to add tar-based phar \"%s\" to phar registry", fname);
 		}
@@ -665,7 +667,7 @@ next:
 				if (error) {
 					spprintf(error, 4096, "phar error: Unable to add tar-based phar \"%s\", alias is already in use", fname);
 				}
-				zend_hash_str_del(&(PHAR_G(phar_fname_map)), myphar->fname, fname_len);
+				zend_hash_del(&(PHAR_G(phar_fname_map)), myphar->fname);
 				return FAILURE;
 			}
 		}
@@ -679,7 +681,7 @@ next:
 					if (error) {
 						spprintf(error, 4096, "phar error: Unable to add tar-based phar \"%s\", alias is already in use", fname);
 					}
-					zend_hash_str_del(&(PHAR_G(phar_fname_map)), myphar->fname, fname_len);
+					zend_hash_del(&(PHAR_G(phar_fname_map)), myphar->fname);
 					return FAILURE;
 				}
 			}
@@ -687,8 +689,8 @@ next:
 			myphar->alias = pestrndup(alias, alias_len, myphar->is_persistent);
 			myphar->alias_len = alias_len;
 		} else {
-			myphar->alias = pestrndup(myphar->fname, fname_len, myphar->is_persistent);
-			myphar->alias_len = fname_len;
+			myphar->alias = pestrndup(ZSTR_VAL(myphar->fname), ZSTR_LEN(myphar->fname), myphar->is_persistent);
+			myphar->alias_len = ZSTR_LEN(myphar->fname);
 		}
 
 		myphar->is_temporary_alias = 1;
@@ -737,7 +739,7 @@ static int phar_tar_writeheaders_int(phar_entry_info *entry, void *argument) /* 
 		char *boundary;
 		if (ZSTR_LEN(entry->filename) > 256) {
 			if (fp->error) {
-				spprintf(fp->error, 4096, "tar-based phar \"%s\" cannot be created, filename \"%s\" is too long for tar file format", entry->phar->fname, ZSTR_VAL(entry->filename));
+				spprintf(fp->error, 4096, "tar-based phar \"%s\" cannot be created, filename \"%s\" is too long for tar file format", ZSTR_VAL(entry->phar->fname), ZSTR_VAL(entry->filename));
 			}
 			return ZEND_HASH_APPLY_STOP;
 		}
@@ -747,7 +749,7 @@ static int phar_tar_writeheaders_int(phar_entry_info *entry, void *argument) /* 
 		}
 		if (!*boundary || ((boundary - ZSTR_VAL(entry->filename)) > 155)) {
 			if (fp->error) {
-				spprintf(fp->error, 4096, "tar-based phar \"%s\" cannot be created, filename \"%s\" is too long for tar file format", entry->phar->fname, ZSTR_VAL(entry->filename));
+				spprintf(fp->error, 4096, "tar-based phar \"%s\" cannot be created, filename \"%s\" is too long for tar file format", ZSTR_VAL(entry->phar->fname), ZSTR_VAL(entry->filename));
 			}
 			return ZEND_HASH_APPLY_STOP;
 		}
@@ -761,14 +763,14 @@ static int phar_tar_writeheaders_int(phar_entry_info *entry, void *argument) /* 
 
 	if (FAILURE == phar_tar_octal(header.size, entry->uncompressed_filesize, sizeof(header.size)-1)) {
 		if (fp->error) {
-			spprintf(fp->error, 4096, "tar-based phar \"%s\" cannot be created, filename \"%s\" is too large for tar file format", entry->phar->fname, ZSTR_VAL(entry->filename));
+			spprintf(fp->error, 4096, "tar-based phar \"%s\" cannot be created, filename \"%s\" is too large for tar file format", ZSTR_VAL(entry->phar->fname), ZSTR_VAL(entry->filename));
 		}
 		return ZEND_HASH_APPLY_STOP;
 	}
 
 	if (FAILURE == phar_tar_octal(header.mtime, entry->timestamp, sizeof(header.mtime)-1)) {
 		if (fp->error) {
-			spprintf(fp->error, 4096, "tar-based phar \"%s\" cannot be created, file modification time of file \"%s\" is too large for tar file format", entry->phar->fname, ZSTR_VAL(entry->filename));
+			spprintf(fp->error, 4096, "tar-based phar \"%s\" cannot be created, file modification time of file \"%s\" is too large for tar file format", ZSTR_VAL(entry->phar->fname), ZSTR_VAL(entry->filename));
 		}
 		return ZEND_HASH_APPLY_STOP;
 	}
@@ -779,7 +781,7 @@ static int phar_tar_writeheaders_int(phar_entry_info *entry, void *argument) /* 
 	if (entry->symlink) {
 		if (strlcpy(header.linkname, ZSTR_VAL(entry->symlink), sizeof(header.linkname)) >= sizeof(header.linkname)) {
 			if (fp->error) {
-				spprintf(fp->error, 4096, "tar-based phar \"%s\" cannot be created, link \"%s\" is too long for format", entry->phar->fname, ZSTR_VAL(entry->symlink));
+				spprintf(fp->error, 4096, "tar-based phar \"%s\" cannot be created, link \"%s\" is too long for format", ZSTR_VAL(entry->phar->fname), ZSTR_VAL(entry->symlink));
 			}
 			return ZEND_HASH_APPLY_STOP;
 		}
@@ -792,7 +794,7 @@ static int phar_tar_writeheaders_int(phar_entry_info *entry, void *argument) /* 
 
 	if (FAILURE == phar_tar_octal(header.checksum, entry->crc32, sizeof(header.checksum)-1)) {
 		if (fp->error) {
-			spprintf(fp->error, 4096, "tar-based phar \"%s\" cannot be created, checksum of file \"%s\" is too large for tar file format", entry->phar->fname, ZSTR_VAL(entry->filename));
+			spprintf(fp->error, 4096, "tar-based phar \"%s\" cannot be created, checksum of file \"%s\" is too large for tar file format", ZSTR_VAL(entry->phar->fname), ZSTR_VAL(entry->filename));
 		}
 		return ZEND_HASH_APPLY_STOP;
 	}
@@ -802,7 +804,7 @@ static int phar_tar_writeheaders_int(phar_entry_info *entry, void *argument) /* 
 
 	if (sizeof(header) != php_stream_write(fp->new, (char *) &header, sizeof(header))) {
 		if (fp->error) {
-			spprintf(fp->error, 4096, "tar-based phar \"%s\" cannot be created, header for  file \"%s\" could not be written", entry->phar->fname, ZSTR_VAL(entry->filename));
+			spprintf(fp->error, 4096, "tar-based phar \"%s\" cannot be created, header for  file \"%s\" could not be written", ZSTR_VAL(entry->phar->fname), ZSTR_VAL(entry->filename));
 		}
 		return ZEND_HASH_APPLY_STOP;
 	}
@@ -817,14 +819,14 @@ static int phar_tar_writeheaders_int(phar_entry_info *entry, void *argument) /* 
 
 		if (-1 == phar_seek_efp(entry, 0, SEEK_SET, 0, false)) {
 			if (fp->error) {
-				spprintf(fp->error, 4096, "tar-based phar \"%s\" cannot be created, contents of file \"%s\" could not be written, seek failed", entry->phar->fname, ZSTR_VAL(entry->filename));
+				spprintf(fp->error, 4096, "tar-based phar \"%s\" cannot be created, contents of file \"%s\" could not be written, seek failed", ZSTR_VAL(entry->phar->fname), ZSTR_VAL(entry->filename));
 			}
 			return ZEND_HASH_APPLY_STOP;
 		}
 
 		if (SUCCESS != php_stream_copy_to_stream_ex(phar_get_efp(entry, false), fp->new, entry->uncompressed_filesize, NULL)) {
 			if (fp->error) {
-				spprintf(fp->error, 4096, "tar-based phar \"%s\" cannot be created, contents of file \"%s\" could not be written", entry->phar->fname, ZSTR_VAL(entry->filename));
+				spprintf(fp->error, 4096, "tar-based phar \"%s\" cannot be created, contents of file \"%s\" could not be written", ZSTR_VAL(entry->phar->fname), ZSTR_VAL(entry->filename));
 			}
 			return ZEND_HASH_APPLY_STOP;
 		}
@@ -982,7 +984,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_tar_flush(phar_archive_data *phar, ze
 	entry.filename = NULL;
 
 	if (phar->is_persistent) {
-		spprintf(error, 0, "internal error: attempt to flush cached tar-based phar \"%s\"", phar->fname);
+		spprintf(error, 0, "internal error: attempt to flush cached tar-based phar \"%s\"", ZSTR_VAL(phar->fname));
 		return EOF;
 	}
 
@@ -998,7 +1000,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_tar_flush(phar_archive_data *phar, ze
 			return EOF;
 		}
 		if (phar->alias_len != php_stream_write(entry.fp, phar->alias, phar->alias_len)) {
-			spprintf(error, 0, "unable to set alias in tar-based phar \"%s\"", phar->fname);
+			spprintf(error, 0, "unable to set alias in tar-based phar \"%s\"", ZSTR_VAL(phar->fname));
 			php_stream_close(entry.fp);
 			return EOF;
 		}
@@ -1018,7 +1020,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_tar_flush(phar_archive_data *phar, ze
 		char *pos = php_stristr(ZSTR_VAL(user_stub), halt_stub, ZSTR_LEN(user_stub), sizeof(halt_stub) - 1);
 
 		if (pos == NULL) {
-			spprintf(error, 0, "illegal stub for tar-based phar \"%s\"", phar->fname);
+			spprintf(error, 0, "illegal stub for tar-based phar \"%s\"", ZSTR_VAL(phar->fname));
 			return EOF;
 		}
 
@@ -1037,7 +1039,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_tar_flush(phar_archive_data *phar, ze
 			len != php_stream_write(entry.fp, ZSTR_VAL(user_stub), len)
 			|| end_sequence_len != php_stream_write(entry.fp, end_sequence, end_sequence_len)
 		) {
-			spprintf(error, 0, "unable to create stub from string in new tar-based phar \"%s\"", phar->fname);
+			spprintf(error, 0, "unable to create stub from string in new tar-based phar \"%s\"", ZSTR_VAL(phar->fname));
 			php_stream_close(entry.fp);
 			return EOF;
 		}
@@ -1054,7 +1056,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_tar_flush(phar_archive_data *phar, ze
 		if (sizeof(newstub)-1 != php_stream_write(entry.fp, newstub, sizeof(newstub)-1)) {
 			php_stream_close(entry.fp);
 			spprintf(error, 0, "unable to %s stub in%star-based phar \"%s\", failed",
-				user_stub ? "overwrite" : "create", user_stub ? " " : " new ", phar->fname);
+				user_stub ? "overwrite" : "create", user_stub ? " " : " new ", ZSTR_VAL(phar->fname));
 			return EOF;
 		}
 
@@ -1066,7 +1068,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_tar_flush(phar_archive_data *phar, ze
 				if (NULL == zend_hash_add_mem(&phar->manifest, entry.filename, &entry, sizeof(phar_entry_info))) {
 					php_stream_close(entry.fp);
 					zend_string_efree(entry.filename);
-					spprintf(error, 0, "unable to create stub in tar-based phar \"%s\"", phar->fname);
+					spprintf(error, 0, "unable to create stub in tar-based phar \"%s\"", ZSTR_VAL(phar->fname));
 					return EOF;
 				}
 			} else {
@@ -1083,7 +1085,7 @@ nostub:
 		must_close_old_file = false;
 		php_stream_rewind(oldfile);
 	} else {
-		oldfile = php_stream_open_wrapper(phar->fname, "rb", 0, NULL);
+		oldfile = php_stream_open_wrapper(ZSTR_VAL(phar->fname), "rb", 0, NULL);
 		must_close_old_file = oldfile != NULL;
 	}
 
@@ -1122,7 +1124,7 @@ nostub:
 			mentry = zend_hash_add_mem(&phar->manifest, newentry.filename, &newentry, sizeof(phar_entry_info));
 			if (!mentry) {
 				zend_string_efree(newentry.filename);
-				spprintf(error, 0, "phar tar error: unable to add magic metadata file to manifest for phar archive \"%s\"", phar->fname);
+				spprintf(error, 0, "phar tar error: unable to add magic metadata file to manifest for phar archive \"%s\"", ZSTR_VAL(phar->fname));
 				if (must_close_old_file) {
 					php_stream_close(oldfile);
 				}
@@ -1205,7 +1207,7 @@ nostub:
 
 		if (8 != php_stream_write(entry.fp, sigbuf, 8) || signature_length != php_stream_write(entry.fp, signature, signature_length)) {
 			efree(signature);
-			spprintf(error, 0, "phar error: unable to write signature to tar-based phar %s", phar->fname);
+			spprintf(error, 0, "phar error: unable to write signature to tar-based phar %s", ZSTR_VAL(phar->fname));
 
 			if (must_close_old_file) {
 				php_stream_close(oldfile);
@@ -1259,10 +1261,10 @@ nostub:
 		/* deferred flush */
 		phar->fp = newfile;
 	} else {
-		phar->fp = php_stream_open_wrapper(phar->fname, "w+b", IGNORE_URL|STREAM_MUST_SEEK|REPORT_ERRORS, NULL);
+		phar->fp = php_stream_open_wrapper(ZSTR_VAL(phar->fname), "w+b", IGNORE_URL|STREAM_MUST_SEEK|REPORT_ERRORS, NULL);
 		if (!phar->fp) {
 			phar->fp = newfile;
-			spprintf(error, 0, "unable to open new phar \"%s\" for writing", phar->fname);
+			spprintf(error, 0, "unable to open new phar \"%s\" for writing", ZSTR_VAL(phar->fname));
 			return EOF;
 		}
 
@@ -1284,7 +1286,7 @@ nostub:
 				/* copy contents uncompressed rather than lose them */
 				php_stream_copy_to_stream_ex(newfile, phar->fp, PHP_STREAM_COPY_ALL, NULL);
 				php_stream_close(newfile);
-				spprintf(error, 4096, "unable to compress all contents of phar \"%s\" using zlib, PHP versions older than 5.2.6 have a buggy zlib", phar->fname);
+				spprintf(error, 4096, "unable to compress all contents of phar \"%s\" using zlib, PHP versions older than 5.2.6 have a buggy zlib", ZSTR_VAL(phar->fname));
 				return EOF;
 			}
 

--- a/ext/phar/util.c
+++ b/ext/phar/util.c
@@ -291,10 +291,10 @@ zend_string *phar_find_in_include_path(zend_string *filename, phar_archive_data 
 	if (
 		PHAR_G(last_phar)
 		&& is_file_a_phar_wrapper
-		&& ZSTR_LEN(fname) - length_phar_protocol >= PHAR_G(last_phar_name_len)
-		&& !memcmp(ZSTR_VAL(fname) + length_phar_protocol, PHAR_G(last_phar_name), PHAR_G(last_phar_name_len))
+		&& ZSTR_LEN(fname) - length_phar_protocol >= ZSTR_LEN(PHAR_G(last_phar_name))
+		&& !memcmp(ZSTR_VAL(fname) + length_phar_protocol, ZSTR_VAL(PHAR_G(last_phar_name)), ZSTR_LEN(PHAR_G(last_phar_name)))
 	) {
-		arch = zend_string_init(PHAR_G(last_phar_name), PHAR_G(last_phar_name_len), false);
+		arch = zend_string_init(ZSTR_VAL(PHAR_G(last_phar_name)), ZSTR_LEN(PHAR_G(last_phar_name)), false);
 		phar = PHAR_G(last_phar);
 		goto splitted;
 	}
@@ -440,7 +440,7 @@ ZEND_ATTRIBUTE_NONNULL static zend_result phar_separate_entry_fp(phar_entry_info
 	}
 
 	if (SUCCESS != php_stream_copy_to_stream_ex(phar_get_efp(link, false), fp, link->uncompressed_filesize, NULL)) {
-		spprintf(error, 4096, "phar error: cannot separate entry file \"%s\" contents in phar archive \"%s\" for write access", ZSTR_VAL(entry->filename), entry->phar->fname);
+		spprintf(error, 4096, "phar error: cannot separate entry file \"%s\" contents in phar archive \"%s\" for write access", ZSTR_VAL(entry->filename), ZSTR_VAL(entry->phar->fname));
 		return FAILURE;
 	}
 
@@ -688,7 +688,7 @@ ZEND_ATTRIBUTE_NONNULL phar_entry_data *phar_get_or_create_entry_data(char *fnam
 	if (!entry) {
 		php_stream_close(etemp.fp);
 		spprintf(error, 0, "phar error: unable to add new entry \"%s\" to phar \"%s\"",
-			ZSTR_VAL(etemp.filename), phar->fname);
+			ZSTR_VAL(etemp.filename), ZSTR_VAL(phar->fname));
 		efree(ret);
 		zend_string_efree(etemp.filename);
 		return NULL;
@@ -723,11 +723,11 @@ php_stream *phar_open_archive_fp(phar_archive_data *phar) /* {{{ */
 		return stream;
 	}
 
-	if (php_check_open_basedir(phar->fname)) {
+	if (php_check_open_basedir(ZSTR_VAL(phar->fname))) {
 		return NULL;
 	}
 
-	stream = php_stream_open_wrapper(phar->fname, "rb", IGNORE_URL|STREAM_MUST_SEEK, NULL);
+	stream = php_stream_open_wrapper(ZSTR_VAL(phar->fname), "rb", IGNORE_URL|STREAM_MUST_SEEK, NULL);
 	phar_set_pharfp(phar, stream);
 
 	return stream;
@@ -768,7 +768,7 @@ ZEND_ATTRIBUTE_NONNULL zend_result phar_copy_entry_fp(phar_entry_info *source, p
 		php_stream_close(dest->fp);
 		dest->fp_type = PHAR_FP;
 		spprintf(error, 4096, "phar error: unable to copy contents of file \"%s\" to \"%s\" in phar archive \"%s\"",
-			ZSTR_VAL(source->filename), ZSTR_VAL(dest->filename), source->phar->fname);
+			ZSTR_VAL(source->filename), ZSTR_VAL(dest->filename), ZSTR_VAL(source->phar->fname));
 		return FAILURE;
 	}
 
@@ -835,7 +835,7 @@ ZEND_ATTRIBUTE_NONNULL zend_result phar_open_entry_fp(phar_entry_info *entry, ch
 
 	if (!phar_get_pharfp(phar)) {
 		if (!phar_open_archive_fp(phar)) {
-			spprintf(error, 4096, "phar error: Cannot open phar archive \"%s\" for reading", phar->fname);
+			spprintf(error, 4096, "phar error: Cannot open phar archive \"%s\" for reading", ZSTR_VAL(phar->fname));
 			return FAILURE;
 		}
 	}
@@ -854,7 +854,7 @@ ZEND_ATTRIBUTE_NONNULL zend_result phar_open_entry_fp(phar_entry_info *entry, ch
 	if (!phar_get_entrypufp(entry)) {
 		phar_set_entrypufp(entry, php_stream_fopen_tmpfile());
 		if (!phar_get_entrypufp(entry)) {
-			spprintf(error, 4096, "phar error: Cannot open temporary file for decompressing phar archive \"%s\" file \"%s\"", phar->fname, ZSTR_VAL(entry->filename));
+			spprintf(error, 4096, "phar error: Cannot open temporary file for decompressing phar archive \"%s\" file \"%s\"", ZSTR_VAL(phar->fname), ZSTR_VAL(entry->filename));
 			return FAILURE;
 		}
 	}
@@ -877,7 +877,7 @@ ZEND_ATTRIBUTE_NONNULL zend_result phar_open_entry_fp(phar_entry_info *entry, ch
 	}
 
 	if (!filter) {
-		spprintf(error, 4096, "phar error: unable to read phar \"%s\" (cannot create %s filter while decompressing file \"%s\")", phar->fname, phar_decompress_filter(entry, true), ZSTR_VAL(entry->filename));
+		spprintf(error, 4096, "phar error: unable to read phar \"%s\" (cannot create %s filter while decompressing file \"%s\")", ZSTR_VAL(phar->fname), phar_decompress_filter(entry, true), ZSTR_VAL(entry->filename));
 		return FAILURE;
 	}
 
@@ -890,7 +890,7 @@ ZEND_ATTRIBUTE_NONNULL zend_result phar_open_entry_fp(phar_entry_info *entry, ch
 
 	if (entry->uncompressed_filesize) {
 		if (SUCCESS != php_stream_copy_to_stream_ex(phar_get_entrypfp(entry), ufp, entry->compressed_filesize, NULL)) {
-			spprintf(error, 4096, "phar error: internal corruption of phar \"%s\" (actual filesize mismatch on file \"%s\")", phar->fname, ZSTR_VAL(entry->filename));
+			spprintf(error, 4096, "phar error: internal corruption of phar \"%s\" (actual filesize mismatch on file \"%s\")", ZSTR_VAL(phar->fname), ZSTR_VAL(entry->filename));
 			php_stream_filter_remove(filter, 1);
 			return FAILURE;
 		}
@@ -901,7 +901,7 @@ ZEND_ATTRIBUTE_NONNULL zend_result phar_open_entry_fp(phar_entry_info *entry, ch
 	php_stream_filter_remove(filter, 1);
 
 	if (php_stream_tell(ufp) - loc != (zend_off_t) entry->uncompressed_filesize) {
-		spprintf(error, 4096, "phar error: internal corruption of phar \"%s\" (actual filesize mismatch on file \"%s\")", phar->fname, ZSTR_VAL(entry->filename));
+		spprintf(error, 4096, "phar error: internal corruption of phar \"%s\" (actual filesize mismatch on file \"%s\")", ZSTR_VAL(phar->fname), ZSTR_VAL(entry->filename));
 		return FAILURE;
 	}
 
@@ -929,7 +929,7 @@ ZEND_ATTRIBUTE_NONNULL phar_entry_info * phar_open_jit(const phar_archive_data *
 		return NULL;
 	}
 	if (-1 == phar_seek_efp(entry, 0, SEEK_SET, 0, true)) {
-		spprintf(error, 4096, "phar error: cannot seek to start of file \"%s\" in phar \"%s\"", ZSTR_VAL(entry->filename), phar->fname);
+		spprintf(error, 4096, "phar error: cannot seek to start of file \"%s\" in phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(phar->fname));
 		return NULL;
 	}
 	return entry;
@@ -943,7 +943,7 @@ zend_result phar_free_alias(const phar_archive_data *phar) /* {{{ */
 	}
 
 	/* this archive has no open references, so emit a notice and remove it */
-	if (zend_hash_str_del(&(PHAR_G(phar_fname_map)), phar->fname, phar->fname_len) != SUCCESS) {
+	if (zend_hash_del(&(PHAR_G(phar_fname_map)), phar->fname) != SUCCESS) {
 		return FAILURE;
 	}
 
@@ -973,13 +973,13 @@ zend_result phar_get_archive(phar_archive_data **archive, const char *fname, siz
 
 	*archive = NULL;
 
-	if (PHAR_G(last_phar) && fname_len == PHAR_G(last_phar_name_len) && !memcmp(fname, PHAR_G(last_phar_name), fname_len)) {
+	if (PHAR_G(last_phar) && zend_string_equals_cstr(PHAR_G(last_phar_name), fname, fname_len)) {
 		*archive = PHAR_G(last_phar);
 		if (alias && alias_len) {
 
 			if (!PHAR_G(last_phar)->is_temporary_alias && (alias_len != PHAR_G(last_phar)->alias_len || memcmp(PHAR_G(last_phar)->alias, alias, alias_len))) {
 				if (error) {
-					spprintf(error, 0, "alias \"%s\" is already used for archive \"%s\" cannot be overloaded with \"%s\"", alias, PHAR_G(last_phar)->fname, fname);
+					spprintf(error, 0, "alias \"%s\" is already used for archive \"%s\" cannot be overloaded with \"%s\"", alias, ZSTR_VAL(PHAR_G(last_phar)->fname), fname);
 				}
 				*archive = NULL;
 				return FAILURE;
@@ -1007,9 +1007,9 @@ zend_result phar_get_archive(phar_archive_data **archive, const char *fname, siz
 		fd_ptr = zend_hash_str_find_ptr(&(PHAR_G(phar_alias_map)), alias, alias_len);
 		if (fd_ptr) {
 alias_success:
-			if (fname && (fname_len != fd_ptr->fname_len || strncmp(fname, fd_ptr->fname, fname_len))) {
+			if (!zend_string_equals_cstr(fd_ptr->fname, fname, fname_len)) {
 				if (error) {
-					spprintf(error, 0, "alias \"%s\" is already used for archive \"%s\" cannot be overloaded with \"%s\"", alias, fd_ptr->fname, fname);
+					spprintf(error, 0, "alias \"%s\" is already used for archive \"%s\" cannot be overloaded with \"%s\"", alias, ZSTR_VAL(fd_ptr->fname), fname);
 				}
 				if (SUCCESS == phar_free_alias(fd_ptr)) {
 					if (error) {
@@ -1024,7 +1024,6 @@ alias_success:
 			fd = fd_ptr;
 			PHAR_G(last_phar) = fd;
 			PHAR_G(last_phar_name) = fd->fname;
-			PHAR_G(last_phar_name_len) = fd->fname_len;
 			PHAR_G(last_alias) = alias;
 			PHAR_G(last_alias_len) = alias_len;
 
@@ -1049,7 +1048,7 @@ alias_success:
 			if (alias && alias_len) {
 				if (!fd->is_temporary_alias && (alias_len != fd->alias_len || memcmp(fd->alias, alias, alias_len))) {
 					if (error) {
-						spprintf(error, 0, "alias \"%s\" is already used for archive \"%s\" cannot be overloaded with \"%s\"", alias, fd_ptr->fname, fname);
+						spprintf(error, 0, "alias \"%s\" is already used for archive \"%s\" cannot be overloaded with \"%s\"", alias, ZSTR_VAL(fd_ptr->fname), fname);
 					}
 					return FAILURE;
 				}
@@ -1063,7 +1062,6 @@ alias_success:
 
 			PHAR_G(last_phar) = fd;
 			PHAR_G(last_phar_name) = fd->fname;
-			PHAR_G(last_phar_name_len) = fd->fname_len;
 			PHAR_G(last_alias) = fd->alias;
 			PHAR_G(last_alias_len) = fd->alias_len;
 
@@ -1079,7 +1077,7 @@ alias_success:
 			if (!fd->is_temporary_alias && alias && alias_len) {
 				if (alias_len != fd->alias_len || memcmp(fd->alias, alias, alias_len)) {
 					if (error) {
-						spprintf(error, 0, "alias \"%s\" is already used for archive \"%s\" cannot be overloaded with \"%s\"", alias, fd_ptr->fname, fname);
+						spprintf(error, 0, "alias \"%s\" is already used for archive \"%s\" cannot be overloaded with \"%s\"", alias, ZSTR_VAL(fd_ptr->fname), fname);
 					}
 					return FAILURE;
 				}
@@ -1087,7 +1085,6 @@ alias_success:
 
 			PHAR_G(last_phar) = fd;
 			PHAR_G(last_phar_name) = fd->fname;
-			PHAR_G(last_phar_name_len) = fd->fname_len;
 			PHAR_G(last_alias) = fd->alias;
 			PHAR_G(last_alias_len) = fd->alias_len;
 
@@ -1100,7 +1097,6 @@ alias_success:
 
 			PHAR_G(last_phar) = fd;
 			PHAR_G(last_phar_name) = fd->fname;
-			PHAR_G(last_phar_name_len) = fd->fname_len;
 			PHAR_G(last_alias) = fd->alias;
 			PHAR_G(last_alias_len) = fd->alias_len;
 
@@ -1112,7 +1108,6 @@ alias_success:
 
 			PHAR_G(last_phar) = fd;
 			PHAR_G(last_phar_name) = fd->fname;
-			PHAR_G(last_phar_name_len) = fd->fname_len;
 			PHAR_G(last_alias) = fd->alias;
 			PHAR_G(last_alias_len) = fd->alias_len;
 
@@ -1147,7 +1142,6 @@ realpath_success:
 
 			PHAR_G(last_phar) = fd;
 			PHAR_G(last_phar_name) = fd->fname;
-			PHAR_G(last_phar_name_len) = fd->fname_len;
 			PHAR_G(last_alias) = fd->alias;
 			PHAR_G(last_alias_len) = fd->alias_len;
 
@@ -1875,7 +1869,7 @@ ZEND_ATTRIBUTE_NONNULL zend_result phar_create_signature(phar_archive_data *phar
 			in = BIO_new_mem_buf(PHAR_G(openssl_privatekey), PHAR_G(openssl_privatekey_len));
 
 			if (in == NULL) {
-				spprintf(error, 0, "unable to write to phar \"%s\" with requested openssl signature", phar->fname);
+				spprintf(error, 0, "unable to write to phar \"%s\" with requested openssl signature", ZSTR_VAL(phar->fname));
 				return FAILURE;
 			}
 
@@ -1890,7 +1884,7 @@ ZEND_ATTRIBUTE_NONNULL zend_result phar_create_signature(phar_archive_data *phar
 			md_ctx = EVP_MD_CTX_create();
 			if (md_ctx == NULL) {
 				EVP_PKEY_free(key);
-				spprintf(error, 0, "unable to initialize openssl signature for phar \"%s\"", phar->fname);
+				spprintf(error, 0, "unable to initialize openssl signature for phar \"%s\"", ZSTR_VAL(phar->fname));
 				return FAILURE;
 			}
 
@@ -1901,7 +1895,7 @@ ZEND_ATTRIBUTE_NONNULL zend_result phar_create_signature(phar_archive_data *phar
 				EVP_PKEY_free(key);
 				EVP_MD_CTX_destroy(md_ctx);
 				efree(sigbuf);
-				spprintf(error, 0, "unable to initialize openssl signature for phar \"%s\"", phar->fname);
+				spprintf(error, 0, "unable to initialize openssl signature for phar \"%s\"", ZSTR_VAL(phar->fname));
 				return FAILURE;
 			}
 
@@ -1910,7 +1904,7 @@ ZEND_ATTRIBUTE_NONNULL zend_result phar_create_signature(phar_archive_data *phar
 					EVP_PKEY_free(key);
 					EVP_MD_CTX_destroy(md_ctx);
 					efree(sigbuf);
-					spprintf(error, 0, "unable to update the openssl signature for phar \"%s\"", phar->fname);
+					spprintf(error, 0, "unable to update the openssl signature for phar \"%s\"", ZSTR_VAL(phar->fname));
 					return FAILURE;
 				}
 			}
@@ -1919,7 +1913,7 @@ ZEND_ATTRIBUTE_NONNULL zend_result phar_create_signature(phar_archive_data *phar
 				EVP_PKEY_free(key);
 				EVP_MD_CTX_destroy(md_ctx);
 				efree(sigbuf);
-				spprintf(error, 0, "unable to write phar \"%s\" with requested openssl signature", phar->fname);
+				spprintf(error, 0, "unable to write phar \"%s\" with requested openssl signature", ZSTR_VAL(phar->fname));
 				return FAILURE;
 			}
 
@@ -1933,7 +1927,7 @@ ZEND_ATTRIBUTE_NONNULL zend_result phar_create_signature(phar_archive_data *phar
 			php_stream_seek(fp, 0, SEEK_END);
 
 			if (FAILURE == phar_call_openssl_signverify(true, fp, php_stream_tell(fp), PHAR_G(openssl_privatekey), PHAR_G(openssl_privatekey_len), (char **)&sigbuf, &siglen, phar->sig_flags)) {
-				spprintf(error, 0, "unable to write phar \"%s\" with requested openssl signature", phar->fname);
+				spprintf(error, 0, "unable to write phar \"%s\" with requested openssl signature", ZSTR_VAL(phar->fname));
 				return FAILURE;
 			}
 #endif
@@ -2039,15 +2033,12 @@ static void phar_copy_cached_phar(phar_archive_data **pphar) /* {{{ */
 {
 	phar_archive_data *phar;
 	HashTable newmanifest;
-	char *fname;
 	phar_archive_object *objphar;
 
 	phar = (phar_archive_data *) emalloc(sizeof(phar_archive_data));
 	*phar = **pphar;
 	phar->is_persistent = 0;
-	fname = phar->fname;
-	phar->fname = estrndup(phar->fname, phar->fname_len);
-	phar->ext = phar->fname + (phar->ext - fname);
+	zend_string_addref(phar->fname);
 
 	if (phar->alias) {
 		phar->alias = estrndup(phar->alias, phar->alias_len);
@@ -2073,7 +2064,7 @@ static void phar_copy_cached_phar(phar_archive_data **pphar) /* {{{ */
 
 	/* now, scan the list of persistent Phar objects referencing this phar and update the pointers */
 	ZEND_HASH_MAP_FOREACH_PTR(&PHAR_G(phar_persist_map), objphar) {
-		if (objphar->archive->fname_len == phar->fname_len && !memcmp(objphar->archive->fname, phar->fname, phar->fname_len)) {
+		if (zend_string_equals(objphar->archive->fname, phar->fname)) {
 			objphar->archive = phar;
 		}
 	} ZEND_HASH_FOREACH_END();
@@ -2086,7 +2077,8 @@ zend_result phar_copy_on_write(phar_archive_data **pphar) /* {{{ */
 	phar_archive_data *newpphar;
 
 	ZVAL_PTR(&zv, *pphar);
-	if (NULL == (pzv = zend_hash_str_add(&(PHAR_G(phar_fname_map)), (*pphar)->fname, (*pphar)->fname_len, &zv))) {
+	pzv = zend_hash_add(&(PHAR_G(phar_fname_map)), (*pphar)->fname, &zv);
+	if (!pzv) {
 		return FAILURE;
 	}
 
@@ -2098,7 +2090,7 @@ zend_result phar_copy_on_write(phar_archive_data **pphar) /* {{{ */
 	PHAR_G(last_phar_name) = NULL;
 
 	if (newpphar->alias_len && NULL == zend_hash_str_add_ptr(&(PHAR_G(phar_alias_map)), newpphar->alias, newpphar->alias_len, newpphar)) {
-		zend_hash_str_del(&(PHAR_G(phar_fname_map)), (*pphar)->fname, (*pphar)->fname_len);
+		zend_hash_del(&(PHAR_G(phar_fname_map)), (*pphar)->fname);
 		return FAILURE;
 	}
 

--- a/ext/phar/zip.c
+++ b/ext/phar/zip.c
@@ -308,21 +308,23 @@ zend_result phar_parse_zipfile(php_stream *fp, const char *fname, size_t fname_l
 		ZVAL_UNDEF(&mydata->metadata_tracker.val);
 	}
 
-	mydata->fname = pestrndup(fname, fname_len, mydata->is_persistent);
+	mydata->fname = zend_string_init(fname, fname_len, mydata->is_persistent);
+	if (mydata->is_persistent) {
+		GC_MAKE_PERSISTENT_LOCAL(mydata->fname);
+	}
 #ifdef PHP_WIN32
-	phar_unixify_path_separators(mydata->fname, fname_len);
+	phar_unixify_path_separators(ZSTR_VAL(mydata->fname), ZSTR_LEN(mydata->fname));
 #endif
 	mydata->is_zip = 1;
-	mydata->fname_len = fname_len;
-	ext = strrchr(mydata->fname, '/');
+	ext = strrchr(ZSTR_VAL(mydata->fname), '/');
 
 	if (ext) {
-		mydata->ext = memchr(ext, '.', (mydata->fname + fname_len) - ext);
+		mydata->ext = memchr(ext, '.', (ZSTR_VAL(mydata->fname) + ZSTR_LEN(mydata->fname)) - ext);
 		if (mydata->ext == ext) {
-			mydata->ext = memchr(ext + 1, '.', (mydata->fname + fname_len) - ext - 1);
+			mydata->ext = memchr(ext + 1, '.', (ZSTR_VAL(mydata->fname) + ZSTR_LEN(mydata->fname)) - ext - 1);
 		}
 		if (mydata->ext) {
-			mydata->ext_len = (mydata->fname + fname_len) - mydata->ext;
+			mydata->ext_len = (ZSTR_VAL(mydata->fname) + ZSTR_LEN(mydata->fname)) - mydata->ext;
 		}
 	}
 
@@ -354,9 +356,9 @@ zend_result phar_parse_zipfile(php_stream *fp, const char *fname, size_t fname_l
 				efree(mydata->signature); \
 			} \
 			if (error) { \
-				spprintf(error, 4096, "phar error: %s in zip-based phar \"%s\"", errmsg, mydata->fname); \
+				spprintf(error, 4096, "phar error: %s in zip-based phar \"%s\"", errmsg, ZSTR_VAL(mydata->fname)); \
 			} \
-			pefree(mydata->fname, mydata->is_persistent); \
+			zend_string_release_ex(mydata->fname, mydata->is_persistent); \
 			if (mydata->alias) { \
 				pefree(mydata->alias, mydata->is_persistent); \
 			} \
@@ -723,7 +725,7 @@ zend_result phar_parse_zipfile(php_stream *fp, const char *fname, size_t fname_l
 
 	mydata->fp = fp;
 
-	zend_hash_str_add_ptr(&(PHAR_G(phar_fname_map)), mydata->fname, fname_len, mydata);
+	zend_hash_add_ptr(&(PHAR_G(phar_fname_map)), mydata->fname, mydata);
 
 	if (actual_alias) {
 
@@ -732,7 +734,7 @@ zend_result phar_parse_zipfile(php_stream *fp, const char *fname, size_t fname_l
 				spprintf(error, 4096, "phar error: invalid alias \"%s\" in zip-based phar \"%s\"", actual_alias, fname);
 			}
 			efree(actual_alias);
-			zend_hash_str_del(&(PHAR_G(phar_fname_map)), mydata->fname, fname_len);
+			zend_hash_del(&(PHAR_G(phar_fname_map)), mydata->fname);
 			return FAILURE;
 		}
 
@@ -745,7 +747,7 @@ zend_result phar_parse_zipfile(php_stream *fp, const char *fname, size_t fname_l
 					spprintf(error, 4096, "phar error: Unable to add zip-based phar \"%s\" with implicit alias, alias is already in use", fname);
 				}
 				efree(actual_alias);
-				zend_hash_str_del(&(PHAR_G(phar_fname_map)), mydata->fname, fname_len);
+				zend_hash_del(&(PHAR_G(phar_fname_map)), mydata->fname);
 				return FAILURE;
 			}
 		}
@@ -765,7 +767,7 @@ zend_result phar_parse_zipfile(php_stream *fp, const char *fname, size_t fname_l
 					if (error) {
 						spprintf(error, 4096, "phar error: Unable to add zip-based phar \"%s\" with explicit alias, alias is already in use", fname);
 					}
-					zend_hash_str_del(&(PHAR_G(phar_fname_map)), mydata->fname, fname_len);
+					zend_hash_del(&(PHAR_G(phar_fname_map)), mydata->fname);
 					return FAILURE;
 				}
 			}
@@ -774,7 +776,7 @@ zend_result phar_parse_zipfile(php_stream *fp, const char *fname, size_t fname_l
 			mydata->alias = pestrndup(alias, alias_len, mydata->is_persistent);
 			mydata->alias_len = alias_len;
 		} else {
-			mydata->alias = pestrndup(mydata->fname, fname_len, mydata->is_persistent);
+			mydata->alias = pestrndup(ZSTR_VAL(mydata->fname), ZSTR_LEN(mydata->fname), mydata->is_persistent);
 			mydata->alias_len = fname_len;
 		}
 
@@ -914,7 +916,7 @@ static int phar_zip_changed_apply_int(phar_entry_info *entry, void *arg) /* {{{ 
 		}
 
 		if (FAILURE == phar_open_entry_fp(entry, p->error, false)) {
-			spprintf(p->error, 0, "unable to open file contents of file \"%s\" in zip-based phar \"%s\"", ZSTR_VAL(entry->filename), entry->phar->fname);
+			spprintf(p->error, 0, "unable to open file contents of file \"%s\" in zip-based phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(entry->phar->fname));
 			return ZEND_HASH_APPLY_STOP;
 		}
 
@@ -925,7 +927,7 @@ static int phar_zip_changed_apply_int(phar_entry_info *entry, void *arg) /* {{{ 
 		}
 
 		if (-1 == phar_seek_efp(entry, 0, SEEK_SET, 0, false)) {
-			spprintf(p->error, 0, "unable to seek to start of file \"%s\" to zip-based phar \"%s\"", ZSTR_VAL(entry->filename), entry->phar->fname);
+			spprintf(p->error, 0, "unable to seek to start of file \"%s\" to zip-based phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(entry->phar->fname));
 			return ZEND_HASH_APPLY_STOP;
 		}
 
@@ -950,9 +952,9 @@ static int phar_zip_changed_apply_int(phar_entry_info *entry, void *arg) /* {{{ 
 
 		if (!filter) {
 			if (entry->flags & PHAR_ENT_COMPRESSED_GZ) {
-				spprintf(p->error, 0, "unable to gzip compress file \"%s\" to zip-based phar \"%s\"", ZSTR_VAL(entry->filename), entry->phar->fname);
+				spprintf(p->error, 0, "unable to gzip compress file \"%s\" to zip-based phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(entry->phar->fname));
 			} else {
-				spprintf(p->error, 0, "unable to bzip2 compress file \"%s\" to zip-based phar \"%s\"", ZSTR_VAL(entry->filename), entry->phar->fname);
+				spprintf(p->error, 0, "unable to bzip2 compress file \"%s\" to zip-based phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(entry->phar->fname));
 			}
 			return ZEND_HASH_APPLY_STOP;
 		}
@@ -964,7 +966,7 @@ static int phar_zip_changed_apply_int(phar_entry_info *entry, void *arg) /* {{{ 
 
 		if (!entry->cfp) {
 			php_stream_filter_free(filter);
-			spprintf(p->error, 0, "unable to create temporary file for file \"%s\" while creating zip-based phar \"%s\"", ZSTR_VAL(entry->filename), entry->phar->fname);
+			spprintf(p->error, 0, "unable to create temporary file for file \"%s\" while creating zip-based phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(entry->phar->fname));
 			return ZEND_HASH_APPLY_STOP;
 		}
 
@@ -972,7 +974,7 @@ static int phar_zip_changed_apply_int(phar_entry_info *entry, void *arg) /* {{{ 
 
 		if (-1 == phar_seek_efp(entry, 0, SEEK_SET, 0, false)) {
 			php_stream_filter_free(filter);
-			spprintf(p->error, 0, "unable to seek to start of file \"%s\" to zip-based phar \"%s\"", ZSTR_VAL(entry->filename), entry->phar->fname);
+			spprintf(p->error, 0, "unable to seek to start of file \"%s\" to zip-based phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(entry->phar->fname));
 			return ZEND_HASH_APPLY_STOP;
 		}
 
@@ -980,7 +982,7 @@ static int phar_zip_changed_apply_int(phar_entry_info *entry, void *arg) /* {{{ 
 
 		if (SUCCESS != php_stream_copy_to_stream_ex(efp, entry->cfp, entry->uncompressed_filesize, NULL)) {
 			php_stream_filter_remove(filter, 1);
-			spprintf(p->error, 0, "unable to copy compressed file contents of file \"%s\" while creating new phar \"%s\"", ZSTR_VAL(entry->filename), entry->phar->fname);
+			spprintf(p->error, 0, "unable to copy compressed file contents of file \"%s\" while creating new phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(entry->phar->fname));
 			return ZEND_HASH_APPLY_STOP;
 		}
 
@@ -1003,7 +1005,7 @@ is_compressed:
 		PHAR_SET_32(local.compsize, entry->compressed_filesize);
 		if (p->old) {
 			if (-1 == php_stream_seek(p->old, entry->offset_abs, SEEK_SET)) {
-				spprintf(p->error, 0, "unable to seek to start of file \"%s\" while creating zip-based phar \"%s\"", ZSTR_VAL(entry->filename), entry->phar->fname);
+				spprintf(p->error, 0, "unable to seek to start of file \"%s\" while creating zip-based phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(entry->phar->fname));
 				return ZEND_HASH_APPLY_STOP;
 			}
 		}
@@ -1022,61 +1024,61 @@ continue_dir:
 	offset = entry->header_offset + sizeof(local) + ZSTR_LEN(entry->filename) + (entry->is_dir ? 1 : 0) + sizeof(perms);
 
 	if (sizeof(local) != php_stream_write(p->filefp, (char *)&local, sizeof(local))) {
-		spprintf(p->error, 0, "unable to write local file header of file \"%s\" to zip-based phar \"%s\"", ZSTR_VAL(entry->filename), entry->phar->fname);
+		spprintf(p->error, 0, "unable to write local file header of file \"%s\" to zip-based phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(entry->phar->fname));
 		return ZEND_HASH_APPLY_STOP;
 	}
 
 	if (sizeof(central) != php_stream_write(p->centralfp, (char *)&central, sizeof(central))) {
-		spprintf(p->error, 0, "unable to write central directory entry for file \"%s\" while creating zip-based phar \"%s\"", ZSTR_VAL(entry->filename), entry->phar->fname);
+		spprintf(p->error, 0, "unable to write central directory entry for file \"%s\" while creating zip-based phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(entry->phar->fname));
 		return ZEND_HASH_APPLY_STOP;
 	}
 
 	if (entry->is_dir) {
 		if (ZSTR_LEN(entry->filename) != php_stream_write(p->filefp, ZSTR_VAL(entry->filename), ZSTR_LEN(entry->filename))) {
-			spprintf(p->error, 0, "unable to write filename to local directory entry for directory \"%s\" while creating zip-based phar \"%s\"", ZSTR_VAL(entry->filename), entry->phar->fname);
+			spprintf(p->error, 0, "unable to write filename to local directory entry for directory \"%s\" while creating zip-based phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(entry->phar->fname));
 			return ZEND_HASH_APPLY_STOP;
 		}
 
 		if (1 != php_stream_write(p->filefp, "/", 1)) {
-			spprintf(p->error, 0, "unable to write filename to local directory entry for directory \"%s\" while creating zip-based phar \"%s\"", ZSTR_VAL(entry->filename), entry->phar->fname);
+			spprintf(p->error, 0, "unable to write filename to local directory entry for directory \"%s\" while creating zip-based phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(entry->phar->fname));
 			return ZEND_HASH_APPLY_STOP;
 		}
 
 		if (ZSTR_LEN(entry->filename) != php_stream_write(p->centralfp, ZSTR_VAL(entry->filename), ZSTR_LEN(entry->filename))) {
-			spprintf(p->error, 0, "unable to write filename to central directory entry for directory \"%s\" while creating zip-based phar \"%s\"", ZSTR_VAL(entry->filename), entry->phar->fname);
+			spprintf(p->error, 0, "unable to write filename to central directory entry for directory \"%s\" while creating zip-based phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(entry->phar->fname));
 			return ZEND_HASH_APPLY_STOP;
 		}
 
 		if (1 != php_stream_write(p->centralfp, "/", 1)) {
-			spprintf(p->error, 0, "unable to write filename to central directory entry for directory \"%s\" while creating zip-based phar \"%s\"", ZSTR_VAL(entry->filename), entry->phar->fname);
+			spprintf(p->error, 0, "unable to write filename to central directory entry for directory \"%s\" while creating zip-based phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(entry->phar->fname));
 			return ZEND_HASH_APPLY_STOP;
 		}
 	} else {
 		if (ZSTR_LEN(entry->filename) != php_stream_write(p->filefp, ZSTR_VAL(entry->filename), ZSTR_LEN(entry->filename))) {
-			spprintf(p->error, 0, "unable to write filename to local directory entry for file \"%s\" while creating zip-based phar \"%s\"", ZSTR_VAL(entry->filename), entry->phar->fname);
+			spprintf(p->error, 0, "unable to write filename to local directory entry for file \"%s\" while creating zip-based phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(entry->phar->fname));
 			return ZEND_HASH_APPLY_STOP;
 		}
 
 		if (ZSTR_LEN(entry->filename) != php_stream_write(p->centralfp, ZSTR_VAL(entry->filename), ZSTR_LEN(entry->filename))) {
-			spprintf(p->error, 0, "unable to write filename to central directory entry for file \"%s\" while creating zip-based phar \"%s\"", ZSTR_VAL(entry->filename), entry->phar->fname);
+			spprintf(p->error, 0, "unable to write filename to central directory entry for file \"%s\" while creating zip-based phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(entry->phar->fname));
 			return ZEND_HASH_APPLY_STOP;
 		}
 	}
 
 	if (sizeof(perms) != php_stream_write(p->filefp, (char *)&perms, sizeof(perms))) {
-		spprintf(p->error, 0, "unable to write local extra permissions file header of file \"%s\" to zip-based phar \"%s\"", ZSTR_VAL(entry->filename), entry->phar->fname);
+		spprintf(p->error, 0, "unable to write local extra permissions file header of file \"%s\" to zip-based phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(entry->phar->fname));
 		return ZEND_HASH_APPLY_STOP;
 	}
 
 	if (sizeof(perms) != php_stream_write(p->centralfp, (char *)&perms, sizeof(perms))) {
-		spprintf(p->error, 0, "unable to write central extra permissions file header of file \"%s\" to zip-based phar \"%s\"", ZSTR_VAL(entry->filename), entry->phar->fname);
+		spprintf(p->error, 0, "unable to write central extra permissions file header of file \"%s\" to zip-based phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(entry->phar->fname));
 		return ZEND_HASH_APPLY_STOP;
 	}
 
 	if (!not_really_modified && entry->is_modified) {
 		if (entry->cfp) {
 			if (SUCCESS != php_stream_copy_to_stream_ex(entry->cfp, p->filefp, entry->compressed_filesize, NULL)) {
-				spprintf(p->error, 0, "unable to write compressed contents of file \"%s\" in zip-based phar \"%s\"", ZSTR_VAL(entry->filename), entry->phar->fname);
+				spprintf(p->error, 0, "unable to write compressed contents of file \"%s\" in zip-based phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(entry->phar->fname));
 				return ZEND_HASH_APPLY_STOP;
 			}
 
@@ -1090,7 +1092,7 @@ continue_dir:
 			phar_seek_efp(entry, 0, SEEK_SET, 0, false);
 
 			if (SUCCESS != php_stream_copy_to_stream_ex(phar_get_efp(entry, false), p->filefp, entry->uncompressed_filesize, NULL)) {
-				spprintf(p->error, 0, "unable to write contents of file \"%s\" in zip-based phar \"%s\"", ZSTR_VAL(entry->filename), entry->phar->fname);
+				spprintf(p->error, 0, "unable to write contents of file \"%s\" in zip-based phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(entry->phar->fname));
 				return ZEND_HASH_APPLY_STOP;
 			}
 		}
@@ -1116,7 +1118,7 @@ continue_dir:
 		}
 
 		if (!entry->is_dir && entry->compressed_filesize && SUCCESS != php_stream_copy_to_stream_ex(p->old, p->filefp, entry->compressed_filesize, NULL)) {
-			spprintf(p->error, 0, "unable to copy contents of file \"%s\" while creating zip-based phar \"%s\"", ZSTR_VAL(entry->filename), entry->phar->fname);
+			spprintf(p->error, 0, "unable to copy contents of file \"%s\" while creating zip-based phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(entry->phar->fname));
 			return ZEND_HASH_APPLY_STOP;
 		}
 	}
@@ -1127,7 +1129,7 @@ continue_dir:
 
 	if (entry->metadata_tracker.str) {
 		if (ZSTR_LEN(entry->metadata_tracker.str) != php_stream_write(p->centralfp, ZSTR_VAL(entry->metadata_tracker.str), ZSTR_LEN(entry->metadata_tracker.str))) {
-			spprintf(p->error, 0, "unable to write metadata as file comment for file \"%s\" while creating zip-based phar \"%s\"", ZSTR_VAL(entry->filename), entry->phar->fname);
+			spprintf(p->error, 0, "unable to write metadata as file comment for file \"%s\" while creating zip-based phar \"%s\"", ZSTR_VAL(entry->filename), ZSTR_VAL(entry->phar->fname));
 			return ZEND_HASH_APPLY_STOP;
 		}
 	}
@@ -1195,7 +1197,7 @@ static zend_result phar_zip_applysignature(phar_archive_data *phar, struct _phar
 		if (Z_UL(8) != php_stream_write(entry.fp, sigbuf, 8) || signature_length != php_stream_write(entry.fp, signature, signature_length)) {
 			efree(signature);
 			if (pass->error) {
-				spprintf(pass->error, 0, "phar error: unable to write signature to zip-based phar %s", phar->fname);
+				spprintf(pass->error, 0, "phar error: unable to write signature to zip-based phar %s", ZSTR_VAL(phar->fname));
 			}
 
 			php_stream_close(newfile);
@@ -1240,7 +1242,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_zip_flush(phar_archive_data *phar, ze
 	entry.fp_type = PHAR_MOD;
 
 	if (phar->is_persistent) {
-		spprintf(error, 0, "internal error: attempt to flush cached zip-based phar \"%s\"", phar->fname);
+		spprintf(error, 0, "internal error: attempt to flush cached zip-based phar \"%s\"", ZSTR_VAL(phar->fname));
 		return EOF;
 	}
 
@@ -1257,7 +1259,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_zip_flush(phar_archive_data *phar, ze
 		}
 		if (phar->alias_len != php_stream_write(entry.fp, phar->alias, phar->alias_len)) {
 			php_stream_close(entry.fp);
-			spprintf(error, 0, "unable to set alias in zip-based phar \"%s\"", phar->fname);
+			spprintf(error, 0, "unable to set alias in zip-based phar \"%s\"", ZSTR_VAL(phar->fname));
 			return EOF;
 		}
 
@@ -1271,7 +1273,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_zip_flush(phar_archive_data *phar, ze
 
 	/* register alias */
 	if (phar->alias_len) {
-		if (FAILURE == phar_get_archive(&phar, phar->fname, phar->fname_len, phar->alias, phar->alias_len, error)) {
+		if (FAILURE == phar_get_archive(&phar, ZSTR_VAL(phar->fname), ZSTR_LEN(phar->fname), phar->alias, phar->alias_len, error)) {
 			return EOF;
 		}
 	}
@@ -1281,7 +1283,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_zip_flush(phar_archive_data *phar, ze
 		const char *pos = php_stristr(ZSTR_VAL(user_stub), halt_stub, ZSTR_LEN(user_stub), strlen(halt_stub));
 
 		if (pos == NULL) {
-			spprintf(error, 0, "illegal stub for zip-based phar \"%s\"", phar->fname);
+			spprintf(error, 0, "illegal stub for zip-based phar \"%s\"", ZSTR_VAL(phar->fname));
 			return EOF;
 		}
 
@@ -1300,7 +1302,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_zip_flush(phar_archive_data *phar, ze
 			len != php_stream_write(entry.fp, ZSTR_VAL(user_stub), len)
 			|| end_sequence_len != php_stream_write(entry.fp, end_sequence, end_sequence_len)
 		) {
-			spprintf(error, 0, "unable to create stub from string in new zip-based phar \"%s\"", phar->fname);
+			spprintf(error, 0, "unable to create stub from string in new zip-based phar \"%s\"", ZSTR_VAL(phar->fname));
 			php_stream_close(entry.fp);
 			return EOF;
 		}
@@ -1317,7 +1319,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_zip_flush(phar_archive_data *phar, ze
 		}
 		if (sizeof(newstub)-1 != php_stream_write(entry.fp, newstub, sizeof(newstub)-1)) {
 			php_stream_close(entry.fp);
-			spprintf(error, 0, "unable to %s stub in%szip-based phar \"%s\", failed", user_stub ? "overwrite" : "create", user_stub ? " " : " new ", phar->fname);
+			spprintf(error, 0, "unable to %s stub in%szip-based phar \"%s\", failed", user_stub ? "overwrite" : "create", user_stub ? " " : " new ", ZSTR_VAL(phar->fname));
 			return EOF;
 		}
 
@@ -1329,7 +1331,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_zip_flush(phar_archive_data *phar, ze
 				if (NULL == zend_hash_add_mem(&phar->manifest, entry.filename, &entry, sizeof(phar_entry_info))) {
 					php_stream_close(entry.fp);
 					zend_string_efree(entry.filename);
-					spprintf(error, 0, "unable to create stub in zip-based phar \"%s\"", phar->fname);
+					spprintf(error, 0, "unable to create stub in zip-based phar \"%s\"", ZSTR_VAL(phar->fname));
 					return EOF;
 				}
 			} else {
@@ -1346,7 +1348,7 @@ nostub:
 		must_close_old_file = false;
 		php_stream_rewind(oldfile);
 	} else {
-		oldfile = php_stream_open_wrapper(phar->fname, "rb", 0, NULL);
+		oldfile = php_stream_open_wrapper(ZSTR_VAL(phar->fname), "rb", 0, NULL);
 		must_close_old_file = oldfile != NULL;
 	}
 
@@ -1362,7 +1364,7 @@ fperror:
 		if (must_close_old_file) {
 			php_stream_close(oldfile);
 		}
-		spprintf(error, 4096, "phar zip flush of \"%s\" failed: unable to open temporary file", phar->fname);
+		spprintf(error, 4096, "phar zip flush of \"%s\" failed: unable to open temporary file", ZSTR_VAL(phar->fname));
 		return EOF;
 	}
 
@@ -1392,7 +1394,7 @@ fperror:
 	phar_metadata_tracker_try_ensure_has_serialized_data(&phar->metadata_tracker, phar->is_persistent);
 	if (pass_error
 	 || FAILURE == phar_zip_applysignature(phar, &pass)) {
-		spprintf(error, 4096, "phar zip flush of \"%s\" failed: %s", phar->fname, pass_error);
+		spprintf(error, 4096, "phar zip flush of \"%s\" failed: %s", ZSTR_VAL(phar->fname), pass_error);
 		efree(pass_error);
 nopasserror:
 		php_stream_close(pass.centralfp);
@@ -1415,7 +1417,7 @@ nocentralerror:
 		size_t clen;
 		zend_result ret = php_stream_copy_to_stream_ex(pass.centralfp, pass.filefp, PHP_STREAM_COPY_ALL, &clen);
 		if (SUCCESS != ret || clen != cdir_size) {
-			spprintf(error, 4096, "phar zip flush of \"%s\" failed: unable to write central-directory", phar->fname);
+			spprintf(error, 4096, "phar zip flush of \"%s\" failed: unable to write central-directory", ZSTR_VAL(phar->fname));
 			goto nopasserror;
 		}
 	}
@@ -1428,17 +1430,17 @@ nocentralerror:
 		PHAR_SET_16(eocd.comment_len, ZSTR_LEN(phar->metadata_tracker.str));
 
 		if (sizeof(eocd) != php_stream_write(pass.filefp, (char *)&eocd, sizeof(eocd))) {
-			spprintf(error, 4096, "phar zip flush of \"%s\" failed: unable to write end of central-directory", phar->fname);
+			spprintf(error, 4096, "phar zip flush of \"%s\" failed: unable to write end of central-directory", ZSTR_VAL(phar->fname));
 			goto nocentralerror;
 		}
 
 		if (ZSTR_LEN(phar->metadata_tracker.str) != php_stream_write(pass.filefp, ZSTR_VAL(phar->metadata_tracker.str), ZSTR_LEN(phar->metadata_tracker.str))) {
-			spprintf(error, 4096, "phar zip flush of \"%s\" failed: unable to write metadata to zip comment", phar->fname);
+			spprintf(error, 4096, "phar zip flush of \"%s\" failed: unable to write metadata to zip comment", ZSTR_VAL(phar->fname));
 			goto nocentralerror;
 		}
 	} else {
 		if (sizeof(eocd) != php_stream_write(pass.filefp, (char *)&eocd, sizeof(eocd))) {
-			spprintf(error, 4096, "phar zip flush of \"%s\" failed: unable to write end of central-directory", phar->fname);
+			spprintf(error, 4096, "phar zip flush of \"%s\" failed: unable to write end of central-directory", ZSTR_VAL(phar->fname));
 			goto nocentralerror;
 		}
 	}
@@ -1461,13 +1463,13 @@ nocentralerror:
 		/* deferred flush */
 		phar->fp = pass.filefp;
 	} else {
-		phar->fp = php_stream_open_wrapper(phar->fname, "w+b", IGNORE_URL|STREAM_MUST_SEEK|REPORT_ERRORS, NULL);
+		phar->fp = php_stream_open_wrapper(ZSTR_VAL(phar->fname), "w+b", IGNORE_URL|STREAM_MUST_SEEK|REPORT_ERRORS, NULL);
 		if (!phar->fp) {
 			if (must_close_old_file) {
 				php_stream_close(oldfile);
 			}
 			phar->fp = pass.filefp;
-			spprintf(error, 4096, "unable to open new phar \"%s\" for writing", phar->fname);
+			spprintf(error, 4096, "unable to open new phar \"%s\" for writing", ZSTR_VAL(phar->fname));
 			return EOF;
 		}
 		php_stream_rewind(pass.filefp);


### PR DESCRIPTION
Convert relevant global to zend_string as well

This is in preparation for future refactorings to convert functions taking a char* + size_t pair to zend_string*