### PR TITLE
Use alignment builtins for ZEND_MM_ALIGNED macros

### DIFF
--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -176,15 +176,15 @@ typedef uint32_t   zend_mm_page_info; /* 4-byte integer */
 typedef zend_ulong zend_mm_bitset;    /* 4-byte or 8-byte integer */
 
 #ifdef PHP_HAVE_BUILTIN_ALIGN_DOWN
-# define ZEND_MM_ALIGNED_OFFSET(size, alignment) \
-	(((size_t)(size)) - (size_t)__builtin_align_down((size), (alignment)))
 # define ZEND_MM_ALIGNED_BASE(ptr, alignment) \
 	__builtin_align_down((ptr), (alignment))
+# define ZEND_MM_ALIGNED_OFFSET(ptr, alignment) \
+	(((size_t)(ptr)) - (size_t)ZEND_MM_ALIGNED_BASE(ptr, alignment))
 #else
-# define ZEND_MM_ALIGNED_OFFSET(size, alignment) \
-	(((size_t)(size)) & ((alignment) - 1))
 # define ZEND_MM_ALIGNED_BASE(ptr, alignment) \
 	(((uintptr_t)(ptr)) & ~((alignment) - 1))
+# define ZEND_MM_ALIGNED_OFFSET(ptr, alignment) \
+	(((size_t)(ptr)) & ((alignment) - 1))
 #endif
 
 #ifdef PHP_HAVE_BUILTIN_ALIGN_UP

--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -175,12 +175,25 @@ static size_t _real_page_size = ZEND_MM_PAGE_SIZE;
 typedef uint32_t   zend_mm_page_info; /* 4-byte integer */
 typedef zend_ulong zend_mm_bitset;    /* 4-byte or 8-byte integer */
 
-#define ZEND_MM_ALIGNED_OFFSET(size, alignment) \
+#ifdef PHP_HAVE_BUILTIN_ALIGN_DOWN
+# define ZEND_MM_ALIGNED_OFFSET(size, alignment) \
+	(((size_t)(size)) - (size_t)__builtin_align_down((size), (alignment)))
+# define ZEND_MM_ALIGNED_BASE(ptr, alignment) \
+	__builtin_align_down((ptr), (alignment))
+#else
+# define ZEND_MM_ALIGNED_OFFSET(size, alignment) \
 	(((size_t)(size)) & ((alignment) - 1))
-#define ZEND_MM_ALIGNED_BASE(ptr, alignment) \
+# define ZEND_MM_ALIGNED_BASE(ptr, alignment) \
 	(((uintptr_t)(ptr)) & ~((alignment) - 1))
-#define ZEND_MM_SIZE_TO_NUM(size, alignment) \
+#endif
+
+#ifdef PHP_HAVE_BUILTIN_ALIGN_UP
+# define ZEND_MM_SIZE_TO_NUM(size, alignment) \
+	(__builtin_align_up((size), (alignment)) / (alignment))
+#else
+# define ZEND_MM_SIZE_TO_NUM(size, alignment) \
 	(((size_t)(size) + ((alignment) - 1)) / (alignment))
+#endif
 
 #define ZEND_MM_BITSET_LEN		(sizeof(zend_mm_bitset) * 8)       /* 32 or 64 */
 #define ZEND_MM_PAGE_MAP_LEN	(ZEND_MM_PAGES / ZEND_MM_BITSET_LEN) /* 16 or 8 */

--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -177,8 +177,8 @@ typedef zend_ulong zend_mm_bitset;    /* 4-byte or 8-byte integer */
 
 #define ZEND_MM_ALIGNED_OFFSET(size, alignment) \
 	(((size_t)(size)) & ((alignment) - 1))
-#define ZEND_MM_ALIGNED_BASE(size, alignment) \
-	(((size_t)(size)) & ~((alignment) - 1))
+#define ZEND_MM_ALIGNED_BASE(ptr, alignment) \
+	(((uintptr_t)(ptr)) & ~((alignment) - 1))
 #define ZEND_MM_SIZE_TO_NUM(size, alignment) \
 	(((size_t)(size) + ((alignment) - 1)) / (alignment))
 

--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -177,12 +177,12 @@ typedef zend_ulong zend_mm_bitset;    /* 4-byte or 8-byte integer */
 
 #ifdef PHP_HAVE_BUILTIN_ALIGN_DOWN
 # define ZEND_MM_ALIGNED_BASE(ptr, alignment) \
-	__builtin_align_down((ptr), (alignment))
+	__builtin_align_down((void*)(ptr), (alignment))
 # define ZEND_MM_ALIGNED_OFFSET(ptr, alignment) \
 	(((size_t)(ptr)) - (size_t)ZEND_MM_ALIGNED_BASE(ptr, alignment))
 #else
 # define ZEND_MM_ALIGNED_BASE(ptr, alignment) \
-	(((uintptr_t)(ptr)) & ~((alignment) - 1))
+	((void*)(((uintptr_t)(ptr)) & ~((alignment) - 1)))
 # define ZEND_MM_ALIGNED_OFFSET(ptr, alignment) \
 	(((size_t)(ptr)) & ((alignment) - 1))
 #endif

--- a/build/php.m4
+++ b/build/php.m4
@@ -2380,6 +2380,8 @@ AC_CACHE_CHECK([for $1], [php_var],
   [__builtin_ssubll_overflow], [long long tmpvar; return $1(3, 7, &tmpvar);],
   [__builtin_unreachable], [$1();],
   [__builtin_usub_overflow], [unsigned int tmpvar; return $1(3, 7, &tmpvar);],
+  [__builtin_align_down], [return $1(1, 2) == 0 ? 1 : 0;],
+  [__builtin_align_up], [return $1(1, 2) == 2 ? 1 : 0;],
   [
     m4_warn([syntax], [Unsupported builtin '$1', the test may fail.])
     $1();

--- a/configure.ac
+++ b/configure.ac
@@ -490,6 +490,8 @@ PHP_CHECK_BUILTIN([__builtin_ssubl_overflow])
 PHP_CHECK_BUILTIN([__builtin_ssubll_overflow])
 PHP_CHECK_BUILTIN([__builtin_unreachable])
 PHP_CHECK_BUILTIN([__builtin_usub_overflow])
+PHP_CHECK_BUILTIN([__builtin_align_down])
+PHP_CHECK_BUILTIN([__builtin_align_up])
 
 dnl Check AVX512
 PHP_CHECK_AVX512_SUPPORTS

--- a/sapi/phpdbg/phpdbg_watch.h
+++ b/sapi/phpdbg/phpdbg_watch.h
@@ -134,7 +134,11 @@ void phpdbg_watch_efree(void *ptr ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC);
 static long phpdbg_pagesize;
 
 static zend_always_inline void *phpdbg_get_page_boundary(void *addr) {
+#ifdef PHP_HAVE_BUILTIN_ALIGN_DOWN
+	return __builtin_align_down(addr, phpdbg_pagesize);
+#else
 	return (void *) ((size_t) addr & ~(phpdbg_pagesize - 1));
+#endif
 }
 
 static zend_always_inline size_t phpdbg_get_total_page_size(void *addr, size_t size) {

--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -370,6 +370,8 @@ if (VS_TOOLSET) {
 	AC_DEFINE("PHP_HAVE_BUILTIN_SSUBLL_OVERFLOW", 1, "Define to 1 if the compiler supports '__builtin_ssubll_overflow'.");
 	AC_DEFINE("PHP_HAVE_BUILTIN_SMULL_OVERFLOW", 1, "Define to 1 if the compiler supports '__builtin_smull_overflow '.");
 	AC_DEFINE("PHP_HAVE_BUILTIN_SMULLL_OVERFLOW", 1, "Define to 1 if the compiler supports '__builtin_smulll_overflow'.");
+	AC_DEFINE("PHP_HAVE_BUILTIN_ALIGN_DOWN", 1, "Define to 1 if the compiler supports '__builtin_align_down'.");
+	AC_DEFINE("PHP_HAVE_BUILTIN_ALIGN_UP", 1, "Define to 1 if the compiler supports '__builtin_align_up'.");
 
 	if (PHP_SANITIZER == "yes") {
 		if (COMPILER_NUMERIC_VERSION < 500) {


### PR DESCRIPTION
Where available, these provide a more descriptive way of aligning pointers than direct bitwise manipulation. The additional abstraction they provide also makes them more compatible with platforms like [CHERI](https://en.wikipedia.org/wiki/Capability_Hardware_Enhanced_RISC_Instructions).

Also, the non-builtin `ZEND_MM_ALIGNED_BASE` implementation now casts to `uintptr_t` instead of `size_t`, since the returned value tends to be used as a pointer, not a size. This makes intent clearer and also improves compatibility.

These patches are from a port of PHP to pure-capability CHERI (where pointers are wider than `size_t` and narrowing invalidates the pointer). Using these builtins improves compatibility generally and they seem preferable due to the abstraction. I thought I would send this patch upstream in case it is of interest.

See: https://clang.llvm.org/docs/LanguageExtensions.html#alignment-builtins