### PR TITLE
Fix GH-21824: Avoid unserialize context reuse during cleanup

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@ PHP                                                                        NEWS
 ?? ??? ????, PHP 8.6.0alpha1
 
 - Core:
+  . Fixed bug GH-21824 (Crash in unserialize()). (Pratik Bhujel)
   . Added first-class callable cache to share instances for the duration of the
     request. (ilutov)
   . It is now possible to use reference assign on WeakMap without the key

--- a/ext/standard/tests/serialize/gh21824.phpt
+++ b/ext/standard/tests/serialize/gh21824.phpt
@@ -1,0 +1,24 @@
+--TEST--
+GH-21824 (Crash in unserialize() with destructor reentry)
+--ENV--
+USE_ZEND_ALLOC=0
+--FILE--
+<?php
+class Trigger {
+    public function __destruct() {
+        @unserialize('i:1;');
+    }
+}
+
+$payload = 'a:1019:{';
+for ($i = 0; $i < 1017; $i++) {
+    $payload .= "i:$i;s:1:\"A\";";
+}
+$payload .= 'i:1017;O:7:"Trigger":0:{}';
+$payload .= 'i:1017;i:0;}';
+
+@unserialize($payload);
+echo "Done\n";
+?>
+--EXPECT--
+Done

--- a/ext/standard/var_unserializer.re
+++ b/ext/standard/var_unserializer.re
@@ -81,12 +81,17 @@ PHPAPI php_unserialize_data_t php_var_unserialize_init(void) {
 
 PHPAPI void php_var_unserialize_destroy(php_unserialize_data_t d) {
 	/* fprintf(stderr, "UNSERIALIZE_DESTROY == lock: %u, level: %u\n", BG(serialize_lock), BG(unserialize).level); */
-	if (BG(serialize_lock) || BG(unserialize).level == 1) {
+	if (BG(serialize_lock)) {
 		var_destroy(&d);
 		efree(d);
-	}
-	if (!BG(serialize_lock) && !--BG(unserialize).level) {
+	} else if (BG(unserialize).level == 1) {
+		/* var_destroy() may re-enter unserialize() while running destructors. */
 		BG(unserialize).data = NULL;
+		BG(unserialize).level = 0;
+		var_destroy(&d);
+		efree(d);
+	} else {
+		--BG(unserialize).level;
 	}
 }
 


### PR DESCRIPTION
Fixes GH-21824.

The crash happens while the outermost unserialize context is being destroyed. `var_destroy()` can run destructors, and those destructors may call `unserialize()` again.

At that point `BG(unserialize)` was still pointing at the outer context, even though that context was already being torn down.

Clear the outer context before running `var_destroy()`, so re-entrant `unserialize()` starts with fresh state instead of reusing the cleanup state.

Tested with:

sapi/cli/php run-tests.php -q ext/standard/tests/serialize/gh21824.phpt ext/standard/tests/serialize