### PR TITLE
Add zend_argument_type_error_ex, zend_argument_error_ex

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -130,7 +130,8 @@ PHP 8.6 INTERNALS UPGRADE NOTES
     ReflectionProperty::setRawValueWithoutLazyInitialization() and
     ReflectionProperty::setRawValue() to C extensions.
   . zend_argument_error_variadic() now takes a new 'function' parameters.
-  . Added zend_argument_error_ex(), zend_argument_type_error_ex().
+  . Added zend_argument_error_ex(), zend_argument_type_error_ex(),
+    zend_argument_value_error_ex().
 
 ========================
 2. Build system changes

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -129,6 +129,8 @@ PHP 8.6 INTERNALS UPGRADE NOTES
     zend_reflection_property_set_raw_value() to expose the functionality of
     ReflectionProperty::setRawValueWithoutLazyInitialization() and
     ReflectionProperty::setRawValue() to C extensions.
+  . zend_argument_error_variadic() now takes a new 'function' parameters.
+  . Added zend_argument_error_ex(), zend_argument_type_error_ex().
 
 ========================
 2. Build system changes

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -374,7 +374,9 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_unexpected_extra_named_error(void)
 	);
 }
 
-ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_error_variadic(zend_class_entry *error_ce, uint32_t arg_num, const char *format, va_list va) /* {{{ */
+ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_error_variadic_ex(
+		const zend_function *function, uint32_t arg_num,
+		zend_class_entry *error_ce, const char *format, va_list va)
 {
 	zend_string *func_name;
 	const char *arg_name;
@@ -383,8 +385,8 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_error_variadic(zend_class_en
 		return;
 	}
 
-	func_name = get_active_function_or_method_name();
-	arg_name = get_active_function_arg_name(arg_num);
+	func_name = get_function_or_method_name(function);
+	arg_name = get_function_arg_name(function, arg_num);
 
 	zend_vspprintf(&message, 0, format, va);
 	zend_throw_error(error_ce, "%s(): Argument #%d%s%s%s %s",
@@ -394,7 +396,26 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_error_variadic(zend_class_en
 	efree(message);
 	zend_string_release(func_name);
 }
+
+ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_error_variadic(zend_class_entry *error_ce, uint32_t arg_num, const char *format, va_list va) /* {{{ */
+{
+	ZEND_ASSERT(zend_is_executing());
+
+	const zend_function *function = zend_active_function();
+
+	zend_argument_error_variadic_ex(function, arg_num, error_ce, format, va);
+}
 /* }}} */
+
+ZEND_API ZEND_COLD void zend_argument_error_ex(const zend_function *function,
+		uint32_t arg_num, zend_class_entry *error_ce, const char *format, ...)
+{
+	va_list va;
+
+	va_start(va, format);
+	zend_argument_error_variadic_ex(function, arg_num, error_ce, format, va);
+	va_end(va);
+}
 
 ZEND_API ZEND_COLD void zend_argument_error(zend_class_entry *error_ce, uint32_t arg_num, const char *format, ...) /* {{{ */
 {
@@ -405,6 +426,18 @@ ZEND_API ZEND_COLD void zend_argument_error(zend_class_entry *error_ce, uint32_t
 	va_end(va);
 }
 /* }}} */
+
+ZEND_API ZEND_COLD void zend_argument_type_error_ex(
+		const zend_function *function, uint32_t arg_num,
+		const char *format, ...)
+{
+	va_list va;
+
+	va_start(va, format);
+	zend_argument_error_variadic_ex(function, arg_num,
+			zend_ce_type_error, format, va);
+	va_end(va);
+}
 
 ZEND_API ZEND_COLD void zend_argument_type_error(uint32_t arg_num, const char *format, ...) /* {{{ */
 {

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -375,8 +375,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_unexpected_extra_named_error(void)
 }
 
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_error_variadic(
-		const zend_function *function, uint32_t arg_num,
-		zend_class_entry *error_ce, const char *format, va_list va)
+	zend_class_entry *error_ce, const zend_function *function, uint32_t arg_num, const char *format, va_list va)
 {
 	zend_string *func_name;
 	const char *arg_name;
@@ -397,13 +396,12 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_error_variadic(
 	zend_string_release(func_name);
 }
 
-ZEND_API ZEND_COLD void zend_argument_error_ex(const zend_function *function,
-		uint32_t arg_num, zend_class_entry *error_ce, const char *format, ...)
+ZEND_API ZEND_COLD void zend_argument_error_ex(zend_class_entry *error_ce, const zend_function *function, uint32_t arg_num, const char *format, ...)
 {
 	va_list va;
 
 	va_start(va, format);
-	zend_argument_error_variadic(function, arg_num, error_ce, format, va);
+	zend_argument_error_variadic(error_ce, function, arg_num, format, va);
 	va_end(va);
 }
 
@@ -413,19 +411,18 @@ ZEND_API ZEND_COLD void zend_argument_error(zend_class_entry *error_ce, uint32_t
 	const zend_function *function = zend_active_function();
 
 	va_start(va, format);
-	zend_argument_error_variadic(function, arg_num, error_ce, format, va);
+	zend_argument_error_variadic(error_ce, function, arg_num, format, va);
 	va_end(va);
 }
 /* }}} */
 
 ZEND_API ZEND_COLD void zend_argument_type_error_ex(
-		const zend_function *function, uint32_t arg_num,
-		const char *format, ...)
+		const zend_function *function, uint32_t arg_num, const char *format, ...)
 {
 	va_list va;
 
 	va_start(va, format);
-	zend_argument_error_variadic(function, arg_num, zend_ce_type_error, format, va);
+	zend_argument_error_variadic(zend_ce_type_error, function, arg_num, format, va);
 	va_end(va);
 }
 
@@ -435,7 +432,7 @@ ZEND_API ZEND_COLD void zend_argument_type_error(uint32_t arg_num, const char *f
 	const zend_function *function = zend_active_function();
 
 	va_start(va, format);
-	zend_argument_error_variadic(function, arg_num, zend_ce_type_error, format, va);
+	zend_argument_error_variadic(zend_ce_type_error, function, arg_num, format, va);
 	va_end(va);
 }
 /* }}} */
@@ -446,7 +443,7 @@ ZEND_API ZEND_COLD void zend_argument_value_error(uint32_t arg_num, const char *
 	const zend_function *function = zend_active_function();
 
 	va_start(va, format);
-	zend_argument_error_variadic(function, arg_num, zend_ce_value_error, format, va);
+	zend_argument_error_variadic(zend_ce_value_error, function, arg_num, format, va);
 	va_end(va);
 }
 /* }}} */

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -374,7 +374,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_unexpected_extra_named_error(void)
 	);
 }
 
-ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_error_variadic_ex(
+ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_error_variadic(
 		const zend_function *function, uint32_t arg_num,
 		zend_class_entry *error_ce, const char *format, va_list va)
 {
@@ -397,32 +397,23 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_error_variadic_ex(
 	zend_string_release(func_name);
 }
 
-ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_error_variadic(zend_class_entry *error_ce, uint32_t arg_num, const char *format, va_list va) /* {{{ */
-{
-	ZEND_ASSERT(zend_is_executing());
-
-	const zend_function *function = zend_active_function();
-
-	zend_argument_error_variadic_ex(function, arg_num, error_ce, format, va);
-}
-/* }}} */
-
 ZEND_API ZEND_COLD void zend_argument_error_ex(const zend_function *function,
 		uint32_t arg_num, zend_class_entry *error_ce, const char *format, ...)
 {
 	va_list va;
 
 	va_start(va, format);
-	zend_argument_error_variadic_ex(function, arg_num, error_ce, format, va);
+	zend_argument_error_variadic(function, arg_num, error_ce, format, va);
 	va_end(va);
 }
 
 ZEND_API ZEND_COLD void zend_argument_error(zend_class_entry *error_ce, uint32_t arg_num, const char *format, ...) /* {{{ */
 {
 	va_list va;
+	const zend_function *function = zend_active_function();
 
 	va_start(va, format);
-	zend_argument_error_variadic(error_ce, arg_num, format, va);
+	zend_argument_error_variadic(function, arg_num, error_ce, format, va);
 	va_end(va);
 }
 /* }}} */
@@ -434,17 +425,17 @@ ZEND_API ZEND_COLD void zend_argument_type_error_ex(
 	va_list va;
 
 	va_start(va, format);
-	zend_argument_error_variadic_ex(function, arg_num,
-			zend_ce_type_error, format, va);
+	zend_argument_error_variadic(function, arg_num, zend_ce_type_error, format, va);
 	va_end(va);
 }
 
 ZEND_API ZEND_COLD void zend_argument_type_error(uint32_t arg_num, const char *format, ...) /* {{{ */
 {
 	va_list va;
+	const zend_function *function = zend_active_function();
 
 	va_start(va, format);
-	zend_argument_error_variadic(zend_ce_type_error, arg_num, format, va);
+	zend_argument_error_variadic(function, arg_num, zend_ce_type_error, format, va);
 	va_end(va);
 }
 /* }}} */
@@ -452,9 +443,10 @@ ZEND_API ZEND_COLD void zend_argument_type_error(uint32_t arg_num, const char *f
 ZEND_API ZEND_COLD void zend_argument_value_error(uint32_t arg_num, const char *format, ...) /* {{{ */
 {
 	va_list va;
+	const zend_function *function = zend_active_function();
 
 	va_start(va, format);
-	zend_argument_error_variadic(zend_ce_value_error, arg_num, format, va);
+	zend_argument_error_variadic(function, arg_num, zend_ce_value_error, format, va);
 	va_end(va);
 }
 /* }}} */

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -437,6 +437,16 @@ ZEND_API ZEND_COLD void zend_argument_type_error(uint32_t arg_num, const char *f
 }
 /* }}} */
 
+ZEND_API ZEND_COLD void zend_argument_value_error_ex(
+	const zend_function *function, uint32_t arg_num, const char *format, ...)
+{
+	va_list va;
+
+	va_start(va, format);
+	zend_argument_error_variadic(zend_ce_value_error, function, arg_num, format, va);
+	va_end(va);
+}
+
 ZEND_API ZEND_COLD void zend_argument_value_error(uint32_t arg_num, const char *format, ...) /* {{{ */
 {
 	va_list va;

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -1580,8 +1580,16 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_callback_error(uint32_t num, ch
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_callback_or_null_error(uint32_t num, char *error);
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_unexpected_extra_named_error(void);
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_error_variadic(zend_class_entry *error_ce, uint32_t arg_num, const char *format, va_list va);
+ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_error_variadic_ex(
+		const zend_function *function, uint32_t arg_num,
+		zend_class_entry *error_ce, const char *format, va_list va);
 ZEND_API ZEND_COLD void zend_argument_error(zend_class_entry *error_ce, uint32_t arg_num, const char *format, ...);
+ZEND_API ZEND_COLD void zend_argument_error_ex(const zend_function *function,
+		uint32_t arg_num, zend_class_entry *error_ce, const char *format, ...);
 ZEND_API ZEND_COLD void zend_argument_type_error(uint32_t arg_num, const char *format, ...);
+ZEND_API ZEND_COLD void zend_argument_type_error_ex(
+		const zend_function *function, uint32_t arg_num,
+		const char *format, ...);
 ZEND_API ZEND_COLD void zend_argument_value_error(uint32_t arg_num, const char *format, ...);
 ZEND_API ZEND_COLD void zend_argument_must_not_be_empty_error(uint32_t arg_num);
 ZEND_API ZEND_COLD void zend_class_redeclaration_error(int type, const zend_class_entry *old_ce);

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -1579,16 +1579,11 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_parameter_class_or_string_or_nu
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_callback_error(uint32_t num, char *error);
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_callback_or_null_error(uint32_t num, char *error);
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_unexpected_extra_named_error(void);
-ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_error_variadic(
-		const zend_function *function, uint32_t arg_num,
-		zend_class_entry *error_ce, const char *format, va_list va);
+ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_error_variadic(zend_class_entry *error_ce, const zend_function *function, uint32_t arg_num, const char *format, va_list va);
 ZEND_API ZEND_COLD void zend_argument_error(zend_class_entry *error_ce, uint32_t arg_num, const char *format, ...);
-ZEND_API ZEND_COLD void zend_argument_error_ex(const zend_function *function,
-		uint32_t arg_num, zend_class_entry *error_ce, const char *format, ...);
+ZEND_API ZEND_COLD void zend_argument_error_ex(zend_class_entry *error_ce, const zend_function *function, uint32_t arg_num, const char *format, ...);
 ZEND_API ZEND_COLD void zend_argument_type_error(uint32_t arg_num, const char *format, ...);
-ZEND_API ZEND_COLD void zend_argument_type_error_ex(
-		const zend_function *function, uint32_t arg_num,
-		const char *format, ...);
+ZEND_API ZEND_COLD void zend_argument_type_error_ex(const zend_function *function, uint32_t arg_num, const char *format, ...);
 ZEND_API ZEND_COLD void zend_argument_value_error(uint32_t arg_num, const char *format, ...);
 ZEND_API ZEND_COLD void zend_argument_must_not_be_empty_error(uint32_t arg_num);
 ZEND_API ZEND_COLD void zend_class_redeclaration_error(int type, const zend_class_entry *old_ce);

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -1579,8 +1579,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_parameter_class_or_string_or_nu
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_callback_error(uint32_t num, char *error);
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_callback_or_null_error(uint32_t num, char *error);
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_unexpected_extra_named_error(void);
-ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_error_variadic(zend_class_entry *error_ce, uint32_t arg_num, const char *format, va_list va);
-ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_error_variadic_ex(
+ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_error_variadic(
 		const zend_function *function, uint32_t arg_num,
 		zend_class_entry *error_ce, const char *format, va_list va);
 ZEND_API ZEND_COLD void zend_argument_error(zend_class_entry *error_ce, uint32_t arg_num, const char *format, ...);

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -1585,6 +1585,7 @@ ZEND_API ZEND_COLD void zend_argument_error_ex(zend_class_entry *error_ce, const
 ZEND_API ZEND_COLD void zend_argument_type_error(uint32_t arg_num, const char *format, ...);
 ZEND_API ZEND_COLD void zend_argument_type_error_ex(const zend_function *function, uint32_t arg_num, const char *format, ...);
 ZEND_API ZEND_COLD void zend_argument_value_error(uint32_t arg_num, const char *format, ...);
+ZEND_API ZEND_COLD void zend_argument_value_error_ex(const zend_function *function, uint32_t arg_num, const char *format, ...);
 ZEND_API ZEND_COLD void zend_argument_must_not_be_empty_error(uint32_t arg_num);
 ZEND_API ZEND_COLD void zend_class_redeclaration_error(int type, const zend_class_entry *old_ce);
 ZEND_API ZEND_COLD void zend_class_redeclaration_error_ex(int type, zend_string *new_name, const zend_class_entry *old_ce);

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -8921,9 +8921,10 @@ ZEND_VM_HOT_HANDLER(211, ZEND_TYPE_ASSERT, CONST, ANY, NUM)
 		zend_arg_info *arginfo = &fbc->common.arg_info[argno - 1];
 
 		if (!zend_check_type(&arginfo->type, value, /* is_return_type */ false, /* is_internal */ true)) {
-			const char *param_name = get_function_arg_name(fbc, argno);
 			zend_string *expected = zend_type_to_string(arginfo->type);
-			zend_type_error("%s(): Argument #%d%s%s%s must be of type %s, %s given", ZSTR_VAL(fbc->common.function_name), argno, param_name ? " ($" : "", param_name ? param_name : "", param_name ? ")" : "", ZSTR_VAL(expected), zend_zval_value_name(value));
+			zend_argument_type_error_ex(fbc, argno,
+					"must be of type %s, %s given",
+					ZSTR_VAL(expected), zend_zval_value_name(value));
 			zend_string_release(expected);
 		}
 	}

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -6170,9 +6170,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_T
 		zend_arg_info *arginfo = &fbc->common.arg_info[argno - 1];
 
 		if (!zend_check_type(&arginfo->type, value, /* is_return_type */ false, /* is_internal */ true)) {
-			const char *param_name = get_function_arg_name(fbc, argno);
 			zend_string *expected = zend_type_to_string(arginfo->type);
-			zend_type_error("%s(): Argument #%d%s%s%s must be of type %s, %s given", ZSTR_VAL(fbc->common.function_name), argno, param_name ? " ($" : "", param_name ? param_name : "", param_name ? ")" : "", ZSTR_VAL(expected), zend_zval_value_name(value));
+			zend_argument_type_error_ex(fbc, argno,
+					"must be of type %s, %s given",
+					ZSTR_VAL(expected), zend_zval_value_name(value));
 			zend_string_release(expected);
 		}
 	}
@@ -58859,9 +58860,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_TYPE_A
 		zend_arg_info *arginfo = &fbc->common.arg_info[argno - 1];
 
 		if (!zend_check_type(&arginfo->type, value, /* is_return_type */ false, /* is_internal */ true)) {
-			const char *param_name = get_function_arg_name(fbc, argno);
 			zend_string *expected = zend_type_to_string(arginfo->type);
-			zend_type_error("%s(): Argument #%d%s%s%s must be of type %s, %s given", ZSTR_VAL(fbc->common.function_name), argno, param_name ? " ($" : "", param_name ? param_name : "", param_name ? ")" : "", ZSTR_VAL(expected), zend_zval_value_name(value));
+			zend_argument_type_error_ex(fbc, argno,
+					"must be of type %s, %s given",
+					ZSTR_VAL(expected), zend_zval_value_name(value));
 			zend_string_release(expected);
 		}
 	}

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -640,7 +640,7 @@ static void php_openssl_check_path_error(uint32_t arg_num, int type, const char 
 	va_start(va, format);
 
 	if (type == E_ERROR) {
-		zend_argument_error_variadic(zend_active_function(), arg_num, zend_ce_value_error, format, va);
+		zend_argument_error_variadic(zend_ce_value_error, zend_active_function(), arg_num, format, va);
 	} else {
 		arg_name = get_active_function_arg_name(arg_num);
 		php_verror(NULL, arg_name, type, format, va);

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -640,7 +640,7 @@ static void php_openssl_check_path_error(uint32_t arg_num, int type, const char 
 	va_start(va, format);
 
 	if (type == E_ERROR) {
-		zend_argument_error_variadic(zend_ce_value_error, arg_num, format, va);
+		zend_argument_error_variadic(zend_active_function(), arg_num, zend_ce_value_error, format, va);
 	} else {
 		arg_name = get_active_function_arg_name(arg_num);
 		php_verror(NULL, arg_name, type, format, va);


### PR DESCRIPTION
These variants take the function as parameter instead of inferring it from the call stack. This is useful in ZEND_TYPE_ASSERT, and will be used in PFA impl.
