### PR TITLE
zend_object_handlers: Fix type of `struct _zend_object_handlers`’s `offset` field

### DIFF
--- a/Zend/zend_object_handlers.h
+++ b/Zend/zend_object_handlers.h
@@ -204,7 +204,7 @@ typedef zend_result (*zend_object_do_operation_t)(uint8_t opcode, zval *result, 
 
 struct _zend_object_handlers {
 	/* offset of real object header (usually zero) */
-	int										offset;
+	size_t										offset;
 	/* object handlers */
 	zend_object_free_obj_t					free_obj;             /* required */
 	zend_object_dtor_obj_t					dtor_obj;             /* required */


### PR DESCRIPTION
This is used with `offsetof()` which evaluates to `size_t`.