### PR TITLE
ext/zlib: Remove `zval_get_long` usage in `inflate_init`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -207,5 +207,7 @@ PHP                                                                        NEWS
   . deflate_init() now raises a TypeError when the value for option
     "level", "memory", "window", or "strategy" is not of type int.
     (Weilin Du)
+  . inflate_init() now raises a TypeError when the value for option
+    "window" is not of type int. (Weilin Du)
 
 <<< NOTE: Insert NEWS from last stable release here prior to actual release! >>>

--- a/UPGRADING
+++ b/UPGRADING
@@ -104,6 +104,8 @@ PHP 8.6 UPGRADE NOTES
 - Zlib:
   . deflate_init() now raises a TypeError when the value for option
     "level", "memory", "window", or "strategy" is not of type int.
+  . inflate_init() now raises a TypeError when the value for option
+    "window" is not of type int.
 
 ========================================
 2. New Features

--- a/ext/zlib/tests/inflate_init_window_type_error.phpt
+++ b/ext/zlib/tests/inflate_init_window_type_error.phpt
@@ -1,0 +1,16 @@
+--TEST--
+inflate_init(): window option type validation
+--EXTENSIONS--
+zlib
+--FILE--
+<?php
+
+try {
+    inflate_init(ZLIB_ENCODING_DEFLATE, ['window' => []]);
+} catch (TypeError $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+inflate_init(): Argument #2 ($options) the value for option "window" must be of type int, array given

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -885,16 +885,14 @@ PHP_FUNCTION(inflate_init)
 	zend_long encoding, window = 15;
 	char *dict = NULL;
 	size_t dictlen = 0;
-	HashTable *options = NULL;
-	zval *option_buffer;
+	HashTable *options = (HashTable *) &zend_empty_array;
 
 	if (SUCCESS != zend_parse_parameters(ZEND_NUM_ARGS(), "l|H", &encoding, &options)) {
 		RETURN_THROWS();
 	}
 
-	if (options && (option_buffer = zend_hash_str_find(options, ZEND_STRL("window"))) != NULL) {
-		ZVAL_DEINDIRECT(option_buffer);
-		window = zval_get_long(option_buffer);
+	if (!zlib_get_long_option(options, ZEND_STRL("window"), &window)) {
+		RETURN_THROWS();
 	}
 	if (window < 8 || window > 15) {
 		zend_value_error("zlib window size (logarithm) (" ZEND_LONG_FMT ") must be within 8..15", window);


### PR DESCRIPTION
Same thing of #21860, but for `inflate_init`. 

Another occasion of silent cast in the zlib extension appears in the `zlib://compress` filter. I think I would take a look at that one in the future if it make sense :)