### PR TITLE
ext/xsl: discard partially-constructed xmlNs on xmlStrdup failure

### DIFF
--- a/ext/xsl/xsltprocessor.c
+++ b/ext/xsl/xsltprocessor.c
@@ -140,6 +140,12 @@ static void xsl_add_ns_def(xmlNodePtr node)
 				ns->type = XML_LOCAL_NAMESPACE;
 				ns->href = should_free ? attr_value : xmlStrdup(attr_value);
 				ns->prefix = attr->ns->prefix ? xmlStrdup(attr->name) : NULL;
+
+				if (UNEXPECTED(ns->href == NULL || (attr->ns->prefix != NULL && ns->prefix == NULL))) {
+					xmlFreeNs(ns);
+					return;
+				}
+
 				ns->next = node->nsDef;
 				node->nsDef = ns;
 			}


### PR DESCRIPTION
If `xmlStrdup` fails for either `href` or `prefix` in `xsl_add_ns_def`, the partially-constructed `xmlNs` (NULL `href`, or NULL `prefix` when one was expected) was linked into `node->nsDef`. Subsequent libxml2 traversal of the namespace chain dereferenced those NULLs. Free the `xmlNs` via `xmlFreeNs` and return without linking it.
