### PR TITLE
fix(cli): clear getopt optarg for optional long options

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,9 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 8.5.7
 
+- CLI:
+  . Fixed bug GH-21901 (Stale getopt() optional value). (onthebed)
+
 - Opcache:
   . Fixed tracing JIT crash when a VM interrupt is handled during an observed
     user function call. (Levi Morrison)

--- a/main/getopt.c
+++ b/main/getopt.c
@@ -59,6 +59,9 @@ PHPAPI int php_getopt(int argc, char* const *argv, const opt_struct opts[], char
 	static char **prev_optarg = NULL;
 
 	php_optidx = -1;
+	if (optarg) {
+		*optarg = NULL;
+	}
 
 	if(prev_optarg && prev_optarg != optarg) {
 		/* reset the state */

--- a/sapi/cli/tests/gh21901.phpt
+++ b/sapi/cli/tests/gh21901.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Stale getopt() optional value in CLI
+--FILE--
+<?php
+$php_escaped = getenv('TEST_PHP_EXECUTABLE_ESCAPED');
+$cmd = $php_escaped . ' -n -d foo=bar --ini';
+echo shell_exec($cmd);
+?>
+--EXPECTF--
+Configuration File (php.ini) Path: "%S"
+Loaded Configuration File:         "%S"
+Scan for additional .ini files in: %s
+Additional .ini files parsed:      %s


### PR DESCRIPTION
`php_getopt()` left `*optarg` unchanged when a long option with an optional argument was passed without a value, so the CLI parser could reuse the previous option's argument for `--ini`.

Clear `optarg` at the start of `php_getopt()` and add a regression test that exercises `-d foo=bar --ini`.

Fixes #21901
