### PR TITLE
Zlib: Fix the bug when zval_get_long silently cast several options into long in deflate_init

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -199,6 +199,7 @@ PHP                                                                        NEWS
 
 - Zlib:
   . deflate_init() now raises a TypeError when the value for option
-    "strategy" is not of type int. (Weilin Du)
+    "level", "memory", "window", or "strategy" is not of type int.
+    (Weilin Du)
 
 <<< NOTE: Insert NEWS from last stable release here prior to actual release! >>>

--- a/UPGRADING
+++ b/UPGRADING
@@ -103,7 +103,7 @@ PHP 8.6 UPGRADE NOTES
 
 - Zlib:
   . deflate_init() now raises a TypeError when the value for option
-    "strategy" is not of type int.
+    "level", "memory", "window", or "strategy" is not of type int.
 
 ========================================
 2. New Features

--- a/ext/zlib/tests/deflate_init_strategy_type_error.phpt
+++ b/ext/zlib/tests/deflate_init_strategy_type_error.phpt
@@ -5,8 +5,11 @@ zlib
 --FILE--
 <?php
 
+class A {}
+$fp = fopen('php://memory', 'r');
+
 try {
-    deflate_init(ZLIB_ENCODING_DEFLATE, ['level' => []]);
+    deflate_init(ZLIB_ENCODING_DEFLATE, ['level' => 'foo']);
 } catch (TypeError $e) {
     echo $e->getMessage(), PHP_EOL;
 }
@@ -18,20 +21,22 @@ try {
 }
 
 try {
-    deflate_init(ZLIB_ENCODING_DEFLATE, ['window' => []]);
+    deflate_init(ZLIB_ENCODING_DEFLATE, ['window' => new A()]);
 } catch (TypeError $e) {
     echo $e->getMessage(), PHP_EOL;
 }
 
 try {
-    deflate_init(ZLIB_ENCODING_DEFLATE, ['strategy' => []]);
+    deflate_init(ZLIB_ENCODING_DEFLATE, ['strategy' => $fp]);
 } catch (TypeError $e) {
     echo $e->getMessage(), PHP_EOL;
 }
 
+fclose($fp);
+
 ?>
 --EXPECT--
-deflate_init(): Argument #2 ($options) the value for option "level" must be of type int, array given
+deflate_init(): Argument #2 ($options) the value for option "level" must be of type int, string given
 deflate_init(): Argument #2 ($options) the value for option "memory" must be of type int, array given
-deflate_init(): Argument #2 ($options) the value for option "window" must be of type int, array given
-deflate_init(): Argument #2 ($options) the value for option "strategy" must be of type int, array given
+deflate_init(): Argument #2 ($options) the value for option "window" must be of type int, A given
+deflate_init(): Argument #2 ($options) the value for option "strategy" must be of type int, resource given

--- a/ext/zlib/tests/deflate_init_strategy_type_error.phpt
+++ b/ext/zlib/tests/deflate_init_strategy_type_error.phpt
@@ -1,9 +1,27 @@
 --TEST--
-deflate_init(): strategy option type validation
+deflate_init(): options type validation
 --EXTENSIONS--
 zlib
 --FILE--
 <?php
+
+try {
+    deflate_init(ZLIB_ENCODING_DEFLATE, ['level' => []]);
+} catch (TypeError $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+try {
+    deflate_init(ZLIB_ENCODING_DEFLATE, ['memory' => []]);
+} catch (TypeError $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+try {
+    deflate_init(ZLIB_ENCODING_DEFLATE, ['window' => []]);
+} catch (TypeError $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
 
 try {
     deflate_init(ZLIB_ENCODING_DEFLATE, ['strategy' => []]);
@@ -13,4 +31,7 @@ try {
 
 ?>
 --EXPECT--
+deflate_init(): Argument #2 ($options) the value for option "level" must be of type int, array given
+deflate_init(): Argument #2 ($options) the value for option "memory" must be of type int, array given
+deflate_init(): Argument #2 ($options) the value for option "window" must be of type int, array given
 deflate_init(): Argument #2 ($options) the value for option "strategy" must be of type int, array given

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -863,6 +863,7 @@ ZEND_ATTRIBUTE_NONNULL static bool zlib_get_long_option(HashTable *options, cons
 		return true;
 	}
 
+	/* The |H ZPP specifier may leave HashTable entries wrapped in IS_INDIRECT. */
 	ZVAL_DEINDIRECT(option_buffer);
 	*value = zval_try_get_long(option_buffer, &failed);
 	if (UNEXPECTED(failed)) {

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -854,12 +854,12 @@ static bool zlib_create_dictionary_string(HashTable *options, char **dict, size_
 	return true;
 }
 
-static bool zlib_get_long_option(HashTable *options, const char *option_name, size_t option_name_len, zend_long *value)
+ZEND_ATTRIBUTE_NONNULL static bool zlib_get_long_option(HashTable *options, const char *option_name, size_t option_name_len, zend_long *value)
 {
-	zval *option_buffer;
 	bool failed = false;
+	zval *option_buffer = zend_hash_str_find(options, option_name, option_name_len);
 
-	if (!options || (option_buffer = zend_hash_str_find(options, option_name, option_name_len)) == NULL) {
+	if (!option_buffer) {
 		return true;
 	}
 
@@ -1103,7 +1103,7 @@ PHP_FUNCTION(deflate_init)
 	zend_long encoding, level = -1, memory = 8, window = 15, strategy = Z_DEFAULT_STRATEGY;
 	char *dict = NULL;
 	size_t dictlen = 0;
-	HashTable *options = NULL;
+	HashTable *options = (HashTable*)&zend_empty_array;
 
 	if (SUCCESS != zend_parse_parameters(ZEND_NUM_ARGS(), "l|H", &encoding, &options)) {
 		RETURN_THROWS();

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -854,6 +854,29 @@ static bool zlib_create_dictionary_string(HashTable *options, char **dict, size_
 	return true;
 }
 
+static bool zlib_get_long_option(HashTable *options, const char *option_name, size_t option_name_len, zend_long *value)
+{
+	zval *option_buffer;
+	bool failed = false;
+
+	if (!options || (option_buffer = zend_hash_str_find(options, option_name, option_name_len)) == NULL) {
+		return true;
+	}
+
+	ZVAL_DEINDIRECT(option_buffer);
+	*value = zval_try_get_long(option_buffer, &failed);
+	if (UNEXPECTED(failed)) {
+		zend_argument_type_error(
+			2,
+			"the value for option \"%.*s\" must be of type int, %s given",
+			(int) option_name_len, option_name, zend_zval_value_name(option_buffer)
+		);
+		return false;
+	}
+
+	return true;
+}
+
 /* {{{ Initialize an incremental inflate context with the specified encoding */
 PHP_FUNCTION(inflate_init)
 {
@@ -1081,48 +1104,37 @@ PHP_FUNCTION(deflate_init)
 	char *dict = NULL;
 	size_t dictlen = 0;
 	HashTable *options = NULL;
-	zval *option_buffer;
 
 	if (SUCCESS != zend_parse_parameters(ZEND_NUM_ARGS(), "l|H", &encoding, &options)) {
 		RETURN_THROWS();
 	}
 
-	if (options && (option_buffer = zend_hash_str_find(options, ZEND_STRL("level"))) != NULL) {
-		ZVAL_DEINDIRECT(option_buffer);
-		level = zval_get_long(option_buffer);
+	if (!zlib_get_long_option(options, ZEND_STRL("level"), &level)) {
+		RETURN_THROWS();
 	}
 	if (level < -1 || level > 9) {
 		zend_value_error("deflate_init(): \"level\" option must be between -1 and 9");
 		RETURN_THROWS();
 	}
 
-	if (options && (option_buffer = zend_hash_str_find(options, ZEND_STRL("memory"))) != NULL) {
-		ZVAL_DEINDIRECT(option_buffer);
-		memory = zval_get_long(option_buffer);
+	if (!zlib_get_long_option(options, ZEND_STRL("memory"), &memory)) {
+		RETURN_THROWS();
 	}
 	if (memory < 1 || memory > 9) {
 		zend_value_error("deflate_init(): \"memory\" option must be between 1 and 9");
 		RETURN_THROWS();
 	}
 
-	if (options && (option_buffer = zend_hash_str_find(options, ZEND_STRL("window"))) != NULL) {
-		ZVAL_DEINDIRECT(option_buffer);
-		window = zval_get_long(option_buffer);
+	if (!zlib_get_long_option(options, ZEND_STRL("window"), &window)) {
+		RETURN_THROWS();
 	}
 	if (window < 8 || window > 15) {
 		zend_value_error("deflate_init(): \"window\" option must be between 8 and 15");
 		RETURN_THROWS();
 	}
 
-	if (options && (option_buffer = zend_hash_str_find(options, ZEND_STRL("strategy"))) != NULL) {
-		bool failed = false;
-
-		ZVAL_DEINDIRECT(option_buffer);
-		strategy = zval_try_get_long(option_buffer, &failed);
-		if (UNEXPECTED(failed)) {
-			zend_argument_type_error(2, "the value for option \"strategy\" must be of type int, %s given", zend_zval_value_name(option_buffer));
-			RETURN_THROWS();
-		}
+	if (!zlib_get_long_option(options, ZEND_STRL("strategy"), &strategy)) {
+		RETURN_THROWS();
 	}
 	switch (strategy) {
 		case Z_FILTERED:


### PR DESCRIPTION
I opened #21841 yesterday to fix the case in one option `strategy` and after a closer look this morning I realized almost every options in this function has the same problem. So this follow-up PR fix them all. (I will take a look of similar occasions in the future :) ).

plus: to make things easy I write a helper function to throw errors