### PR TITLE
Fix GH-21869: pdo_pgsql DEALLOCATE in destructor can poison the enclosing transaction.

### DIFF
--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -242,10 +242,59 @@ void pdo_pgsql_close_lob_streams(pdo_dbh_t *dbh)
 	}
 }
 
+void pdo_pgsql_defer_close(pdo_pgsql_db_handle *H, const char *cmd, size_t cmd_len, bool is_deallocate)
+{
+	pdo_pgsql_pending_close *pc;
+
+	if (is_deallocate && H->deallocate_unsupported) {
+		return;
+	}
+
+	pc = pemalloc(sizeof(*pc) + cmd_len, H->is_persistent);
+	memcpy(pc->cmd, cmd, cmd_len + 1);
+	pc->is_deallocate = is_deallocate;
+	pc->next = H->pending_closes;
+	H->pending_closes = pc;
+}
+
+void pdo_pgsql_discard_pending_closes(pdo_pgsql_db_handle *H)
+{
+	while (H->pending_closes) {
+		pdo_pgsql_pending_close *pc = H->pending_closes;
+
+		H->pending_closes = pc->next;
+		pefree(pc, H->is_persistent);
+	}
+}
+
+void pdo_pgsql_run_pending_closes(pdo_pgsql_db_handle *H)
+{
+	if (!H->pending_closes || !H->server
+			|| PQtransactionStatus(H->server) != PQTRANS_IDLE) {
+		return;
+	}
+
+	do {
+		pdo_pgsql_pending_close *pc = H->pending_closes;
+		PGresult *res = PQexec(H->server, pc->cmd);
+
+		if (res) {
+			if (pc->is_deallocate && pdo_pgsql_sqlstate_is(res, "0A000")) {
+				H->deallocate_unsupported = true;
+			}
+			PQclear(res);
+		}
+
+		H->pending_closes = pc->next;
+		pefree(pc, H->is_persistent);
+	} while (H->pending_closes);
+}
+
 static void pgsql_handle_closer(pdo_dbh_t *dbh) /* {{{ */
 {
 	pdo_pgsql_db_handle *H = (pdo_pgsql_db_handle *)dbh->driver_data;
 	if (H) {
+		pdo_pgsql_discard_pending_closes(H);
 		if (H->lob_streams) {
 			pdo_pgsql_close_lob_streams(dbh);
 			zend_hash_destroy(H->lob_streams);
@@ -560,6 +609,7 @@ static zend_result pdo_pgsql_check_liveness(pdo_dbh_t *dbh)
 	pdo_pgsql_db_handle *H = (pdo_pgsql_db_handle *)dbh->driver_data;
 	if (!PQconsumeInput(H->server) || PQstatus(H->server) == CONNECTION_BAD) {
 		PQreset(H->server);
+		pdo_pgsql_discard_pending_closes(H);
 	}
 	return (PQstatus(H->server) == CONNECTION_OK) ? SUCCESS : FAILURE;
 }
@@ -605,17 +655,22 @@ static bool pgsql_handle_commit(pdo_dbh_t *dbh)
 	} else {
 		dbh->in_txn = pgsql_handle_in_transaction(dbh);
 	}
+	pdo_pgsql_run_pending_closes((pdo_pgsql_db_handle *)dbh->driver_data);
 
 	return ret;
 }
 
 static bool pgsql_handle_rollback(pdo_dbh_t *dbh)
 {
+	pdo_pgsql_db_handle *H = (pdo_pgsql_db_handle *)dbh->driver_data;
 	int ret = pdo_pgsql_transaction_cmd("ROLLBACK", dbh);
 
 	if (ret) {
 		pdo_pgsql_close_lob_streams(dbh);
 	}
+	/* cursors declared in the transaction are gone with it */
+	H->rollback_counter++;
+	pdo_pgsql_run_pending_closes(H);
 
 	return ret;
 }
@@ -1391,6 +1446,7 @@ static int pdo_pgsql_handle_factory(pdo_dbh_t *dbh, zval *driver_options) /* {{{
 	smart_str_0(&conn_str);
 
 	H->server = PQconnectdb(ZSTR_VAL(conn_str.s));
+	H->is_persistent = dbh->is_persistent;
 	H->lob_streams = (HashTable *) pemalloc(sizeof(HashTable), dbh->is_persistent);
 	zend_hash_init(H->lob_streams, 0, NULL, NULL, 1);
 

--- a/ext/pdo_pgsql/pgsql_statement.c
+++ b/ext/pdo_pgsql/pgsql_statement.c
@@ -81,40 +81,16 @@ static int pgsql_stmt_dtor(pdo_stmt_t *stmt)
 			char *q = NULL;
 			PGTransactionStatusType tstatus = PQtransactionStatus(H->server);
 
-			switch (tstatus) {
-			case PQTRANS_ACTIVE:
-			case PQTRANS_INERROR:
-			case PQTRANS_UNKNOWN:
-				res = NULL;
-				break;
-			case PQTRANS_INTRANS:
-				spprintf(&q, 0, 
-					"SAVEPOINT pdo_pgsql_deallocate_%s;"
-					"DEALLOCATE %s;"
-					"RELEASE SAVEPOINT pdo_pgsql_deallocate_%s",
-					S->stmt_name,
-					S->stmt_name,
-					S->stmt_name);
-				res = PQexec(H->server, q);
-				efree(q);
-				if (res && PQresultStatus(res) != PGRES_COMMAND_OK) {
-					spprintf(&q, 0,
-						"ROLLBACK TO SAVEPOINT pdo_pgsql_deallocate_%s;"
-						"RELEASE SAVEPOINT pdo_pgsql_deallocate_%s",
-						S->stmt_name,
-						S->stmt_name);
-					PGresult *rollres;
-					PQclear(res);
-					rollres = PQexec(H->server, q);
-					res = rollres;
-					efree(q);
-				}
-				break;
-			default:
+			if (tstatus == PQTRANS_IDLE) {
 				spprintf(&q, 0, "DEALLOCATE %s", S->stmt_name);
 				res = PQexec(H->server, q);
 				efree(q);
-				break;
+			} else {
+				/* Inside a transaction, already aborted, or connection is unusable:
+				 * skip DEALLOCATE. On servers that reject it (e.g. Aurora DSQL) it
+				 * would poison the transaction (GH-21869); on any server the server
+				 * frees the prepared statement when the transaction ends. */
+				res = NULL;
 			}
 #else
 			res = PQclosePrepared(H->server, S->stmt_name);

--- a/ext/pdo_pgsql/pgsql_statement.c
+++ b/ext/pdo_pgsql/pgsql_statement.c
@@ -86,10 +86,9 @@ static int pgsql_stmt_dtor(pdo_stmt_t *stmt)
 				res = PQexec(H->server, q);
 				efree(q);
 			} else {
-				/* Inside a transaction, already aborted, or connection is unusable:
-				 * skip DEALLOCATE. On servers that reject it (e.g. Aurora DSQL) it
-				 * would poison the transaction (GH-21869); on any server the server
-				 * frees the prepared statement when the transaction ends. */
+				/* Outside PQTRANS_IDLE, skip DEALLOCATE: on libpq < 17 some servers
+				 * (e.g. Aurora DSQL) reject it and poison the tx (GH-21869). The
+				 * statement is session-scoped, so it's freed on disconnect. */
 				res = NULL;
 			}
 #else

--- a/ext/pdo_pgsql/pgsql_statement.c
+++ b/ext/pdo_pgsql/pgsql_statement.c
@@ -79,9 +79,43 @@ static int pgsql_stmt_dtor(pdo_stmt_t *stmt)
 			// TODO (??) libpq does not support close statement protocol < postgres 17
 			// check if we can circumvent this.
 			char *q = NULL;
-			spprintf(&q, 0, "DEALLOCATE %s", S->stmt_name);
-			res = PQexec(H->server, q);
-			efree(q);
+			PGTransactionStatusType tstatus = PQtransactionStatus(H->server);
+
+			switch (tstatus) {
+			case PQTRANS_ACTIVE:
+			case PQTRANS_INERROR:
+			case PQTRANS_UNKNOWN:
+				res = NULL;
+				break;
+			case PQTRANS_INTRANS:
+				spprintf(&q, 0, 
+					"SAVEPOINT pdo_pgsql_deallocate_%s;"
+					"DEALLOCATE %s;"
+					"RELEASE SAVEPOINT pdo_pgsql_deallocate_%s",
+					S->stmt_name,
+					S->stmt_name,
+					S->stmt_name);
+				res = PQexec(H->server, q);
+				efree(q);
+				if (res && PQresultStatus(res) != PGRES_COMMAND_OK) {
+					spprintf(&q, 0,
+						"ROLLBACK TO SAVEPOINT pdo_pgsql_deallocate_%s;"
+						"RELEASE SAVEPOINT pdo_pgsql_deallocate_%s",
+						S->stmt_name,
+						S->stmt_name);
+					PGresult *rollres;
+					PQclear(res);
+					rollres = PQexec(H->server, q);
+					res = rollres;
+					efree(q);
+				}
+				break;
+			default:
+				spprintf(&q, 0, "DEALLOCATE %s", S->stmt_name);
+				res = PQexec(H->server, q);
+				efree(q);
+				break;
+			}
 #else
 			res = PQclosePrepared(H->server, S->stmt_name);
 #endif

--- a/ext/pdo_pgsql/pgsql_statement.c
+++ b/ext/pdo_pgsql/pgsql_statement.c
@@ -79,18 +79,20 @@ static int pgsql_stmt_dtor(pdo_stmt_t *stmt)
 			// TODO (??) libpq does not support close statement protocol < postgres 17
 			// check if we can circumvent this.
 			char *q = NULL;
-			PGTransactionStatusType tstatus = PQtransactionStatus(H->server);
+			size_t q_len = spprintf(&q, 0, "DEALLOCATE %s", S->stmt_name);
 
-			if (tstatus == PQTRANS_IDLE) {
-				spprintf(&q, 0, "DEALLOCATE %s", S->stmt_name);
-				res = PQexec(H->server, q);
-				efree(q);
+			if (PQtransactionStatus(H->server) == PQTRANS_IDLE) {
+				res = H->deallocate_unsupported ? NULL : PQexec(H->server, q);
+				if (res && pdo_pgsql_sqlstate_is(res, "0A000")) {
+					H->deallocate_unsupported = true;
+				}
 			} else {
-				/* Outside PQTRANS_IDLE, skip DEALLOCATE: on libpq < 17 some servers
-				 * (e.g. Aurora DSQL) reject it and poison the tx (GH-21869). The
-				 * statement is session-scoped, so it's freed on disconnect. */
+				/* a rejected DEALLOCATE would abort the caller's transaction,
+				 * so hold it back until the connection is idle again */
+				pdo_pgsql_defer_close(H, q, q_len, true);
 				res = NULL;
 			}
+			efree(q);
 #else
 			res = PQclosePrepared(H->server, S->stmt_name);
 #endif
@@ -123,18 +125,27 @@ static int pgsql_stmt_dtor(pdo_stmt_t *stmt)
 	}
 
 	if (S->cursor_name) {
-		if (server_obj_usable) {
+		if (server_obj_usable && S->is_prepared) {
 			pdo_pgsql_db_handle *H = S->H;
 			char *q = NULL;
-			PGresult *res;
+			size_t q_len = spprintf(&q, 0, "CLOSE %s", S->cursor_name);
 
-			spprintf(&q, 0, "CLOSE %s", S->cursor_name);
-			res = PQexec(H->server, q);
+			if (S->declared_at_rollback == H->rollback_counter
+					|| PQtransactionStatus(H->server) == PQTRANS_IDLE) {
+				PQclear(PQexec(H->server, q));
+			} else {
+				/* the rollback may have dropped the cursor, and the failing
+				 * CLOSE would abort the caller's transaction */
+				pdo_pgsql_defer_close(H, q, q_len, false);
+			}
 			efree(q);
-			if (res) PQclear(res);
 		}
 		efree(S->cursor_name);
 		S->cursor_name = NULL;
+	}
+
+	if (server_obj_usable) {
+		pdo_pgsql_run_pending_closes(S->H);
 	}
 
 	if(S->cols) {
@@ -151,6 +162,7 @@ static int pgsql_stmt_execute(pdo_stmt_t *stmt)
 	pdo_pgsql_stmt *S = (pdo_pgsql_stmt*)stmt->driver_data;
 	pdo_pgsql_db_handle *H = S->H;
 	ExecStatusType status;
+	bool prepare_retried = false;
 
 	bool in_trans = stmt->dbh->methods->in_transaction(stmt->dbh);
 
@@ -185,6 +197,7 @@ static int pgsql_stmt_execute(pdo_stmt_t *stmt)
 
 		/* the cursor was declared correctly */
 		S->is_prepared = 1;
+		S->declared_at_rollback = H->rollback_counter;
 
 		/* fetch to be able to get the number of tuples later, but don't advance the cursor pointer */
 		spprintf(&q, 0, "FETCH FORWARD 0 FROM %s", S->cursor_name);
@@ -216,7 +229,7 @@ stmt_retry:
 					 * chance to DEALLOCATE the prepared statements it has created. so, if we hit a 42P05 we
 					 * deallocate it and retry ONCE (thies 2005.12.15)
 					 */
-					if (sqlstate && !strcmp(sqlstate, "42P05")) {
+					if (!prepare_retried && sqlstate && !strcmp(sqlstate, "42P05")) {
 						PGresult *res;
 #ifndef HAVE_PQCLOSEPREPARED
 						char buf[100]; /* stmt_name == "pdo_crsr_%08x" */
@@ -228,6 +241,9 @@ stmt_retry:
 						if (res) {
 							PQclear(res);
 						}
+						PQclear(S->result);
+						S->result = NULL;
+						prepare_retried = true;
 						goto stmt_retry;
 					} else {
 						pdo_pgsql_error_stmt(stmt, status, sqlstate);

--- a/ext/pdo_pgsql/php_pdo_pgsql_int.h
+++ b/ext/pdo_pgsql/php_pdo_pgsql_int.h
@@ -34,6 +34,13 @@ typedef struct {
 	char *errmsg;
 } pdo_pgsql_error_info;
 
+/* a DEALLOCATE or CLOSE held back until the connection leaves its transaction */
+typedef struct pdo_pgsql_pending_close {
+	struct pdo_pgsql_pending_close *next;
+	bool is_deallocate;
+	char cmd[1];
+} pdo_pgsql_pending_close;
+
 /* stuff we use in a pgsql database handle */
 typedef struct {
 	PGconn		*server;
@@ -49,6 +56,10 @@ typedef struct {
 	bool		disable_prepares;
 	HashTable       *lob_streams;
 	zend_fcall_info_cache *notice_callback;
+	pdo_pgsql_pending_close *pending_closes;
+	unsigned int	rollback_counter;
+	bool		is_persistent;
+	bool		deallocate_unsupported;
 } pdo_pgsql_db_handle;
 
 typedef struct {
@@ -67,6 +78,7 @@ typedef struct {
 	int *param_formats;
 	Oid *param_types;
 	int                     current_row;
+	unsigned int            declared_at_rollback;
 	bool is_prepared;
 } pdo_pgsql_stmt;
 
@@ -88,6 +100,13 @@ extern int _pdo_pgsql_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, int errcode, const
 extern const struct pdo_stmt_methods pgsql_stmt_methods;
 
 #define pdo_pgsql_sqlstate(r) PQresultErrorField(r, PG_DIAG_SQLSTATE)
+
+static zend_always_inline bool pdo_pgsql_sqlstate_is(PGresult *res, const char *sqlstate)
+{
+	const char *result_state = pdo_pgsql_sqlstate(res);
+
+	return result_state && !strcmp(result_state, sqlstate);
+}
 
 enum {
 	PDO_PGSQL_ATTR_DISABLE_PREPARES = PDO_ATTR_DRIVER_SPECIFIC,
@@ -116,6 +135,9 @@ void pdo_pgsql_cleanup_notice_callback(pdo_pgsql_db_handle *H);
 
 void pdo_libpq_version(char *buf, size_t len);
 void pdo_pgsql_close_lob_streams(pdo_dbh_t *dbh);
+void pdo_pgsql_defer_close(pdo_pgsql_db_handle *H, const char *cmd, size_t cmd_len, bool is_deallocate);
+void pdo_pgsql_run_pending_closes(pdo_pgsql_db_handle *H);
+void pdo_pgsql_discard_pending_closes(pdo_pgsql_db_handle *H);
 
 void pgsqlCopyFromArray_internal(INTERNAL_FUNCTION_PARAMETERS);
 void pgsqlCopyFromFile_internal(INTERNAL_FUNCTION_PARAMETERS);

--- a/ext/pdo_pgsql/tests/gh21869.phpt
+++ b/ext/pdo_pgsql/tests/gh21869.phpt
@@ -1,0 +1,46 @@
+--TEST--
+GH-21869 pdo_pgsql: DEALLOCATE failure in destructor must not poison the enclosing transaction
+--EXTENSIONS--
+pdo
+pdo_pgsql
+--SKIPIF--
+<?php
+require __DIR__ . '/config.inc';
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+PDOTest::skip();
+$pdo = PDOTest::factory();
+if (version_compare($pdo->getAttribute(PDO::ATTR_CLIENT_VERSION), '17', '>=')) {
+    die('skip libpq >= 17 uses PQclosePrepared instead of the DEALLOCATE query');
+}
+?>
+--FILE--
+<?php
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$pdo = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+
+$pdo->exec('CREATE TABLE gh21869 (a integer not null)');
+
+$pdo->beginTransaction();
+$stmt = $pdo->prepare('INSERT INTO gh21869 (a) VALUES (?)');
+$stmt->execute([1]);
+
+foreach ($pdo->query('SELECT name FROM pg_prepared_statements') as $row) {
+    $pdo->exec('DEALLOCATE ' . $row['name']);
+}
+
+unset($stmt);
+
+$pdo->commit();
+
+var_dump((int) $pdo->query('SELECT count(*) FROM gh21869')->fetchColumn());
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$pdo = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$pdo->exec('DROP TABLE IF EXISTS gh21869');
+?>
+--EXPECT--
+int(1)

--- a/ext/pdo_pgsql/tests/gh21869_cursor.phpt
+++ b/ext/pdo_pgsql/tests/gh21869_cursor.phpt
@@ -1,0 +1,50 @@
+--TEST--
+GH-21869 pdo_pgsql: closing a scrollable cursor must not poison the enclosing transaction
+--EXTENSIONS--
+pdo
+pdo_pgsql
+--SKIPIF--
+<?php
+require __DIR__ . '/config.inc';
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+PDOTest::skip();
+?>
+--FILE--
+<?php
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$pdo = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$pdo->exec('CREATE TABLE gh21869_cursor (a integer not null)');
+
+/* a rollback drops the cursor, so the destructor's CLOSE no longer matches anything */
+$pdo->beginTransaction();
+$stmt = $pdo->prepare('SELECT a FROM gh21869_cursor', [PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL]);
+$stmt->execute();
+$pdo->rollBack();
+
+$pdo->beginTransaction();
+unset($stmt);
+$pdo->exec('INSERT INTO gh21869_cursor (a) VALUES (1)');
+$pdo->commit();
+
+var_dump((int) $pdo->query('SELECT count(*) FROM gh21869_cursor')->fetchColumn());
+
+/* the cursor was never declared, there is nothing to close */
+$pdo->beginTransaction();
+$stmt = $pdo->prepare('SELECT a FROM gh21869_cursor', [PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL]);
+unset($stmt);
+$pdo->exec('INSERT INTO gh21869_cursor (a) VALUES (2)');
+$pdo->commit();
+
+var_dump((int) $pdo->query('SELECT count(*) FROM gh21869_cursor')->fetchColumn());
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$pdo = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$pdo->exec('DROP TABLE IF EXISTS gh21869_cursor');
+?>
+--EXPECT--
+int(1)
+int(2)

--- a/ext/pdo_pgsql/tests/gh21869_cursor_deferred_close.phpt
+++ b/ext/pdo_pgsql/tests/gh21869_cursor_deferred_close.phpt
@@ -1,0 +1,47 @@
+--TEST--
+GH-21869 pdo_pgsql: a cursor CLOSE held back during a transaction runs once it ends
+--EXTENSIONS--
+pdo
+pdo_pgsql
+--SKIPIF--
+<?php
+require __DIR__ . '/config.inc';
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+PDOTest::skip();
+?>
+--FILE--
+<?php
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$pdo = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+function open_cursors(PDO $pdo): int
+{
+    return (int) $pdo->query("SELECT count(*) FROM pg_cursors WHERE name LIKE 'pdo_crsr%'")->fetchColumn();
+}
+
+$pdo->exec('CREATE TABLE gh21869_cursor_deferred (a integer not null)');
+
+/* declared outside a transaction, so WITH HOLD keeps it alive */
+$stmt = $pdo->prepare('SELECT a FROM gh21869_cursor_deferred', [PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL]);
+$stmt->execute();
+
+/* an unrelated rollback: the cursor can no longer be assumed to exist */
+$pdo->beginTransaction();
+$pdo->rollBack();
+
+$pdo->beginTransaction();
+unset($stmt);
+var_dump(open_cursors($pdo));
+$pdo->commit();
+var_dump(open_cursors($pdo));
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$pdo = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$pdo->exec('DROP TABLE IF EXISTS gh21869_cursor_deferred');
+?>
+--EXPECT--
+int(1)
+int(0)


### PR DESCRIPTION
On libpq < 17 the raw DEALLOCATE can fail (e.g. Aurora DSQL rejects it),
which aborts the user's transaction and turns the next COMMIT into a
silent ROLLBACK. Wrap it in a SAVEPOINT so a failure is contained, and
skip it when the transaction is already aborted or the connection is gone.