### PR TITLE
zend_types: Remove `ZEND_RESULT_CODE` typedef

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -91,6 +91,7 @@ PHP 8.6 INTERNALS UPGRADE NOTES
   . Functions using zend_forbid_dynamic_call() *must* be flagged with
     ZEND_ACC2_FORBID_DYN_CALLS (@forbid-dynamic-calls in stubs). In debug
     builds, failing to include that flag will lead to assertion failures.
+  . The ZEND_RESULT_CODE type has been removed. Use zend_result directly.
 
 ========================
 2. Build system changes

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -54,12 +54,10 @@
 
 typedef unsigned char zend_uchar;
 
-typedef enum {
+typedef enum zend_result {
   SUCCESS =  0,
   FAILURE = -1,		/* this MUST stay a negative number, or it may affect functions! */
-} ZEND_RESULT_CODE;
-
-typedef ZEND_RESULT_CODE zend_result;
+} zend_result;
 
 /* This constant is deprecated, use SIZE_MAX instead */
 #define ZEND_SIZE_MAX SIZE_MAX


### PR DESCRIPTION
This simplifies the definition of `zend_result`, since it's no longer a multilayered `typedef` of an anonymous enum.