### PR TITLE
Throw a ValueError when the parameter includes NUL bytes in `strptime`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -172,6 +172,8 @@ PHP                                                                        NEWS
     (Weilin Du)
   . getenv() and putenv() now raises a ValueError when the first argument
     contains null bytes. (Weilin Du)
+  . strptime() now raises a ValueError when $timestamp or $format contains
+    null bytes. (Weilin Du)
 
 - Streams:
   . Added so_keepalive, tcp_keepidle, tcp_keepintvl and tcp_keepcnt stream

--- a/UPGRADING
+++ b/UPGRADING
@@ -95,6 +95,8 @@ PHP 8.6 UPGRADE NOTES
     argument value is passed.
   . scandir() now raises a ValueError when an invalid $sorting_order
     argument value is passed.
+  . strptime() now raises a ValueError when the $timestamp or $format
+    argument contains null bytes.
 
 - Zip:
   . ZipArchive::extractTo now raises a TypeError for the

--- a/ext/standard/datetime.c
+++ b/ext/standard/datetime.c
@@ -38,8 +38,8 @@ PHP_FUNCTION(strptime)
 	char      *unparsed_part;
 
 	ZEND_PARSE_PARAMETERS_START(2, 2)
-		Z_PARAM_STRING(ts, ts_length)
-		Z_PARAM_STRING(format, format_length)
+		Z_PARAM_PATH(ts, ts_length)
+		Z_PARAM_PATH(format, format_length)
 	ZEND_PARSE_PARAMETERS_END();
 
 	memset(&parsed_time, 0, sizeof(parsed_time));

--- a/ext/standard/tests/time/strptime_null_bytes.phpt
+++ b/ext/standard/tests/time/strptime_null_bytes.phpt
@@ -1,0 +1,30 @@
+--TEST--
+strptime() rejects null bytes
+--SKIPIF--
+<?php
+if (!function_exists('strptime')) {
+    die("skip - strptime() function not available in this build");
+}
+?>
+--FILE--
+<?php
+
+try {
+    strptime("2024-01-01\0UTC", "%Y-%m-%d");
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    strptime("2024-01-01", "%Y-%m-%d\0");
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECTF--
+Deprecated: Function strptime() is deprecated since 8.2, use date_parse_from_format() (for locale-independent parsing), or IntlDateFormatter::parse() (for locale-dependent parsing) instead in %s on line %d
+strptime(): Argument #1 ($timestamp) must not contain any null bytes
+
+Deprecated: Function strptime() is deprecated since 8.2, use date_parse_from_format() (for locale-independent parsing), or IntlDateFormatter::parse() (for locale-dependent parsing) instead in %s on line %d
+strptime(): Argument #2 ($format) must not contain any null bytes


### PR DESCRIPTION
```php
<?php
echo strptime("2024-01-11\0UTC", "%Y-%m-%d")['unparsed'];
echo strptime("2024-01-11UTC", "%Y-%m-%d")['unparsed'];
```
resulted in:
```
UTC
```
Actually the ValueError-type changes can be done in bulk in the future. However,  `strptime` is now deprecated so I don't sure if we should update this function as well. Feel free to close this if this shouldn't be done on deprecated functions