### PR TITLE
Follow-up GH-21434: Fixed the behavior when using `FETCH_DEFAULT`

### DIFF
--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -1729,17 +1729,15 @@ bool pdo_stmt_setup_fetch_mode(pdo_stmt_t *stmt, zend_long mode, uint32_t mode_a
 			;
 	}
 
-	stmt->default_fetch_type = PDO_FETCH_BOTH;
+	stmt->default_fetch_type = stmt->dbh->default_fetch_type;
 
 	flags = mode & PDO_FETCH_FLAGS;
-
-	if ((mode & ~PDO_FETCH_FLAGS) == PDO_FETCH_USE_DEFAULT) {
-		mode = stmt->dbh->default_fetch_type | flags;
-	}
 
 	if (!pdo_stmt_verify_mode(stmt, mode, mode_arg_num, false)) {
 		return false;
 	}
+
+	bool use_default = (mode & ~PDO_FETCH_FLAGS) == PDO_FETCH_USE_DEFAULT;
 
 	switch (mode & ~PDO_FETCH_FLAGS) {
 		case PDO_FETCH_USE_DEFAULT:
@@ -1862,7 +1860,9 @@ bool pdo_stmt_setup_fetch_mode(pdo_stmt_t *stmt, zend_long mode, uint32_t mode_a
 			return false;
 	}
 
-	stmt->default_fetch_type = mode;
+	if (!use_default) {
+		stmt->default_fetch_type = mode;
+	}
 
 	return true;
 }


### PR DESCRIPTION
Follow up https://github.com/php/php-src/pull/21434

The changes in the above PR resolve most of the issue, but validation can still fail when `FETCH_DEFAULT` is combined with additional flags.

This happens because the default value already stores both the mode and its flags, and the implementation then attempts to combine it further with newly specified flags.

In the validation function, when `FETCH_DEFAULT` is specified, any flags provided alongside it are completely ignored, and validation is performed under the assumption that the existing default value will be used as-is.

The manual describes `FETCH_DEFAULT` as “Special value for using the current default fetch mode.” While it is somewhat unclear whether flags should be included in the default value, the current behavior does include flags as part of the default. Therefore, this change respects the existing implementation.

Specifically, when attempting to set `FETCH_DEFAULT` as a new default value, the update is skipped to avoid overwriting the current setting.
