### PR TITLE
Fix GH-17126: get_class_methods omits __invoke for Closure

### DIFF
--- a/Zend/tests/get_class_methods/gh17126.phpt
+++ b/Zend/tests/get_class_methods/gh17126.phpt
@@ -1,0 +1,48 @@
+--TEST--
+GH-17126 (get_class_methods($closure) doesn't return __invoke)
+--FILE--
+<?php
+
+$closure = fn (string $str) => "hello {$str}";
+
+echo "from object:\n";
+$methods = get_class_methods($closure);
+sort($methods);
+print_r($methods);
+
+echo "from class name:\n";
+$methods = get_class_methods('Closure');
+sort($methods);
+print_r($methods);
+
+echo "unrelated class unaffected:\n";
+class NoInvoke { public function foo() {} }
+print_r(get_class_methods('NoInvoke'));
+
+?>
+--EXPECT--
+from object:
+Array
+(
+    [0] => __invoke
+    [1] => bind
+    [2] => bindTo
+    [3] => call
+    [4] => fromCallable
+    [5] => getCurrent
+)
+from class name:
+Array
+(
+    [0] => __invoke
+    [1] => bind
+    [2] => bindTo
+    [3] => call
+    [4] => fromCallable
+    [5] => getCurrent
+)
+unrelated class unaffected:
+Array
+(
+    [0] => foo
+)

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -945,6 +945,11 @@ ZEND_FUNCTION(get_class_methods)
 			zend_hash_next_index_insert_new(Z_ARRVAL_P(return_value), &method_name);
 		}
 	} ZEND_HASH_FOREACH_END();
+
+	if (ce == zend_ce_closure) {
+		ZVAL_STR_COPY(&method_name, ZSTR_KNOWN(ZEND_STR_MAGIC_INVOKE));
+		zend_hash_next_index_insert_new(Z_ARRVAL_P(return_value), &method_name);
+	}
 }
 /* }}} */
 


### PR DESCRIPTION
Closure::__invoke is documented and reachable via `method_exists()` and `ReflectionClass` (`getMethod`, `hasMethod`, `getMethods`), but `get_class_methods()` walks `ce->function_table` directly and Closure does not register `__invoke` there: the parameter list is materialized per-instance by `zend_get_closure_invoke_method()`. `get_class_methods()` now appends `__invoke` when `ce == zend_ce_closure`, the same predicate `is_closure_invoke()` already uses in `ext/reflection`.

Fixes #17126
