### PR TITLE
ext/standard: Reject null bytes in proc_open() $cwd

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -180,6 +180,8 @@ PHP                                                                        NEWS
     (Weilin Du)
   . getenv() and putenv() now raises a ValueError when the first argument
     contains null bytes. (Weilin Du)
+  . proc_open() now raises a ValueError when the $cwd argument contains
+    null bytes. (Weilin Du)
 
 - Streams:
   . Added so_keepalive, tcp_keepidle, tcp_keepintvl and tcp_keepcnt stream

--- a/UPGRADING
+++ b/UPGRADING
@@ -95,6 +95,8 @@ PHP 8.6 UPGRADE NOTES
     argument value is passed.
   . scandir() now raises a ValueError when an invalid $sorting_order
     argument value is passed.
+  . proc_open() now raises a ValueError when the $cwd argument contains
+    null bytes.
 
 - Zip:
   . ZipArchive::extractTo now raises a TypeError for the

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -1240,7 +1240,7 @@ PHP_FUNCTION(proc_open)
 		Z_PARAM_ARRAY_HT(descriptorspec)
 		Z_PARAM_ZVAL(pipes)
 		Z_PARAM_OPTIONAL
-		Z_PARAM_STRING_OR_NULL(cwd, cwd_len)
+		Z_PARAM_PATH_OR_NULL(cwd, cwd_len)
 		Z_PARAM_ARRAY_HT_OR_NULL(environment)
 		Z_PARAM_ARRAY_OR_NULL(other_options)
 	ZEND_PARSE_PARAMETERS_END();

--- a/ext/standard/tests/general_functions/proc_open_cwd_null_bytes.phpt
+++ b/ext/standard/tests/general_functions/proc_open_cwd_null_bytes.phpt
@@ -1,0 +1,18 @@
+--TEST--
+proc_open() rejects null bytes in cwd
+--SKIPIF--
+<?php
+if (!function_exists("proc_open")) echo "skip proc_open() is not available";
+?>
+--FILE--
+<?php
+
+try {
+    proc_open("does_not_matter", [], $pipes, "foo\0bar");
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+proc_open(): Argument #4 ($cwd) must not contain any null bytes


### PR DESCRIPTION
In function [`proc_open`](https://www.php.net/manual/en/function.proc-open.php), although the we check the parameter `$commend` to reject NUL bytes, we didn't actually check `$cwd`, so this would happen:
```php
<?php
  $cwd = sys_get_temp_dir() . '/php-src-proc-open-nul-poc';
  @mkdir($cwd);

  $proc = proc_open(
      [PHP_BINARY, '-r', 'echo getcwd(), PHP_EOL;'],
      [1 => ['pipe', 'w']],
      $pipes,
      $cwd . "\0/ignored"
  );

  echo stream_get_contents($pipes[1]);
  proc_close($proc);
``` 
The output would be `/php-src-proc-open-nul-poc`, ignoring trailing `\0/ignored`

reproduce in: https://3v4l.org/o56Sq#v
