### PR TITLE
Replace dependencies on /ext/hash in various extensions

### DIFF
--- a/Zend/zend_system_id.c
+++ b/Zend/zend_system_id.c
@@ -17,7 +17,6 @@
 #include "zend_system_id.h"
 #include "zend_extensions.h"
 #include "ext/standard/md5.h"
-#include "ext/hash/php_hash.h"
 
 ZEND_API char zend_system_id[32];
 
@@ -88,6 +87,6 @@ void zend_finalize_system_id(void)
 	}
 
 	PHP_MD5Final(digest, &context);
-	php_hash_bin2hex(zend_system_id, digest, sizeof digest);
+	zend_bin2hex(zend_system_id, digest, sizeof digest);
 	finalized = 1;
 }

--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -401,7 +401,7 @@ static void php_hash_do_hash(
 	} else {
 		zend_string *hex_digest = zend_string_safe_alloc(ops->digest_size, 2, 0, 0);
 
-		php_hash_bin2hex(ZSTR_VAL(hex_digest), (unsigned char *) ZSTR_VAL(digest), ops->digest_size);
+		zend_bin2hex(ZSTR_VAL(hex_digest), (unsigned char *) ZSTR_VAL(digest), ops->digest_size);
 		ZSTR_VAL(hex_digest)[2 * ops->digest_size] = 0;
 		zend_string_efree(digest);
 		RETURN_NEW_STR(hex_digest);
@@ -558,7 +558,7 @@ static void php_hash_do_hash_hmac(
 	} else {
 		zend_string *hex_digest = zend_string_safe_alloc(ops->digest_size, 2, 0, 0);
 
-		php_hash_bin2hex(ZSTR_VAL(hex_digest), (unsigned char *) ZSTR_VAL(digest), ops->digest_size);
+		zend_bin2hex(ZSTR_VAL(hex_digest), (unsigned char *) ZSTR_VAL(digest), ops->digest_size);
 		ZSTR_VAL(hex_digest)[2 * ops->digest_size] = 0;
 		zend_string_efree(digest);
 		RETURN_NEW_STR(hex_digest);
@@ -819,7 +819,7 @@ PHP_FUNCTION(hash_final)
 	} else {
 		zend_string *hex_digest = zend_string_safe_alloc(digest_len, 2, 0, 0);
 
-		php_hash_bin2hex(ZSTR_VAL(hex_digest), (unsigned char *) ZSTR_VAL(digest), digest_len);
+		zend_bin2hex(ZSTR_VAL(hex_digest), (unsigned char *) ZSTR_VAL(digest), digest_len);
 		ZSTR_VAL(hex_digest)[2 * digest_len] = 0;
 		zend_string_efree(digest);
 		RETURN_NEW_STR(hex_digest);
@@ -1089,7 +1089,7 @@ PHP_FUNCTION(hash_pbkdf2)
 	if (raw_output) {
 		memcpy(ZSTR_VAL(returnval), result, length);
 	} else {
-		php_hash_bin2hex(ZSTR_VAL(returnval), result, digest_length);
+		zend_bin2hex(ZSTR_VAL(returnval), result, digest_length);
 	}
 	ZSTR_VAL(returnval)[length] = 0;
 	efree(result);

--- a/ext/hash/php_hash.h
+++ b/ext/hash/php_hash.h
@@ -182,15 +182,4 @@ static inline void php_hash_free_context(const php_hash_ops *ops, void *ctx) {
 	efree(ctx);
 }
 
-static inline void php_hash_bin2hex(char *out, const unsigned char *in, size_t in_len)
-{
-	static const char hexits[17] = "0123456789abcdef";
-	size_t i;
-
-	for(i = 0; i < in_len; i++) {
-		out[i * 2]       = hexits[in[i] >> 4];
-		out[(i * 2) + 1] = hexits[in[i] &  0x0F];
-	}
-}
-
 #endif	/* PHP_HASH_H */

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -50,7 +50,6 @@
 #include "ext/standard/basic_functions.h"
 
 #ifdef ZEND_WIN32
-# include "ext/hash/php_hash.h"
 # include "ext/standard/md5.h"
 #endif
 
@@ -2532,7 +2531,7 @@ static zend_result accel_gen_uname_id(void)
 	PHP_MD5Update(&ctx, (void *) uname, (unsize - 1) * sizeof(wchar_t));
 	PHP_MD5Update(&ctx, ZCG(accel_directives).cache_id, strlen(ZCG(accel_directives).cache_id));
 	PHP_MD5Final(digest, &ctx);
-	php_hash_bin2hex(accel_uname_id, digest, sizeof digest);
+	zend_bin2hex(accel_uname_id, digest, sizeof digest);
 	return SUCCESS;
 }
 #endif

--- a/ext/soap/php_http.c
+++ b/ext/soap/php_http.c
@@ -15,7 +15,6 @@
 */
 
 #include "php_soap.h"
-#include "ext/hash/php_hash.h" /* For php_hash_bin2hex() */
 #include "ext/uri/php_uri.h"
 
 static char *get_http_header_value_nodup(char *headers, char *type, size_t *len);
@@ -696,7 +695,7 @@ try_again:
 					return false;
 				}
 
-				php_hash_bin2hex(cnonce, nonce, sizeof(nonce));
+				zend_bin2hex(cnonce, nonce, sizeof(nonce));
 				cnonce[32] = 0;
 
 				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(digest), "nc", sizeof("nc")-1)) != NULL &&

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -45,31 +45,10 @@
 
 #include "zend_simd.h"
 
-/* this is read-only, so it's ok */
-ZEND_SET_ALIGNED(16, static const char hexconvtab[]) = "0123456789abcdef";
-
 /* localeconv mutex */
 #ifdef ZTS
 static MUTEX_T locale_mutex = NULL;
 #endif
-
-/* {{{ php_bin2hex */
-static zend_string *php_bin2hex(const unsigned char *old, const size_t oldlen)
-{
-	zend_string *result;
-	size_t i, j;
-
-	result = zend_string_safe_alloc(oldlen, 2 * sizeof(char), 0, 0);
-
-	for (i = j = 0; i < oldlen; i++) {
-		ZSTR_VAL(result)[j++] = hexconvtab[old[i] >> 4];
-		ZSTR_VAL(result)[j++] = hexconvtab[old[i] & 15];
-	}
-	ZSTR_VAL(result)[j] = '\0';
-
-	return result;
-}
-/* }}} */
 
 /* {{{ php_hex2bin */
 static zend_string *php_hex2bin(const unsigned char *old, const size_t oldlen)
@@ -158,7 +137,7 @@ PHP_FUNCTION(bin2hex)
 		Z_PARAM_STR(data)
 	ZEND_PARSE_PARAMETERS_END();
 
-	result = php_bin2hex((unsigned char *)ZSTR_VAL(data), ZSTR_LEN(data));
+	result = zend_bin2hex_str((unsigned char *) ZSTR_VAL(data), ZSTR_LEN(data));
 
 	RETURN_STR(result);
 }


### PR DESCRIPTION
Followup-PR for #21724. Using the new API in #21724 to replace dependencies on /ext/hash in

- ext/opcache/ZendAccelerator/
- ext/soap/php_http.c
- Zend/zend_system_id.c

In the following ext, there are independent implementation of bin2hex. This PR also change them to directly using the new Zend API.

- ext/standard/string.c
- ext/hash/php_hash.h