### PR TITLE
RFC: Deprecate metaphone()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -179,6 +179,7 @@ PHP                                                                        NEWS
     (Weilin Du)
   . getenv() and putenv() now raises a ValueError when the first argument
     contains null bytes. (Weilin Du)
+  . metaphone() is now deprecated. (Weilin Du)
 
 - Streams:
   . Added so_keepalive, tcp_keepidle, tcp_keepintvl and tcp_keepcnt stream

--- a/NEWS
+++ b/NEWS
@@ -636,6 +636,7 @@ PHP                                                                        NEWS
     (Weilin Du)
   . getenv() and putenv() now raises a ValueError when the first argument
     contains NUL bytes. (Weilin Du)
+  . metaphone() is now deprecated. (Weilin Du)
   . dl() now raises a ValueError when the $extension_filename argument contains
     NUL bytes. (Weilin Du)
   . openlog() now raises a ValueError when the $prefix argument contains NUL

--- a/NEWS
+++ b/NEWS
@@ -94,6 +94,7 @@ PHP                                                                        NEWS
   . Added the "filter.max_filter_count" stream context option for php://filter
     URLs. Using more than 16 filters without configuring this option is now
     deprecated. (Sjoerd Langkemper)
+  . metaphone() is now deprecated. (Weilin Du)
   . Improved performance of array_intersect(). (mehmetcansahin)
   . Fixed bug GH-23006 (phpcredits() full-page HTML title says phpinfo()).
     (Weilin Du)
@@ -636,7 +637,6 @@ PHP                                                                        NEWS
     (Weilin Du)
   . getenv() and putenv() now raises a ValueError when the first argument
     contains NUL bytes. (Weilin Du)
-  . metaphone() is now deprecated. (Weilin Du)
   . dl() now raises a ValueError when the $extension_filename argument contains
     NUL bytes. (Weilin Du)
   . openlog() now raises a ValueError when the $prefix argument contains NUL

--- a/UPGRADING
+++ b/UPGRADING
@@ -154,6 +154,11 @@ PHP 8.6 UPGRADE NOTES
 4. Deprecated Functionality
 ========================================
 
+- Standard:
+  . metaphone() is deprecated.
+    Please use a userland phonetic matching library instead.
+    RFC: https://wiki.php.net/rfc/deprecate-metaphone
+
 ========================================
 5. Changed Functions
 ========================================

--- a/UPGRADING
+++ b/UPGRADING
@@ -492,7 +492,7 @@ PHP 8.6 UPGRADE NOTES
 - Standard:
   . metaphone() is deprecated.
     Please use a userland phonetic matching library instead.
-    RFC: https://wiki.php.net/rfc/deprecate-metaphone
+    RFC: https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_metaphone_function
   . Using more than 16 filters in a php://filter URL without configuring the
     "filter.max_filter_count" stream context option now emits an E_DEPRECATED
     warning. Use stream_filter_append() or configure this option explicitly.

--- a/UPGRADING
+++ b/UPGRADING
@@ -157,7 +157,7 @@ PHP 8.6 UPGRADE NOTES
 - Standard:
   . metaphone() is deprecated.
     Please use a userland phonetic matching library instead.
-    RFC: https://wiki.php.net/rfc/deprecate-metaphone
+    RFC: https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_metaphone_function
 
 ========================================
 5. Changed Functions

--- a/UPGRADING
+++ b/UPGRADING
@@ -490,6 +490,9 @@ PHP 8.6 UPGRADE NOTES
     RFC: https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_arrayiterator_methods_that_inherit_arrayobject_implementation
 
 - Standard:
+  . metaphone() is deprecated.
+    Please use a userland phonetic matching library instead.
+    RFC: https://wiki.php.net/rfc/deprecate-metaphone
   . Using more than 16 filters in a php://filter URL without configuring the
     "filter.max_filter_count" stream context option now emits an E_DEPRECATED
     warning. Use stream_filter_append() or configure this option explicitly.

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -2239,6 +2239,7 @@ function inet_pton(string $ip): string|false {}
 /* metaphone.c */
 
 /** @refcount 1 */
+#[\Deprecated(since: '8.6')]
 function metaphone(string $string, int $max_phonemes = 0): string {}
 
 /* {{{ head.c */

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -2239,7 +2239,7 @@ function inet_pton(string $ip): string|false {}
 /* metaphone.c */
 
 /** @refcount 1 */
-#[\Deprecated(since: '8.6')]
+#[\Deprecated(since: '8.6', message: 'use a userland phonetic matching library instead')]
 function metaphone(string $string, int $max_phonemes = 0): string {}
 
 /* {{{ head.c */

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit basic_functions.stub.php instead.
- * Stub hash: 36b71aa7bbfe478a5e4af400b2822a77067efa2f
+ * Stub hash: 98e3535dd6c306b2198f2fe4635820cf65685093
  * Has decl header: yes */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
@@ -3121,7 +3121,7 @@ static const zend_function_entry ext_functions[] = {
 #endif
 	ZEND_FE(inet_ntop, arginfo_inet_ntop)
 	ZEND_FE(inet_pton, arginfo_inet_pton)
-	ZEND_FE(metaphone, arginfo_metaphone)
+	ZEND_RAW_FENTRY("metaphone", zif_metaphone, arginfo_metaphone, ZEND_ACC_DEPRECATED, NULL, NULL)
 	ZEND_FE(header, arginfo_header)
 	ZEND_FE(header_remove, arginfo_header_remove)
 	ZEND_FE(setrawcookie, arginfo_setrawcookie)
@@ -3925,6 +3925,11 @@ static void register_basic_functions_symbols(int module_number)
 	ZVAL_STR(&attribute_Deprecated_func_strptime_0->args[1].value, attribute_Deprecated_func_strptime_0_arg1_str);
 	attribute_Deprecated_func_strptime_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 #endif
+
+	zend_attribute *attribute_Deprecated_func_metaphone_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "metaphone", sizeof("metaphone") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
+	zend_string *attribute_Deprecated_func_metaphone_0_arg0_str = zend_string_init("8.6", strlen("8.6"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_metaphone_0->args[0].value, attribute_Deprecated_func_metaphone_0_arg0_str);
+	attribute_Deprecated_func_metaphone_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
 
 	zend_attribute *attribute_Deprecated_func_assert_options_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "assert_options", sizeof("assert_options") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
 	ZVAL_STR(&attribute_Deprecated_func_assert_options_0->args[0].value, ZSTR_KNOWN(ZEND_STR_8_DOT_3));

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit basic_functions.stub.php instead.
- * Stub hash: 21b2089bd39aadeeb8730e4bb2fecbb32e65d1c8
+ * Stub hash: 915a002c40896449b4313f33a0c0f14b50293598
  * Has decl header: yes */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
@@ -3136,7 +3136,7 @@ static const zend_function_entry ext_functions[] = {
 #endif
 	ZEND_FE(inet_ntop, arginfo_inet_ntop)
 	ZEND_FE(inet_pton, arginfo_inet_pton)
-	ZEND_FE(metaphone, arginfo_metaphone)
+	ZEND_RAW_FENTRY("metaphone", zif_metaphone, arginfo_metaphone, ZEND_ACC_DEPRECATED, NULL, NULL)
 	ZEND_FE(header, arginfo_header)
 	ZEND_FE(header_remove, arginfo_header_remove)
 	ZEND_FE(setrawcookie, arginfo_setrawcookie)
@@ -3944,6 +3944,11 @@ static void register_basic_functions_symbols(int module_number)
 	attribute_Deprecated_func_strptime_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 #endif
 
+	zend_attribute *attribute_Deprecated_func_metaphone_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "metaphone", sizeof("metaphone") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
+	zend_string *attribute_Deprecated_func_metaphone_0_arg0_str = zend_string_init("8.6", strlen("8.6"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_metaphone_0->args[0].value, attribute_Deprecated_func_metaphone_0_arg0_str);
+	attribute_Deprecated_func_metaphone_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+
 	zend_attribute *attribute_Deprecated_func_assert_options_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "assert_options", sizeof("assert_options") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
 	ZVAL_STR(&attribute_Deprecated_func_assert_options_0->args[0].value, ZSTR_KNOWN(ZEND_STR_8_DOT_3));
 	attribute_Deprecated_func_assert_options_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
@@ -3952,8 +3957,7 @@ static void register_basic_functions_symbols(int module_number)
 	zend_string *attribute_Deprecated_func_strcoll_0_arg0_str = zend_string_init("use Collator::compare() instead", strlen("use Collator::compare() instead"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_strcoll_0->args[0].value, attribute_Deprecated_func_strcoll_0_arg0_str);
 	attribute_Deprecated_func_strcoll_0->args[0].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
-	zend_string *attribute_Deprecated_func_strcoll_0_arg1_str = zend_string_init("8.6", strlen("8.6"), 1);
-	ZVAL_STR(&attribute_Deprecated_func_strcoll_0->args[1].value, attribute_Deprecated_func_strcoll_0_arg1_str);
+	ZVAL_STR_COPY(&attribute_Deprecated_func_strcoll_0->args[1].value, attribute_Deprecated_func_metaphone_0_arg0_str);
 	attribute_Deprecated_func_strcoll_0->args[1].name = ZSTR_KNOWN(ZEND_STR_SINCE);
 
 	zend_attribute *attribute_Deprecated_func_utf8_encode_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "utf8_encode", sizeof("utf8_encode") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
@@ -3986,34 +3990,34 @@ static void register_basic_functions_symbols(int module_number)
 	zend_string *attribute_Deprecated_func_doubleval_0_arg0_str = zend_string_init("use floatval() instead", strlen("use floatval() instead"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_doubleval_0->args[0].value, attribute_Deprecated_func_doubleval_0_arg0_str);
 	attribute_Deprecated_func_doubleval_0->args[0].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
-	ZVAL_STR_COPY(&attribute_Deprecated_func_doubleval_0->args[1].value, attribute_Deprecated_func_strcoll_0_arg1_str);
+	ZVAL_STR_COPY(&attribute_Deprecated_func_doubleval_0->args[1].value, attribute_Deprecated_func_metaphone_0_arg0_str);
 	attribute_Deprecated_func_doubleval_0->args[1].name = ZSTR_KNOWN(ZEND_STR_SINCE);
 
 	zend_attribute *attribute_Deprecated_func_is_integer_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "is_integer", sizeof("is_integer") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zend_string *attribute_Deprecated_func_is_integer_0_arg0_str = zend_string_init("use is_int() instead", strlen("use is_int() instead"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_is_integer_0->args[0].value, attribute_Deprecated_func_is_integer_0_arg0_str);
 	attribute_Deprecated_func_is_integer_0->args[0].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
-	ZVAL_STR_COPY(&attribute_Deprecated_func_is_integer_0->args[1].value, attribute_Deprecated_func_strcoll_0_arg1_str);
+	ZVAL_STR_COPY(&attribute_Deprecated_func_is_integer_0->args[1].value, attribute_Deprecated_func_metaphone_0_arg0_str);
 	attribute_Deprecated_func_is_integer_0->args[1].name = ZSTR_KNOWN(ZEND_STR_SINCE);
 
 	zend_attribute *attribute_Deprecated_func_is_long_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "is_long", sizeof("is_long") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	ZVAL_STR_COPY(&attribute_Deprecated_func_is_long_0->args[0].value, attribute_Deprecated_func_is_integer_0_arg0_str);
 	attribute_Deprecated_func_is_long_0->args[0].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
-	ZVAL_STR_COPY(&attribute_Deprecated_func_is_long_0->args[1].value, attribute_Deprecated_func_strcoll_0_arg1_str);
+	ZVAL_STR_COPY(&attribute_Deprecated_func_is_long_0->args[1].value, attribute_Deprecated_func_metaphone_0_arg0_str);
 	attribute_Deprecated_func_is_long_0->args[1].name = ZSTR_KNOWN(ZEND_STR_SINCE);
 
 	zend_attribute *attribute_Deprecated_func_is_double_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "is_double", sizeof("is_double") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zend_string *attribute_Deprecated_func_is_double_0_arg0_str = zend_string_init("use is_float() instead", strlen("use is_float() instead"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_is_double_0->args[0].value, attribute_Deprecated_func_is_double_0_arg0_str);
 	attribute_Deprecated_func_is_double_0->args[0].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
-	ZVAL_STR_COPY(&attribute_Deprecated_func_is_double_0->args[1].value, attribute_Deprecated_func_strcoll_0_arg1_str);
+	ZVAL_STR_COPY(&attribute_Deprecated_func_is_double_0->args[1].value, attribute_Deprecated_func_metaphone_0_arg0_str);
 	attribute_Deprecated_func_is_double_0->args[1].name = ZSTR_KNOWN(ZEND_STR_SINCE);
 
 	zend_attribute *attribute_Deprecated_const_SORT_LOCALE_STRING_0 = zend_add_global_constant_attribute(const_SORT_LOCALE_STRING, ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zend_string *attribute_Deprecated_const_SORT_LOCALE_STRING_0_arg0_str = zend_string_init("use one of the Collator::*sort*() methods instead", strlen("use one of the Collator::*sort*() methods instead"), 1);
 	ZVAL_STR(&attribute_Deprecated_const_SORT_LOCALE_STRING_0->args[0].value, attribute_Deprecated_const_SORT_LOCALE_STRING_0_arg0_str);
 	attribute_Deprecated_const_SORT_LOCALE_STRING_0->args[0].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
-	ZVAL_STR_COPY(&attribute_Deprecated_const_SORT_LOCALE_STRING_0->args[1].value, attribute_Deprecated_func_strcoll_0_arg1_str);
+	ZVAL_STR_COPY(&attribute_Deprecated_const_SORT_LOCALE_STRING_0->args[1].value, attribute_Deprecated_func_metaphone_0_arg0_str);
 	attribute_Deprecated_const_SORT_LOCALE_STRING_0->args[1].name = ZSTR_KNOWN(ZEND_STR_SINCE);
 
 	zend_attribute *attribute_Deprecated_const_ASSERT_ACTIVE_0 = zend_add_global_constant_attribute(const_ASSERT_ACTIVE, ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit basic_functions.stub.php instead.
- * Stub hash: 915a002c40896449b4313f33a0c0f14b50293598
+ * Stub hash: 8f5682d85611126ee12182af46cb2905a0bd0e57
  * Has decl header: yes */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
@@ -3944,10 +3944,13 @@ static void register_basic_functions_symbols(int module_number)
 	attribute_Deprecated_func_strptime_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 #endif
 
-	zend_attribute *attribute_Deprecated_func_metaphone_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "metaphone", sizeof("metaphone") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
+	zend_attribute *attribute_Deprecated_func_metaphone_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "metaphone", sizeof("metaphone") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zend_string *attribute_Deprecated_func_metaphone_0_arg0_str = zend_string_init("8.6", strlen("8.6"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_metaphone_0->args[0].value, attribute_Deprecated_func_metaphone_0_arg0_str);
 	attribute_Deprecated_func_metaphone_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zend_string *attribute_Deprecated_func_metaphone_0_arg1_str = zend_string_init("use a userland phonetic matching library instead", strlen("use a userland phonetic matching library instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_metaphone_0->args[1].value, attribute_Deprecated_func_metaphone_0_arg1_str);
+	attribute_Deprecated_func_metaphone_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
 	zend_attribute *attribute_Deprecated_func_assert_options_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "assert_options", sizeof("assert_options") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
 	ZVAL_STR(&attribute_Deprecated_func_assert_options_0->args[0].value, ZSTR_KNOWN(ZEND_STR_8_DOT_3));

--- a/ext/standard/basic_functions_decl.h
+++ b/ext/standard/basic_functions_decl.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit basic_functions.stub.php instead.
- * Stub hash: 36b71aa7bbfe478a5e4af400b2822a77067efa2f */
+ * Stub hash: 98e3535dd6c306b2198f2fe4635820cf65685093 */
 
-#ifndef ZEND_BASIC_FUNCTIONS_DECL_36b71aa7bbfe478a5e4af400b2822a77067efa2f_H
-#define ZEND_BASIC_FUNCTIONS_DECL_36b71aa7bbfe478a5e4af400b2822a77067efa2f_H
+#ifndef ZEND_BASIC_FUNCTIONS_DECL_98e3535dd6c306b2198f2fe4635820cf65685093_H
+#define ZEND_BASIC_FUNCTIONS_DECL_98e3535dd6c306b2198f2fe4635820cf65685093_H
 
 typedef enum zend_enum_SortDirection {
 	ZEND_ENUM_SortDirection_Ascending = 1,
@@ -20,4 +20,4 @@ typedef enum zend_enum_RoundingMode {
 	ZEND_ENUM_RoundingMode_PositiveInfinity = 8,
 } zend_enum_RoundingMode;
 
-#endif /* ZEND_BASIC_FUNCTIONS_DECL_36b71aa7bbfe478a5e4af400b2822a77067efa2f_H */
+#endif /* ZEND_BASIC_FUNCTIONS_DECL_98e3535dd6c306b2198f2fe4635820cf65685093_H */

--- a/ext/standard/basic_functions_decl.h
+++ b/ext/standard/basic_functions_decl.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit basic_functions.stub.php instead.
- * Stub hash: 21b2089bd39aadeeb8730e4bb2fecbb32e65d1c8 */
+ * Stub hash: 915a002c40896449b4313f33a0c0f14b50293598 */
 
-#ifndef ZEND_BASIC_FUNCTIONS_DECL_21b2089bd39aadeeb8730e4bb2fecbb32e65d1c8_H
-#define ZEND_BASIC_FUNCTIONS_DECL_21b2089bd39aadeeb8730e4bb2fecbb32e65d1c8_H
+#ifndef ZEND_BASIC_FUNCTIONS_DECL_915a002c40896449b4313f33a0c0f14b50293598_H
+#define ZEND_BASIC_FUNCTIONS_DECL_915a002c40896449b4313f33a0c0f14b50293598_H
 
 typedef enum zend_enum_SortDirection {
 	ZEND_ENUM_SortDirection_Ascending = 1,
@@ -20,4 +20,4 @@ typedef enum zend_enum_RoundingMode {
 	ZEND_ENUM_RoundingMode_PositiveInfinity = 8,
 } zend_enum_RoundingMode;
 
-#endif /* ZEND_BASIC_FUNCTIONS_DECL_21b2089bd39aadeeb8730e4bb2fecbb32e65d1c8_H */
+#endif /* ZEND_BASIC_FUNCTIONS_DECL_915a002c40896449b4313f33a0c0f14b50293598_H */

--- a/ext/standard/basic_functions_decl.h
+++ b/ext/standard/basic_functions_decl.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit basic_functions.stub.php instead.
- * Stub hash: 915a002c40896449b4313f33a0c0f14b50293598 */
+ * Stub hash: 8f5682d85611126ee12182af46cb2905a0bd0e57 */
 
-#ifndef ZEND_BASIC_FUNCTIONS_DECL_915a002c40896449b4313f33a0c0f14b50293598_H
-#define ZEND_BASIC_FUNCTIONS_DECL_915a002c40896449b4313f33a0c0f14b50293598_H
+#ifndef ZEND_BASIC_FUNCTIONS_DECL_8f5682d85611126ee12182af46cb2905a0bd0e57_H
+#define ZEND_BASIC_FUNCTIONS_DECL_8f5682d85611126ee12182af46cb2905a0bd0e57_H
 
 typedef enum zend_enum_SortDirection {
 	ZEND_ENUM_SortDirection_Ascending = 1,
@@ -20,4 +20,4 @@ typedef enum zend_enum_RoundingMode {
 	ZEND_ENUM_RoundingMode_PositiveInfinity = 8,
 } zend_enum_RoundingMode;
 
-#endif /* ZEND_BASIC_FUNCTIONS_DECL_915a002c40896449b4313f33a0c0f14b50293598_H */
+#endif /* ZEND_BASIC_FUNCTIONS_DECL_8f5682d85611126ee12182af46cb2905a0bd0e57_H */

--- a/ext/standard/tests/GHSA-96wq-48vp-hh57.phpt
+++ b/ext/standard/tests/GHSA-96wq-48vp-hh57.phpt
@@ -14,9 +14,10 @@ if (PHP_INT_SIZE != 8) die('skip 64-bit only');
 <?php
 
 $str = str_repeat('0', 2 * (1024 ** 3) - 2) . 'AE';
-@metaphone($str, 1);
+metaphone($str, 1);
 
 ?>
 ===DONE===
---EXPECT--
+--EXPECTF--
+Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 ===DONE===

--- a/ext/standard/tests/GHSA-96wq-48vp-hh57.phpt
+++ b/ext/standard/tests/GHSA-96wq-48vp-hh57.phpt
@@ -14,7 +14,7 @@ if (PHP_INT_SIZE != 8) die('skip 64-bit only');
 <?php
 
 $str = str_repeat('0', 2 * (1024 ** 3) - 2) . 'AE';
-metaphone($str, 1);
+@metaphone($str, 1);
 
 ?>
 ===DONE===

--- a/ext/standard/tests/strings/bug44242.phpt
+++ b/ext/standard/tests/strings/bug44242.phpt
@@ -3,9 +3,9 @@ Bug #44242 (metaphone('CMXFXM') crashes PHP)
 --FILE--
 <?php
 
-echo metaphone('CMXFXZ'), "\n";
-echo metaphone('CMXFXV'), "\n";
-echo metaphone('CMXFXZXZ'), "\n";
+echo @metaphone('CMXFXZ'), "\n";
+echo @metaphone('CMXFXV'), "\n";
+echo @metaphone('CMXFXZXZ'), "\n";
 
 ?>
 --EXPECT--

--- a/ext/standard/tests/strings/bug44242.phpt
+++ b/ext/standard/tests/strings/bug44242.phpt
@@ -3,12 +3,15 @@ Bug #44242 (metaphone('CMXFXM') crashes PHP)
 --FILE--
 <?php
 
-echo @metaphone('CMXFXZ'), "\n";
-echo @metaphone('CMXFXV'), "\n";
-echo @metaphone('CMXFXZXZ'), "\n";
+echo metaphone('CMXFXZ'), "\n";
+echo metaphone('CMXFXV'), "\n";
+echo metaphone('CMXFXZXZ'), "\n";
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 KMKSFKSS
+Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 KMKSFKSF
+Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 KMKSFKSSKSS

--- a/ext/standard/tests/strings/bug44242.phpt
+++ b/ext/standard/tests/strings/bug44242.phpt
@@ -11,7 +11,9 @@ echo metaphone('CMXFXZXZ'), "\n";
 --EXPECTF--
 Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 KMKSFKSS
+
 Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 KMKSFKSF
+
 Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 KMKSFKSSKSS

--- a/ext/standard/tests/strings/bug47443.phpt
+++ b/ext/standard/tests/strings/bug47443.phpt
@@ -3,9 +3,9 @@ Bug #47443 (metaphone('scratch') returns wrong result)
 --FILE--
 <?php
 
-var_dump(metaphone("scratch"));
-var_dump(metaphone("scrath"));
-var_dump(metaphone("scratc"));
+var_dump(@metaphone("scratch"));
+var_dump(@metaphone("scrath"));
+var_dump(@metaphone("scratc"));
 
 ?>
 --EXPECT--

--- a/ext/standard/tests/strings/bug47443.phpt
+++ b/ext/standard/tests/strings/bug47443.phpt
@@ -3,12 +3,15 @@ Bug #47443 (metaphone('scratch') returns wrong result)
 --FILE--
 <?php
 
-var_dump(@metaphone("scratch"));
-var_dump(@metaphone("scrath"));
-var_dump(@metaphone("scratc"));
+var_dump(metaphone("scratch"));
+var_dump(metaphone("scrath"));
+var_dump(metaphone("scratc"));
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 string(4) "SKRX"
+Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 string(4) "SKR0"
+Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 string(5) "SKRTK"

--- a/ext/standard/tests/strings/bug47443.phpt
+++ b/ext/standard/tests/strings/bug47443.phpt
@@ -11,7 +11,9 @@ var_dump(metaphone("scratc"));
 --EXPECTF--
 Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 string(4) "SKRX"
+
 Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 string(4) "SKR0"
+
 Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 string(5) "SKRTK"

--- a/ext/standard/tests/strings/bug48709.phpt
+++ b/ext/standard/tests/strings/bug48709.phpt
@@ -16,7 +16,7 @@ $exceptions = array(
 );
 
 foreach ($exceptions as $letter) {
-    printf("%s => %s\n", $letter, metaphone($letter));
+    printf("%s => %s\n", $letter, @metaphone($letter));
 }
 
 ?>

--- a/ext/standard/tests/strings/bug48709.phpt
+++ b/ext/standard/tests/strings/bug48709.phpt
@@ -23,17 +23,24 @@ foreach ($exceptions as $letter) {
 --EXPECTF--
 Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 kn => N
+
 Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 gn => N
+
 Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 pn => N
+
 Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 ae => E
+
 Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 wr => R
+
 Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 x => S
+
 Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 wh => W
+
 Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 wa => W

--- a/ext/standard/tests/strings/bug48709.phpt
+++ b/ext/standard/tests/strings/bug48709.phpt
@@ -16,16 +16,24 @@ $exceptions = array(
 );
 
 foreach ($exceptions as $letter) {
-    printf("%s => %s\n", $letter, @metaphone($letter));
+    printf("%s => %s\n", $letter, metaphone($letter));
 }
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 kn => N
+Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 gn => N
+Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 pn => N
+Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 ae => E
+Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 wr => R
+Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 x => S
+Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 wh => W
+Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 wa => W

--- a/ext/standard/tests/strings/metaphone.phpt
+++ b/ext/standard/tests/strings/metaphone.phpt
@@ -3,16 +3,16 @@ metaphone() tests
 --FILE--
 <?php
 
-var_dump(metaphone(""));
-var_dump(metaphone(-1));
+var_dump(@metaphone(""));
+var_dump(@metaphone(-1));
 
 try {
-    var_dump(metaphone("valid phrase", -1));
+    var_dump(@metaphone("valid phrase", -1));
 } catch (ValueError $e) {
     echo $e->getMessage(), "\n";
 }
-var_dump(metaphone("valid phrase", 0));
-var_dump(metaphone("valid phrase", 10000));
+var_dump(@metaphone("valid phrase", 0));
+var_dump(@metaphone("valid phrase", 10000));
 
 $array = array(
 "They fell forward, grovelling heedlessly on the cold earth.",
@@ -22,7 +22,7 @@ $array = array(
 );
 
 foreach($array as $str) {
-    var_dump(metaphone($str));
+    var_dump(@metaphone($str));
 }
 
 echo "Done\n";

--- a/ext/standard/tests/strings/metaphone.phpt
+++ b/ext/standard/tests/strings/metaphone.phpt
@@ -30,20 +30,28 @@ echo "Done\n";
 --EXPECTF--
 Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 string(0) ""
+
 Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 string(0) ""
+
 Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 metaphone(): Argument #2 ($max_phonemes) must be greater than or equal to 0
+
 Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 string(6) "FLTFRS"
+
 Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 string(6) "FLTFRS"
+
 Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 string(26) "0FLFRWRTKRFLNKHTLSLN0KLTR0"
+
 Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 string(56) "BT0XTFHRRHLTNTRTRNTPSNKLWRNRFTBF0MSWPNK0FNRKW0TSFSTLWNKS"
+
 Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 string(69) "ANT0NTWSKNFLYNKBKTMRTRW00SPTF0R0FSRNNTBHNTT0WNTRRTWLFNK0TTMRXSBRNTBLK"
+
 Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 string(56) "0NKTWSTSFRS0YKLTPRSFNT0TSTNTMNSF0MNTNSWSTPLTW00FTFLMNLFT"
 Done

--- a/ext/standard/tests/strings/metaphone.phpt
+++ b/ext/standard/tests/strings/metaphone.phpt
@@ -3,16 +3,16 @@ metaphone() tests
 --FILE--
 <?php
 
-var_dump(@metaphone(""));
-var_dump(@metaphone(-1));
+var_dump(metaphone(""));
+var_dump(metaphone(-1));
 
 try {
-    var_dump(@metaphone("valid phrase", -1));
+    var_dump(metaphone("valid phrase", -1));
 } catch (ValueError $e) {
     echo $e->getMessage(), "\n";
 }
-var_dump(@metaphone("valid phrase", 0));
-var_dump(@metaphone("valid phrase", 10000));
+var_dump(metaphone("valid phrase", 0));
+var_dump(metaphone("valid phrase", 10000));
 
 $array = array(
 "They fell forward, grovelling heedlessly on the cold earth.",
@@ -22,19 +22,28 @@ $array = array(
 );
 
 foreach($array as $str) {
-    var_dump(@metaphone($str));
+    var_dump(metaphone($str));
 }
 
 echo "Done\n";
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 string(0) ""
+Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 string(0) ""
+Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 metaphone(): Argument #2 ($max_phonemes) must be greater than or equal to 0
+Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 string(6) "FLTFRS"
+Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 string(6) "FLTFRS"
+Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 string(26) "0FLFRWRTKRFLNKHTLSLN0KLTR0"
+Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 string(56) "BT0XTFHRRHLTNTRTRNTPSNKLWRNRFTBF0MSWPNK0FNRKW0TSFSTLWNKS"
+Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 string(69) "ANT0NTWSKNFLYNKBKTMRTRW00SPTF0R0FSRNNTBHNTT0WNTRRTWLFNK0TTMRXSBRNTBLK"
+Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 string(56) "0NKTWSTSFRS0YKLTPRSFNT0TSTNTMNSF0MNTNSWSTPLTW00FTFLMNLFT"
 Done

--- a/ext/standard/tests/strings/metaphone_deprecation.phpt
+++ b/ext/standard/tests/strings/metaphone_deprecation.phpt
@@ -1,0 +1,11 @@
+--TEST--
+metaphone() deprecation
+--FILE--
+<?php
+
+var_dump(metaphone("programming"));
+
+?>
+--EXPECTF--
+Deprecated: Function metaphone() is deprecated since 8.6 in %s on line %d
+string(7) "PRKRMNK"

--- a/ext/standard/tests/strings/metaphone_deprecation.phpt
+++ b/ext/standard/tests/strings/metaphone_deprecation.phpt
@@ -7,5 +7,5 @@ var_dump(metaphone("programming"));
 
 ?>
 --EXPECTF--
-Deprecated: Function metaphone() is deprecated since 8.6 in %s on line %d
+Deprecated: Function metaphone() is deprecated since 8.6, use a userland phonetic matching library instead in %s on line %d
 string(7) "PRKRMNK"


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_metaphone_function
Internal thread: https://news-web.php.net/php.internals/130691

no need to look at this until the RFC is accepted/rejected :)