### PR TITLE
ext/gettext: avoid NULL deref in textdomain/bindtextdomain

### DIFF
--- a/ext/gettext/gettext.c
+++ b/ext/gettext/gettext.c
@@ -100,6 +100,11 @@ PHP_FUNCTION(textdomain)
 
 	retval = textdomain(domain_name);
 
+	if (UNEXPECTED(retval == NULL)) {
+		zend_throw_error(NULL, "Could not set text domain");
+		RETURN_THROWS();
+	}
+
 	RETURN_STRING(retval);
 }
 /* }}} */
@@ -212,6 +217,11 @@ PHP_FUNCTION(bindtextdomain)
 	}
 
 	retval = bindtextdomain(ZSTR_VAL(domain), dir_name);
+
+	if (UNEXPECTED(retval == NULL)) {
+		zend_throw_error(NULL, "Could not bind text domain");
+		RETURN_THROWS();
+	}
 
 	RETURN_STRING(retval);
 }


### PR DESCRIPTION
Both `textdomain()` and `bindtextdomain($domain, $dir)` can return NULL on libintl-internal allocation failure. RETURN_STRING then calls strlen(NULL) and crashes. Throw an `Error` in that case instead. Return signatures stay as `string` so static analyzers don't pick up new false branches.
