### PR TITLE
tree-wide: Replace `XtOffsetOf` by its definition

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -96,6 +96,8 @@ PHP 8.6 INTERNALS UPGRADE NOTES
     and ZEND_PARSE_PARAMS_THROW have been removed due to being misleading,
     since ZPP always throws, unless ZEND_PARSE_PARAMS_QUIET is given. Use
     the non-throw versions.
+  . The XtOffsetOf() alias of C’s offsetof() macro has been removed. Use
+    offsetof() directly.
 
 ========================
 2. Build system changes

--- a/Zend/Optimizer/zend_optimizer.c
+++ b/Zend/Optimizer/zend_optimizer.c
@@ -780,7 +780,7 @@ static bool zend_optimizer_ignore_class(zval *ce_zv, const zend_string *filename
 		if (CG(compiler_options) & ZEND_COMPILE_WITH_FILE_CACHE) {
 			return true;
 		}
-		const Bucket *ce_bucket = (const Bucket*)((uintptr_t)ce_zv - XtOffsetOf(Bucket, val));
+		const Bucket *ce_bucket = (const Bucket*)((uintptr_t)ce_zv - offsetof(Bucket, val));
 		size_t offset = ce_bucket - EG(class_table)->arData;
 		if (offset < EG(persistent_classes_count)) {
 			return false;
@@ -801,7 +801,7 @@ static bool zend_optimizer_ignore_function(zval *fbc_zv, const zend_string *file
 			if (CG(compiler_options) & ZEND_COMPILE_WITH_FILE_CACHE) {
 				return true;
 			}
-			const Bucket *fbc_bucket = (const Bucket*)((uintptr_t)fbc_zv - XtOffsetOf(Bucket, val));
+			const Bucket *fbc_bucket = (const Bucket*)((uintptr_t)fbc_zv - offsetof(Bucket, val));
 			size_t offset = fbc_bucket - EG(function_table)->arData;
 			if (offset < EG(persistent_functions_count)) {
 				return false;

--- a/Zend/zend_ast.h
+++ b/Zend/zend_ast.h
@@ -358,7 +358,7 @@ typedef void (*zend_ast_apply_func)(zend_ast **ast_ptr, void *context);
 ZEND_API void zend_ast_apply(zend_ast *ast, zend_ast_apply_func fn, void *context);
 
 static zend_always_inline size_t zend_ast_size(uint32_t children) {
-	return XtOffsetOf(zend_ast, child) + (sizeof(zend_ast *) * children);
+	return offsetof(zend_ast, child) + (sizeof(zend_ast *) * children);
 }
 
 static zend_always_inline bool zend_ast_is_special(const zend_ast *ast) {

--- a/Zend/zend_closures.c
+++ b/Zend/zend_closures.c
@@ -829,7 +829,7 @@ static void zend_create_closure_ex(zval *res, zend_function *func, zend_class_en
 		/* wrap internal function handler to avoid memory leak */
 		if (UNEXPECTED(closure->func.internal_function.handler == zend_closure_internal_handler)) {
 			/* avoid infinity recursion, by taking handler from nested closure */
-			zend_closure *nested = (zend_closure*)((char*)func - XtOffsetOf(zend_closure, func));
+			zend_closure *nested = (zend_closure*)((char*)func - offsetof(zend_closure, func));
 			ZEND_ASSERT(nested->std.ce == zend_ce_closure);
 			closure->orig_internal_handler = nested->orig_internal_handler;
 		} else {

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5175,7 +5175,7 @@ static zend_result zend_compile_func_array_map(znode *result, zend_ast_list *arg
 	opline->lineno = lineno;
 	opline->extended_value = (2 << 16) | IS_ARRAY;
 	const zval *fbc_zv = zend_hash_find(CG(function_table), lcname);
-	const Bucket *fbc_bucket = (const Bucket*)((uintptr_t)fbc_zv - XtOffsetOf(Bucket, val));
+	const Bucket *fbc_bucket = (const Bucket*)((uintptr_t)fbc_zv - offsetof(Bucket, val));
 	Z_EXTRA_P(CT_CONSTANT(opline->op1)) = fbc_bucket - CG(function_table)->arData;
 
 	/* Initialize the result array. */
@@ -5472,7 +5472,7 @@ static void zend_compile_call(znode *result, const zend_ast *ast, uint32_t type)
 
 		/* Store offset to function from symbol table in op2.extra. */
 		if (fbc->type == ZEND_INTERNAL_FUNCTION) {
-			const Bucket *fbc_bucket = (const Bucket*)((uintptr_t)fbc_zv - XtOffsetOf(Bucket, val));
+			const Bucket *fbc_bucket = (const Bucket*)((uintptr_t)fbc_zv - offsetof(Bucket, val));
 			Z_EXTRA_P(CT_CONSTANT(opline->op2)) = fbc_bucket - CG(function_table)->arData;
 		}
 

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -481,7 +481,7 @@ typedef struct _zend_property_info {
 #define OBJ_PROP_NUM(obj, num) \
 	(&(obj)->properties_table[(num)])
 #define OBJ_PROP_TO_OFFSET(num) \
-	((uint32_t)(XtOffsetOf(zend_object, properties_table) + sizeof(zval) * (num)))
+	((uint32_t)(offsetof(zend_object, properties_table) + sizeof(zval) * (num)))
 #define OBJ_PROP_TO_NUM(offset) \
 	(((offset) - OBJ_PROP_TO_OFFSET(0)) / sizeof(zval))
 #define OBJ_PROP_SLOT_TO_OFFSET(obj, slot) \

--- a/Zend/zend_enum.c
+++ b/Zend/zend_enum.c
@@ -176,7 +176,7 @@ void zend_register_enum_ce(void)
 	zend_ce_backed_enum->interface_gets_implemented = zend_implement_backed_enum;
 
 	memcpy(&zend_enum_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	zend_enum_object_handlers.offset = XtOffsetOf(zend_enum_obj, std);
+	zend_enum_object_handlers.offset = offsetof(zend_enum_obj, std);
 	zend_enum_object_handlers.clone_obj = NULL;
 	zend_enum_object_handlers.compare = zend_objects_not_comparable;
 }

--- a/Zend/zend_enum.h
+++ b/Zend/zend_enum.h
@@ -36,7 +36,7 @@ typedef struct zend_enum_obj {
 
 static inline zend_enum_obj *zend_enum_obj_from_obj(zend_object *zobj) {
 	ZEND_ASSERT(zobj->ce->ce_flags & ZEND_ACC_ENUM);
-	return (zend_enum_obj*)((char*)(zobj) - XtOffsetOf(zend_enum_obj, std));
+	return (zend_enum_obj*)((char*)(zobj) - offsetof(zend_enum_obj, std));
 }
 
 void zend_enum_startup(void);

--- a/Zend/zend_fibers.h
+++ b/Zend/zend_fibers.h
@@ -154,7 +154,7 @@ static zend_always_inline zend_fiber *zend_fiber_from_context(zend_fiber_context
 {
 	ZEND_ASSERT(context->kind == zend_ce_fiber && "Fiber context does not belong to a Zend fiber");
 
-	return (zend_fiber *)(((char *) context) - XtOffsetOf(zend_fiber, context));
+	return (zend_fiber *)(((char *) context) - offsetof(zend_fiber, context));
 }
 
 static zend_always_inline zend_fiber_context *zend_fiber_get_context(zend_fiber *fiber)

--- a/Zend/zend_ini.h
+++ b/Zend/zend_ini.h
@@ -182,18 +182,18 @@ END_EXTERN_C()
 
 #ifdef ZTS
 #define STD_ZEND_INI_ENTRY(name, default_value, modifiable, on_modify, property_name, struct_type, struct_ptr) \
-	ZEND_INI_ENTRY2(name, default_value, modifiable, on_modify, (void *) XtOffsetOf(struct_type, property_name), (void *) &struct_ptr##_id)
+	ZEND_INI_ENTRY2(name, default_value, modifiable, on_modify, (void *) offsetof(struct_type, property_name), (void *) &struct_ptr##_id)
 #define STD_ZEND_INI_ENTRY_EX(name, default_value, modifiable, on_modify, property_name, struct_type, struct_ptr, displayer) \
-	ZEND_INI_ENTRY2_EX(name, default_value, modifiable, on_modify, (void *) XtOffsetOf(struct_type, property_name), (void *) &struct_ptr##_id, displayer)
+	ZEND_INI_ENTRY2_EX(name, default_value, modifiable, on_modify, (void *) offsetof(struct_type, property_name), (void *) &struct_ptr##_id, displayer)
 #define STD_ZEND_INI_BOOLEAN(name, default_value, modifiable, on_modify, property_name, struct_type, struct_ptr) \
-	ZEND_INI_ENTRY3_EX(name, default_value, modifiable, on_modify, (void *) XtOffsetOf(struct_type, property_name), (void *) &struct_ptr##_id, NULL, zend_ini_boolean_displayer_cb)
+	ZEND_INI_ENTRY3_EX(name, default_value, modifiable, on_modify, (void *) offsetof(struct_type, property_name), (void *) &struct_ptr##_id, NULL, zend_ini_boolean_displayer_cb)
 #else
 #define STD_ZEND_INI_ENTRY(name, default_value, modifiable, on_modify, property_name, struct_type, struct_ptr) \
-	ZEND_INI_ENTRY2(name, default_value, modifiable, on_modify, (void *) XtOffsetOf(struct_type, property_name), (void *) &struct_ptr)
+	ZEND_INI_ENTRY2(name, default_value, modifiable, on_modify, (void *) offsetof(struct_type, property_name), (void *) &struct_ptr)
 #define STD_ZEND_INI_ENTRY_EX(name, default_value, modifiable, on_modify, property_name, struct_type, struct_ptr, displayer) \
-	ZEND_INI_ENTRY2_EX(name, default_value, modifiable, on_modify, (void *) XtOffsetOf(struct_type, property_name), (void *) &struct_ptr, displayer)
+	ZEND_INI_ENTRY2_EX(name, default_value, modifiable, on_modify, (void *) offsetof(struct_type, property_name), (void *) &struct_ptr, displayer)
 #define STD_ZEND_INI_BOOLEAN(name, default_value, modifiable, on_modify, property_name, struct_type, struct_ptr) \
-	ZEND_INI_ENTRY3_EX(name, default_value, modifiable, on_modify, (void *) XtOffsetOf(struct_type, property_name), (void *) &struct_ptr, NULL, zend_ini_boolean_displayer_cb)
+	ZEND_INI_ENTRY3_EX(name, default_value, modifiable, on_modify, (void *) offsetof(struct_type, property_name), (void *) &struct_ptr, NULL, zend_ini_boolean_displayer_cb)
 #endif
 
 #define REGISTER_INI_ENTRIES() zend_register_ini_entries_ex(ini_entries, module_number, type)

--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -430,10 +430,6 @@ char *alloca();
 # define UNEXPECTED(condition) (condition)
 #endif
 
-#ifndef XtOffsetOf
-# define XtOffsetOf(s_type, field) offsetof(s_type, field)
-#endif
-
 #ifndef ZEND_WIN32
 # define SETJMP(a) sigsetjmp(a, 0)
 # define LONGJMP(a,b) siglongjmp(a, b)

--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -115,7 +115,7 @@ static zend_always_inline zend_string *ZSTR_KNOWN(size_t idx) {
 	return zend_known_strings[idx];
 }
 
-#define _ZSTR_HEADER_SIZE XtOffsetOf(zend_string, val)
+#define _ZSTR_HEADER_SIZE offsetof(zend_string, val)
 
 #define _ZSTR_STRUCT_SIZE(len) (_ZSTR_HEADER_SIZE + len + 1)
 

--- a/Zend/zend_weakrefs.c
+++ b/Zend/zend_weakrefs.c
@@ -58,10 +58,10 @@ static zend_class_entry *zend_ce_weakmap;
 static zend_object_handlers zend_weakref_handlers;
 static zend_object_handlers zend_weakmap_handlers;
 
-#define zend_weakref_from(o) ((zend_weakref*)(((char*) o) - XtOffsetOf(zend_weakref, std)))
+#define zend_weakref_from(o) ((zend_weakref*)(((char*) o) - offsetof(zend_weakref, std)))
 #define zend_weakref_fetch(z) zend_weakref_from(Z_OBJ_P(z))
 
-#define zend_weakmap_from(o) ((zend_weakmap*)(((char*) o) - XtOffsetOf(zend_weakmap, std)))
+#define zend_weakmap_from(o) ((zend_weakmap*)(((char*) o) - offsetof(zend_weakmap, std)))
 #define zend_weakmap_fetch(z) zend_weakmap_from(Z_OBJ_P(z))
 
 static inline void zend_weakref_unref_single(
@@ -796,7 +796,7 @@ void zend_register_weakref_ce(void) /* {{{ */
 	zend_ce_weakref->default_object_handlers = &zend_weakref_handlers;
 
 	memcpy(&zend_weakref_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
-	zend_weakref_handlers.offset = XtOffsetOf(zend_weakref, std);
+	zend_weakref_handlers.offset = offsetof(zend_weakref, std);
 
 	zend_weakref_handlers.free_obj = zend_weakref_free;
 	zend_weakref_handlers.get_debug_info = zend_weakref_get_debug_info;
@@ -809,7 +809,7 @@ void zend_register_weakref_ce(void) /* {{{ */
 	zend_ce_weakmap->default_object_handlers = &zend_weakmap_handlers;
 
 	memcpy(&zend_weakmap_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
-	zend_weakmap_handlers.offset = XtOffsetOf(zend_weakmap, std);
+	zend_weakmap_handlers.offset = offsetof(zend_weakmap, std);
 	zend_weakmap_handlers.free_obj = zend_weakmap_free_obj;
 	zend_weakmap_handlers.read_dimension = zend_weakmap_read_dimension;
 	zend_weakmap_handlers.write_dimension = zend_weakmap_write_dimension;

--- a/ext/bcmath/bcmath.c
+++ b/ext/bcmath/bcmath.c
@@ -877,7 +877,7 @@ static int bcmath_number_compare(zval *op1, zval *op2);
 
 static zend_always_inline bcmath_number_obj_t *get_bcmath_number_from_obj(const zend_object *obj)
 {
-	return (bcmath_number_obj_t*)((char*)(obj) - XtOffsetOf(bcmath_number_obj_t, std));
+	return (bcmath_number_obj_t*)((char*)(obj) - offsetof(bcmath_number_obj_t, std));
 }
 
 static zend_always_inline bcmath_number_obj_t *get_bcmath_number_from_zval(const zval *zv)
@@ -1024,7 +1024,7 @@ static void bcmath_number_register_class(void)
 	bcmath_number_ce->default_object_handlers = &bcmath_number_obj_handlers;
 
 	memcpy(&bcmath_number_obj_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	bcmath_number_obj_handlers.offset = XtOffsetOf(bcmath_number_obj_t, std);
+	bcmath_number_obj_handlers.offset = offsetof(bcmath_number_obj_t, std);
 	bcmath_number_obj_handlers.free_obj = bcmath_number_free;
 	bcmath_number_obj_handlers.clone_obj = bcmath_number_clone;
 	bcmath_number_obj_handlers.do_operation = bcmath_number_do_operation;

--- a/ext/curl/curl_private.h
+++ b/ext/curl/curl_private.h
@@ -152,13 +152,13 @@ void _php_setup_easy_copy_handlers(php_curl *ch, php_curl *source);
 zend_long php_curl_get_long(zval *zv);
 
 static inline php_curl *curl_from_obj(zend_object *obj) {
-	return (php_curl *)((char *)(obj) - XtOffsetOf(php_curl, std));
+	return (php_curl *)((char *)(obj) - offsetof(php_curl, std));
 }
 
 #define Z_CURL_P(zv) curl_from_obj(Z_OBJ_P(zv))
 
 static inline php_curlsh *curl_share_from_obj(zend_object *obj) {
-	return (php_curlsh *)((char *)(obj) - XtOffsetOf(php_curlsh, std));
+	return (php_curlsh *)((char *)(obj) - offsetof(php_curlsh, std));
 }
 
 #define Z_CURL_SHARE_P(zv) curl_share_from_obj(Z_OBJ_P(zv))

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -357,7 +357,7 @@ PHP_MINIT_FUNCTION(curl)
 	curl_ce->default_object_handlers = &curl_object_handlers;
 
 	memcpy(&curl_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	curl_object_handlers.offset = XtOffsetOf(php_curl, std);
+	curl_object_handlers.offset = offsetof(php_curl, std);
 	curl_object_handlers.free_obj = curl_free_obj;
 	curl_object_handlers.get_gc = curl_get_gc;
 	curl_object_handlers.get_constructor = curl_get_constructor;

--- a/ext/curl/multi.c
+++ b/ext/curl/multi.c
@@ -49,7 +49,7 @@
 zend_class_entry *curl_multi_ce;
 
 static inline php_curlm *curl_multi_from_obj(zend_object *obj) {
-	return (php_curlm *)((char *)(obj) - XtOffsetOf(php_curlm, std));
+	return (php_curlm *)((char *)(obj) - offsetof(php_curlm, std));
 }
 
 #define Z_CURL_MULTI_P(zv) curl_multi_from_obj(Z_OBJ_P(zv))
@@ -605,7 +605,7 @@ void curl_multi_register_handlers(void) {
 	curl_multi_ce->default_object_handlers = &curl_multi_handlers;
 
 	memcpy(&curl_multi_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	curl_multi_handlers.offset = XtOffsetOf(php_curlm, std);
+	curl_multi_handlers.offset = offsetof(php_curlm, std);
 	curl_multi_handlers.free_obj = curl_multi_free_obj;
 	curl_multi_handlers.get_gc = curl_multi_get_gc;
 	curl_multi_handlers.get_constructor = curl_multi_get_constructor;

--- a/ext/curl/share.c
+++ b/ext/curl/share.c
@@ -303,7 +303,7 @@ void curl_share_register_handlers(void) {
 	curl_share_ce->default_object_handlers = &curl_share_handlers;
 
 	memcpy(&curl_share_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	curl_share_handlers.offset = XtOffsetOf(php_curlsh, std);
+	curl_share_handlers.offset = offsetof(php_curlsh, std);
 	curl_share_handlers.free_obj = curl_share_free_obj;
 	curl_share_handlers.get_constructor = curl_share_get_constructor;
 	curl_share_handlers.clone_obj = NULL;
@@ -324,7 +324,7 @@ void curl_share_persistent_register_handlers(void) {
 	curl_share_persistent_ce->default_object_handlers = &curl_share_persistent_handlers;
 
 	memcpy(&curl_share_persistent_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	curl_share_persistent_handlers.offset = XtOffsetOf(php_curlsh, std);
+	curl_share_persistent_handlers.offset = offsetof(php_curlsh, std);
 	curl_share_persistent_handlers.get_constructor = curl_share_persistent_get_constructor;
 	curl_share_persistent_handlers.clone_obj = NULL;
 	curl_share_persistent_handlers.compare = zend_objects_not_comparable;

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -1754,7 +1754,7 @@ static void date_register_classes(void) /* {{{ */
 	date_ce_date->create_object = date_object_new_date;
 	date_ce_date->default_object_handlers = &date_object_handlers_date;
 	memcpy(&date_object_handlers_date, &std_object_handlers, sizeof(zend_object_handlers));
-	date_object_handlers_date.offset = XtOffsetOf(php_date_obj, std);
+	date_object_handlers_date.offset = offsetof(php_date_obj, std);
 	date_object_handlers_date.free_obj = date_object_free_storage_date;
 	date_object_handlers_date.clone_obj = date_object_clone_date;
 	date_object_handlers_date.compare = date_object_compare_date;
@@ -1774,7 +1774,7 @@ static void date_register_classes(void) /* {{{ */
 	date_ce_timezone->create_object = date_object_new_timezone;
 	date_ce_timezone->default_object_handlers = &date_object_handlers_timezone;
 	memcpy(&date_object_handlers_timezone, &std_object_handlers, sizeof(zend_object_handlers));
-	date_object_handlers_timezone.offset = XtOffsetOf(php_timezone_obj, std);
+	date_object_handlers_timezone.offset = offsetof(php_timezone_obj, std);
 	date_object_handlers_timezone.free_obj = date_object_free_storage_timezone;
 	date_object_handlers_timezone.clone_obj = date_object_clone_timezone;
 	date_object_handlers_timezone.get_properties_for = date_object_get_properties_for_timezone;
@@ -1786,7 +1786,7 @@ static void date_register_classes(void) /* {{{ */
 	date_ce_interval->create_object = date_object_new_interval;
 	date_ce_interval->default_object_handlers = &date_object_handlers_interval;
 	memcpy(&date_object_handlers_interval, &std_object_handlers, sizeof(zend_object_handlers));
-	date_object_handlers_interval.offset = XtOffsetOf(php_interval_obj, std);
+	date_object_handlers_interval.offset = offsetof(php_interval_obj, std);
 	date_object_handlers_interval.free_obj = date_object_free_storage_interval;
 	date_object_handlers_interval.clone_obj = date_object_clone_interval;
 	date_object_handlers_interval.has_property = date_interval_has_property;
@@ -1802,7 +1802,7 @@ static void date_register_classes(void) /* {{{ */
 	date_ce_period->default_object_handlers = &date_object_handlers_period;
 	date_ce_period->get_iterator = date_object_period_get_iterator;
 	memcpy(&date_object_handlers_period, &std_object_handlers, sizeof(zend_object_handlers));
-	date_object_handlers_period.offset = XtOffsetOf(php_period_obj, std);
+	date_object_handlers_period.offset = offsetof(php_period_obj, std);
 	date_object_handlers_period.free_obj = date_object_free_storage_period;
 	date_object_handlers_period.clone_obj = date_object_clone_period;
 	date_object_handlers_period.get_gc = date_object_get_gc_period;

--- a/ext/date/php_date.h
+++ b/ext/date/php_date.h
@@ -59,7 +59,7 @@ struct _php_date_obj {
 };
 
 static inline php_date_obj *php_date_obj_from_obj(zend_object *obj) {
-	return (php_date_obj*)((char*)(obj) - XtOffsetOf(php_date_obj, std));
+	return (php_date_obj*)((char*)(obj) - offsetof(php_date_obj, std));
 }
 
 #define Z_PHPDATE_P(zv)  php_date_obj_from_obj(Z_OBJ_P((zv)))
@@ -76,7 +76,7 @@ struct _php_timezone_obj {
 };
 
 static inline php_timezone_obj *php_timezone_obj_from_obj(zend_object *obj) {
-	return (php_timezone_obj*)((char*)(obj) - XtOffsetOf(php_timezone_obj, std));
+	return (php_timezone_obj*)((char*)(obj) - offsetof(php_timezone_obj, std));
 }
 
 #define Z_PHPTIMEZONE_P(zv)  php_timezone_obj_from_obj(Z_OBJ_P((zv)))
@@ -94,7 +94,7 @@ struct _php_interval_obj {
 };
 
 static inline php_interval_obj *php_interval_obj_from_obj(zend_object *obj) {
-	return (php_interval_obj*)((char*)(obj) - XtOffsetOf(php_interval_obj, std));
+	return (php_interval_obj*)((char*)(obj) - offsetof(php_interval_obj, std));
 }
 
 #define Z_PHPINTERVAL_P(zv)  php_interval_obj_from_obj(Z_OBJ_P((zv)))
@@ -113,7 +113,7 @@ struct _php_period_obj {
 };
 
 static inline php_period_obj *php_period_obj_from_obj(zend_object *obj) {
-	return (php_period_obj*)((char*)(obj) - XtOffsetOf(php_period_obj, std));
+	return (php_period_obj*)((char*)(obj) - offsetof(php_period_obj, std));
 }
 
 #define Z_PHPPERIOD_P(zv)  php_period_obj_from_obj(Z_OBJ_P((zv)))

--- a/ext/dba/dba.c
+++ b/ext/dba/dba.c
@@ -337,7 +337,7 @@ static zend_result dba_connection_cast_object(zend_object *obj, zval *result, in
 
 static inline dba_connection *dba_connection_from_obj(zend_object *obj)
 {
-	return (dba_connection *)((char *)(obj) - XtOffsetOf(dba_connection, std));
+	return (dba_connection *)((char *)(obj) - offsetof(dba_connection, std));
 }
 
 #define Z_DBA_CONNECTION_P(zv) dba_connection_from_obj(Z_OBJ_P(zv))
@@ -409,7 +409,7 @@ PHP_MINIT_FUNCTION(dba)
 	dba_connection_ce->default_object_handlers = &dba_connection_object_handlers;
 
 	memcpy(&dba_connection_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	dba_connection_object_handlers.offset = XtOffsetOf(dba_connection, std);
+	dba_connection_object_handlers.offset = offsetof(dba_connection, std);
 	dba_connection_object_handlers.free_obj = dba_connection_free_obj;
 	dba_connection_object_handlers.get_constructor = dba_connection_get_constructor;
 	dba_connection_object_handlers.clone_obj = NULL;

--- a/ext/dom/namespace_compat.c
+++ b/ext/dom/namespace_compat.c
@@ -59,7 +59,7 @@ static HashTable *php_dom_libxml_ns_mapper_ensure_prefix_map(php_dom_libxml_ns_m
 		zend_hash_add_new(&mapper->uri_to_prefix_map, *uri, &zv_prefix_map);
 	} else {
 		/* cast to Bucket* only works if this holds, I would prefer a static assert but we're stuck at C99. */
-		ZEND_ASSERT(XtOffsetOf(Bucket, val) == 0);
+		ZEND_ASSERT(offsetof(Bucket, val) == 0);
 		ZEND_ASSERT(Z_TYPE_P(zv) == IS_ARRAY);
 		Bucket *bucket = (Bucket *) zv;
 		/* Make sure we take the value from the key string that lives long enough. */

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -792,7 +792,7 @@ HashTable *dom_xpath_get_gc(zend_object *object, zval **table, int *n);
 PHP_MINIT_FUNCTION(dom)
 {
 	memcpy(&dom_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	dom_object_handlers.offset = XtOffsetOf(dom_object, std);
+	dom_object_handlers.offset = offsetof(dom_object, std);
 	dom_object_handlers.free_obj = dom_objects_free_storage;
 	dom_object_handlers.read_property = dom_read_property;
 	dom_object_handlers.write_property = dom_write_property;
@@ -837,12 +837,12 @@ PHP_MINIT_FUNCTION(dom)
 	dom_html_collection_object_handlers.get_gc = dom_html_collection_get_gc;
 
 	memcpy(&dom_object_namespace_node_handlers, &dom_object_handlers, sizeof(zend_object_handlers));
-	dom_object_namespace_node_handlers.offset = XtOffsetOf(dom_object_namespace_node, dom.std);
+	dom_object_namespace_node_handlers.offset = offsetof(dom_object_namespace_node, dom.std);
 	dom_object_namespace_node_handlers.free_obj = dom_object_namespace_node_free_storage;
 	dom_object_namespace_node_handlers.clone_obj = dom_object_namespace_node_clone_obj;
 
 	memcpy(&dom_token_list_object_handlers, &dom_object_handlers, sizeof(zend_object_handlers));
-	dom_token_list_object_handlers.offset = XtOffsetOf(dom_token_list_object, dom.std);
+	dom_token_list_object_handlers.offset = offsetof(dom_token_list_object, dom.std);
 	dom_token_list_object_handlers.free_obj = dom_token_list_free_obj;
 	/* The Web IDL (Web Interface Description Language - https://webidl.spec.whatwg.org) has the [SameObject] constraint
 	 * for this object, which is incompatible with cloning because it imposes that there is only one instance
@@ -1333,7 +1333,7 @@ PHP_MINIT_FUNCTION(dom)
 
 #ifdef LIBXML_XPATH_ENABLED
 	memcpy(&dom_xpath_object_handlers, &dom_object_handlers, sizeof(zend_object_handlers));
-	dom_xpath_object_handlers.offset = XtOffsetOf(dom_xpath_object, dom) + XtOffsetOf(dom_object, std);
+	dom_xpath_object_handlers.offset = offsetof(dom_xpath_object, dom) + offsetof(dom_object, std);
 	dom_xpath_object_handlers.free_obj = dom_xpath_objects_free_storage;
 	dom_xpath_object_handlers.get_gc = dom_xpath_get_gc;
 	dom_xpath_object_handlers.clone_obj = NULL;
@@ -1570,7 +1570,7 @@ zend_object *dom_xpath_objects_new(zend_class_entry *class_type)
 
 /* The char pointer MUST refer to the char* of a zend_string struct */
 static void dom_zend_string_release_from_char_pointer(xmlChar *ptr) {
-	zend_string_release((zend_string*) (ptr - XtOffsetOf(zend_string, val)));
+	zend_string_release((zend_string*) (ptr - offsetof(zend_string, val)));
 }
 
 void dom_nnodemap_objects_free_storage(zend_object *object) /* {{{ */

--- a/ext/dom/php_dom.h
+++ b/ext/dom/php_dom.h
@@ -68,7 +68,7 @@ typedef struct dom_xpath_object {
 
 static inline dom_xpath_object *php_xpath_obj_from_obj(zend_object *obj) {
 	return (dom_xpath_object*)((char*)(obj)
-		- XtOffsetOf(dom_xpath_object, dom) - XtOffsetOf(dom_object, std));
+		- offsetof(dom_xpath_object, dom) - offsetof(dom_object, std));
 }
 
 #define Z_XPATHOBJ_P(zv)  php_xpath_obj_from_obj(Z_OBJ_P((zv)))
@@ -94,7 +94,7 @@ struct php_dom_libxml_ns_mapper;
 typedef struct php_dom_libxml_ns_mapper php_dom_libxml_ns_mapper;
 
 static inline dom_object_namespace_node *php_dom_namespace_node_obj_from_obj(zend_object *obj) {
-	return (dom_object_namespace_node*)((char*)(obj) - XtOffsetOf(dom_object_namespace_node, dom.std));
+	return (dom_object_namespace_node*)((char*)(obj) - offsetof(dom_object_namespace_node, dom.std));
 }
 
 #include "domexception.h"

--- a/ext/dom/token_list.c
+++ b/ext/dom/token_list.c
@@ -575,7 +575,7 @@ PHP_METHOD(Dom_TokenList, toggle)
 	HashTable *token_set = TOKEN_LIST_GET_SET(intern);
 	zval *found_token = zend_hash_find(token_set, token);
 	if (found_token != NULL) {
-		ZEND_ASSERT(XtOffsetOf(Bucket, val) == 0 && "the cast only works if this is true");
+		ZEND_ASSERT(offsetof(Bucket, val) == 0 && "the cast only works if this is true");
 		Bucket *bucket = (Bucket *) found_token;
 
 		/* 3.1. If force is either not given or is false, then remove token from this’s token set,
@@ -625,7 +625,7 @@ PHP_METHOD(Dom_TokenList, replace)
 	}
 
 	/* 4. Replace token in this’s token set with newToken. */
-	ZEND_ASSERT(XtOffsetOf(Bucket, val) == 0 && "the cast only works if this is true");
+	ZEND_ASSERT(offsetof(Bucket, val) == 0 && "the cast only works if this is true");
 	Bucket *bucket = (Bucket *) found_token;
 	if (zend_hash_set_bucket_key(token_set, bucket, new_token) == NULL) {
 		/* It already exists, remove token instead. */

--- a/ext/dom/token_list.h
+++ b/ext/dom/token_list.h
@@ -25,12 +25,12 @@ typedef struct dom_token_list_object {
 
 static inline dom_token_list_object *php_dom_token_list_from_obj(zend_object *obj)
 {
-	return (dom_token_list_object *)((char *) obj - XtOffsetOf(dom_token_list_object, dom.std));
+	return (dom_token_list_object *)((char *) obj - offsetof(dom_token_list_object, dom.std));
 }
 
 static inline dom_token_list_object *php_dom_token_list_from_dom_obj(dom_object *obj)
 {
-	return (dom_token_list_object *)((char *) obj - XtOffsetOf(dom_token_list_object, dom));
+	return (dom_token_list_object *)((char *) obj - offsetof(dom_token_list_object, dom));
 }
 
 void dom_ordered_set_parser(HashTable *token_set, const char *position, bool to_lowercase);

--- a/ext/dom/xml_common.h
+++ b/ext/dom/xml_common.h
@@ -28,7 +28,7 @@ typedef struct _dom_object {
 } dom_object;
 
 static inline dom_object *php_dom_obj_from_obj(zend_object *obj) {
-	return (dom_object*)((char*)(obj) - XtOffsetOf(dom_object, std));
+	return (dom_object*)((char*)(obj) - offsetof(dom_object, std));
 }
 
 #define Z_DOMOBJ_P(zv)  php_dom_obj_from_obj(Z_OBJ_P((zv)))

--- a/ext/dom/xpath.c
+++ b/ext/dom/xpath.c
@@ -189,7 +189,7 @@ zend_result dom_xpath_document_read(dom_object *obj, zval *retval)
 
 /* {{{ registerNodeNamespaces bool*/
 static inline dom_xpath_object *php_xpath_obj_from_dom_obj(dom_object *obj) {
-	return (dom_xpath_object*)((char*)(obj) - XtOffsetOf(dom_xpath_object, dom));
+	return (dom_xpath_object*)((char*)(obj) - offsetof(dom_xpath_object, dom));
 }
 
 zend_result dom_xpath_register_node_ns_read(dom_object *obj, zval *retval)

--- a/ext/enchant/enchant.c
+++ b/ext/enchant/enchant.c
@@ -49,7 +49,7 @@ zend_class_entry *enchant_broker_ce;
 static zend_object_handlers enchant_broker_handlers;
 
 static inline enchant_broker *enchant_broker_from_obj(zend_object *obj) {
-	return (enchant_broker *)((char *)(obj) - XtOffsetOf(enchant_broker, std));
+	return (enchant_broker *)((char *)(obj) - offsetof(enchant_broker, std));
 }
 
 #define Z_ENCHANT_BROKER_P(zv) enchant_broker_from_obj(Z_OBJ_P(zv))
@@ -67,7 +67,7 @@ zend_class_entry *enchant_dict_ce;
 static zend_object_handlers enchant_dict_handlers;
 
 static inline enchant_dict *enchant_dict_from_obj(zend_object *obj) {
-	return (enchant_dict *)((char *)(obj) - XtOffsetOf(enchant_dict, std));
+	return (enchant_dict *)((char *)(obj) - offsetof(enchant_dict, std));
 }
 
 #define Z_ENCHANT_DICT_P(zv) enchant_dict_from_obj(Z_OBJ_P(zv))
@@ -190,7 +190,7 @@ PHP_MINIT_FUNCTION(enchant)
 	enchant_broker_ce->default_object_handlers = &enchant_broker_handlers;
 
 	memcpy(&enchant_broker_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	enchant_broker_handlers.offset = XtOffsetOf(enchant_broker, std);
+	enchant_broker_handlers.offset = offsetof(enchant_broker, std);
 	enchant_broker_handlers.free_obj = php_enchant_broker_free;
 	enchant_broker_handlers.clone_obj = NULL;
 	enchant_broker_handlers.compare = zend_objects_not_comparable;
@@ -200,7 +200,7 @@ PHP_MINIT_FUNCTION(enchant)
 	enchant_dict_ce->default_object_handlers = &enchant_dict_handlers;
 
 	memcpy(&enchant_dict_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	enchant_dict_handlers.offset = XtOffsetOf(enchant_dict, std);
+	enchant_dict_handlers.offset = offsetof(enchant_dict, std);
 	enchant_dict_handlers.free_obj = php_enchant_dict_free;
 	enchant_dict_handlers.clone_obj = NULL;
 	enchant_dict_handlers.compare = zend_objects_not_comparable;

--- a/ext/fileinfo/fileinfo.c
+++ b/ext/fileinfo/fileinfo.c
@@ -44,7 +44,7 @@ typedef struct _finfo_object {
 } finfo_object;
 
 static inline finfo_object *php_finfo_fetch_object(zend_object *obj) {
-	return (finfo_object *)((char*)(obj) - XtOffsetOf(finfo_object, zo));
+	return (finfo_object *)((char*)(obj) - offsetof(finfo_object, zo));
 }
 
 #define Z_FINFO_P(zv) php_finfo_fetch_object(Z_OBJ_P((zv)))
@@ -82,7 +82,7 @@ PHP_MINIT_FUNCTION(finfo)
 
 	/* copy the standard object handlers to you handler table */
 	memcpy(&finfo_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	finfo_object_handlers.offset = XtOffsetOf(finfo_object, zo);
+	finfo_object_handlers.offset = offsetof(finfo_object, zo);
 	finfo_object_handlers.free_obj = finfo_objects_free;
 	finfo_object_handlers.clone_obj = NULL;
 

--- a/ext/ftp/php_ftp.c
+++ b/ext/ftp/php_ftp.c
@@ -99,7 +99,7 @@ PHP_MINIT_FUNCTION(ftp)
 	php_ftp_ce->create_object = ftp_object_create;
 
 	memcpy(&ftp_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	ftp_object_handlers.offset = XtOffsetOf(php_ftp_object, std);
+	ftp_object_handlers.offset = offsetof(php_ftp_object, std);
 	ftp_object_handlers.get_constructor = ftp_object_get_constructor;
 	ftp_object_handlers.free_obj = ftp_object_destroy;
 	ftp_object_handlers.clone_obj = NULL;

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -150,7 +150,7 @@ static zend_function *php_gd_image_object_get_constructor(zend_object *object)
 
 static zend_always_inline php_gd_image_object* php_gd_exgdimage_from_zobj_p(zend_object* obj)
 {
-	return (php_gd_image_object *) ((char *) (obj) - XtOffsetOf(php_gd_image_object, std));
+	return (php_gd_image_object *) ((char *) (obj) - offsetof(php_gd_image_object, std));
 }
 
 /**
@@ -206,7 +206,7 @@ static void php_gd_object_minit_helper(void)
 	php_gd_image_object_handlers.free_obj = php_gd_image_object_free;
 	php_gd_image_object_handlers.get_constructor = php_gd_image_object_get_constructor;
 	php_gd_image_object_handlers.compare = zend_objects_not_comparable;
-	php_gd_image_object_handlers.offset = XtOffsetOf(php_gd_image_object, std);
+	php_gd_image_object_handlers.offset = offsetof(php_gd_image_object, std);
 }
 
 static zend_class_entry *gd_font_ce = NULL;
@@ -271,7 +271,7 @@ static void php_gd_font_minit_helper(void)
 	php_gd_font_object_handlers.clone_obj = NULL;
 	php_gd_font_object_handlers.free_obj = php_gd_font_object_free;
 	php_gd_font_object_handlers.get_constructor = php_gd_font_object_get_constructor;
-	php_gd_font_object_handlers.offset = XtOffsetOf(php_gd_font_object, std);
+	php_gd_font_object_handlers.offset = offsetof(php_gd_font_object, std);
 }
 
 /*********************************************************

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -586,7 +586,7 @@ ZEND_MINIT_FUNCTION(gmp)
 	gmp_ce->unserialize = gmp_unserialize;
 
 	memcpy(&gmp_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	gmp_object_handlers.offset = XtOffsetOf(gmp_object, std);
+	gmp_object_handlers.offset = offsetof(gmp_object, std);
 	gmp_object_handlers.free_obj = gmp_free_object_storage;
 	gmp_object_handlers.cast_object = gmp_cast_object;
 	gmp_object_handlers.get_debug_info = gmp_get_debug_info;

--- a/ext/gmp/php_gmp_int.h
+++ b/ext/gmp/php_gmp_int.h
@@ -36,7 +36,7 @@ typedef struct _gmp_object {
 } gmp_object;
 
 static inline gmp_object *php_gmp_object_from_zend_object(zend_object *zobj) {
-	return (gmp_object *)( ((char *)zobj) - XtOffsetOf(gmp_object, std) );
+	return (gmp_object *)( ((char *)zobj) - offsetof(gmp_object, std) );
 }
 
 PHP_GMP_API zend_class_entry *php_gmp_class_entry(void);

--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -1652,7 +1652,7 @@ PHP_MINIT_FUNCTION(hash)
 
 	memcpy(&php_hashcontext_handlers, &std_object_handlers,
 	       sizeof(zend_object_handlers));
-	php_hashcontext_handlers.offset = XtOffsetOf(php_hashcontext_object, std);
+	php_hashcontext_handlers.offset = offsetof(php_hashcontext_object, std);
 	php_hashcontext_handlers.free_obj = php_hashcontext_free;
 	php_hashcontext_handlers.clone_obj = php_hashcontext_clone;
 

--- a/ext/intl/breakiterator/breakiterator_class.cpp
+++ b/ext/intl/breakiterator/breakiterator_class.cpp
@@ -212,7 +212,7 @@ U_CFUNC void breakiterator_register_BreakIterator_class(void)
 
 	memcpy(&BreakIterator_handlers, &std_object_handlers,
 		sizeof BreakIterator_handlers);
-	BreakIterator_handlers.offset = XtOffsetOf(BreakIterator_object, zo);
+	BreakIterator_handlers.offset = offsetof(BreakIterator_object, zo);
 	BreakIterator_handlers.compare = BreakIterator_compare_objects;
 	BreakIterator_handlers.clone_obj = BreakIterator_clone_obj;
 	BreakIterator_handlers.get_debug_info = BreakIterator_get_debug_info;

--- a/ext/intl/breakiterator/breakiterator_class.h
+++ b/ext/intl/breakiterator/breakiterator_class.h
@@ -42,7 +42,7 @@ typedef struct {
 } BreakIterator_object;
 
 static inline BreakIterator_object *php_intl_breakiterator_fetch_object(zend_object *obj) {
-	return (BreakIterator_object *)((char*)(obj) - XtOffsetOf(BreakIterator_object, zo));
+	return (BreakIterator_object *)((char*)(obj) - offsetof(BreakIterator_object, zo));
 }
 #define Z_INTL_BREAKITERATOR_P(zv) php_intl_breakiterator_fetch_object(Z_OBJ_P(zv))
 

--- a/ext/intl/calendar/calendar_class.cpp
+++ b/ext/intl/calendar/calendar_class.cpp
@@ -256,7 +256,7 @@ void calendar_register_IntlCalendar_class(void)
 
 	memcpy( &Calendar_handlers, &std_object_handlers,
 		sizeof Calendar_handlers);
-	Calendar_handlers.offset = XtOffsetOf(Calendar_object, zo);
+	Calendar_handlers.offset = offsetof(Calendar_object, zo);
 	Calendar_handlers.clone_obj = Calendar_clone_obj;
 	Calendar_handlers.get_debug_info = Calendar_get_debug_info;
 	Calendar_handlers.free_obj = Calendar_objects_free;

--- a/ext/intl/calendar/calendar_class.h
+++ b/ext/intl/calendar/calendar_class.h
@@ -39,7 +39,7 @@ typedef struct {
 } Calendar_object;
 
 static inline Calendar_object *php_intl_calendar_fetch_object(zend_object *obj) {
-	return (Calendar_object *)((char*)(obj) - XtOffsetOf(Calendar_object, zo));
+	return (Calendar_object *)((char*)(obj) - offsetof(Calendar_object, zo));
 }
 #define Z_INTL_CALENDAR_P(zv) php_intl_calendar_fetch_object(Z_OBJ_P(zv))
 

--- a/ext/intl/collator/collator_class.cpp
+++ b/ext/intl/collator/collator_class.cpp
@@ -76,7 +76,7 @@ U_CFUNC void collator_register_Collator_symbols(int module_number)
 		sizeof Collator_handlers);
 	/* Collator has no usable clone semantics - ucol_cloneBinary/ucol_openBinary require binary buffer
 	   for which we don't have the place to keep */
-	Collator_handlers.offset = XtOffsetOf(Collator_object, zo);
+	Collator_handlers.offset = offsetof(Collator_object, zo);
 	Collator_handlers.clone_obj = nullptr;
 	Collator_handlers.free_obj = Collator_objects_free;
 }

--- a/ext/intl/collator/collator_class.h
+++ b/ext/intl/collator/collator_class.h
@@ -48,7 +48,7 @@ typedef struct {
 #define COLLATOR_ERROR_CODE_P(co) &(INTL_ERROR_CODE(COLLATOR_ERROR(co)))
 
 static inline Collator_object *php_intl_collator_fetch_object(zend_object *obj) {
-	return (Collator_object *)((char*)(obj) - XtOffsetOf(Collator_object, zo));
+	return (Collator_object *)((char*)(obj) - offsetof(Collator_object, zo));
 }
 #define Z_INTL_COLLATOR_P(zv) php_intl_collator_fetch_object(Z_OBJ_P(zv))
 

--- a/ext/intl/common/common_enum.cpp
+++ b/ext/intl/common/common_enum.cpp
@@ -294,7 +294,7 @@ U_CFUNC void intl_register_common_symbols(int module_number)
 
 	memcpy(&IntlIterator_handlers, &std_object_handlers,
 		sizeof IntlIterator_handlers);
-	IntlIterator_handlers.offset = XtOffsetOf(IntlIterator_object, zo);
+	IntlIterator_handlers.offset = offsetof(IntlIterator_object, zo);
 	IntlIterator_handlers.clone_obj = NULL;
 	IntlIterator_handlers.dtor_obj = IntlIterator_objects_dtor;
 	IntlIterator_handlers.free_obj = IntlIterator_objects_free;

--- a/ext/intl/common/common_enum.h
+++ b/ext/intl/common/common_enum.h
@@ -53,7 +53,7 @@ typedef struct {
 
 
 static inline IntlIterator_object *php_intl_iterator_fetch_object(zend_object *obj) {
-	return (IntlIterator_object *)((char*)(obj) - XtOffsetOf(IntlIterator_object, zo));
+	return (IntlIterator_object *)((char*)(obj) - offsetof(IntlIterator_object, zo));
 }
 #define Z_INTL_ITERATOR_P(zv) php_intl_iterator_fetch_object(Z_OBJ_P(zv))
 

--- a/ext/intl/converter/converter.cpp
+++ b/ext/intl/converter/converter.cpp
@@ -37,7 +37,7 @@ typedef struct _php_converter_object {
 
 
 static inline php_converter_object *php_converter_fetch_object(zend_object *obj) {
-	return (php_converter_object *)((char*)(obj) - XtOffsetOf(php_converter_object, obj));
+	return (php_converter_object *)((char*)(obj) - offsetof(php_converter_object, obj));
 }
 #define Z_INTL_CONVERTER_P(zv) php_converter_fetch_object(Z_OBJ_P(zv))
 
@@ -975,7 +975,7 @@ U_CFUNC int php_converter_minit(INIT_FUNC_ARGS) {
 	php_converter_ce->create_object = php_converter_create_object;
 	php_converter_ce->default_object_handlers = &php_converter_object_handlers;
 	memcpy(&php_converter_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	php_converter_object_handlers.offset = XtOffsetOf(php_converter_object, obj);
+	php_converter_object_handlers.offset = offsetof(php_converter_object, obj);
 	php_converter_object_handlers.clone_obj = php_converter_clone_object;
 	php_converter_object_handlers.free_obj = php_converter_free_object;
 

--- a/ext/intl/dateformat/dateformat_class.cpp
+++ b/ext/intl/dateformat/dateformat_class.cpp
@@ -104,7 +104,7 @@ void dateformat_register_IntlDateFormatter_class( void )
 
 	memcpy(&IntlDateFormatter_handlers, &std_object_handlers,
 		sizeof IntlDateFormatter_handlers);
-	IntlDateFormatter_handlers.offset = XtOffsetOf(IntlDateFormatter_object, zo);
+	IntlDateFormatter_handlers.offset = offsetof(IntlDateFormatter_object, zo);
 	IntlDateFormatter_handlers.clone_obj = IntlDateFormatter_object_clone;
 	IntlDateFormatter_handlers.free_obj = IntlDateFormatter_object_free;
 }

--- a/ext/intl/dateformat/dateformat_class.h
+++ b/ext/intl/dateformat/dateformat_class.h
@@ -37,7 +37,7 @@ typedef struct {
 } IntlDateFormatter_object;
 
 static inline IntlDateFormatter_object *php_intl_dateformatter_fetch_object(zend_object *obj) {
-	return (IntlDateFormatter_object *)((char*)(obj) - XtOffsetOf(IntlDateFormatter_object, zo));
+	return (IntlDateFormatter_object *)((char*)(obj) - offsetof(IntlDateFormatter_object, zo));
 }
 #define Z_INTL_DATEFORMATTER_P(zv) php_intl_dateformatter_fetch_object(Z_OBJ_P(zv))
 

--- a/ext/intl/dateformat/datepatterngenerator_class.cpp
+++ b/ext/intl/dateformat/datepatterngenerator_class.cpp
@@ -106,7 +106,7 @@ void dateformat_register_IntlDatePatternGenerator_class( void )
 
 	memcpy(&IntlDatePatternGenerator_handlers, &std_object_handlers,
 		sizeof IntlDatePatternGenerator_handlers);
-	IntlDatePatternGenerator_handlers.offset = XtOffsetOf(IntlDatePatternGenerator_object, zo);
+	IntlDatePatternGenerator_handlers.offset = offsetof(IntlDatePatternGenerator_object, zo);
 	IntlDatePatternGenerator_handlers.clone_obj = IntlDatePatternGenerator_object_clone;
 	IntlDatePatternGenerator_handlers.free_obj = IntlDatePatternGenerator_object_free;
 }

--- a/ext/intl/dateformat/datepatterngenerator_class.h
+++ b/ext/intl/dateformat/datepatterngenerator_class.h
@@ -37,7 +37,7 @@ typedef struct {
 } IntlDatePatternGenerator_object;
 
 static inline IntlDatePatternGenerator_object *php_intl_datepatterngenerator_fetch_object(zend_object *obj) {
-	return (IntlDatePatternGenerator_object *)((char*)(obj) - XtOffsetOf(IntlDatePatternGenerator_object, zo));
+	return (IntlDatePatternGenerator_object *)((char*)(obj) - offsetof(IntlDatePatternGenerator_object, zo));
 }
 #define Z_INTL_DATEPATTERNGENERATOR_P(zv) php_intl_datepatterngenerator_fetch_object(Z_OBJ_P(zv))
 

--- a/ext/intl/formatter/formatter_class.cpp
+++ b/ext/intl/formatter/formatter_class.cpp
@@ -101,7 +101,7 @@ U_CFUNC void formatter_register_class( void )
 
 	memcpy(&NumberFormatter_handlers, &std_object_handlers,
 		sizeof(NumberFormatter_handlers));
-	NumberFormatter_handlers.offset = XtOffsetOf(NumberFormatter_object, zo);
+	NumberFormatter_handlers.offset = offsetof(NumberFormatter_object, zo);
 	NumberFormatter_handlers.clone_obj = NumberFormatter_object_clone;
 	NumberFormatter_handlers.free_obj = NumberFormatter_object_free;
 }

--- a/ext/intl/formatter/formatter_class.h
+++ b/ext/intl/formatter/formatter_class.h
@@ -34,7 +34,7 @@ typedef struct {
 } NumberFormatter_object;
 
 static inline NumberFormatter_object *php_intl_number_format_fetch_object(zend_object *obj) {
-	return (NumberFormatter_object *)((char*)(obj) - XtOffsetOf(NumberFormatter_object, zo));
+	return (NumberFormatter_object *)((char*)(obj) - offsetof(NumberFormatter_object, zo));
 }
 #define Z_INTL_NUMBERFORMATTER_P(zv) php_intl_number_format_fetch_object(Z_OBJ_P(zv))
 

--- a/ext/intl/listformatter/listformatter_class.cpp
+++ b/ext/intl/listformatter/listformatter_class.cpp
@@ -238,7 +238,7 @@ void listformatter_register_class(void)
     class_entry->create_object = listformatter_create_object;
     
     memcpy(&listformatter_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
-    listformatter_handlers.offset = XtOffsetOf(ListFormatter_object, zo);
+    listformatter_handlers.offset = offsetof(ListFormatter_object, zo);
     listformatter_handlers.free_obj = listformatter_free_obj;
     listformatter_handlers.clone_obj = nullptr;
 }

--- a/ext/intl/listformatter/listformatter_class.h
+++ b/ext/intl/listformatter/listformatter_class.h
@@ -37,7 +37,7 @@ typedef struct {
 } ListFormatter_object;
 
 static inline ListFormatter_object *php_intl_listformatter_fetch_object(zend_object *obj) {
-    return (ListFormatter_object *)((char*)(obj) - XtOffsetOf(ListFormatter_object, zo));
+    return (ListFormatter_object *)((char*)(obj) - offsetof(ListFormatter_object, zo));
 }
 #define Z_INTL_LISTFORMATTER_P(zv) php_intl_listformatter_fetch_object(Z_OBJ_P(zv))
 

--- a/ext/intl/msgformat/msgformat_class.cpp
+++ b/ext/intl/msgformat/msgformat_class.cpp
@@ -96,7 +96,7 @@ void msgformat_register_class( void )
 
 	memcpy(&MessageFormatter_handlers, &std_object_handlers,
 		sizeof MessageFormatter_handlers);
-	MessageFormatter_handlers.offset = XtOffsetOf(MessageFormatter_object, zo);
+	MessageFormatter_handlers.offset = offsetof(MessageFormatter_object, zo);
 	MessageFormatter_handlers.clone_obj = MessageFormatter_object_clone;
 	MessageFormatter_handlers.free_obj = MessageFormatter_object_free;
 }

--- a/ext/intl/msgformat/msgformat_class.h
+++ b/ext/intl/msgformat/msgformat_class.h
@@ -32,7 +32,7 @@ typedef struct {
 
 
 static inline MessageFormatter_object *php_intl_messageformatter_fetch_object(zend_object *obj) {
-	return (MessageFormatter_object *)((char*)(obj) - XtOffsetOf(MessageFormatter_object, zo));
+	return (MessageFormatter_object *)((char*)(obj) - offsetof(MessageFormatter_object, zo));
 }
 #define Z_INTL_MESSAGEFORMATTER_P(zv) php_intl_messageformatter_fetch_object(Z_OBJ_P(zv))
 

--- a/ext/intl/rangeformatter/rangeformatter_class.cpp
+++ b/ext/intl/rangeformatter/rangeformatter_class.cpp
@@ -219,7 +219,7 @@ void rangeformatter_register_class(void)
     class_entry_IntlNumberRangeFormatter->create_object = IntlNumberRangeFormatter_object_create;
 
     memcpy(&rangeformatter_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
-    rangeformatter_handlers.offset = XtOffsetOf(IntlNumberRangeFormatter_object, zo);
+    rangeformatter_handlers.offset = offsetof(IntlNumberRangeFormatter_object, zo);
     rangeformatter_handlers.free_obj = IntlNumberRangeFormatter_object_free;
     rangeformatter_handlers.clone_obj = NULL;
 }

--- a/ext/intl/rangeformatter/rangeformatter_class.h
+++ b/ext/intl/rangeformatter/rangeformatter_class.h
@@ -37,7 +37,7 @@ typedef struct {
 } IntlNumberRangeFormatter_object;
 
 static inline IntlNumberRangeFormatter_object *php_intl_numberrangeformatter_fetch_object(zend_object *obj) {
-    return (IntlNumberRangeFormatter_object *)((char*)(obj) - XtOffsetOf(IntlNumberRangeFormatter_object, zo));
+    return (IntlNumberRangeFormatter_object *)((char*)(obj) - offsetof(IntlNumberRangeFormatter_object, zo));
 }
 
 #define Z_INTL_RANGEFORMATTER_P(zv) php_intl_numberrangeformatter_fetch_object(Z_OBJ_P(zv))

--- a/ext/intl/resourcebundle/resourcebundle_class.cpp
+++ b/ext/intl/resourcebundle/resourcebundle_class.cpp
@@ -424,7 +424,7 @@ U_CFUNC void resourcebundle_register_class( void )
 	ResourceBundle_ce_ptr->get_iterator = resourcebundle_get_iterator;
 
 	ResourceBundle_object_handlers = std_object_handlers;
-	ResourceBundle_object_handlers.offset = XtOffsetOf(ResourceBundle_object, zend);
+	ResourceBundle_object_handlers.offset = offsetof(ResourceBundle_object, zend);
 	ResourceBundle_object_handlers.clone_obj	  = NULL; /* ICU ResourceBundle has no clone implementation */
 	ResourceBundle_object_handlers.free_obj = ResourceBundle_object_free;
 	ResourceBundle_object_handlers.read_dimension = resourcebundle_array_get;

--- a/ext/intl/resourcebundle/resourcebundle_class.h
+++ b/ext/intl/resourcebundle/resourcebundle_class.h
@@ -36,7 +36,7 @@ typedef struct {
 } ResourceBundle_object;
 
 static inline ResourceBundle_object *php_intl_resourcebundle_fetch_object(zend_object *obj) {
-	return (ResourceBundle_object *)((char*)(obj) - XtOffsetOf(ResourceBundle_object, zend));
+	return (ResourceBundle_object *)((char*)(obj) - offsetof(ResourceBundle_object, zend));
 }
 #define Z_INTL_RESOURCEBUNDLE_P(zv) php_intl_resourcebundle_fetch_object(Z_OBJ_P(zv))
 

--- a/ext/intl/spoofchecker/spoofchecker_class.cpp
+++ b/ext/intl/spoofchecker/spoofchecker_class.cpp
@@ -98,7 +98,7 @@ U_CFUNC void spoofchecker_register_Spoofchecker_class(void)
 
 	memcpy(&Spoofchecker_handlers, &std_object_handlers,
 		sizeof Spoofchecker_handlers);
-	Spoofchecker_handlers.offset = XtOffsetOf(Spoofchecker_object, zo);
+	Spoofchecker_handlers.offset = offsetof(Spoofchecker_object, zo);
 	Spoofchecker_handlers.clone_obj = spoofchecker_clone_obj;
 	Spoofchecker_handlers.free_obj = Spoofchecker_objects_free;
 }

--- a/ext/intl/spoofchecker/spoofchecker_class.h
+++ b/ext/intl/spoofchecker/spoofchecker_class.h
@@ -43,7 +43,7 @@ typedef struct {
 } Spoofchecker_object;
 
 static inline Spoofchecker_object *php_intl_spoofchecker_fetch_object(zend_object *obj) {
-	    return (Spoofchecker_object *)((char*)(obj) - XtOffsetOf(Spoofchecker_object, zo));
+	    return (Spoofchecker_object *)((char*)(obj) - offsetof(Spoofchecker_object, zo));
 }
 #define Z_INTL_SPOOFCHECKER_P(zv) php_intl_spoofchecker_fetch_object((Z_OBJ_P(zv)))
 

--- a/ext/intl/timezone/timezone_class.cpp
+++ b/ext/intl/timezone/timezone_class.cpp
@@ -357,7 +357,7 @@ U_CFUNC void timezone_register_IntlTimeZone_class(void)
 
 	memcpy(&TimeZone_handlers, &std_object_handlers,
 		sizeof TimeZone_handlers);
-	TimeZone_handlers.offset = XtOffsetOf(TimeZone_object, zo);
+	TimeZone_handlers.offset = offsetof(TimeZone_object, zo);
 	TimeZone_handlers.clone_obj = TimeZone_clone_obj;
 	TimeZone_handlers.compare = TimeZone_compare_objects;
 	TimeZone_handlers.get_debug_info = TimeZone_get_debug_info;

--- a/ext/intl/timezone/timezone_class.h
+++ b/ext/intl/timezone/timezone_class.h
@@ -47,7 +47,7 @@ typedef struct {
 } TimeZone_object;
 
 static inline TimeZone_object *php_intl_timezone_fetch_object(zend_object *obj) {
-	return (TimeZone_object *)((char*)(obj) - XtOffsetOf(TimeZone_object, zo));
+	return (TimeZone_object *)((char*)(obj) - offsetof(TimeZone_object, zo));
 }
 #define Z_INTL_TIMEZONE_P(zv) php_intl_timezone_fetch_object(Z_OBJ_P(zv))
 

--- a/ext/intl/transliterator/transliterator_class.cpp
+++ b/ext/intl/transliterator/transliterator_class.cpp
@@ -167,7 +167,7 @@ U_CFUNC void transliterator_register_Transliterator_class( void )
 	Transliterator_ce_ptr->create_object = Transliterator_object_create;
 	Transliterator_ce_ptr->default_object_handlers = &Transliterator_handlers;
 	memcpy( &Transliterator_handlers, &std_object_handlers, sizeof Transliterator_handlers );
-	Transliterator_handlers.offset = XtOffsetOf(Transliterator_object, zo);
+	Transliterator_handlers.offset = offsetof(Transliterator_object, zo);
 	Transliterator_handlers.free_obj = Transliterator_objects_free;
 	Transliterator_handlers.clone_obj = Transliterator_clone_obj;
 }

--- a/ext/intl/transliterator/transliterator_class.h
+++ b/ext/intl/transliterator/transliterator_class.h
@@ -39,7 +39,7 @@ typedef struct {
 } Transliterator_object;
 
 static inline Transliterator_object *php_intl_transliterator_fetch_object(zend_object *obj) {
-	return (Transliterator_object *)((char*)(obj) - XtOffsetOf(Transliterator_object, zo));
+	return (Transliterator_object *)((char*)(obj) - offsetof(Transliterator_object, zo));
 }
 #define Z_INTL_TRANSLITERATOR_P(zv) php_intl_transliterator_fetch_object(Z_OBJ_P(zv))
 

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -101,7 +101,7 @@ ZEND_GET_MODULE(ldap)
 #endif
 
 static inline ldap_linkdata *ldap_link_from_obj(zend_object *obj) {
-	return (ldap_linkdata *)((char *)(obj) - XtOffsetOf(ldap_linkdata, std));
+	return (ldap_linkdata *)((char *)(obj) - offsetof(ldap_linkdata, std));
 }
 
 #define Z_LDAP_LINK_P(zv) ldap_link_from_obj(Z_OBJ_P(zv))
@@ -148,7 +148,7 @@ static void ldap_link_free_obj(zend_object *obj)
 }
 
 static inline ldap_resultdata *ldap_result_from_obj(zend_object *obj) {
-	return (ldap_resultdata *)((char *)(obj) - XtOffsetOf(ldap_resultdata, std));
+	return (ldap_resultdata *)((char *)(obj) - offsetof(ldap_resultdata, std));
 }
 
 #define Z_LDAP_RESULT_P(zv) ldap_result_from_obj(Z_OBJ_P(zv))
@@ -185,7 +185,7 @@ static void ldap_result_free_obj(zend_object *obj)
 }
 
 static inline ldap_result_entry *ldap_result_entry_from_obj(zend_object *obj) {
-	return (ldap_result_entry *)((char *)(obj) - XtOffsetOf(ldap_result_entry, std));
+	return (ldap_result_entry *)((char *)(obj) - offsetof(ldap_result_entry, std));
 }
 
 #define Z_LDAP_RESULT_ENTRY_P(zv) ldap_result_entry_from_obj(Z_OBJ_P(zv))
@@ -271,7 +271,7 @@ static zend_string* php_ldap_try_get_ldap_value_from_zval(zval *zv) {
 
 /* The char pointer MUST refer to the char* of a zend_string struct */
 static void php_ldap_zend_string_release_from_char_pointer(char *ptr) {
-	zend_string_release((zend_string*) (ptr - XtOffsetOf(zend_string, val)));
+	zend_string_release((zend_string*) (ptr - offsetof(zend_string, val)));
 }
 
 /* {{{ Parse controls from and to arrays */
@@ -877,7 +877,7 @@ PHP_MINIT_FUNCTION(ldap)
 	ldap_link_ce->default_object_handlers = &ldap_link_object_handlers;
 
 	memcpy(&ldap_link_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	ldap_link_object_handlers.offset = XtOffsetOf(ldap_linkdata, std);
+	ldap_link_object_handlers.offset = offsetof(ldap_linkdata, std);
 	ldap_link_object_handlers.free_obj = ldap_link_free_obj;
 	ldap_link_object_handlers.get_constructor = ldap_link_get_constructor;
 	ldap_link_object_handlers.clone_obj = NULL;
@@ -888,7 +888,7 @@ PHP_MINIT_FUNCTION(ldap)
 	ldap_result_ce->default_object_handlers = &ldap_result_object_handlers;
 
 	memcpy(&ldap_result_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	ldap_result_object_handlers.offset = XtOffsetOf(ldap_resultdata, std);
+	ldap_result_object_handlers.offset = offsetof(ldap_resultdata, std);
 	ldap_result_object_handlers.free_obj = ldap_result_free_obj;
 	ldap_result_object_handlers.get_constructor = ldap_result_get_constructor;
 	ldap_result_object_handlers.clone_obj = NULL;
@@ -899,7 +899,7 @@ PHP_MINIT_FUNCTION(ldap)
 	ldap_result_entry_ce->default_object_handlers = &ldap_result_entry_object_handlers;
 
 	memcpy(&ldap_result_entry_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	ldap_result_entry_object_handlers.offset = XtOffsetOf(ldap_result_entry, std);
+	ldap_result_entry_object_handlers.offset = offsetof(ldap_result_entry, std);
 	ldap_result_entry_object_handlers.free_obj = ldap_result_entry_free_obj;
 	ldap_result_entry_object_handlers.get_constructor = ldap_result_entry_get_constructor;
 	ldap_result_entry_object_handlers.clone_obj = NULL;

--- a/ext/mysqli/mysqli.c
+++ b/ext/mysqli/mysqli.c
@@ -479,7 +479,7 @@ PHP_MINIT_FUNCTION(mysqli)
 	REGISTER_INI_ENTRIES();
 
 	memcpy(&mysqli_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	mysqli_object_handlers.offset = XtOffsetOf(mysqli_object, zo);
+	mysqli_object_handlers.offset = offsetof(mysqli_object, zo);
 	mysqli_object_handlers.free_obj = mysqli_objects_free_storage;
 	mysqli_object_handlers.clone_obj = NULL;
 	mysqli_object_handlers.read_property = mysqli_read_property;

--- a/ext/mysqli/php_mysqli_structs.h
+++ b/ext/mysqli/php_mysqli_structs.h
@@ -62,7 +62,7 @@ typedef struct _mysqli_object {
 } mysqli_object; /* extends zend_object */
 
 static inline mysqli_object *php_mysqli_fetch_object(zend_object *obj) {
-	return (mysqli_object *)((char*)(obj) - XtOffsetOf(mysqli_object, zo));
+	return (mysqli_object *)((char*)(obj) - offsetof(mysqli_object, zo));
 }
 
 #define Z_MYSQLI_P(zv) php_mysqli_fetch_object(Z_OBJ_P((zv)))

--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -87,7 +87,7 @@ static void odbc_insert_new_result(odbc_connection *connection, zval *result)
 
 static inline odbc_link *odbc_link_from_obj(zend_object *obj)
 {
-	return (odbc_link *)((char *)(obj) - XtOffsetOf(odbc_link, std));
+	return (odbc_link *)((char *)(obj) - offsetof(odbc_link, std));
 }
 
 static int _close_pconn_with_res(zval *zv, void *p)
@@ -204,7 +204,7 @@ static void odbc_connection_free_obj(zend_object *obj)
 
 static inline odbc_result *odbc_result_from_obj(zend_object *obj)
 {
-	return (odbc_result *)((char *)(obj) - XtOffsetOf(odbc_result, std));
+	return (odbc_result *)((char *)(obj) - offsetof(odbc_result, std));
 }
 
 static zend_object *odbc_result_create_object(zend_class_entry *class_type)
@@ -507,7 +507,7 @@ PHP_MINIT_FUNCTION(odbc)
 	odbc_connection_ce->default_object_handlers = &odbc_connection_object_handlers;
 
 	memcpy(&odbc_connection_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	odbc_connection_object_handlers.offset = XtOffsetOf(odbc_link, std);
+	odbc_connection_object_handlers.offset = offsetof(odbc_link, std);
 	odbc_connection_object_handlers.free_obj = odbc_connection_free_obj;
 	odbc_connection_object_handlers.get_constructor = odbc_connection_get_constructor;
 	odbc_connection_object_handlers.clone_obj = NULL;
@@ -519,7 +519,7 @@ PHP_MINIT_FUNCTION(odbc)
 	odbc_result_ce->default_object_handlers = &odbc_result_object_handlers;
 
 	memcpy(&odbc_result_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	odbc_result_object_handlers.offset = XtOffsetOf(odbc_result, std);
+	odbc_result_object_handlers.offset = offsetof(odbc_result, std);
 	odbc_result_object_handlers.free_obj = odbc_result_free_obj;
 	odbc_result_object_handlers.get_constructor = odbc_result_get_constructor;
 	odbc_result_object_handlers.clone_obj = NULL;

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -386,7 +386,7 @@ PHP_MINIT_FUNCTION(openssl)
 	php_openssl_certificate_ce->default_object_handlers = &php_openssl_certificate_object_handlers;
 
 	memcpy(&php_openssl_certificate_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	php_openssl_certificate_object_handlers.offset = XtOffsetOf(php_openssl_certificate_object, std);
+	php_openssl_certificate_object_handlers.offset = offsetof(php_openssl_certificate_object, std);
 	php_openssl_certificate_object_handlers.free_obj = php_openssl_certificate_free_obj;
 	php_openssl_certificate_object_handlers.get_constructor = php_openssl_certificate_get_constructor;
 	php_openssl_certificate_object_handlers.clone_obj = NULL;
@@ -397,7 +397,7 @@ PHP_MINIT_FUNCTION(openssl)
 	php_openssl_request_ce->default_object_handlers = &php_openssl_request_object_handlers;
 
 	memcpy(&php_openssl_request_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	php_openssl_request_object_handlers.offset = XtOffsetOf(php_openssl_request_object, std);
+	php_openssl_request_object_handlers.offset = offsetof(php_openssl_request_object, std);
 	php_openssl_request_object_handlers.free_obj = php_openssl_request_free_obj;
 	php_openssl_request_object_handlers.get_constructor = php_openssl_request_get_constructor;
 	php_openssl_request_object_handlers.clone_obj = NULL;
@@ -408,7 +408,7 @@ PHP_MINIT_FUNCTION(openssl)
 	php_openssl_pkey_ce->default_object_handlers = &php_openssl_pkey_object_handlers;
 
 	memcpy(&php_openssl_pkey_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	php_openssl_pkey_object_handlers.offset = XtOffsetOf(php_openssl_pkey_object, std);
+	php_openssl_pkey_object_handlers.offset = offsetof(php_openssl_pkey_object, std);
 	php_openssl_pkey_object_handlers.free_obj = php_openssl_pkey_free_obj;
 	php_openssl_pkey_object_handlers.get_constructor = php_openssl_pkey_get_constructor;
 	php_openssl_pkey_object_handlers.clone_obj = NULL;

--- a/ext/openssl/php_openssl.h
+++ b/ext/openssl/php_openssl.h
@@ -162,7 +162,7 @@ typedef struct _php_openssl_certificate_object {
 extern zend_class_entry *php_openssl_certificate_ce;
 
 static inline php_openssl_certificate_object *php_openssl_certificate_from_obj(zend_object *obj) {
-	return (php_openssl_certificate_object *)((char *)(obj) - XtOffsetOf(php_openssl_certificate_object, std));
+	return (php_openssl_certificate_object *)((char *)(obj) - offsetof(php_openssl_certificate_object, std));
 }
 
 #define Z_OPENSSL_CERTIFICATE_P(zv) php_openssl_certificate_from_obj(Z_OBJ_P(zv))
@@ -177,7 +177,7 @@ typedef struct _php_openssl_x509_request_object {
 } php_openssl_request_object;
 
 static inline php_openssl_request_object *php_openssl_request_from_obj(zend_object *obj) {
-	return (php_openssl_request_object *)((char *)(obj) - XtOffsetOf(php_openssl_request_object, std));
+	return (php_openssl_request_object *)((char *)(obj) - offsetof(php_openssl_request_object, std));
 }
 
 #define Z_OPENSSL_REQUEST_P(zv) php_openssl_request_from_obj(Z_OBJ_P(zv))
@@ -193,7 +193,7 @@ typedef struct _php_openssl_pkey_object {
 } php_openssl_pkey_object;
 
 static inline php_openssl_pkey_object *php_openssl_pkey_from_obj(zend_object *obj) {
-	return (php_openssl_pkey_object *)((char *)(obj) - XtOffsetOf(php_openssl_pkey_object, std));
+	return (php_openssl_pkey_object *)((char *)(obj) - offsetof(php_openssl_pkey_object, std));
 }
 
 #define Z_OPENSSL_PKEY_P(zv) php_openssl_pkey_from_obj(Z_OBJ_P(zv))

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -1529,7 +1529,7 @@ void pdo_dbh_init(int module_number)
 	pdo_dbh_ce->default_object_handlers = &pdo_dbh_object_handlers;
 
 	memcpy(&pdo_dbh_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	pdo_dbh_object_handlers.offset = XtOffsetOf(pdo_dbh_object_t, std);
+	pdo_dbh_object_handlers.offset = offsetof(pdo_dbh_object_t, std);
 	pdo_dbh_object_handlers.free_obj = pdo_dbh_free_storage;
 	pdo_dbh_object_handlers.clone_obj = NULL;
 	pdo_dbh_object_handlers.get_method = dbh_method_get;

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -2420,7 +2420,7 @@ void pdo_stmt_init(void)
 	pdo_dbstmt_ce->default_object_handlers = &pdo_dbstmt_object_handlers;
 
 	memcpy(&pdo_dbstmt_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	pdo_dbstmt_object_handlers.offset = XtOffsetOf(pdo_stmt_t, std);
+	pdo_dbstmt_object_handlers.offset = offsetof(pdo_stmt_t, std);
 	pdo_dbstmt_object_handlers.free_obj = pdo_dbstmt_free_storage;
 	pdo_dbstmt_object_handlers.write_property = dbstmt_prop_write;
 	pdo_dbstmt_object_handlers.unset_property = dbstmt_prop_delete;
@@ -2434,7 +2434,7 @@ void pdo_stmt_init(void)
 	pdo_row_ce->default_object_handlers = &pdo_row_object_handlers;
 
 	memcpy(&pdo_row_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	pdo_row_object_handlers.offset = XtOffsetOf(pdo_row_t, std);
+	pdo_row_object_handlers.offset = offsetof(pdo_row_t, std);
 	pdo_row_object_handlers.free_obj = pdo_row_free_storage;
 	pdo_row_object_handlers.clone_obj = NULL;
 	pdo_row_object_handlers.get_property_ptr_ptr = pdo_row_get_property_ptr_ptr;

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -518,11 +518,11 @@ struct _pdo_dbh_object_t {
 };
 
 static inline pdo_dbh_t *php_pdo_dbh_fetch_inner(zend_object *obj) {
-	return (pdo_dbh_t *)(((pdo_dbh_object_t *)((char*)(obj) - XtOffsetOf(pdo_dbh_object_t, std)))->inner);
+	return (pdo_dbh_t *)(((pdo_dbh_object_t *)((char*)(obj) - offsetof(pdo_dbh_object_t, std)))->inner);
 }
 
 static inline pdo_dbh_object_t *php_pdo_dbh_fetch_object(zend_object *obj) {
-	return (pdo_dbh_object_t *)((char*)(obj) - XtOffsetOf(pdo_dbh_object_t, std));
+	return (pdo_dbh_object_t *)((char*)(obj) - offsetof(pdo_dbh_object_t, std));
 }
 
 #define Z_PDO_DBH_P(zv) php_pdo_dbh_fetch_inner(Z_OBJ_P((zv)))
@@ -640,7 +640,7 @@ struct _pdo_stmt_t {
 
 
 static inline pdo_stmt_t *php_pdo_stmt_fetch_object(zend_object *obj) {
-	return (pdo_stmt_t *)((char*)(obj) - XtOffsetOf(pdo_stmt_t, std));
+	return (pdo_stmt_t *)((char*)(obj) - offsetof(pdo_stmt_t, std));
 }
 
 #define Z_PDO_STMT_P(zv) php_pdo_stmt_fetch_object(Z_OBJ_P((zv)))
@@ -651,7 +651,7 @@ struct _pdo_row_t {
 };
 
 static inline pdo_row_t *php_pdo_row_fetch_object(zend_object *obj) {
-	return (pdo_row_t *)((char*)(obj) - XtOffsetOf(pdo_row_t, std));
+	return (pdo_row_t *)((char*)(obj) - offsetof(pdo_row_t, std));
 }
 
 struct _pdo_scanner_t {

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -152,7 +152,7 @@ static zend_class_entry *pgsql_link_ce, *pgsql_result_ce, *pgsql_lob_ce;
 static zend_object_handlers pgsql_link_object_handlers, pgsql_result_object_handlers, pgsql_lob_object_handlers;
 
 static inline pgsql_link_handle *pgsql_link_from_obj(zend_object *obj) {
-	return (pgsql_link_handle *)((char *)(obj) - XtOffsetOf(pgsql_link_handle, std));
+	return (pgsql_link_handle *)((char *)(obj) - offsetof(pgsql_link_handle, std));
 }
 
 #define Z_PGSQL_LINK_P(zv) pgsql_link_from_obj(Z_OBJ_P(zv))
@@ -208,7 +208,7 @@ static void pgsql_link_free_obj(zend_object *obj)
 }
 
 static inline pgsql_result_handle *pgsql_result_from_obj(zend_object *obj) {
-	return (pgsql_result_handle *)((char *)(obj) - XtOffsetOf(pgsql_result_handle, std));
+	return (pgsql_result_handle *)((char *)(obj) - offsetof(pgsql_result_handle, std));
 }
 
 #define Z_PGSQL_RESULT_P(zv) pgsql_result_from_obj(Z_OBJ_P(zv))
@@ -245,7 +245,7 @@ static void pgsql_result_free_obj(zend_object *obj)
 }
 
 static inline pgLofp *pgsql_lob_from_obj(zend_object *obj) {
-	return (pgLofp *)((char *)(obj) - XtOffsetOf(pgLofp, std));
+	return (pgLofp *)((char *)(obj) - offsetof(pgLofp, std));
 }
 
 #define Z_PGSQL_LOB_P(zv) pgsql_lob_from_obj(Z_OBJ_P(zv))
@@ -574,7 +574,7 @@ PHP_MINIT_FUNCTION(pgsql)
 	pgsql_link_ce->default_object_handlers = &pgsql_link_object_handlers;
 
 	memcpy(&pgsql_link_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	pgsql_link_object_handlers.offset = XtOffsetOf(pgsql_link_handle, std);
+	pgsql_link_object_handlers.offset = offsetof(pgsql_link_handle, std);
 	pgsql_link_object_handlers.free_obj = pgsql_link_free_obj;
 	pgsql_link_object_handlers.get_constructor = pgsql_link_get_constructor;
 	pgsql_link_object_handlers.clone_obj = NULL;
@@ -585,7 +585,7 @@ PHP_MINIT_FUNCTION(pgsql)
 	pgsql_result_ce->default_object_handlers = &pgsql_result_object_handlers;
 
 	memcpy(&pgsql_result_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	pgsql_result_object_handlers.offset = XtOffsetOf(pgsql_result_handle, std);
+	pgsql_result_object_handlers.offset = offsetof(pgsql_result_handle, std);
 	pgsql_result_object_handlers.free_obj = pgsql_result_free_obj;
 	pgsql_result_object_handlers.get_constructor = pgsql_result_get_constructor;
 	pgsql_result_object_handlers.clone_obj = NULL;
@@ -596,7 +596,7 @@ PHP_MINIT_FUNCTION(pgsql)
 	pgsql_lob_ce->default_object_handlers = &pgsql_lob_object_handlers;
 
 	memcpy(&pgsql_lob_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	pgsql_lob_object_handlers.offset = XtOffsetOf(pgLofp, std);
+	pgsql_lob_object_handlers.offset = offsetof(pgLofp, std);
 	pgsql_lob_object_handlers.free_obj = pgsql_lob_free_obj;
 	pgsql_lob_object_handlers.get_constructor = pgsql_lob_get_constructor;
 	pgsql_lob_object_handlers.clone_obj = NULL;
@@ -1228,7 +1228,7 @@ PHP_FUNCTION(pg_query)
 
 /* The char pointer MUST refer to the char* of a zend_string struct */
 static void php_pgsql_zend_string_release_from_char_pointer(char *ptr) {
-	zend_string_release((zend_string*) (ptr - XtOffsetOf(zend_string, val)));
+	zend_string_release((zend_string*) (ptr - offsetof(zend_string, val)));
 }
 
 static void _php_pgsql_free_params(char **params, uint32_t num_params)

--- a/ext/random/php_random.h
+++ b/ext/random/php_random.h
@@ -126,11 +126,11 @@ extern PHPAPI zend_class_entry *random_ce_Random_Randomizer;
 extern PHPAPI zend_class_entry *random_ce_Random_IntervalBoundary;
 
 static inline php_random_engine *php_random_engine_from_obj(zend_object *object) {
-	return (php_random_engine *)((char *)(object) - XtOffsetOf(php_random_engine, std));
+	return (php_random_engine *)((char *)(object) - offsetof(php_random_engine, std));
 }
 
 static inline php_random_randomizer *php_random_randomizer_from_obj(zend_object *object) {
-	return (php_random_randomizer *)((char *)(object) - XtOffsetOf(php_random_randomizer, std));
+	return (php_random_randomizer *)((char *)(object) - offsetof(php_random_randomizer, std));
 }
 
 # define Z_RANDOM_ENGINE_P(zval) php_random_engine_from_obj(Z_OBJ_P(zval))

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -745,7 +745,7 @@ PHP_MINIT_FUNCTION(random)
 	random_ce_Random_Engine_Mt19937->create_object = php_random_engine_mt19937_new;
 	random_ce_Random_Engine_Mt19937->default_object_handlers = &random_engine_mt19937_object_handlers;
 	memcpy(&random_engine_mt19937_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
-	random_engine_mt19937_object_handlers.offset = XtOffsetOf(php_random_engine, std);
+	random_engine_mt19937_object_handlers.offset = offsetof(php_random_engine, std);
 	random_engine_mt19937_object_handlers.free_obj = php_random_engine_common_free_object;
 	random_engine_mt19937_object_handlers.clone_obj = php_random_engine_common_clone_object;
 
@@ -754,7 +754,7 @@ PHP_MINIT_FUNCTION(random)
 	random_ce_Random_Engine_PcgOneseq128XslRr64->create_object = php_random_engine_pcgoneseq128xslrr64_new;
 	random_ce_Random_Engine_PcgOneseq128XslRr64->default_object_handlers = &random_engine_pcgoneseq128xslrr64_object_handlers;
 	memcpy(&random_engine_pcgoneseq128xslrr64_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
-	random_engine_pcgoneseq128xslrr64_object_handlers.offset = XtOffsetOf(php_random_engine, std);
+	random_engine_pcgoneseq128xslrr64_object_handlers.offset = offsetof(php_random_engine, std);
 	random_engine_pcgoneseq128xslrr64_object_handlers.free_obj = php_random_engine_common_free_object;
 	random_engine_pcgoneseq128xslrr64_object_handlers.clone_obj = php_random_engine_common_clone_object;
 
@@ -763,7 +763,7 @@ PHP_MINIT_FUNCTION(random)
 	random_ce_Random_Engine_Xoshiro256StarStar->create_object = php_random_engine_xoshiro256starstar_new;
 	random_ce_Random_Engine_Xoshiro256StarStar->default_object_handlers = &random_engine_xoshiro256starstar_object_handlers;
 	memcpy(&random_engine_xoshiro256starstar_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
-	random_engine_xoshiro256starstar_object_handlers.offset = XtOffsetOf(php_random_engine, std);
+	random_engine_xoshiro256starstar_object_handlers.offset = offsetof(php_random_engine, std);
 	random_engine_xoshiro256starstar_object_handlers.free_obj = php_random_engine_common_free_object;
 	random_engine_xoshiro256starstar_object_handlers.clone_obj = php_random_engine_common_clone_object;
 
@@ -772,7 +772,7 @@ PHP_MINIT_FUNCTION(random)
 	random_ce_Random_Engine_Secure->create_object = php_random_engine_secure_new;
 	random_ce_Random_Engine_Secure->default_object_handlers = &random_engine_secure_object_handlers;
 	memcpy(&random_engine_secure_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
-	random_engine_secure_object_handlers.offset = XtOffsetOf(php_random_engine, std);
+	random_engine_secure_object_handlers.offset = offsetof(php_random_engine, std);
 	random_engine_secure_object_handlers.free_obj = php_random_engine_common_free_object;
 	random_engine_secure_object_handlers.clone_obj = NULL;
 
@@ -781,7 +781,7 @@ PHP_MINIT_FUNCTION(random)
 	random_ce_Random_Randomizer->create_object = php_random_randomizer_new;
 	random_ce_Random_Randomizer->default_object_handlers = &random_randomizer_object_handlers;
 	memcpy(&random_randomizer_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
-	random_randomizer_object_handlers.offset = XtOffsetOf(php_random_randomizer, std);
+	random_randomizer_object_handlers.offset = offsetof(php_random_randomizer, std);
 	random_randomizer_object_handlers.free_obj = randomizer_free_obj;
 	random_randomizer_object_handlers.clone_obj = NULL;
 

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -175,7 +175,7 @@ typedef struct {
 } reflection_object;
 
 static inline reflection_object *reflection_object_from_obj(zend_object *obj) {
-	return (reflection_object*)((char*)(obj) - XtOffsetOf(reflection_object, zo));
+	return (reflection_object*)((char*)(obj) - offsetof(reflection_object, zo));
 }
 
 #define Z_REFLECTION_P(zv)  reflection_object_from_obj(Z_OBJ_P((zv)))
@@ -8159,7 +8159,7 @@ ZEND_METHOD(ReflectionConstant, __toString)
 PHP_MINIT_FUNCTION(reflection) /* {{{ */
 {
 	memcpy(&reflection_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	reflection_object_handlers.offset = XtOffsetOf(reflection_object, zo);
+	reflection_object_handlers.offset = offsetof(reflection_object, zo);
 	reflection_object_handlers.free_obj = reflection_free_objects_storage;
 	reflection_object_handlers.clone_obj = NULL;
 	reflection_object_handlers.write_property = _reflection_write_property;

--- a/ext/shmop/shmop.c
+++ b/ext/shmop/shmop.c
@@ -70,7 +70,7 @@ static zend_object_handlers shmop_object_handlers;
 
 static inline php_shmop *shmop_from_obj(zend_object *obj)
 {
-	return (php_shmop *)((char *)(obj) - XtOffsetOf(php_shmop, std));
+	return (php_shmop *)((char *)(obj) - offsetof(php_shmop, std));
 }
 
 #define Z_SHMOP_P(zv) shmop_from_obj(Z_OBJ_P(zv))
@@ -108,7 +108,7 @@ PHP_MINIT_FUNCTION(shmop)
 	shmop_ce->default_object_handlers = &shmop_object_handlers;
 
 	memcpy(&shmop_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	shmop_object_handlers.offset = XtOffsetOf(php_shmop, std);
+	shmop_object_handlers.offset = offsetof(php_shmop, std);
 	shmop_object_handlers.free_obj = shmop_free_obj;
 	shmop_object_handlers.get_constructor = shmop_get_constructor;
 	shmop_object_handlers.clone_obj = NULL;

--- a/ext/simplexml/php_simplexml_exports.h
+++ b/ext/simplexml/php_simplexml_exports.h
@@ -36,7 +36,7 @@
 PHP_SXE_API zend_object *sxe_object_new(zend_class_entry *ce);
 
 static inline php_sxe_object *php_sxe_fetch_object(zend_object *obj) /* {{{ */ {
-	return (php_sxe_object *)((char*)(obj) - XtOffsetOf(php_sxe_object, zo));
+	return (php_sxe_object *)((char*)(obj) - offsetof(php_sxe_object, zo));
 }
 /* }}} */
 

--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -2631,7 +2631,7 @@ PHP_MINIT_FUNCTION(simplexml)
 	ce_SimpleXMLElement->get_iterator = php_sxe_get_iterator;
 
 	memcpy(&sxe_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	sxe_object_handlers.offset = XtOffsetOf(php_sxe_object, zo);
+	sxe_object_handlers.offset = offsetof(php_sxe_object, zo);
 	sxe_object_handlers.free_obj = sxe_object_free_storage;
 	sxe_object_handlers.clone_obj = sxe_object_clone;
 	sxe_object_handlers.read_property = sxe_property_read;

--- a/ext/snmp/php_snmp.h
+++ b/ext/snmp/php_snmp.h
@@ -57,7 +57,7 @@ typedef struct _php_snmp_object {
 } php_snmp_object;
 
 static inline php_snmp_object *php_snmp_fetch_object(zend_object *obj) {
-	return (php_snmp_object *)((char*)(obj) - XtOffsetOf(php_snmp_object, zo));
+	return (php_snmp_object *)((char*)(obj) - offsetof(php_snmp_object, zo));
 }
 
 #define Z_SNMP_P(zv) php_snmp_fetch_object(Z_OBJ_P((zv)))

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -624,7 +624,7 @@ retry:
 
 static void php_snmp_zend_string_release_from_char_pointer(char *ptr) {
 	if (ptr) {
-		zend_string *pptr = (zend_string *)(ptr - XtOffsetOf(zend_string, val));
+		zend_string *pptr = (zend_string *)(ptr - offsetof(zend_string, val));
 		zend_string_release(pptr);
 	}
 }
@@ -2144,7 +2144,7 @@ PHP_MINIT_FUNCTION(snmp)
 	php_snmp_ce = register_class_SNMP();
 	php_snmp_ce->create_object = php_snmp_object_new;
 	php_snmp_ce->default_object_handlers = &php_snmp_object_handlers;
-	php_snmp_object_handlers.offset = XtOffsetOf(php_snmp_object, zo);
+	php_snmp_object_handlers.offset = offsetof(php_snmp_object, zo);
 	php_snmp_object_handlers.clone_obj = NULL;
 	php_snmp_object_handlers.free_obj = php_snmp_object_free_storage;
 

--- a/ext/soap/php_soap.h
+++ b/ext/soap/php_soap.h
@@ -260,7 +260,7 @@ typedef struct soap_url_object {
 
 static inline soap_url_object *soap_url_object_fetch(zend_object *obj)
 {
-	return (soap_url_object *) ((char *) obj - XtOffsetOf(soap_url_object, std));
+	return (soap_url_object *) ((char *) obj - offsetof(soap_url_object, std));
 }
 
 #define Z_SOAP_URL_P(zv) soap_url_object_fetch(Z_OBJ_P(zv))

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -206,11 +206,11 @@ typedef struct {
 } soap_client_object;
 
 static inline soap_client_object *soap_client_object_fetch(zend_object *obj) {
-	return (soap_client_object *) ((char *) obj - XtOffsetOf(soap_client_object, std));
+	return (soap_client_object *) ((char *) obj - offsetof(soap_client_object, std));
 }
 
 static inline soap_server_object *soap_server_object_fetch(zend_object *obj) {
-	return (soap_server_object *) ((char *) obj - XtOffsetOf(soap_server_object, std));
+	return (soap_server_object *) ((char *) obj - offsetof(soap_server_object, std));
 }
 
 static zend_object *soap_client_object_create(zend_class_entry *ce)
@@ -288,7 +288,7 @@ static zend_result soap_url_cast_object(zend_object *obj, zval *result, int type
 
 static inline soap_sdl_object *soap_sdl_object_fetch(zend_object *obj)
 {
-	return (soap_sdl_object *) ((char *) obj - XtOffsetOf(soap_sdl_object, std));
+	return (soap_sdl_object *) ((char *) obj - offsetof(soap_sdl_object, std));
 }
 
 #define Z_SOAP_SDL_P(zv) soap_sdl_object_fetch(Z_OBJ_P(zv))
@@ -532,7 +532,7 @@ PHP_MINIT_FUNCTION(soap)
 	soap_class_entry->default_object_handlers = &soap_client_object_handlers;
 
 	memcpy(&soap_client_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	soap_client_object_handlers.offset = XtOffsetOf(soap_client_object, std);
+	soap_client_object_handlers.offset = offsetof(soap_client_object, std);
 	soap_client_object_handlers.free_obj = soap_client_object_free;
 	soap_client_object_handlers.clone_obj = NULL;
 
@@ -545,7 +545,7 @@ PHP_MINIT_FUNCTION(soap)
 	soap_server_class_entry->default_object_handlers = &soap_server_object_handlers;
 
 	memcpy(&soap_server_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	soap_server_object_handlers.offset = XtOffsetOf(soap_server_object, std);
+	soap_server_object_handlers.offset = offsetof(soap_server_object, std);
 	soap_server_object_handlers.free_obj = soap_server_object_free;
 	soap_server_object_handlers.clone_obj = NULL;
 
@@ -562,7 +562,7 @@ PHP_MINIT_FUNCTION(soap)
 	soap_url_class_entry->default_object_handlers = &soap_url_object_handlers;
 
 	memcpy(&soap_url_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	soap_url_object_handlers.offset = XtOffsetOf(soap_url_object, std);
+	soap_url_object_handlers.offset = offsetof(soap_url_object, std);
 	soap_url_object_handlers.free_obj = soap_url_object_free;
 	soap_url_object_handlers.get_constructor = soap_url_object_get_constructor;
 	soap_url_object_handlers.clone_obj = NULL;
@@ -574,7 +574,7 @@ PHP_MINIT_FUNCTION(soap)
 	soap_sdl_class_entry->default_object_handlers = &soap_sdl_object_handlers;
 
 	memcpy(&soap_sdl_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	soap_sdl_object_handlers.offset = XtOffsetOf(soap_sdl_object, std);
+	soap_sdl_object_handlers.offset = offsetof(soap_sdl_object, std);
 	soap_sdl_object_handlers.free_obj = soap_sdl_object_free;
 	soap_sdl_object_handlers.get_constructor = soap_sdl_object_get_constructor;
 	soap_sdl_object_handlers.clone_obj = NULL;

--- a/ext/sockets/php_sockets.h
+++ b/ext/sockets/php_sockets.h
@@ -76,7 +76,7 @@ typedef struct {
 extern PHP_SOCKETS_API zend_class_entry *socket_ce;
 
 static inline php_socket *socket_from_obj(zend_object *obj) {
-	return (php_socket *)((char *)(obj) - XtOffsetOf(php_socket, std));
+	return (php_socket *)((char *)(obj) - offsetof(php_socket, std));
 }
 
 #define Z_SOCKET_P(zv) socket_from_obj(Z_OBJ_P(zv))

--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -181,7 +181,7 @@ zend_class_entry *address_info_ce;
 static zend_object_handlers address_info_object_handlers;
 
 static inline php_addrinfo *address_info_from_obj(zend_object *obj) {
-	return (php_addrinfo *)((char *)(obj) - XtOffsetOf(php_addrinfo, std));
+	return (php_addrinfo *)((char *)(obj) - offsetof(php_addrinfo, std));
 }
 
 #define Z_ADDRESS_INFO_P(zv) address_info_from_obj(Z_OBJ_P(zv))
@@ -484,7 +484,7 @@ static PHP_MINIT_FUNCTION(sockets)
 	socket_ce->default_object_handlers = &socket_object_handlers;
 
 	memcpy(&socket_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	socket_object_handlers.offset = XtOffsetOf(php_socket, std);
+	socket_object_handlers.offset = offsetof(php_socket, std);
 	socket_object_handlers.free_obj = socket_free_obj;
 	socket_object_handlers.get_constructor = socket_get_constructor;
 	socket_object_handlers.clone_obj = NULL;
@@ -496,7 +496,7 @@ static PHP_MINIT_FUNCTION(sockets)
 	address_info_ce->default_object_handlers = &address_info_object_handlers;
 
 	memcpy(&address_info_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	address_info_object_handlers.offset = XtOffsetOf(php_addrinfo, std);
+	address_info_object_handlers.offset = offsetof(php_addrinfo, std);
 	address_info_object_handlers.free_obj = address_info_free_obj;
 	address_info_object_handlers.get_constructor = address_info_get_constructor;
 	address_info_object_handlers.clone_obj = NULL;
@@ -1272,7 +1272,7 @@ PHP_FUNCTION(socket_connect)
 			s_un.sun_family = AF_UNIX;
 			memcpy(&s_un.sun_path, ZSTR_VAL(addr), ZSTR_LEN(addr));
 			retval = connect(php_sock->bsd_socket, (struct sockaddr *) &s_un,
-				(socklen_t)(XtOffsetOf(struct sockaddr_un, sun_path) + ZSTR_LEN(addr)));
+				(socklen_t)(offsetof(struct sockaddr_un, sun_path) + ZSTR_LEN(addr)));
 			break;
 		}
 

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -52,7 +52,7 @@ typedef struct _spl_array_object {
 } spl_array_object;
 
 static inline spl_array_object *spl_array_from_obj(zend_object *obj) /* {{{ */ {
-	return (spl_array_object*)((char*)(obj) - XtOffsetOf(spl_array_object, std));
+	return (spl_array_object*)((char*)(obj) - offsetof(spl_array_object, std));
 }
 /* }}} */
 
@@ -1847,7 +1847,7 @@ PHP_MINIT_FUNCTION(spl_array)
 
 	memcpy(&spl_handler_ArrayObject, &std_object_handlers, sizeof(zend_object_handlers));
 
-	spl_handler_ArrayObject.offset = XtOffsetOf(spl_array_object, std);
+	spl_handler_ArrayObject.offset = offsetof(spl_array_object, std);
 
 	spl_handler_ArrayObject.clone_obj = spl_array_object_clone;
 	spl_handler_ArrayObject.read_dimension = spl_array_read_dimension;

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -50,7 +50,7 @@ PHPAPI zend_class_entry *spl_ce_SplTempFileObject;
 
 /* Object helper */
 static inline spl_filesystem_object *spl_filesystem_from_obj(zend_object *obj) /* {{{ */ {
-	return (spl_filesystem_object*)((char*)(obj) - XtOffsetOf(spl_filesystem_object, std));
+	return (spl_filesystem_object*)((char*)(obj) - offsetof(spl_filesystem_object, std));
 }
 /* }}} */
 
@@ -188,8 +188,8 @@ static zend_object *spl_filesystem_object_new(zend_class_entry *class_type)
 	intern = emalloc(sizeof(spl_filesystem_object) + zend_object_properties_size(class_type));
 	/* Avoid initializing the entirety of spl_filesystem_object.u.dir.entry. */
 	memset(intern, 0,
-		MAX(XtOffsetOf(spl_filesystem_object, u.dir.entry),
-			XtOffsetOf(spl_filesystem_object, u.file.escape) + sizeof(int)));
+		MAX(offsetof(spl_filesystem_object, u.dir.entry),
+			offsetof(spl_filesystem_object, u.file.escape) + sizeof(int)));
 	/* intern->type = SPL_FS_INFO; done by set 0 */
 	intern->file_class = spl_ce_SplFileObject;
 	intern->info_class = spl_ce_SplFileInfo;
@@ -2682,7 +2682,7 @@ PHP_MINIT_FUNCTION(spl_directory)
 	spl_ce_SplFileInfo->default_object_handlers = &spl_filesystem_object_handlers;
 
 	memcpy(&spl_filesystem_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	spl_filesystem_object_handlers.offset = XtOffsetOf(spl_filesystem_object, std);
+	spl_filesystem_object_handlers.offset = offsetof(spl_filesystem_object, std);
 	spl_filesystem_object_handlers.clone_obj = spl_filesystem_object_clone;
 	spl_filesystem_object_handlers.dtor_obj = spl_filesystem_object_destroy_object;
 	spl_filesystem_object_handlers.free_obj = spl_filesystem_object_free_storage;

--- a/ext/spl/spl_dllist.c
+++ b/ext/spl/spl_dllist.c
@@ -86,7 +86,7 @@ struct _spl_dllist_it {
 };
 
 static inline spl_dllist_object *spl_dllist_from_obj(zend_object *obj) /* {{{ */ {
-	return (spl_dllist_object*)((char*)(obj) - XtOffsetOf(spl_dllist_object, std));
+	return (spl_dllist_object*)((char*)(obj) - offsetof(spl_dllist_object, std));
 }
 /* }}} */
 
@@ -1207,7 +1207,7 @@ PHP_MINIT_FUNCTION(spl_dllist) /* {{{ */
 
 	memcpy(&spl_handler_SplDoublyLinkedList, &std_object_handlers, sizeof(zend_object_handlers));
 
-	spl_handler_SplDoublyLinkedList.offset = XtOffsetOf(spl_dllist_object, std);
+	spl_handler_SplDoublyLinkedList.offset = offsetof(spl_dllist_object, std);
 	spl_handler_SplDoublyLinkedList.clone_obj = spl_dllist_object_clone;
 	spl_handler_SplDoublyLinkedList.count_elements = spl_dllist_object_count_elements;
 	spl_handler_SplDoublyLinkedList.get_gc = spl_dllist_object_get_gc;

--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -55,7 +55,7 @@ typedef struct _spl_fixedarray_it {
 
 static spl_fixedarray_object *spl_fixed_array_from_obj(zend_object *obj)
 {
-	return (spl_fixedarray_object*)((char*)(obj) - XtOffsetOf(spl_fixedarray_object, std));
+	return (spl_fixedarray_object*)((char*)(obj) - offsetof(spl_fixedarray_object, std));
 }
 
 #define Z_SPLFIXEDARRAY_P(zv)  spl_fixed_array_from_obj(Z_OBJ_P((zv)))
@@ -952,7 +952,7 @@ PHP_MINIT_FUNCTION(spl_fixedarray)
 
 	memcpy(&spl_handler_SplFixedArray, &std_object_handlers, sizeof(zend_object_handlers));
 
-	spl_handler_SplFixedArray.offset          = XtOffsetOf(spl_fixedarray_object, std);
+	spl_handler_SplFixedArray.offset          = offsetof(spl_fixedarray_object, std);
 	spl_handler_SplFixedArray.clone_obj       = spl_fixedarray_object_clone;
 	spl_handler_SplFixedArray.read_dimension  = spl_fixedarray_object_read_dimension;
 	spl_handler_SplFixedArray.write_dimension = spl_fixedarray_object_write_dimension;

--- a/ext/spl/spl_heap.c
+++ b/ext/spl/spl_heap.c
@@ -71,7 +71,7 @@ typedef struct _spl_pqueue_elem {
 } spl_pqueue_elem;
 
 static inline spl_heap_object *spl_heap_from_obj(zend_object *obj) /* {{{ */ {
-	return (spl_heap_object*)((char*)(obj) - XtOffsetOf(spl_heap_object, std));
+	return (spl_heap_object*)((char*)(obj) - offsetof(spl_heap_object, std));
 }
 /* }}} */
 
@@ -1332,7 +1332,7 @@ PHP_MINIT_FUNCTION(spl_heap) /* {{{ */
 
 	memcpy(&spl_handler_SplHeap, &std_object_handlers, sizeof(zend_object_handlers));
 
-	spl_handler_SplHeap.offset         = XtOffsetOf(spl_heap_object, std);
+	spl_handler_SplHeap.offset         = offsetof(spl_heap_object, std);
 	spl_handler_SplHeap.clone_obj      = spl_heap_object_clone;
 	spl_handler_SplHeap.count_elements = spl_heap_object_count_elements;
 	spl_handler_SplHeap.get_gc         = spl_heap_object_get_gc;
@@ -1353,7 +1353,7 @@ PHP_MINIT_FUNCTION(spl_heap) /* {{{ */
 
 	memcpy(&spl_handler_SplPriorityQueue, &std_object_handlers, sizeof(zend_object_handlers));
 
-	spl_handler_SplPriorityQueue.offset         = XtOffsetOf(spl_heap_object, std);
+	spl_handler_SplPriorityQueue.offset         = offsetof(spl_heap_object, std);
 	spl_handler_SplPriorityQueue.clone_obj      = spl_heap_object_clone;
 	spl_handler_SplPriorityQueue.count_elements = spl_heap_object_count_elements;
 	spl_handler_SplPriorityQueue.get_gc         = spl_pqueue_object_get_gc;

--- a/ext/spl/spl_iterators.c
+++ b/ext/spl/spl_iterators.c
@@ -137,14 +137,14 @@ static zend_object_handlers spl_handlers_rec_it_it;
 static zend_object_handlers spl_handlers_dual_it;
 
 static inline spl_recursive_it_object *spl_recursive_it_from_obj(zend_object *obj) /* {{{ */ {
-	return (spl_recursive_it_object*)((char*)(obj) - XtOffsetOf(spl_recursive_it_object, std));
+	return (spl_recursive_it_object*)((char*)(obj) - offsetof(spl_recursive_it_object, std));
 }
 /* }}} */
 
 #define Z_SPLRECURSIVE_IT_P(zv)  spl_recursive_it_from_obj(Z_OBJ_P((zv)))
 
 static inline spl_dual_it_object *spl_dual_it_from_obj(zend_object *obj) /* {{{ */ {
-	return (spl_dual_it_object*)((char*)(obj) - XtOffsetOf(spl_dual_it_object, std));
+	return (spl_dual_it_object*)((char*)(obj) - offsetof(spl_dual_it_object, std));
 } /* }}} */
 
 #define Z_SPLDUAL_IT_P(zv)  spl_dual_it_from_obj(Z_OBJ_P((zv)))
@@ -3134,14 +3134,14 @@ PHP_MINIT_FUNCTION(spl_iterators)
 	spl_ce_RecursiveIteratorIterator->get_iterator = spl_recursive_it_get_iterator;
 
 	memcpy(&spl_handlers_rec_it_it, &std_object_handlers, sizeof(zend_object_handlers));
-	spl_handlers_rec_it_it.offset = XtOffsetOf(spl_recursive_it_object, std);
+	spl_handlers_rec_it_it.offset = offsetof(spl_recursive_it_object, std);
 	spl_handlers_rec_it_it.get_method = spl_recursive_it_get_method;
 	spl_handlers_rec_it_it.clone_obj = NULL;
 	spl_handlers_rec_it_it.free_obj = spl_RecursiveIteratorIterator_free_storage;
 	spl_handlers_rec_it_it.get_gc = spl_RecursiveIteratorIterator_get_gc;
 
 	memcpy(&spl_handlers_dual_it, &std_object_handlers, sizeof(zend_object_handlers));
-	spl_handlers_dual_it.offset = XtOffsetOf(spl_dual_it_object, std);
+	spl_handlers_dual_it.offset = offsetof(spl_dual_it_object, std);
 	spl_handlers_dual_it.get_method = spl_dual_it_get_method;
 	spl_handlers_dual_it.clone_obj = NULL;
 	spl_handlers_dual_it.free_obj = spl_dual_it_free_storage;

--- a/ext/spl/spl_observer.c
+++ b/ext/spl/spl_observer.c
@@ -63,7 +63,7 @@ typedef struct _spl_SplObjectStorageElement {
 } spl_SplObjectStorageElement; /* }}} */
 
 static inline spl_SplObjectStorage *spl_object_storage_from_obj(zend_object *obj) /* {{{ */ {
-	return (spl_SplObjectStorage*)((char*)(obj) - XtOffsetOf(spl_SplObjectStorage, std));
+	return (spl_SplObjectStorage*)((char*)(obj) - offsetof(spl_SplObjectStorage, std));
 }
 /* }}} */
 
@@ -1378,7 +1378,7 @@ PHP_MINIT_FUNCTION(spl_observer)
 
 	memcpy(&spl_handler_SplObjectStorage, &std_object_handlers, sizeof(zend_object_handlers));
 
-	spl_handler_SplObjectStorage.offset          = XtOffsetOf(spl_SplObjectStorage, std);
+	spl_handler_SplObjectStorage.offset          = offsetof(spl_SplObjectStorage, std);
 	spl_handler_SplObjectStorage.compare         = spl_object_storage_compare_objects;
 	spl_handler_SplObjectStorage.clone_obj       = spl_object_storage_clone;
 	spl_handler_SplObjectStorage.get_gc          = spl_object_storage_get_gc;

--- a/ext/sqlite3/php_sqlite3_structs.h
+++ b/ext/sqlite3/php_sqlite3_structs.h
@@ -73,7 +73,7 @@ typedef struct _php_sqlite3_db_object  {
 } php_sqlite3_db_object;
 
 static inline php_sqlite3_db_object *php_sqlite3_db_from_obj(zend_object *obj) {
-	return (php_sqlite3_db_object*)((char*)(obj) - XtOffsetOf(php_sqlite3_db_object, zo));
+	return (php_sqlite3_db_object*)((char*)(obj) - offsetof(php_sqlite3_db_object, zo));
 }
 
 #define Z_SQLITE3_DB_P(zv)  php_sqlite3_db_from_obj(Z_OBJ_P((zv)))
@@ -102,7 +102,7 @@ struct _php_sqlite3_result_object  {
 };
 
 static inline php_sqlite3_result *php_sqlite3_result_from_obj(zend_object *obj) {
-	return (php_sqlite3_result*)((char*)(obj) - XtOffsetOf(php_sqlite3_result, zo));
+	return (php_sqlite3_result*)((char*)(obj) - offsetof(php_sqlite3_result, zo));
 }
 
 #define Z_SQLITE3_RESULT_P(zv)  php_sqlite3_result_from_obj(Z_OBJ_P((zv)))
@@ -120,7 +120,7 @@ struct _php_sqlite3_stmt_object  {
 };
 
 static inline php_sqlite3_stmt *php_sqlite3_stmt_from_obj(zend_object *obj) {
-	return (php_sqlite3_stmt*)((char*)(obj) - XtOffsetOf(php_sqlite3_stmt, zo));
+	return (php_sqlite3_stmt*)((char*)(obj) - offsetof(php_sqlite3_stmt, zo));
 }
 
 #define Z_SQLITE3_STMT_P(zv)  php_sqlite3_stmt_from_obj(Z_OBJ_P((zv)))

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -2480,7 +2480,7 @@ PHP_MINIT_FUNCTION(sqlite3)
 	memcpy(&sqlite3_result_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 
 	/* Register SQLite 3 Class */
-	sqlite3_object_handlers.offset = XtOffsetOf(php_sqlite3_db_object, zo);
+	sqlite3_object_handlers.offset = offsetof(php_sqlite3_db_object, zo);
 	sqlite3_object_handlers.clone_obj = NULL;
 	sqlite3_object_handlers.free_obj = php_sqlite3_object_free_storage;
 	sqlite3_object_handlers.get_gc = php_sqlite3_get_gc;
@@ -2489,7 +2489,7 @@ PHP_MINIT_FUNCTION(sqlite3)
 	php_sqlite3_sc_entry->default_object_handlers = &sqlite3_object_handlers;
 
 	/* Register SQLite 3 Prepared Statement Class */
-	sqlite3_stmt_object_handlers.offset = XtOffsetOf(php_sqlite3_stmt, zo);
+	sqlite3_stmt_object_handlers.offset = offsetof(php_sqlite3_stmt, zo);
 	sqlite3_stmt_object_handlers.clone_obj = NULL;
 	sqlite3_stmt_object_handlers.free_obj = php_sqlite3_stmt_object_free_storage;
 	php_sqlite3_stmt_entry = register_class_SQLite3Stmt();
@@ -2497,7 +2497,7 @@ PHP_MINIT_FUNCTION(sqlite3)
 	php_sqlite3_stmt_entry->default_object_handlers = &sqlite3_stmt_object_handlers;
 
 	/* Register SQLite 3 Result Class */
-	sqlite3_result_object_handlers.offset = XtOffsetOf(php_sqlite3_result, zo);
+	sqlite3_result_object_handlers.offset = offsetof(php_sqlite3_result, zo);
 	sqlite3_result_object_handlers.clone_obj = NULL;
 	sqlite3_result_object_handlers.free_obj = php_sqlite3_result_object_free_storage;
 	php_sqlite3_result_entry = register_class_SQLite3Result();

--- a/ext/standard/url_scanner_ex.re
+++ b/ext/standard/url_scanner_ex.re
@@ -661,7 +661,7 @@ static void php_url_scanner_ex_activate(bool is_session)
 		ctx = &BG(url_adapt_output_ex);
 	}
 
-	memset(ctx, 0, XtOffsetOf(url_adapt_state_ex_t, tags));
+	memset(ctx, 0, offsetof(url_adapt_state_ex_t, tags));
 }
 
 static void php_url_scanner_ex_deactivate(bool is_session)

--- a/ext/sysvmsg/sysvmsg.c
+++ b/ext/sysvmsg/sysvmsg.c
@@ -66,7 +66,7 @@ zend_class_entry *sysvmsg_queue_ce;
 static zend_object_handlers sysvmsg_queue_object_handlers;
 
 static inline sysvmsg_queue_t *sysvmsg_queue_from_obj(zend_object *obj) {
-	return (sysvmsg_queue_t *)((char *)(obj) - XtOffsetOf(sysvmsg_queue_t, std));
+	return (sysvmsg_queue_t *)((char *)(obj) - offsetof(sysvmsg_queue_t, std));
 }
 
 #define Z_SYSVMSG_QUEUE_P(zv) sysvmsg_queue_from_obj(Z_OBJ_P(zv))
@@ -101,7 +101,7 @@ PHP_MINIT_FUNCTION(sysvmsg)
 	sysvmsg_queue_ce->default_object_handlers = &sysvmsg_queue_object_handlers;
 
 	memcpy(&sysvmsg_queue_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	sysvmsg_queue_object_handlers.offset = XtOffsetOf(sysvmsg_queue_t, std);
+	sysvmsg_queue_object_handlers.offset = offsetof(sysvmsg_queue_t, std);
 	sysvmsg_queue_object_handlers.free_obj = sysvmsg_queue_free_obj;
 	sysvmsg_queue_object_handlers.get_constructor = sysvmsg_queue_get_constructor;
 	sysvmsg_queue_object_handlers.clone_obj = NULL;

--- a/ext/sysvsem/sysvsem.c
+++ b/ext/sysvsem/sysvsem.c
@@ -83,7 +83,7 @@ zend_class_entry *sysvsem_ce;
 static zend_object_handlers sysvsem_object_handlers;
 
 static inline sysvsem_sem *sysvsem_from_obj(zend_object *obj) {
-	return (sysvsem_sem *)((char *)(obj) - XtOffsetOf(sysvsem_sem, std));
+	return (sysvsem_sem *)((char *)(obj) - offsetof(sysvsem_sem, std));
 }
 
 #define Z_SYSVSEM_P(zv) sysvsem_from_obj(Z_OBJ_P(zv))
@@ -147,7 +147,7 @@ PHP_MINIT_FUNCTION(sysvsem)
 	sysvsem_ce->default_object_handlers = &sysvsem_object_handlers;
 
 	memcpy(&sysvsem_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	sysvsem_object_handlers.offset = XtOffsetOf(sysvsem_sem, std);
+	sysvsem_object_handlers.offset = offsetof(sysvsem_sem, std);
 	sysvsem_object_handlers.free_obj = sysvsem_free_obj;
 	sysvsem_object_handlers.get_constructor = sysvsem_get_constructor;
 	sysvsem_object_handlers.clone_obj = NULL;

--- a/ext/sysvshm/sysvshm.c
+++ b/ext/sysvshm/sysvshm.c
@@ -34,7 +34,7 @@ zend_class_entry *sysvshm_ce;
 static zend_object_handlers sysvshm_object_handlers;
 
 static inline sysvshm_shm *sysvshm_from_obj(zend_object *obj) {
-	return (sysvshm_shm *)((char *)(obj) - XtOffsetOf(sysvshm_shm, std));
+	return (sysvshm_shm *)((char *)(obj) - offsetof(sysvshm_shm, std));
 }
 
 #define Z_SYSVSHM_P(zv) sysvshm_from_obj(Z_OBJ_P(zv))
@@ -100,7 +100,7 @@ PHP_MINIT_FUNCTION(sysvshm)
 	sysvshm_ce->default_object_handlers = &sysvshm_object_handlers;
 
 	memcpy(&sysvshm_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	sysvshm_object_handlers.offset = XtOffsetOf(sysvshm_shm, std);
+	sysvshm_object_handlers.offset = offsetof(sysvshm_shm, std);
 	sysvshm_object_handlers.free_obj = sysvshm_free_obj;
 	sysvshm_object_handlers.get_constructor = sysvshm_get_constructor;
 	sysvshm_object_handlers.clone_obj = NULL;

--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -105,7 +105,7 @@ struct _PHPTidyObj {
 };
 
 static inline PHPTidyObj *php_tidy_fetch_object(zend_object *obj) {
-	return (PHPTidyObj *)((char*)(obj) - XtOffsetOf(PHPTidyObj, std));
+	return (PHPTidyObj *)((char*)(obj) - offsetof(PHPTidyObj, std));
 }
 
 #define Z_TIDY_P(zv) php_tidy_fetch_object(Z_OBJ_P((zv)))
@@ -848,7 +848,7 @@ static PHP_MINIT_FUNCTION(tidy)
 	tidy_object_handlers_doc.cast_object = tidy_doc_cast_handler;
 	tidy_object_handlers_node.cast_object = tidy_node_cast_handler;
 
-	tidy_object_handlers_node.offset = tidy_object_handlers_doc.offset = XtOffsetOf(PHPTidyObj, std);
+	tidy_object_handlers_node.offset = tidy_object_handlers_doc.offset = offsetof(PHPTidyObj, std);
 	tidy_object_handlers_node.free_obj = tidy_object_handlers_doc.free_obj = tidy_object_free_storage;
 
 	register_tidy_symbols(module_number);

--- a/ext/uri/php_uri.c
+++ b/ext/uri/php_uri.c
@@ -1074,7 +1074,7 @@ static PHP_MINIT_FUNCTION(uri)
 	php_uri_ce_rfc3986_uri->create_object = php_uri_object_create_rfc3986;
 	php_uri_ce_rfc3986_uri->default_object_handlers = &object_handlers_rfc3986_uri;
 	memcpy(&object_handlers_rfc3986_uri, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
-	object_handlers_rfc3986_uri.offset = XtOffsetOf(php_uri_object, std);
+	object_handlers_rfc3986_uri.offset = offsetof(php_uri_object, std);
 	object_handlers_rfc3986_uri.free_obj = php_uri_object_handler_free;
 	object_handlers_rfc3986_uri.clone_obj = php_uri_object_handler_clone;
 
@@ -1082,7 +1082,7 @@ static PHP_MINIT_FUNCTION(uri)
 	php_uri_ce_whatwg_url->create_object = php_uri_object_create_whatwg;
 	php_uri_ce_whatwg_url->default_object_handlers = &object_handlers_whatwg_uri;
 	memcpy(&object_handlers_whatwg_uri, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
-	object_handlers_whatwg_uri.offset = XtOffsetOf(php_uri_object, std);
+	object_handlers_whatwg_uri.offset = offsetof(php_uri_object, std);
 	object_handlers_whatwg_uri.free_obj = php_uri_object_handler_free;
 	object_handlers_whatwg_uri.clone_obj = php_uri_object_handler_clone;
 

--- a/ext/uri/php_uri_common.h
+++ b/ext/uri/php_uri_common.h
@@ -147,7 +147,7 @@ typedef struct php_uri_object {
 } php_uri_object;
 
 static inline php_uri_object *php_uri_object_from_obj(zend_object *object) {
-	return (php_uri_object*)((char*)(object) - XtOffsetOf(php_uri_object, std));
+	return (php_uri_object*)((char*)(object) - offsetof(php_uri_object, std));
 }
 
 #define Z_URI_OBJECT_P(zv) php_uri_object_from_obj(Z_OBJ_P((zv)))

--- a/ext/xml/xml.c
+++ b/ext/xml/xml.c
@@ -222,7 +222,7 @@ PHP_MINIT_FUNCTION(xml)
 	xml_parser_ce->default_object_handlers = &xml_parser_object_handlers;
 
 	memcpy(&xml_parser_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	xml_parser_object_handlers.offset = XtOffsetOf(xml_parser, std);
+	xml_parser_object_handlers.offset = offsetof(xml_parser, std);
 	xml_parser_object_handlers.free_obj = xml_parser_free_obj;
 	xml_parser_object_handlers.get_gc = xml_parser_get_gc;
 	xml_parser_object_handlers.get_constructor = xml_parser_get_constructor;
@@ -296,7 +296,7 @@ static void xml_xmlchar_zval(const XML_Char *s, int len, const XML_Char *encodin
 /* }}} */
 
 static inline xml_parser *xml_parser_from_obj(zend_object *obj) {
-	return (xml_parser *)((char *)(obj) - XtOffsetOf(xml_parser, std));
+	return (xml_parser *)((char *)(obj) - offsetof(xml_parser, std));
 }
 
 #define Z_XMLPARSER_P(zv) xml_parser_from_obj(Z_OBJ_P(zv))

--- a/ext/xmlreader/php_xmlreader.c
+++ b/ext/xmlreader/php_xmlreader.c
@@ -1343,7 +1343,7 @@ PHP_MINIT_FUNCTION(xmlreader)
 {
 
 	memcpy(&xmlreader_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	xmlreader_object_handlers.offset = XtOffsetOf(xmlreader_object, std);
+	xmlreader_object_handlers.offset = offsetof(xmlreader_object, std);
 	xmlreader_object_handlers.free_obj = xmlreader_objects_free_storage;
 	xmlreader_object_handlers.has_property = xmlreader_has_property;
 	xmlreader_object_handlers.read_property = xmlreader_read_property;

--- a/ext/xmlreader/php_xmlreader.h
+++ b/ext/xmlreader/php_xmlreader.h
@@ -45,7 +45,7 @@ typedef struct _xmlreader_object {
 } xmlreader_object;
 
 static inline xmlreader_object *php_xmlreader_fetch_object(zend_object *obj) {
-	return (xmlreader_object *)((char*)(obj) - XtOffsetOf(xmlreader_object, std));
+	return (xmlreader_object *)((char*)(obj) - offsetof(xmlreader_object, std));
 }
 
 #define Z_XMLREADER_P(zv) php_xmlreader_fetch_object(Z_OBJ_P((zv)))

--- a/ext/xmlwriter/php_xmlwriter.c
+++ b/ext/xmlwriter/php_xmlwriter.c
@@ -1048,7 +1048,7 @@ PHP_FUNCTION(xmlwriter_flush)
 static PHP_MINIT_FUNCTION(xmlwriter)
 {
 	memcpy(&xmlwriter_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	xmlwriter_object_handlers.offset = XtOffsetOf(ze_xmlwriter_object, std);
+	xmlwriter_object_handlers.offset = offsetof(ze_xmlwriter_object, std);
 	xmlwriter_object_handlers.dtor_obj = xmlwriter_object_dtor;
 	xmlwriter_object_handlers.clone_obj = NULL;
 	xmlwriter_class_entry_ce = register_class_XMLWriter();

--- a/ext/xmlwriter/php_xmlwriter.h
+++ b/ext/xmlwriter/php_xmlwriter.h
@@ -38,7 +38,7 @@ typedef struct _ze_xmlwriter_object {
 } ze_xmlwriter_object;
 
 static inline ze_xmlwriter_object *php_xmlwriter_fetch_object(zend_object *obj) {
-	return (ze_xmlwriter_object *)((char*)(obj) - XtOffsetOf(ze_xmlwriter_object, std));
+	return (ze_xmlwriter_object *)((char*)(obj) - offsetof(ze_xmlwriter_object, std));
 }
 
 #define Z_XMLWRITER_P(zv) php_xmlwriter_fetch_object(Z_OBJ_P((zv)))

--- a/ext/xsl/php_xsl.c
+++ b/ext/xsl/php_xsl.c
@@ -266,7 +266,7 @@ static void xsl_libxslt_error_handler(void *ctx, const char *msg, ...)
 PHP_MINIT_FUNCTION(xsl)
 {
 	memcpy(&xsl_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	xsl_object_handlers.offset = XtOffsetOf(xsl_object, std);
+	xsl_object_handlers.offset = offsetof(xsl_object, std);
 	xsl_object_handlers.clone_obj = NULL;
 	xsl_object_handlers.free_obj = xsl_objects_free_storage;
 	xsl_object_handlers.get_gc = xsl_objects_get_gc;

--- a/ext/xsl/php_xsl.h
+++ b/ext/xsl/php_xsl.h
@@ -61,7 +61,7 @@ typedef struct xsl_object {
 } xsl_object;
 
 static inline xsl_object *php_xsl_fetch_object(zend_object *obj) {
-	return (xsl_object *)((char*)(obj) - XtOffsetOf(xsl_object, std));
+	return (xsl_object *)((char*)(obj) - offsetof(xsl_object, std));
 }
 
 #define Z_XSL_P(zv) php_xsl_fetch_object(Z_OBJ_P((zv)))

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -1044,7 +1044,7 @@ static zend_object *zend_test_class_new(zend_class_entry *class_type)
 
 static void zend_test_class_free_obj(zend_object *object)
 {
-	zend_test_object *intern = (zend_test_object*)((char*)object - XtOffsetOf(zend_test_object, std));
+	zend_test_object *intern = (zend_test_object*)((char*)object - offsetof(zend_test_object, std));
 
 	if (intern->tmp_method) {
 		zend_internal_function *func = intern->tmp_method;
@@ -1059,7 +1059,7 @@ static void zend_test_class_free_obj(zend_object *object)
 
 static zend_function *zend_test_class_method_get(zend_object **object, zend_string *name, const zval *key)
 {
-	zend_test_object *intern = (zend_test_object*)((char*)(*object) - XtOffsetOf(zend_test_object, std));
+	zend_test_object *intern = (zend_test_object*)((char*)(*object) - offsetof(zend_test_object, std));
 
 	if (zend_string_equals_literal_ci(name, "test")) {
 		zend_internal_function *fptr;
@@ -1526,7 +1526,7 @@ PHP_MINIT_FUNCTION(zend_test)
 	zend_test_class_handlers.get_method = zend_test_class_method_get;
 	zend_test_class_handlers.clone_obj = NULL;
 	zend_test_class_handlers.free_obj = zend_test_class_free_obj;
-	zend_test_class_handlers.offset = XtOffsetOf(zend_test_object, std);
+	zend_test_class_handlers.offset = offsetof(zend_test_object, std);
 
 	zend_test_gen_stub_flag_compatibility_test = register_class_ZendTestGenStubFlagCompatibilityTest();
 

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -3051,7 +3051,7 @@ static void php_zip_free_prop_handler(zval *el) /* {{{ */ {
 static PHP_MINIT_FUNCTION(zip)
 {
 	memcpy(&zip_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	zip_object_handlers.offset = XtOffsetOf(ze_zip_object, zo);
+	zip_object_handlers.offset = offsetof(ze_zip_object, zo);
 	zip_object_handlers.free_obj = php_zip_object_free_storage;
 	zip_object_handlers.dtor_obj = php_zip_object_dtor;
 	zip_object_handlers.clone_obj = NULL;

--- a/ext/zip/php_zip.h
+++ b/ext/zip/php_zip.h
@@ -82,7 +82,7 @@ typedef struct _ze_zip_object {
 } ze_zip_object;
 
 static inline ze_zip_object *php_zip_fetch_object(zend_object *obj) {
-	return (ze_zip_object *)((char*)(obj) - XtOffsetOf(ze_zip_object, zo));
+	return (ze_zip_object *)((char*)(obj) - offsetof(ze_zip_object, zo));
 }
 
 #define Z_ZIP_P(zv) php_zip_fetch_object(Z_OBJ_P((zv)))

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -48,7 +48,7 @@ zend_class_entry *inflate_context_ce;
 static zend_object_handlers inflate_context_object_handlers;
 
 static inline php_zlib_context *inflate_context_from_obj(zend_object *obj) {
-	return (php_zlib_context *)((char *)(obj) - XtOffsetOf(php_zlib_context, std));
+	return (php_zlib_context *)((char *)(obj) - offsetof(php_zlib_context, std));
 }
 
 #define Z_INFLATE_CONTEXT_P(zv) inflate_context_from_obj(Z_OBJ_P(zv))
@@ -86,7 +86,7 @@ zend_class_entry *deflate_context_ce;
 static zend_object_handlers deflate_context_object_handlers;
 
 static inline php_zlib_context *deflate_context_from_obj(zend_object *obj) {
-	return (php_zlib_context *)((char *)(obj) - XtOffsetOf(php_zlib_context, std));
+	return (php_zlib_context *)((char *)(obj) - offsetof(php_zlib_context, std));
 }
 
 #define Z_DEFLATE_CONTEXT_P(zv) deflate_context_from_obj(Z_OBJ_P(zv))
@@ -1342,7 +1342,7 @@ static PHP_MINIT_FUNCTION(zlib)
 	inflate_context_ce->default_object_handlers = &inflate_context_object_handlers;
 
 	memcpy(&inflate_context_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	inflate_context_object_handlers.offset = XtOffsetOf(php_zlib_context, std);
+	inflate_context_object_handlers.offset = offsetof(php_zlib_context, std);
 	inflate_context_object_handlers.free_obj = inflate_context_free_obj;
 	inflate_context_object_handlers.get_constructor = inflate_context_get_constructor;
 	inflate_context_object_handlers.clone_obj = NULL;
@@ -1353,7 +1353,7 @@ static PHP_MINIT_FUNCTION(zlib)
 	deflate_context_ce->default_object_handlers = &deflate_context_object_handlers;
 
 	memcpy(&deflate_context_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	deflate_context_object_handlers.offset = XtOffsetOf(php_zlib_context, std);
+	deflate_context_object_handlers.offset = offsetof(php_zlib_context, std);
 	deflate_context_object_handlers.free_obj = deflate_context_free_obj;
 	deflate_context_object_handlers.get_constructor = deflate_context_get_constructor;
 	deflate_context_object_handlers.clone_obj = NULL;

--- a/main/fastcgi.c
+++ b/main/fastcgi.c
@@ -735,7 +735,7 @@ int fcgi_listen(const char *path, int backlog)
 		memset(&sa.sa_unix, 0, sizeof(sa.sa_unix));
 		sa.sa_unix.sun_family = AF_UNIX;
 		memcpy(sa.sa_unix.sun_path, path, path_len + 1);
-		sock_len = XtOffsetOf(struct sockaddr_un, sun_path) + path_len;
+		sock_len = offsetof(struct sockaddr_un, sun_path) + path_len;
 #ifdef HAVE_STRUCT_SOCKADDR_UN_SUN_LEN
 		sa.sa_unix.sun_len = sock_len;
 #endif

--- a/main/streams/xp_socket.c
+++ b/main/streams/xp_socket.c
@@ -698,7 +698,7 @@ static inline int php_tcp_sockop_bind(php_stream *stream, php_netstream_data_t *
 		parse_unix_address(xparam, &unix_addr);
 
 		int result = bind(sock->socket, (const struct sockaddr *)&unix_addr,
-			(socklen_t) XtOffsetOf(struct sockaddr_un, sun_path) + xparam->inputs.namelen);
+			(socklen_t) offsetof(struct sockaddr_un, sun_path) + xparam->inputs.namelen);
 		if (result == -1 && xparam->want_errortext) {
 			char errstr[256];
 			xparam->outputs.error_text = strpprintf(0, "%s", php_socket_strerror_s(errno, errstr, sizeof(errstr)));
@@ -834,7 +834,7 @@ static inline int php_tcp_sockop_connect(php_stream *stream, php_netstream_data_
 		parse_unix_address(xparam, &unix_addr);
 
 		ret = php_network_connect_socket(sock->socket,
-				(const struct sockaddr *)&unix_addr, (socklen_t) XtOffsetOf(struct sockaddr_un, sun_path) + xparam->inputs.namelen,
+				(const struct sockaddr *)&unix_addr, (socklen_t) offsetof(struct sockaddr_un, sun_path) + xparam->inputs.namelen,
 				xparam->op == STREAM_XPORT_OP_CONNECT_ASYNC, xparam->inputs.timeout,
 				xparam->want_errortext ? &xparam->outputs.error_text : NULL,
 				&err);

--- a/sapi/phpdbg/phpdbg_watch.c
+++ b/sapi/phpdbg/phpdbg_watch.c
@@ -148,7 +148,7 @@ bool phpdbg_check_watch_diff(phpdbg_watchtype type, void *oldPtr, void *newPtr) 
 		case WATCH_ON_REFCOUNTED:
 			return memcmp(oldPtr, newPtr, sizeof(uint32_t) /* no zend_refcounted metadata info */) != 0;
 		case WATCH_ON_STR:
-			return memcmp(oldPtr, newPtr, *(size_t *) oldPtr + XtOffsetOf(zend_string, val) - XtOffsetOf(zend_string, len)) != 0;
+			return memcmp(oldPtr, newPtr, *(size_t *) oldPtr + offsetof(zend_string, val) - offsetof(zend_string, len)) != 0;
 		case WATCH_ON_HASHDATA:
 			ZEND_UNREACHABLE();
 	}
@@ -200,11 +200,11 @@ void phpdbg_print_watch_diff(phpdbg_watchtype type, zend_string *name, void *old
 
 		case WATCH_ON_STR:
 			phpdbg_out("Old value: ");
-			zend_write((char *) oldPtr + XtOffsetOf(zend_string, val) - XtOffsetOf(zend_string, len), *(size_t *) oldPtr);
+			zend_write((char *) oldPtr + offsetof(zend_string, val) - offsetof(zend_string, len), *(size_t *) oldPtr);
 			phpdbg_out("\n");
 
 			phpdbg_out("New value: ");
-			zend_write((char *) newPtr + XtOffsetOf(zend_string, val) - XtOffsetOf(zend_string, len), *(size_t *) newPtr);
+			zend_write((char *) newPtr + offsetof(zend_string, val) - offsetof(zend_string, len), *(size_t *) newPtr);
 			phpdbg_out("\n");
 			break;
 
@@ -378,7 +378,7 @@ void phpdbg_watch_backup_data(phpdbg_watchpoint_t *watch) {
 			if (watch->backup.str) {
 				zend_string_release(watch->backup.str);
 			}
-			watch->backup.str = zend_string_init((char *) watch->addr.ptr + XtOffsetOf(zend_string, val) - XtOffsetOf(zend_string, len), *(size_t *) watch->addr.ptr, 1);
+			watch->backup.str = zend_string_init((char *) watch->addr.ptr + offsetof(zend_string, val) - offsetof(zend_string, len), *(size_t *) watch->addr.ptr, 1);
 			GC_MAKE_PERSISTENT_LOCAL(watch->backup.str);
 			break;
 		case WATCH_ON_HASHTABLE:
@@ -449,7 +449,7 @@ void phpdbg_update_watch_ref(phpdbg_watchpoint_t *watch) {
 				phpdbg_watch_backup_data(&coll->reference);
 			} else if (Z_TYPE_P(watch->addr.zv) == IS_STRING) {
 				coll->reference.type = WATCH_ON_STR;
-				phpdbg_set_addr_watchpoint(&Z_STRLEN_P(watch->addr.zv), XtOffsetOf(zend_string, val) - XtOffsetOf(zend_string, len) + Z_STRLEN_P(watch->addr.zv) + 1, &coll->reference);
+				phpdbg_set_addr_watchpoint(&Z_STRLEN_P(watch->addr.zv), offsetof(zend_string, val) - offsetof(zend_string, len) + Z_STRLEN_P(watch->addr.zv) + 1, &coll->reference);
 				coll->reference.coll = coll;
 				phpdbg_store_watchpoint_btree(&coll->reference);
 				phpdbg_activate_watchpoint(&coll->reference);


### PR DESCRIPTION
`offsetof()` is in `stddef.h` and thus always available. The extra macro is an unnecessary layer of indirection.