### PR TITLE
zend_alloc: Make zend_alloc.h independent of zend_types.h

### DIFF
--- a/Zend/zend_alloc.h
+++ b/Zend/zend_alloc.h
@@ -22,7 +22,7 @@
 
 #include <stdio.h>
 
-#include "zend_types.h"
+#include "zend_portability.h"
 #include "../TSRM/TSRM.h"
 
 #ifndef ZEND_MM_ALIGNMENT


### PR DESCRIPTION
`zend_types.h` itself refers to `emalloc()` in macro definitions (which is defined in `zend_alloc.h`), making this effectively a circular dependency.

Since `zend_alloc.h` does not actually need `zend_types.h`, we can just remove this include from there.