### PR TITLE
Zlib: Fix the bug when `zval_get_long` silently cast `$strategy` into long in `deflate_init`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -198,7 +198,7 @@ PHP                                                                        NEWS
     (Tim Starling, Soner Sayakci, Ghaith Olabi)
 
 - Zlib:
-  . deflate_init() now raises a TypeError when the "strategy" element 
-    in $options is not of type int. (Weilin Du)
+  . deflate_init() now raises a TypeError when the value for option
+    "strategy" is not of type int. (Weilin Du)
 
 <<< NOTE: Insert NEWS from last stable release here prior to actual release! >>>

--- a/NEWS
+++ b/NEWS
@@ -197,4 +197,8 @@ PHP                                                                        NEWS
   . Added ZipArchive::openString() method.
     (Tim Starling, Soner Sayakci, Ghaith Olabi)
 
+- Zlib:
+  . deflate_init() now raises a TypeError when the "strategy" element 
+    in $options is not of type int. (Weilin Du)
+
 <<< NOTE: Insert NEWS from last stable release here prior to actual release! >>>

--- a/UPGRADING
+++ b/UPGRADING
@@ -101,6 +101,10 @@ PHP 8.6 UPGRADE NOTES
     files argument if one or more of the entries is not
     a string.
 
+- Zlib:
+  . deflate_init() now raises a TypeError when the "strategy" element 
+    in $options is not of type int.
+
 ========================================
 2. New Features
 ========================================

--- a/UPGRADING
+++ b/UPGRADING
@@ -102,8 +102,8 @@ PHP 8.6 UPGRADE NOTES
     a string.
 
 - Zlib:
-  . deflate_init() now raises a TypeError when the "strategy" element 
-    in $options is not of type int.
+  . deflate_init() now raises a TypeError when the value for option
+    "strategy" is not of type int.
 
 ========================================
 2. New Features

--- a/ext/zlib/tests/deflate_init_strategy_type_error.phpt
+++ b/ext/zlib/tests/deflate_init_strategy_type_error.phpt
@@ -13,4 +13,4 @@ try {
 
 ?>
 --EXPECT--
-deflate_init(): Argument #2 ($options) the "strategy" element in $options must be of type int, array given
+deflate_init(): Argument #2 ($options) the value for option "strategy" must be of type int, array given

--- a/ext/zlib/tests/deflate_init_strategy_type_error.phpt
+++ b/ext/zlib/tests/deflate_init_strategy_type_error.phpt
@@ -1,0 +1,16 @@
+--TEST--
+deflate_init(): strategy option type validation
+--EXTENSIONS--
+zlib
+--FILE--
+<?php
+
+try {
+    deflate_init(ZLIB_ENCODING_DEFLATE, ['strategy' => []]);
+} catch (TypeError $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+deflate_init(): Argument #2 ($options) "strategy" option must be of type int, array given

--- a/ext/zlib/tests/deflate_init_strategy_type_error.phpt
+++ b/ext/zlib/tests/deflate_init_strategy_type_error.phpt
@@ -13,4 +13,4 @@ try {
 
 ?>
 --EXPECT--
-deflate_init(): Argument #2 ($options) "strategy" option must be of type int, array given
+deflate_init(): Argument #2 ($options) the "strategy" element in $options must be of type int, array given

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -1120,7 +1120,7 @@ PHP_FUNCTION(deflate_init)
 		ZVAL_DEINDIRECT(option_buffer);
 		strategy = zval_try_get_long(option_buffer, &failed);
 		if (UNEXPECTED(failed)) {
-			zend_argument_type_error(2, "the \"strategy\" element in $options must be of type int, %s given", zend_zval_value_name(option_buffer));
+			zend_argument_type_error(2, "the value for option \"strategy\" must be of type int, %s given", zend_zval_value_name(option_buffer));
 			RETURN_THROWS();
 		}
 	}

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -1115,8 +1115,14 @@ PHP_FUNCTION(deflate_init)
 	}
 
 	if (options && (option_buffer = zend_hash_str_find(options, ZEND_STRL("strategy"))) != NULL) {
+		bool failed = false;
+
 		ZVAL_DEINDIRECT(option_buffer);
-		strategy = zval_get_long(option_buffer);
+		strategy = zval_try_get_long(option_buffer, &failed);
+		if (UNEXPECTED(failed)) {
+			zend_argument_type_error(2, "\"strategy\" option must be of type int, %s given", zend_zval_value_name(option_buffer));
+			RETURN_THROWS();
+		}
 	}
 	switch (strategy) {
 		case Z_FILTERED:

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -1120,7 +1120,7 @@ PHP_FUNCTION(deflate_init)
 		ZVAL_DEINDIRECT(option_buffer);
 		strategy = zval_try_get_long(option_buffer, &failed);
 		if (UNEXPECTED(failed)) {
-			zend_argument_type_error(2, "\"strategy\" option must be of type int, %s given", zend_zval_value_name(option_buffer));
+			zend_argument_type_error(2, "the \"strategy\" element in $options must be of type int, %s given", zend_zval_value_name(option_buffer));
 			RETURN_THROWS();
 		}
 	}


### PR DESCRIPTION
When looking at https://github.com/php/php-tasks/issues/32, it reminds me of a bug I know years ago in zlib where users can pass arrays to `deflate_init` as a strategy. Reason here is we use `zval_get_long` which silently cast user's input into long. 

Now as per the php-task issue:

> Ideally, those usages should be reviewed and use the corresponding try function when available.

I would like to open this PR to use `zval_try_get_long` instead in this case. Not sure if this worth a NEWS entry.