### PR TITLE
ext/dom: Sync public headers

### DIFF
--- a/ext/dom/config.w32
+++ b/ext/dom/config.w32
@@ -36,8 +36,7 @@ if (PHP_DOM == "yes") {
 			"dom_ce.h " +
 			"namespace_compat.h " +
 			"xml_common.h " +
-			"xpath_callbacks.h " +
-			"lexbor/selectors-adapted/selectors.h "
+			"xpath_callbacks.h "
 		);
 	} else {
 		WARNING("dom support can't be enabled, libxml is not enabled")


### PR DESCRIPTION
The ext/dom/lexbor/selectors-adapted/selectors.h isn't public header in current code (it isn't needed to use ext/dom in other extensions). And Autotools also doesn't install this header.