### PR TITLE
Fix GH-21738: undefined behavior in isxdigit() callsites with non-ASCII bytes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -162,6 +162,8 @@ PHP                                                                        NEWS
   . Fix NUL byte truncation in sqlite3 TEXT column handling. (ndossche)
 
 - Standard:
+  . Fixed bug GH-21738 (undefined behavior in url_decode functions when
+    passing non-ASCII bytes to isxdigit()). (lacatoire)
   . Fixed bug GH-19926 (reset internal pointer earlier while splicing array
     while COW violation flag is still set). (alexandre-daubois)
   . Added form feed (\f) in the default trimmed characters of trim(), rtrim()

--- a/NEWS
+++ b/NEWS
@@ -162,8 +162,9 @@ PHP                                                                        NEWS
   . Fix NUL byte truncation in sqlite3 TEXT column handling. (ndossche)
 
 - Standard:
-  . Fixed bug GH-21738 (undefined behavior in url_decode functions when
-    passing non-ASCII bytes to isxdigit()). (lacatoire)
+  . Fixed bug GH-21738 (undefined behavior when passing non-ASCII bytes to
+    isxdigit() in url_decode, quoted_printable_decode and stripcslashes).
+    (lacatoire)
   . Fixed bug GH-19926 (reset internal pointer earlier while splicing array
     while COW violation flag is still set). (alexandre-daubois)
   . Added form feed (\f) in the default trimmed characters of trim(), rtrim()

--- a/ext/standard/quot_print.c
+++ b/ext/standard/quot_print.c
@@ -210,8 +210,8 @@ PHP_FUNCTION(quoted_printable_decode)
 		switch (str_in[i]) {
 		case '=':
 			if (str_in[i + 1] && str_in[i + 2] &&
-				isxdigit((int) str_in[i + 1]) &&
-				isxdigit((int) str_in[i + 2]))
+				isxdigit((unsigned char) str_in[i + 1]) &&
+				isxdigit((unsigned char) str_in[i + 2]))
 			{
 				ZSTR_VAL(str_out)[j++] = (php_hex2int((int) str_in[i + 1]) << 4)
 						+ php_hex2int((int) str_in[i + 2]);

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -3760,9 +3760,9 @@ PHPAPI void php_stripcslashes(zend_string *str)
 				case 'f':  *target++='\f'; nlen--; break;
 				case '\\': *target++='\\'; nlen--; break;
 				case 'x':
-					if (source+1 < end && isxdigit((int)(*(source+1)))) {
+					if (source+1 < end && isxdigit((unsigned char)(*(source+1)))) {
 						numtmp[0] = *++source;
-						if (source+1 < end && isxdigit((int)(*(source+1)))) {
+						if (source+1 < end && isxdigit((unsigned char)(*(source+1)))) {
 							numtmp[1] = *++source;
 							numtmp[2] = '\0';
 							nlen-=3;

--- a/ext/standard/url.c
+++ b/ext/standard/url.c
@@ -589,8 +589,8 @@ PHPAPI size_t php_url_decode_ex(char *dest, const char *src, size_t src_len)
 		if (*data == '+') {
 			*dest = ' ';
 		}
-		else if (*data == '%' && src_len >= 2 && isxdigit((int) *(data + 1))
-				 && isxdigit((int) *(data + 2))) {
+		else if (*data == '%' && src_len >= 2 && isxdigit((unsigned char) *(data + 1))
+				 && isxdigit((unsigned char) *(data + 2))) {
 			*dest = (char) php_htoi(data + 1);
 			data += 2;
 			src_len -= 2;
@@ -662,8 +662,8 @@ PHPAPI size_t php_raw_url_decode_ex(char *dest, const char *src, size_t src_len)
 	const char *data = src;
 
 	while (src_len--) {
-		if (*data == '%' && src_len >= 2 && isxdigit((int) *(data + 1))
-			&& isxdigit((int) *(data + 2))) {
+		if (*data == '%' && src_len >= 2 && isxdigit((unsigned char) *(data + 1))
+			&& isxdigit((unsigned char) *(data + 2))) {
 			*dest = (char) php_htoi(data + 1);
 			data += 2;
 			src_len -= 2;


### PR DESCRIPTION
Cast the byte to `unsigned char` before passing it to `isxdigit()`.

`<ctype.h>` functions require their argument to be representable as `unsigned char` (0-255) or `EOF`; passing a sign-extended `char` for high-bit bytes like `\x80` is undefined behavior.

Callsites fixed:
- `php_url_decode_ex` and `php_raw_url_decode_ex` in `ext/standard/url.c`
- `quoted_printable_decode` in `ext/standard/quot_print.c`
- `php_stripcslashes` in `ext/standard/string.c`

Fixes GH-21738