### PR TITLE
ext/xsl: free libxslt buffer when transformToXml output is empty

### DIFF
--- a/ext/xsl/xsltprocessor.c
+++ b/ext/xsl/xsltprocessor.c
@@ -547,8 +547,10 @@ PHP_METHOD(XSLTProcessor, transformToXml)
 	ret = -1;
 	if (newdocp) {
 		ret = xsltSaveResultToString(&doc_txt_ptr, &doc_txt_len, newdocp, sheetp);
-		if (doc_txt_ptr && doc_txt_len) {
-			RETVAL_STRINGL((char *) doc_txt_ptr, doc_txt_len);
+		if (doc_txt_ptr) {
+			if (doc_txt_len > 0) {
+				RETVAL_STRINGL((char *) doc_txt_ptr, doc_txt_len);
+			}
 			xmlFree(doc_txt_ptr);
 		}
 		xmlFreeDoc(newdocp);


### PR DESCRIPTION
`xsltSaveResultToString` can leave `doc_txt_ptr` non-NULL with `doc_txt_len == 0`. The previous gate `if (doc_txt_ptr && doc_txt_len)` skipped `xmlFree` in that case. Current libxslt (1.1.34) sets both fields to NULL/0 on empty output, so this is latent today, but a future libxslt change to that convention turns it into a per-transform leak. Free the buffer whenever it's allocated, regardless of length.
