### PR TITLE
Fix GH-21742: SplFileObject::fgets() throws at EOF in eof/fgets loop

### DIFF
--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -2099,7 +2099,11 @@ PHP_METHOD(SplFileObject, fgets)
 		spl_filesystem_file_free_line(intern);
 		intern->u.file.current_line_num++;
 	} else {
-		if (spl_filesystem_file_read_ex(intern, /* silent */ false, /* line_add */ 1, /* csv */ false) == FAILURE) {
+		if (spl_filesystem_file_read_ex(intern, /* silent */ true, /* line_add */ 1, /* csv */ false) == FAILURE) {
+			if (php_stream_eof(intern->u.file.stream)) {
+				RETURN_EMPTY_STRING();
+			}
+			spl_filesystem_file_cannot_read(intern);
 			RETURN_THROWS();
 		}
 		RETVAL_STR_COPY(intern->u.file.current_line);

--- a/ext/spl/tests/SplFileObject/gh21742.phpt
+++ b/ext/spl/tests/SplFileObject/gh21742.phpt
@@ -1,0 +1,35 @@
+--TEST--
+GH-21742 (SplFileObject::fgets() throws at EOF in while (!$spl->eof()) loop)
+--FILE--
+<?php
+$file = tempnam(sys_get_temp_dir(), 'spl');
+file_put_contents($file, "Line 0\nLine 1\nLine 2\nLine 3\nLine 4\n");
+
+$spl = new SplFileObject($file, 'r');
+while (!$spl->eof()) {
+    echo $spl->fgets();
+}
+echo "clean exit\n";
+
+$empty = tempnam(sys_get_temp_dir(), 'spl');
+file_put_contents($empty, '');
+$spl2 = new SplFileObject($empty, 'r');
+$iter = 0;
+while (!$spl2->eof()) {
+    $iter++;
+    $spl2->fgets();
+    if ($iter > 3) break;
+}
+echo "empty-file iters=$iter\n";
+
+unlink($file);
+unlink($empty);
+?>
+--EXPECT--
+Line 0
+Line 1
+Line 2
+Line 3
+Line 4
+clean exit
+empty-file iters=1


### PR DESCRIPTION
Fix in `08dad097025` made `spl_filesystem_file_read_ex` throw `Cannot read from file` on NULL-buffer. `SplFileObject::fgets()` now throws inside the documented `while (!$spl->eof()) $spl->fgets()`, because eof() returns false until a read attempt returns zero bytes, so the loop always makes one extra fgets call past the final newline.

Narrow fgets to `silent=true` and return empty string when the stream is at EOF; keep the throw for non-EOF read failures so userland wrappers that return NULL without setting EOF still surface the error. next, seek, current, fscanf keep the stricter semantics.

Fixes #21742 - Specifically the issue reported by @xabbuh

P.S. Not a new issue, side-effect of earlier SPL fixes only in master, so no news entry is needed.