### PR TITLE
ext/standard: document stream filter state reset on seek in UPGRADING

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -82,6 +82,9 @@ PHP 8.6 UPGRADE NOTES
     values.
 
 - Standard:
+  . Stateful stream filters (e.g. "dechunk", "consumed", "convert.*") now
+    reset their internal state when the stream is sought to position 0.
+    See bug #49874.
   . Form feed (\f) is now added in the default trimmed characters of trim(),
     rtrim() and ltrim(). RFC: https://wiki.php.net/rfc/trim_form_feed
   . array_filter() now raises a ValueError when an invalid $mode

--- a/ext/standard/tests/filters/dechunk_seek_resets_state.phpt
+++ b/ext/standard/tests/filters/dechunk_seek_resets_state.phpt
@@ -1,0 +1,53 @@
+--TEST--
+dechunk filter: seeking to position 0 resets the filter's internal state
+--SKIPIF--
+<?php
+if (!in_array('dechunk', stream_get_filters(), true)) die('skip dechunk filter not available');
+?>
+--FILE--
+<?php
+
+$body = "8\r\nSymfony \r\n5\r\nis aw\r\n6\r\nesome!\r\n0\r\n\r\n";
+
+// no seek, post-terminator writes are discarded
+$h = fopen('php://temp', 'w+');
+stream_filter_append($h, 'dechunk', STREAM_FILTER_WRITE);
+fwrite($h, $body);
+$before = ftell($h);
+fwrite($h, '-');
+var_dump(ftell($h) === $before);
+
+// rewind() resets the filter: subsequent writes are processed as a
+// new chunked stream, so invalid input like "-" leaks through
+$h = fopen('php://temp', 'w+');
+stream_filter_append($h, 'dechunk', STREAM_FILTER_WRITE);
+fwrite($h, $body);
+rewind($h);
+$before = ftell($h);
+fwrite($h, '-');
+var_dump(ftell($h) > $before);
+
+// stream_get_contents($h, -1, 0) performs an implicit seek to 0
+$h = fopen('php://temp', 'w+');
+stream_filter_append($h, 'dechunk', STREAM_FILTER_WRITE);
+fwrite($h, $body);
+stream_get_contents($h, -1, 0);
+$before = ftell($h);
+fwrite($h, '-');
+var_dump(ftell($h) > $before);
+
+// after reset, the filter correctly decodes a fresh chunked body
+$h = fopen('php://temp', 'w+');
+stream_filter_append($h, 'dechunk', STREAM_FILTER_WRITE);
+fwrite($h, $body);
+rewind($h);
+ftruncate($h, 0);
+fwrite($h, "1\r\nX\r\n0\r\n\r\n");
+var_dump(stream_get_contents($h, -1, 0));
+
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+string(1) "X"


### PR DESCRIPTION
#19981 (bug #49874) made stateful filters reset their state when the stream is sought to 0 (with rewind(), fseek(), or stream_get_contents($h, -1, 0)). It is not currently mentioned in UPGRADING.

It seems to [break Symfony CI](https://github.com/symfony/symfony/actions/runs/24782495613/job/72517221489#step:8:3802). We'll update the code, but it worth mentioning in UPGRADING.