### PR TITLE
ext/pgsql: add meta_cache per-link metadata caching

### DIFF
--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -171,6 +171,15 @@ static zend_function *pgsql_link_get_constructor(zend_object *object) {
 	return NULL;
 }
 
+static inline void pgsql_meta_cache_destroy(HashTable **cache)
+{
+	if (*cache) {
+		zend_hash_destroy(*cache);
+		FREE_HASHTABLE(*cache);
+		*cache = NULL;
+	}
+}
+
 static void pgsql_link_free(pgsql_link_handle *link)
 {
 	PGresult *res;
@@ -194,11 +203,9 @@ static void pgsql_link_free(pgsql_link_handle *link)
 		FREE_HASHTABLE(link->notices);
 		link->notices = NULL;
 	}
-	if (link->meta_cache) {
-		zend_hash_destroy(link->meta_cache);
-		FREE_HASHTABLE(link->meta_cache);
-		link->meta_cache = NULL;
-	}
+	
+	pgsql_meta_cache_destroy(&link->meta_cache);
+
 }
 
 static void pgsql_link_free_obj(zend_object *obj)
@@ -1190,11 +1197,7 @@ PHP_FUNCTION(pg_query)
 		RETURN_FALSE;
 	}
 
-	if (link->meta_cache) {
-		zend_hash_destroy(link->meta_cache);
-		FREE_HASHTABLE(link->meta_cache);
-		link->meta_cache = NULL;
-	}
+	pgsql_meta_cache_destroy(&link->meta_cache);
 
 	while ((pgsql_result = PQgetResult(pgsql))) {
 		PQclear(pgsql_result);
@@ -1325,11 +1328,7 @@ PHP_FUNCTION(pg_query_params)
 		RETURN_FALSE;
 	}
 
-	if (link->meta_cache) {
-		zend_hash_destroy(link->meta_cache);
-		FREE_HASHTABLE(link->meta_cache);
-		link->meta_cache = NULL;
-	}
+	pgsql_meta_cache_destroy(&link->meta_cache);
 
 	while ((pgsql_result = PQgetResult(pgsql))) {
 		PQclear(pgsql_result);
@@ -1426,11 +1425,9 @@ PHP_FUNCTION(pg_prepare)
 		php_error_docref(NULL, E_NOTICE,"Cannot set connection to blocking mode");
 		RETURN_FALSE;
 	}
-	if (link->meta_cache) {
-		zend_hash_destroy(link->meta_cache);
-		FREE_HASHTABLE(link->meta_cache);
-		link->meta_cache = NULL;
-	}
+	
+	pgsql_meta_cache_destroy(&link->meta_cache);
+
 	while ((pgsql_result = PQgetResult(pgsql))) {
 		PQclear(pgsql_result);
 		leftover = true;
@@ -1519,11 +1516,9 @@ PHP_FUNCTION(pg_execute)
 		php_error_docref(NULL, E_NOTICE,"Cannot set connection to blocking mode");
 		RETURN_FALSE;
 	}
-	if (link->meta_cache) {
-		zend_hash_destroy(link->meta_cache);
-		FREE_HASHTABLE(link->meta_cache);
-		link->meta_cache = NULL;
-	}
+	
+	pgsql_meta_cache_destroy(&link->meta_cache);
+
 	while ((pgsql_result = PQgetResult(pgsql))) {
 		PQclear(pgsql_result);
 		leftover = true;
@@ -4029,11 +4024,7 @@ PHP_FUNCTION(pg_send_query)
 		RETURN_FALSE;
 	}
 
-	if (link->meta_cache) {
-		zend_hash_destroy(link->meta_cache);
-		FREE_HASHTABLE(link->meta_cache);
-		link->meta_cache = NULL;
-	}
+	pgsql_meta_cache_destroy(&link->meta_cache);
 
 	if (_php_pgsql_link_has_results(pgsql)) {
 		php_error_docref(NULL, E_NOTICE,
@@ -4108,12 +4099,8 @@ PHP_FUNCTION(pg_send_query_params)
 		php_error_docref(NULL, E_NOTICE, "Cannot set connection to nonblocking mode");
 		RETURN_FALSE;
 	}
-
-	if (link->meta_cache) {
-		zend_hash_destroy(link->meta_cache);
-		FREE_HASHTABLE(link->meta_cache);
-		link->meta_cache = NULL;
-	}
+	
+	pgsql_meta_cache_destroy(&link->meta_cache);
 
 	if (_php_pgsql_link_has_results(pgsql)) {
 		php_error_docref(NULL, E_NOTICE,
@@ -4195,11 +4182,7 @@ PHP_FUNCTION(pg_send_prepare)
 		RETURN_FALSE;
 	}
 
-	if (link->meta_cache) {
-		zend_hash_destroy(link->meta_cache);
-		FREE_HASHTABLE(link->meta_cache);
-		link->meta_cache = NULL;
-	}
+	pgsql_meta_cache_destroy(&link->meta_cache);
 
 	if (_php_pgsql_link_has_results(pgsql)) {
 		php_error_docref(NULL, E_NOTICE,
@@ -4276,11 +4259,7 @@ PHP_FUNCTION(pg_send_execute)
 		RETURN_FALSE;
 	}
 
-	if (link->meta_cache) {
-		zend_hash_destroy(link->meta_cache);
-		FREE_HASHTABLE(link->meta_cache);
-		link->meta_cache = NULL;
-	}
+	pgsql_meta_cache_destroy(&link->meta_cache);
 
 	if (_php_pgsql_link_has_results(pgsql)) {
 		php_error_docref(NULL, E_NOTICE,
@@ -6186,16 +6165,13 @@ PHP_FUNCTION(pg_delete)
 	CHECK_PGSQL_LINK(link);
 	pg_link = link->conn;
 
+	pgsql_meta_cache_destroy(&link->meta_cache);
+
 	if (php_pgsql_flush_query(pg_link)) {
 		php_error_docref(NULL, E_NOTICE, "Detected unhandled result(s) in connection");
 	}
 	if (php_pgsql_delete(pg_link, table, ids, option, &sql) == FAILURE) {
 		RETURN_FALSE;
-	}
-	if (link->meta_cache) {
-		zend_hash_destroy(link->meta_cache);
-		FREE_HASHTABLE(link->meta_cache);
-		link->meta_cache = NULL;
 	}
 	if (option & PGSQL_DML_STRING) {
 		RETURN_STR(sql);

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -194,6 +194,11 @@ static void pgsql_link_free(pgsql_link_handle *link)
 		FREE_HASHTABLE(link->notices);
 		link->notices = NULL;
 	}
+	if (link->meta_cache) {
+		zend_hash_destroy(link->meta_cache);
+		FREE_HASHTABLE(link->meta_cache);
+		link->meta_cache = NULL;
+	}
 }
 
 static void pgsql_link_free_obj(zend_object *obj)
@@ -765,6 +770,7 @@ static void php_pgsql_do_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent)
 		link->conn = pgsql;
 		link->hash = zend_string_copy(str.s);
 		link->notices = NULL;
+		link->meta_cache = NULL;
 		link->persistent = 1;
 	} else { /* Non persistent connection */
 		zval *index_ptr;
@@ -816,6 +822,7 @@ static void php_pgsql_do_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent)
 		link->conn = pgsql;
 		link->hash = zend_string_copy(str.s);
 		link->notices = NULL;
+		link->meta_cache = NULL;
 		link->persistent = 0;
 
 		/* add it to the hash */
@@ -1181,6 +1188,12 @@ PHP_FUNCTION(pg_query)
 	if (PQsetnonblocking(pgsql, 0)) {
 		php_error_docref(NULL, E_NOTICE,"Cannot set connection to blocking mode");
 		RETURN_FALSE;
+	}
+
+	if (link->meta_cache) {
+		zend_hash_destroy(link->meta_cache);
+		FREE_HASHTABLE(link->meta_cache);
+		link->meta_cache = NULL;
 	}
 	while ((pgsql_result = PQgetResult(pgsql))) {
 		PQclear(pgsql_result);
@@ -4550,6 +4563,8 @@ PHP_PGSQL_API zend_result php_pgsql_meta_data(PGconn *pg_link, const zend_string
 	size_t new_len, len;
 	int i, num_rows, err;
 	zval elem;
+	pgsql_link_handle *link;
+	link = FETCH_DEFAULT_LINK_NO_WARNING();
 
 	ZEND_ASSERT(ZSTR_LEN(table_name) != 0);
 
@@ -4620,6 +4635,19 @@ PHP_PGSQL_API zend_result php_pgsql_meta_data(PGconn *pg_link, const zend_string
 	smart_str_0(&querystr);
 	efree(src);
 
+	if (link && link->meta_cache) {
+		zval *meta_cache = zend_hash_find(link->meta_cache, querystr.s);
+
+		if (meta_cache) {
+			if (Z_TYPE_P(meta) != IS_UNDEF) {
+				zval_ptr_dtor(meta);
+			}
+			ZVAL_COPY(meta, meta_cache);
+			smart_str_free(&querystr);
+			return SUCCESS;
+		}
+	}
+
 	pg_result = PQexec(pg_link, ZSTR_VAL(querystr.s));
 	if (PQresultStatus(pg_result) != PGRES_TUPLES_OK || (num_rows = PQntuples(pg_result)) == 0) {
 		php_error_docref(NULL, E_WARNING, "Table '%s' doesn't exists", ZSTR_VAL(table_name));
@@ -4627,7 +4655,6 @@ PHP_PGSQL_API zend_result php_pgsql_meta_data(PGconn *pg_link, const zend_string
 		PQclear(pg_result);
 		return FAILURE;
 	}
-	smart_str_free(&querystr);
 
 	for (i = 0; i < num_rows; i++) {
 		char *name;
@@ -4658,6 +4685,21 @@ PHP_PGSQL_API zend_result php_pgsql_meta_data(PGconn *pg_link, const zend_string
 		name = PQgetvalue(pg_result,i,0);
 		add_assoc_zval(meta, name, &elem);
 	}
+
+	if(link) {
+		if (!link->meta_cache) {
+			ALLOC_HASHTABLE(link->meta_cache);
+			zend_hash_init(link->meta_cache, 8, NULL, ZVAL_PTR_DTOR, 0);
+		}
+
+		zval meta_copy;
+		ZVAL_COPY(&meta_copy, meta);
+		zend_string *key = zend_string_copy(querystr.s);
+
+		zend_hash_update( link->meta_cache, key, &meta_copy);
+		zend_string_release(key);
+	}
+	smart_str_free(&querystr);
 	PQclear(pg_result);
 
 	return SUCCESS;
@@ -6088,6 +6130,11 @@ PHP_FUNCTION(pg_delete)
 	}
 	if (php_pgsql_delete(pg_link, table, ids, option, &sql) == FAILURE) {
 		RETURN_FALSE;
+	}
+	if (link->meta_cache) {
+		zend_hash_destroy(link->meta_cache);
+		FREE_HASHTABLE(link->meta_cache);
+		link->meta_cache = NULL;
 	}
 	if (option & PGSQL_DML_STRING) {
 		RETURN_STR(sql);

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -779,6 +779,9 @@ static void php_pgsql_do_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent)
 		link->notices = NULL;
 		link->meta_cache = NULL;
 		link->persistent = 1;
+		
+		zend_hash_update(&PGG(connections), str.s, return_value);
+
 	} else { /* Non persistent connection */
 		zval *index_ptr;
 

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -1195,6 +1195,7 @@ PHP_FUNCTION(pg_query)
 		FREE_HASHTABLE(link->meta_cache);
 		link->meta_cache = NULL;
 	}
+
 	while ((pgsql_result = PQgetResult(pgsql))) {
 		PQclear(pgsql_result);
 		leftover = true;
@@ -1323,6 +1324,13 @@ PHP_FUNCTION(pg_query_params)
 		php_error_docref(NULL, E_NOTICE,"Cannot set connection to blocking mode");
 		RETURN_FALSE;
 	}
+
+	if (link->meta_cache) {
+		zend_hash_destroy(link->meta_cache);
+		FREE_HASHTABLE(link->meta_cache);
+		link->meta_cache = NULL;
+	}
+
 	while ((pgsql_result = PQgetResult(pgsql))) {
 		PQclear(pgsql_result);
 		leftover = true;
@@ -1418,6 +1426,11 @@ PHP_FUNCTION(pg_prepare)
 		php_error_docref(NULL, E_NOTICE,"Cannot set connection to blocking mode");
 		RETURN_FALSE;
 	}
+	if (link->meta_cache) {
+		zend_hash_destroy(link->meta_cache);
+		FREE_HASHTABLE(link->meta_cache);
+		link->meta_cache = NULL;
+	}
 	while ((pgsql_result = PQgetResult(pgsql))) {
 		PQclear(pgsql_result);
 		leftover = true;
@@ -1505,6 +1518,11 @@ PHP_FUNCTION(pg_execute)
 	if (PQsetnonblocking(pgsql, 0)) {
 		php_error_docref(NULL, E_NOTICE,"Cannot set connection to blocking mode");
 		RETURN_FALSE;
+	}
+	if (link->meta_cache) {
+		zend_hash_destroy(link->meta_cache);
+		FREE_HASHTABLE(link->meta_cache);
+		link->meta_cache = NULL;
 	}
 	while ((pgsql_result = PQgetResult(pgsql))) {
 		PQclear(pgsql_result);
@@ -1710,6 +1728,25 @@ static zend_string *get_field_name(PGconn *pgsql, Oid oid)
 
 	PQclear(result);
 	return ret;
+}
+
+static pgsql_link_handle *pgsql_get_link_from_conn(PGconn *conn)
+{
+    zval *pgsql_link;
+
+    if (!conn) {
+        return NULL;
+    }
+
+    ZEND_HASH_FOREACH_VAL(&PGG(connections), pgsql_link) {
+        pgsql_link_handle *link = Z_PGSQL_LINK_P(pgsql_link);
+
+        if (link && link->conn == conn) {
+            return link;
+        }
+    } ZEND_HASH_FOREACH_END();
+
+    return NULL;
 }
 
 /* Returns the name of the table field belongs to, or table's oid if oid_only is true */
@@ -3992,6 +4029,12 @@ PHP_FUNCTION(pg_send_query)
 		RETURN_FALSE;
 	}
 
+	if (link->meta_cache) {
+		zend_hash_destroy(link->meta_cache);
+		FREE_HASHTABLE(link->meta_cache);
+		link->meta_cache = NULL;
+	}
+
 	if (_php_pgsql_link_has_results(pgsql)) {
 		php_error_docref(NULL, E_NOTICE,
 			"There are results on this connection. Call pg_get_result() until it returns FALSE");
@@ -4064,6 +4107,12 @@ PHP_FUNCTION(pg_send_query_params)
 	if (is_non_blocking == 0 && PQsetnonblocking(pgsql, 1) == -1) {
 		php_error_docref(NULL, E_NOTICE, "Cannot set connection to nonblocking mode");
 		RETURN_FALSE;
+	}
+
+	if (link->meta_cache) {
+		zend_hash_destroy(link->meta_cache);
+		FREE_HASHTABLE(link->meta_cache);
+		link->meta_cache = NULL;
 	}
 
 	if (_php_pgsql_link_has_results(pgsql)) {
@@ -4146,6 +4195,12 @@ PHP_FUNCTION(pg_send_prepare)
 		RETURN_FALSE;
 	}
 
+	if (link->meta_cache) {
+		zend_hash_destroy(link->meta_cache);
+		FREE_HASHTABLE(link->meta_cache);
+		link->meta_cache = NULL;
+	}
+
 	if (_php_pgsql_link_has_results(pgsql)) {
 		php_error_docref(NULL, E_NOTICE,
 			"There are results on this connection. Call pg_get_result() until it returns FALSE");
@@ -4219,6 +4274,12 @@ PHP_FUNCTION(pg_send_execute)
 	if (is_non_blocking == 0 && PQsetnonblocking(pgsql, 1) == -1) {
 		php_error_docref(NULL, E_NOTICE, "Cannot set connection to nonblocking mode");
 		RETURN_FALSE;
+	}
+
+	if (link->meta_cache) {
+		zend_hash_destroy(link->meta_cache);
+		FREE_HASHTABLE(link->meta_cache);
+		link->meta_cache = NULL;
 	}
 
 	if (_php_pgsql_link_has_results(pgsql)) {
@@ -4552,7 +4613,6 @@ PHP_FUNCTION(pg_flush)
 
 /* {{{ php_pgsql_meta_data
  * table_name must not be empty
- * TODO: Add meta_data cache for better performance
  */
 PHP_PGSQL_API zend_result php_pgsql_meta_data(PGconn *pg_link, const zend_string *table_name, zval *meta, bool extended)
 {
@@ -4564,7 +4624,6 @@ PHP_PGSQL_API zend_result php_pgsql_meta_data(PGconn *pg_link, const zend_string
 	int i, num_rows, err;
 	zval elem;
 	pgsql_link_handle *link;
-	link = FETCH_DEFAULT_LINK_NO_WARNING();
 
 	ZEND_ASSERT(ZSTR_LEN(table_name) != 0);
 
@@ -4634,6 +4693,8 @@ PHP_PGSQL_API zend_result php_pgsql_meta_data(PGconn *pg_link, const zend_string
 	smart_str_appends(&querystr, "' ORDER BY a.attnum;");
 	smart_str_0(&querystr);
 	efree(src);
+
+	link = pgsql_get_link_from_conn(pg_link);
 
 	if (link && link->meta_cache) {
 		zval *meta_cache = zend_hash_find(link->meta_cache, querystr.s);

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -649,6 +649,15 @@ PHP_RSHUTDOWN_FUNCTION(pgsql)
 		PGG(default_link) = NULL;
 	}
 
+	zval *pgsql_link;
+
+	ZEND_HASH_FOREACH_VAL(&PGG(connections), pgsql_link) {
+        pgsql_link_handle *link = Z_PGSQL_LINK_P(pgsql_link);
+        if (link) {
+            pgsql_meta_cache_destroy(&link->meta_cache);
+        }
+    } ZEND_HASH_FOREACH_END();
+
 	zend_hash_destroy(&PGG(field_oids));
 	zend_hash_destroy(&PGG(table_oids));
 	/* clean up persistent connection */

--- a/ext/pgsql/php_pgsql.h
+++ b/ext/pgsql/php_pgsql.h
@@ -139,6 +139,7 @@ typedef struct pgsql_link_handle {
 	PGconn *conn;
 	zend_string *hash;
 	HashTable *notices;
+	HashTable *meta_cache;
 	bool persistent;
 	zend_object std;
 } pgsql_link_handle;

--- a/ext/pgsql/tests/pg_meta_data_cache.phpt
+++ b/ext/pgsql/tests/pg_meta_data_cache.phpt
@@ -1,0 +1,78 @@
+--TEST--
+pg_meta_data() - cache behavior and invalidation
+--EXTENSIONS--
+pgsql
+--SKIPIF--
+<?php include("inc/skipif.inc"); ?>
+--FILE--
+<?php
+include('inc/config.inc');
+
+$conn = pg_connect($conn_str);
+if (!$conn) die("Connection failed\n");
+
+pg_query($conn, "DROP TABLE IF EXISTS test_meta_cache");
+pg_query($conn, "CREATE TABLE test_meta_cache (id SERIAL PRIMARY KEY, name TEXT)");
+$meta1 = pg_meta_data($conn, 'test_meta_cache');
+if (!isset($meta1['id']) || !isset($meta1['name'])) {
+    echo "FAIL: Basic metadata missing columns\n";
+    var_dump(array_keys($meta1));
+} else {
+    echo "Basic metadata: OK (columns: " . implode(', ', array_keys($meta1)) . ")\n";
+}
+
+pg_query($conn, "ALTER TABLE test_meta_cache ADD COLUMN age INT");
+$meta2 = pg_meta_data($conn, 'test_meta_cache');
+if (!isset($meta2['age'])) {
+    echo "FAIL: Column 'age' not seen after ALTER\n";
+    var_dump(array_keys($meta2));
+} else {
+    echo "ALTER invalidation: OK ('age' found)\n";
+}
+
+pg_query($conn, "DROP TABLE test_meta_cache");
+pg_query($conn, "CREATE TABLE test_meta_cache (only_column TEXT)");
+$meta3 = pg_meta_data($conn, 'test_meta_cache');
+if (isset($meta3['id']) || isset($meta3['name']) || isset($meta3['age'])) {
+    echo "FAIL: Old columns still present after DROP/CREATE\n";
+    var_dump(array_keys($meta3));
+} elseif (!isset($meta3['only_column'])) {
+    echo "FAIL: New column 'only_column' missing\n";
+    var_dump(array_keys($meta3));
+} else {
+    echo "DROP/CREATE invalidation: OK (only 'only_column' present)\n";
+}
+
+$meta_ext = pg_meta_data($conn, 'test_meta_cache', true);
+if (!isset($meta_ext['only_column']['is enum']) || !isset($meta_ext['only_column']['description'])) {
+    echo "FAIL: Extended metadata missing extra fields\n";
+    var_dump($meta_ext['only_column']);
+} else {
+    echo "Extended metadata: OK (has 'is enum', 'description')\n";
+}
+
+$meta_schema = pg_meta_data($conn, 'public.test_meta_cache');
+if (!isset($meta_schema['only_column'])) {
+    echo "FAIL: Schema-qualified name not recognized\n";
+} else {
+    echo "Schema-qualified name: OK";
+}
+$meta_false = pg_meta_data($conn, 'non_existent_table');
+pg_query($conn, "DROP TABLE test_meta_cache");
+pg_close($conn);
+echo "Done\n";
+?>
+--CLEAN--
+<?php
+include('inc/config.inc');
+$db = pg_connect($conn_str);
+pg_query($db, "DROP TABLE IF EXISTS test_meta_cache CASCADE");
+?>
+--EXPECTF--
+Basic metadata: OK (columns: %s)
+ALTER invalidation: OK ('age' found)
+DROP/CREATE invalidation: OK (only 'only_column' present)
+Extended metadata: OK (has 'is enum', 'description')
+Schema-qualified name: OK
+Warning: pg_meta_data(): Table 'non_existent_table' doesn't exists in %s on line %d
+Done


### PR DESCRIPTION
- Introduce per-connection meta_cache HashTable in pgsql_link_handle
- Cache results of `php_pgsql_meta_data()` to avoid repeated catalog queries
- Add lookup before executing `PQexec()` for faster metadata access
- Initialize meta_cache lazily per connection
- Properly destroy `meta_cache` on connection free and query mutations
- Clear meta_cache on `pg_query/pg_delete` to avoid stale schema data
- Add `NULL-safe` checks for `link->meta_cache` usage

Improves performance by reducing repeated queries.