### PR TITLE
uri: Update to uriparser-1.0.1

### DIFF
--- a/ext/uri/uriparser/include/uriparser/Uri.h
+++ b/ext/uri/uriparser/include/uriparser/Uri.h
@@ -1,4 +1,4 @@
-/* 5abed1007be99942f49ffe603a894d277066b79b9cb824547af0f3b9481cb9ca (1.0.0+)
+/* 53c1cb9f2f728652fe001dc72fa0fa7a0e9fa0b8baaaa9e37561c6cdf88ac4df (1.0.1+)
  *
  * uriparser - RFC 3986 URI parsing library
  *

--- a/ext/uri/uriparser/include/uriparser/UriBase.h
+++ b/ext/uri/uriparser/include/uriparser/UriBase.h
@@ -52,7 +52,7 @@
 /* Version */
 #  define URI_VER_MAJOR 1
 #  define URI_VER_MINOR 0
-#  define URI_VER_RELEASE 0
+#  define URI_VER_RELEASE 1
 #  define URI_VER_SUFFIX_ANSI ""
 #  define URI_VER_SUFFIX_UNICODE URI_ANSI_TO_UNICODE(URI_VER_SUFFIX_ANSI)
 

--- a/ext/uri/uriparser/src/UriCommon.c
+++ b/ext/uri/uriparser/src/UriCommon.c
@@ -66,6 +66,7 @@
 #  endif
 
 #  include <assert.h>
+#  include <stddef.h>
 
 /*extern*/ const URI_CHAR * const URI_FUNC(SafeToPointTo) = _UT("X");
 /*extern*/ const URI_CHAR * const URI_FUNC(ConstPwd) = _UT(".");
@@ -106,6 +107,8 @@ int URI_FUNC(FreeUriPath)(URI_TYPE(Uri) * uri, UriMemoryManager * memory) {
 /* Compares two text ranges for equal text content */
 int URI_FUNC(CompareRange)(const URI_TYPE(TextRange) * a, const URI_TYPE(TextRange) * b) {
     int diff;
+    ptrdiff_t lenA;
+    ptrdiff_t lenB;
 
     /* NOTE: Both NULL means equal! */
     if ((a == NULL) || (b == NULL)) {
@@ -117,14 +120,16 @@ int URI_FUNC(CompareRange)(const URI_TYPE(TextRange) * a, const URI_TYPE(TextRan
         return ((a->first == NULL) ? 0 : 1) - ((b->first == NULL) ? 0 : 1);
     }
 
-    diff = ((int)(a->afterLast - a->first) - (int)(b->afterLast - b->first));
-    if (diff > 0) {
+    lenA = a->afterLast - a->first;
+    lenB = b->afterLast - b->first;
+
+    if (lenA > lenB) {
         return 1;
-    } else if (diff < 0) {
+    } else if (lenA < lenB) {
         return -1;
     }
 
-    diff = URI_STRNCMP(a->first, b->first, (a->afterLast - a->first));
+    diff = URI_STRNCMP(a->first, b->first, (size_t)lenA);
 
     if (diff > 0) {
         return 1;
@@ -727,7 +732,7 @@ UriBool URI_FUNC(FixPathNoScheme)(URI_TYPE(Uri) * uri, UriMemoryManager * memory
 }
 
 /* When dropping a host from a URI without a scheme, an absolute path
- * and and empty first path segment, a consecutive reparse would rightfully
+ * and empty first path segment, a consecutive reparse would rightfully
  * mis-classify the first path segment as a host marker due to the "//".
  * To protect against this case, we prepend an artificial "." segment
  * to the path in here; the function is called after the host has

--- a/ext/uri/uriparser/src/UriMemory.c
+++ b/ext/uri/uriparser/src/UriMemory.c
@@ -45,11 +45,24 @@
 #include "UriConfig.h" /* for HAVE_REALLOCARRAY */
 
 #ifdef HAVE_REALLOCARRAY
-#  ifndef _GNU_SOURCE
-#    define _GNU_SOURCE 1
+// For glibc >=2.29 of 2019-02-01
+#  if !defined(_DEFAULT_SOURCE)
+#    define _DEFAULT_SOURCE 1
 #  endif
-#  ifdef __NetBSD__
+
+// For NetBSD (stdlib.h revision 1.122 of 2020-05-26)
+#  if defined(__NetBSD__) && !defined(_OPENBSD_SOURCE)
 #    define _OPENBSD_SOURCE 1
+#  endif
+
+// POSIX 2024 (XPG8) for e.g. Illumos/SmartOS
+#  if !defined(_XOPEN_SOURCE) || (_XOPEN_SOURCE - 0 < 800)
+#    undef _XOPEN_SOURCE
+#    define _XOPEN_SOURCE 800
+#  endif
+#  if !defined(_POSIX_C_SOURCE) || (_POSIX_C_SOURCE - 0 < 202405L)
+#    undef _POSIX_C_SOURCE
+#    define _POSIX_C_SOURCE 202405L
 #  endif
 #endif
 


### PR DESCRIPTION
This fixes CVE-2026-42371.

------------

@DanielEScherzer @edorian This needs to be picked into 8.5.6. I'm intentionally not adding a NEWS entry here, since NEWS would already be for 8.5.7. Please do the NEWS adjustments after picking the fix.

The NEWS entry is as follows:

```
  . Fixed CVE-2026-42371 (uriparser before 1.0.1 has numeric truncation in
    text range comparison). (CVE-2026-42371) (Joshua W. Windle)
```