### PR TITLE
ext/xsl: handle xsltNewTransformContext allocation failure

### DIFF
--- a/ext/xsl/xsltprocessor.c
+++ b/ext/xsl/xsltprocessor.c
@@ -350,6 +350,9 @@ static xmlDocPtr php_xsl_apply_stylesheet(zval *id, xsl_object *intern, xsltStyl
 	php_libxml_increment_doc_ref(intern->doc, doc);
 
 	ctxt = xsltNewTransformContext(style, doc);
+	if (UNEXPECTED(ctxt == NULL)) {
+		goto out;
+	}
 	ctxt->_private = (void *) intern;
 
 	if (intern->parameter) {

--- a/ext/xsl/xsltprocessor.c
+++ b/ext/xsl/xsltprocessor.c
@@ -140,6 +140,12 @@ static void xsl_add_ns_def(xmlNodePtr node)
 				ns->type = XML_LOCAL_NAMESPACE;
 				ns->href = should_free ? attr_value : xmlStrdup(attr_value);
 				ns->prefix = attr->ns->prefix ? xmlStrdup(attr->name) : NULL;
+
+				if (UNEXPECTED(ns->href == NULL || (attr->ns->prefix != NULL && ns->prefix == NULL))) {
+					xmlFreeNs(ns);
+					return;
+				}
+
 				ns->next = node->nsDef;
 				node->nsDef = ns;
 			}


### PR DESCRIPTION
Two related defensive fixes in ext/xsl, folded per the #21888 review.

- `xsltNewTransformContext` returns NULL on libxslt-internal allocation failure; the next line dereferenced `ctxt` to set `_private` and segfaulted. Bail through the existing `out:` label, which handles `secPrefs` and `intern->doc` cleanup. `xsltFreeTransformContext(NULL)` is a documented no-op in libxslt.
- If `xmlStrdup` fails for either `href` or `prefix` in `xsl_add_ns_def`, the partially-constructed `xmlNs` (NULL `href`, or NULL `prefix` when one was expected) was linked into `node->nsDef`. Subsequent libxml2 traversal of the namespace chain dereferenced those NULLs. Free the `xmlNs` via `xmlFreeNs` and return without linking it.
