### PR TITLE
ext/pdo: update pdo_set_fetch_mode_errors expect for GH-20214

### DIFF
--- a/ext/pdo/tests/pdo_set_fetch_mode_errors.phpt
+++ b/ext/pdo/tests/pdo_set_fetch_mode_errors.phpt
@@ -82,7 +82,7 @@ ValueError: PDOStatement::setFetchMode(): Argument #1 ($mode) cannot use PDO::FE
 Mode: 15
 ValueError: PDOStatement::setFetchMode(): Argument #1 ($mode) cannot use PDO::FETCH_CLASSTYPE, PDO::FETCH_PROPS_LATE, or PDO::FETCH_SERIALIZE fetch flags with a fetch mode other than PDO::FETCH_CLASS
 Mode: 16
-bool(true)
+ValueError: PDOStatement::setFetchMode(): Argument #1 ($mode) cannot use PDO::FETCH_CLASSTYPE, PDO::FETCH_PROPS_LATE, or PDO::FETCH_SERIALIZE fetch flags with a fetch mode other than PDO::FETCH_CLASS
 ValueError: PDOStatement::setFetchMode(): Argument #1 ($mode) cannot use PDO::FETCH_CLASSTYPE, PDO::FETCH_PROPS_LATE, or PDO::FETCH_SERIALIZE fetch flags with a fetch mode other than PDO::FETCH_CLASS
 ValueError: PDOStatement::setFetchMode(): Argument #1 ($mode) must be a bitmask of PDO::FETCH_* constants
 ValueError: PDOStatement::setFetchMode(): Argument #1 ($mode) PDO::FETCH_FUNC can only be used with PDOStatement::fetchAll()


### PR DESCRIPTION
Follow-up to #21434. After that fix, `setFetchMode` rejects `FETCH_CLASSTYPE|FETCH_PROPS_LATE` when the base mode is not `FETCH_CLASS`. The Mode 16 case in the second loop of `pdo_set_fetch_mode_errors.phpt` still expected `bool(true)`, so `common.phpt` fails across every PDO driver once the fix merged up to PHP-8.5. This aligns the expected output with the thrown `ValueError`.
