### PR TITLE
Tailcall VM interrupt crash

### DIFF
--- a/Zend/zend_vm.h
+++ b/Zend/zend_vm.h
@@ -32,12 +32,17 @@ ZEND_API void ZEND_FASTCALL zend_serialize_opcode_handler(zend_op *op);
 ZEND_API void ZEND_FASTCALL zend_deserialize_opcode_handler(zend_op *op);
 ZEND_API const void* ZEND_FASTCALL zend_get_opcode_handler_func(const zend_op *op);
 ZEND_API const zend_op *zend_get_halt_op(void);
+ZEND_API const zend_op *zend_get_interrupt_op(void);
 ZEND_API int ZEND_FASTCALL zend_vm_call_opcode_handler(zend_execute_data *ex);
 ZEND_API int zend_vm_kind(void);
 ZEND_API bool zend_gcc_global_regs(void);
 
 void zend_vm_init(void);
 void zend_vm_dtor(void);
+
+#if ZEND_VM_KIND == ZEND_VM_KIND_TAILCALL
+const struct _zend_op *zend_vm_handle_interrupt(struct _zend_execute_data *execute_data, const struct _zend_op *opline);
+#endif
 
 END_EXTERN_C()
 

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -10523,7 +10523,12 @@ ZEND_VM_DEFINE_OP(137, ZEND_OP_DATA);
 ZEND_VM_HELPER(zend_interrupt_helper, ANY, ANY)
 {
 	zend_atomic_bool_store_ex(&EG(vm_interrupt), false);
+#if ZEND_VM_KIND == ZEND_VM_KIND_TAILCALL
+	/* opline is &call_interrupt_op. Load orig opline. */
+	LOAD_OPLINE();
+#else
 	SAVE_OPLINE();
+#endif
 	if (zend_atomic_bool_load_ex(&EG(timed_out))) {
 		zend_timeout();
 	} else if (zend_interrupt_function) {

--- a/Zend/zend_vm_execute.skl
+++ b/Zend/zend_vm_execute.skl
@@ -161,6 +161,22 @@ ZEND_API const zend_op *zend_get_halt_op(void)
 #endif
 }
 
+ZEND_API const zend_op *zend_get_interrupt_op(void)
+{
+#if ZEND_VM_KIND == ZEND_VM_KIND_TAILCALL
+	return &call_interrupt_op;
+#else
+	return NULL;
+#endif
+}
+
+#if ZEND_VM_KIND == ZEND_VM_KIND_TAILCALL
+ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV zend_vm_handle_interrupt(ZEND_OPCODE_HANDLER_ARGS)
+{
+	return zend_interrupt_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU);
+}
+#endif
+
 ZEND_API int zend_vm_kind(void)
 {
 	return ZEND_VM_KIND;

--- a/Zend/zend_vm_gen.php
+++ b/Zend/zend_vm_gen.php
@@ -1594,6 +1594,19 @@ function gen_halt_handler($f, $kind) {
     out($f,"}\n\n");
 }
 
+function gen_interrupt_func($f, $kind, $spec) {
+    $cconv = $kind === ZEND_VM_KIND_TAILCALL ? 'ZEND_OPCODE_HANDLER_CCONV' : 'ZEND_OPCODE_HANDLER_FUNC_CCONV';
+    $variant = $kind === ZEND_VM_KIND_TAILCALL ? '_TAILCALL' : '';
+    out($f, "static ZEND_COLD zend_never_inline ZEND_OPCODE_HANDLER_RET {$cconv} zend_interrupt{$variant}(ZEND_OPCODE_HANDLER_ARGS) {\n");
+    out($f,"\tSAVE_OPLINE();\n");
+    if ($kind === ZEND_VM_KIND_TAILCALL) {
+        out($f,"\tZEND_VM_TAIL_CALL(zend_interrupt_helper".($spec?"_SPEC":"")."_TAILCALL(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));\n");
+    } else {
+        out($f, "\treturn &call_interrupt_op;\n");
+    }
+    out($f, "}\n");
+}
+
 function extra_spec_name($extra_spec) {
     global $prefix;
 
@@ -1804,10 +1817,12 @@ function gen_executor_code($f, $spec, $kind, $prolog, &$switch_labels = array())
     switch ($kind) {
         case ZEND_VM_KIND_CALL:
             gen_null_handler($f, $kind);
+            gen_interrupt_func($f, $kind, $spec);
             break;
         case ZEND_VM_KIND_TAILCALL:
             gen_null_handler($f, $kind);
             gen_halt_handler($f, $kind);
+            gen_interrupt_func($f, $kind, $spec);
             break;
         case ZEND_VM_KIND_SWITCH:
             out($f,"default: ZEND_NULL_LABEL:\n");
@@ -1845,7 +1860,7 @@ function gen_executor_code($f, $spec, $kind, $prolog, &$switch_labels = array())
         out($f, "#pragma push_macro(\"ZEND_VM_INTERRUPT\")\n");
         out($f, "#undef  ZEND_VM_INTERRUPT\n");
         out($f, "#define ZEND_VM_CONTINUE(handler) return opline\n");
-        out($f, "#define ZEND_VM_INTERRUPT()       return zend_interrupt_helper".($spec?"_SPEC":"")."(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU)\n");
+        out($f, "#define ZEND_VM_INTERRUPT()       return zend_interrupt(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU);\n");
         out($f, $delayed_helpers);
         out($f, "#pragma pop_macro(\"ZEND_VM_INTERRUPT\")\n");
         out($f, "#pragma pop_macro(\"ZEND_VM_CONTINUE\")\n");
@@ -1901,6 +1916,9 @@ function gen_executor($f, $skl, $spec, $kind, $executor_name, $initializer_name)
                         out($f,"#if ZEND_VM_KIND == ZEND_VM_KIND_HYBRID || ZEND_VM_KIND == ZEND_VM_KIND_TAILCALL\n\n");
                         out($f,"static zend_vm_opcode_handler_func_t const * zend_opcode_handler_funcs;\n");
                         out($f,"#endif\n");
+                        out($f,"#if ZEND_VM_KIND == ZEND_VM_KIND_TAILCALL\n\n");
+                        out($f,"static const zend_op call_interrupt_op;\n");
+                        out($f,"#endif\n\n");
                     }
                     out($f,"#if (ZEND_VM_KIND != ZEND_VM_KIND_HYBRID && ZEND_VM_KIND != ZEND_VM_KIND_TAILCALL) || !ZEND_VM_SPEC\n");
                     out($f,"static zend_vm_opcode_handler_t zend_vm_get_opcode_handler(uint8_t opcode, const zend_op* op);\n");
@@ -2038,6 +2056,7 @@ function gen_executor($f, $skl, $spec, $kind, $executor_name, $initializer_name)
                             }
                             out($f,"\n");
                             out($f,"static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV zend_interrupt_helper".($spec?"_SPEC":"")."(ZEND_OPCODE_HANDLER_ARGS);\n");
+                            out($f,"static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV zend_interrupt(ZEND_OPCODE_HANDLER_ARGS);\n");
                             out($f,"static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_NULL_HANDLER(ZEND_OPCODE_HANDLER_ARGS);\n");
                             out($f,"\n");
                             break;
@@ -2136,15 +2155,13 @@ function gen_executor($f, $skl, $spec, $kind, $executor_name, $initializer_name)
                         out($f,"# define ZEND_VM_DISPATCH_TO_HELPER(call) \\\n");
                         out($f,"    do { \\\n");
                         out($f,"        opline = call; \\\n");
-                        out($f,"        if (UNEXPECTED(((uintptr_t)opline & ZEND_VM_ENTER_BIT))) { \\\n");
-                        out($f,"            return opline; \\\n");
-                        out($f,"        } \\\n");
                         out($f,"        ZEND_VM_TAIL_CALL(opline->handler(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU)); \\\n");
                         out($f,"    } while (0)\n");
                         out($f,"# define ZEND_VM_DISPATCH_TO_LEAVE_HELPER(helper) opline = &call_leave_op; SAVE_OPLINE(); ZEND_VM_CONTINUE()\n");
-                        out($f,"# define ZEND_VM_INTERRUPT()        ZEND_VM_TAIL_CALL(zend_interrupt_helper".($spec?"_SPEC":"")."_TAILCALL(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU))\n");
+                        out($f,"# define ZEND_VM_INTERRUPT()        ZEND_VM_TAIL_CALL(zend_interrupt_TAILCALL(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU))\n");
                         out($f,"\n");
                         out($f,"static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV zend_interrupt_helper".($spec?"_SPEC":"")."_TAILCALL(ZEND_OPCODE_HANDLER_ARGS);\n");
+                        out($f,"static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV zend_interrupt_TAILCALL(ZEND_OPCODE_HANDLER_ARGS);\n");
                         out($f,"static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_NULL_TAILCALL_HANDLER(ZEND_OPCODE_HANDLER_ARGS);\n");
                         out($f,"static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_HALT_TAILCALL_HANDLER(ZEND_OPCODE_HANDLER_ARGS);\n");
                         out($f,"static zend_never_inline const zend_op *ZEND_OPCODE_HANDLER_CCONV zend_leave_helper_SPEC_TAILCALL(zend_execute_data *ex, const zend_op *opline);\n");
@@ -2154,6 +2171,9 @@ function gen_executor($f, $skl, $spec, $kind, $executor_name, $initializer_name)
                         out($f,"};\n");
                         out($f,"static const zend_op call_leave_op = {\n");
                         out($f,"    .handler = zend_leave_helper_SPEC_TAILCALL,\n");
+                        out($f,"};\n");
+                        out($f,"static const zend_op call_interrupt_op = {\n");
+                        out($f,"    .handler = zend_interrupt_helper_SPEC_TAILCALL,\n");
                         out($f,"};\n");
                         out($f,"\n");
 

--- a/Zend/zend_vm_gen.php
+++ b/Zend/zend_vm_gen.php
@@ -1597,14 +1597,21 @@ function gen_halt_handler($f, $kind) {
 function gen_interrupt_func($f, $kind, $spec) {
     $cconv = $kind === ZEND_VM_KIND_TAILCALL ? 'ZEND_OPCODE_HANDLER_CCONV' : 'ZEND_OPCODE_HANDLER_FUNC_CCONV';
     $variant = $kind === ZEND_VM_KIND_TAILCALL ? '_TAILCALL' : '';
+    if ($kind !== ZEND_VM_KIND_TAILCALL) {
+        /* Guard: exclude global-reg builds (void return) and TAILCALL builds (have own variant) */
+        out($f, "#if !(defined(ZEND_VM_FP_GLOBAL_REG) && defined(ZEND_VM_IP_GLOBAL_REG)) && ZEND_VM_KIND != ZEND_VM_KIND_TAILCALL\n");
+    }
     out($f, "static ZEND_COLD zend_never_inline ZEND_OPCODE_HANDLER_RET {$cconv} zend_interrupt{$variant}(ZEND_OPCODE_HANDLER_ARGS) {\n");
     out($f,"\tSAVE_OPLINE();\n");
     if ($kind === ZEND_VM_KIND_TAILCALL) {
         out($f,"\tZEND_VM_TAIL_CALL(zend_interrupt_helper".($spec?"_SPEC":"")."_TAILCALL(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));\n");
     } else {
-        out($f, "\treturn &call_interrupt_op;\n");
+        out($f, "\treturn zend_interrupt_helper".($spec?"_SPEC":"")."(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU);\n");
     }
     out($f, "}\n");
+    if ($kind !== ZEND_VM_KIND_TAILCALL) {
+        out($f, "#endif\n");
+    }
 }
 
 function extra_spec_name($extra_spec) {
@@ -1860,7 +1867,11 @@ function gen_executor_code($f, $spec, $kind, $prolog, &$switch_labels = array())
         out($f, "#pragma push_macro(\"ZEND_VM_INTERRUPT\")\n");
         out($f, "#undef  ZEND_VM_INTERRUPT\n");
         out($f, "#define ZEND_VM_CONTINUE(handler) return opline\n");
-        out($f, "#define ZEND_VM_INTERRUPT()       return zend_interrupt(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU);\n");
+        out($f, "#if !(defined(ZEND_VM_FP_GLOBAL_REG) && defined(ZEND_VM_IP_GLOBAL_REG)) && ZEND_VM_KIND != ZEND_VM_KIND_TAILCALL\n");
+        out($f, "# define ZEND_VM_INTERRUPT()      return zend_interrupt(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU);\n");
+        out($f, "#else\n");
+        out($f, "# define ZEND_VM_INTERRUPT()      return zend_interrupt_helper".($spec?"_SPEC":"")."(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU);\n");
+        out($f, "#endif\n");
         out($f, $delayed_helpers);
         out($f, "#pragma pop_macro(\"ZEND_VM_INTERRUPT\")\n");
         out($f, "#pragma pop_macro(\"ZEND_VM_CONTINUE\")\n");
@@ -2056,7 +2067,9 @@ function gen_executor($f, $skl, $spec, $kind, $executor_name, $initializer_name)
                             }
                             out($f,"\n");
                             out($f,"static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV zend_interrupt_helper".($spec?"_SPEC":"")."(ZEND_OPCODE_HANDLER_ARGS);\n");
+                            out($f,"#if !(defined(ZEND_VM_FP_GLOBAL_REG) && defined(ZEND_VM_IP_GLOBAL_REG)) && ZEND_VM_KIND != ZEND_VM_KIND_TAILCALL\n");
                             out($f,"static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV zend_interrupt(ZEND_OPCODE_HANDLER_ARGS);\n");
+                            out($f,"#endif\n");
                             out($f,"static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_NULL_HANDLER(ZEND_OPCODE_HANDLER_ARGS);\n");
                             out($f,"\n");
                             break;

--- a/Zend/zend_vm_gen.php
+++ b/Zend/zend_vm_gen.php
@@ -2136,6 +2136,9 @@ function gen_executor($f, $skl, $spec, $kind, $executor_name, $initializer_name)
                         out($f,"# define ZEND_VM_DISPATCH_TO_HELPER(call) \\\n");
                         out($f,"    do { \\\n");
                         out($f,"        opline = call; \\\n");
+                        out($f,"        if (UNEXPECTED(((uintptr_t)opline & ZEND_VM_ENTER_BIT))) { \\\n");
+                        out($f,"            return opline; \\\n");
+                        out($f,"        } \\\n");
                         out($f,"        ZEND_VM_TAIL_CALL(opline->handler(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU)); \\\n");
                         out($f,"    } while (0)\n");
                         out($f,"# define ZEND_VM_DISPATCH_TO_LEAVE_HELPER(helper) opline = &call_leave_op; SAVE_OPLINE(); ZEND_VM_CONTINUE()\n");

--- a/Zend/zend_vm_gen.php
+++ b/Zend/zend_vm_gen.php
@@ -1595,23 +1595,10 @@ function gen_halt_handler($f, $kind) {
 }
 
 function gen_interrupt_func($f, $kind, $spec) {
-    $cconv = $kind === ZEND_VM_KIND_TAILCALL ? 'ZEND_OPCODE_HANDLER_CCONV' : 'ZEND_OPCODE_HANDLER_FUNC_CCONV';
-    $variant = $kind === ZEND_VM_KIND_TAILCALL ? '_TAILCALL' : '';
-    if ($kind !== ZEND_VM_KIND_TAILCALL) {
-        /* Guard: exclude global-reg builds (void return) and TAILCALL builds (have own variant) */
-        out($f, "#if !(defined(ZEND_VM_FP_GLOBAL_REG) && defined(ZEND_VM_IP_GLOBAL_REG)) && ZEND_VM_KIND != ZEND_VM_KIND_TAILCALL\n");
-    }
-    out($f, "static ZEND_COLD zend_never_inline ZEND_OPCODE_HANDLER_RET {$cconv} zend_interrupt{$variant}(ZEND_OPCODE_HANDLER_ARGS) {\n");
+    out($f, "static ZEND_COLD zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV zend_interrupt_TAILCALL(ZEND_OPCODE_HANDLER_ARGS) {\n");
     out($f,"\tSAVE_OPLINE();\n");
-    if ($kind === ZEND_VM_KIND_TAILCALL) {
-        out($f,"\tZEND_VM_TAIL_CALL(zend_interrupt_helper".($spec?"_SPEC":"")."_TAILCALL(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));\n");
-    } else {
-        out($f, "\treturn zend_interrupt_helper".($spec?"_SPEC":"")."(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU);\n");
-    }
+    out($f,"\tZEND_VM_TAIL_CALL(zend_interrupt_helper".($spec?"_SPEC":"")."_TAILCALL(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));\n");
     out($f, "}\n");
-    if ($kind !== ZEND_VM_KIND_TAILCALL) {
-        out($f, "#endif\n");
-    }
 }
 
 function extra_spec_name($extra_spec) {
@@ -1824,7 +1811,6 @@ function gen_executor_code($f, $spec, $kind, $prolog, &$switch_labels = array())
     switch ($kind) {
         case ZEND_VM_KIND_CALL:
             gen_null_handler($f, $kind);
-            gen_interrupt_func($f, $kind, $spec);
             break;
         case ZEND_VM_KIND_TAILCALL:
             gen_null_handler($f, $kind);
@@ -1867,13 +1853,7 @@ function gen_executor_code($f, $spec, $kind, $prolog, &$switch_labels = array())
         out($f, "#pragma push_macro(\"ZEND_VM_INTERRUPT\")\n");
         out($f, "#undef  ZEND_VM_INTERRUPT\n");
         out($f, "#define ZEND_VM_CONTINUE(handler) return opline\n");
-        out($f, "#if ZEND_VM_KIND == ZEND_VM_KIND_TAILCALL\n");
         out($f, "# define ZEND_VM_INTERRUPT()      SAVE_OPLINE(); return &call_interrupt_op;\n");
-        out($f, "#elif defined(ZEND_VM_FP_GLOBAL_REG) && defined(ZEND_VM_IP_GLOBAL_REG)\n");
-        out($f, "# define ZEND_VM_INTERRUPT()      return zend_interrupt_helper".($spec?"_SPEC":"")."(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU);\n");
-        out($f, "#else\n");
-        out($f, "# define ZEND_VM_INTERRUPT()      return zend_interrupt(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU);\n");
-        out($f, "#endif\n");
         out($f, $delayed_helpers);
         out($f, "#pragma pop_macro(\"ZEND_VM_INTERRUPT\")\n");
         out($f, "#pragma pop_macro(\"ZEND_VM_CONTINUE\")\n");
@@ -2069,9 +2049,6 @@ function gen_executor($f, $skl, $spec, $kind, $executor_name, $initializer_name)
                             }
                             out($f,"\n");
                             out($f,"static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV zend_interrupt_helper".($spec?"_SPEC":"")."(ZEND_OPCODE_HANDLER_ARGS);\n");
-                            out($f,"#if !(defined(ZEND_VM_FP_GLOBAL_REG) && defined(ZEND_VM_IP_GLOBAL_REG)) && ZEND_VM_KIND != ZEND_VM_KIND_TAILCALL\n");
-                            out($f,"static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV zend_interrupt(ZEND_OPCODE_HANDLER_ARGS);\n");
-                            out($f,"#endif\n");
                             out($f,"static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_NULL_HANDLER(ZEND_OPCODE_HANDLER_ARGS);\n");
                             out($f,"\n");
                             break;

--- a/Zend/zend_vm_gen.php
+++ b/Zend/zend_vm_gen.php
@@ -1908,8 +1908,8 @@ function gen_executor($f, $skl, $spec, $kind, $executor_name, $initializer_name)
                     if ($kind == ZEND_VM_KIND_HYBRID || $kind == ZEND_VM_KIND_CALL) {
                         out($f,"#if ZEND_VM_KIND == ZEND_VM_KIND_HYBRID || ZEND_VM_KIND == ZEND_VM_KIND_TAILCALL\n\n");
                         out($f,"static zend_vm_opcode_handler_func_t const * zend_opcode_handler_funcs;\n");
-                        out($f,"#endif\n");
-                        out($f,"#if ZEND_VM_KIND == ZEND_VM_KIND_TAILCALL\n\n");
+                        out($f,"#endif\n\n");
+                        out($f,"#if ZEND_VM_KIND == ZEND_VM_KIND_TAILCALL\n");
                         out($f,"static const zend_op call_interrupt_op;\n");
                         out($f,"#endif\n\n");
                     }

--- a/Zend/zend_vm_gen.php
+++ b/Zend/zend_vm_gen.php
@@ -1595,9 +1595,15 @@ function gen_halt_handler($f, $kind) {
 }
 
 function gen_interrupt_func($f, $kind, $spec) {
-    out($f, "static ZEND_COLD zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV zend_interrupt_TAILCALL(ZEND_OPCODE_HANDLER_ARGS) {\n");
+    $cconv = $kind === ZEND_VM_KIND_TAILCALL ? 'ZEND_OPCODE_HANDLER_CCONV' : 'ZEND_OPCODE_HANDLER_FUNC_CCONV';
+    $variant = $kind === ZEND_VM_KIND_TAILCALL ? '_TAILCALL' : '';
+    out($f, "static ZEND_COLD zend_never_inline ZEND_OPCODE_HANDLER_RET {$cconv} zend_interrupt{$variant}(ZEND_OPCODE_HANDLER_ARGS) {\n");
     out($f,"\tSAVE_OPLINE();\n");
-    out($f,"\tZEND_VM_TAIL_CALL(zend_interrupt_helper".($spec?"_SPEC":"")."_TAILCALL(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));\n");
+    if ($kind === ZEND_VM_KIND_TAILCALL) {
+        out($f,"\tZEND_VM_TAIL_CALL(zend_interrupt_helper".($spec?"_SPEC":"")."_TAILCALL(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));\n");
+    } else {
+        out($f, "\treturn &call_interrupt_op;\n");
+    }
     out($f, "}\n");
 }
 
@@ -1811,6 +1817,9 @@ function gen_executor_code($f, $spec, $kind, $prolog, &$switch_labels = array())
     switch ($kind) {
         case ZEND_VM_KIND_CALL:
             gen_null_handler($f, $kind);
+            out($f, "#if ZEND_VM_KIND == ZEND_VM_KIND_TAILCALL\n");
+            gen_interrupt_func($f, $kind, $spec);
+            out($f, "#endif\n");
             break;
         case ZEND_VM_KIND_TAILCALL:
             gen_null_handler($f, $kind);
@@ -1853,7 +1862,7 @@ function gen_executor_code($f, $spec, $kind, $prolog, &$switch_labels = array())
         out($f, "#pragma push_macro(\"ZEND_VM_INTERRUPT\")\n");
         out($f, "#undef  ZEND_VM_INTERRUPT\n");
         out($f, "#define ZEND_VM_CONTINUE(handler) return opline\n");
-        out($f, "# define ZEND_VM_INTERRUPT()      SAVE_OPLINE(); return &call_interrupt_op;\n");
+        out($f, "# define ZEND_VM_INTERRUPT()      return zend_interrupt(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU)\n");
         out($f, $delayed_helpers);
         out($f, "#pragma pop_macro(\"ZEND_VM_INTERRUPT\")\n");
         out($f, "#pragma pop_macro(\"ZEND_VM_CONTINUE\")\n");
@@ -2153,6 +2162,7 @@ function gen_executor($f, $skl, $spec, $kind, $executor_name, $initializer_name)
                         out($f,"# define ZEND_VM_INTERRUPT()        ZEND_VM_TAIL_CALL(zend_interrupt_TAILCALL(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU))\n");
                         out($f,"\n");
                         out($f,"static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV zend_interrupt_helper".($spec?"_SPEC":"")."_TAILCALL(ZEND_OPCODE_HANDLER_ARGS);\n");
+                        out($f,"static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV zend_interrupt(ZEND_OPCODE_HANDLER_ARGS);\n");
                         out($f,"static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV zend_interrupt_TAILCALL(ZEND_OPCODE_HANDLER_ARGS);\n");
                         out($f,"static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_NULL_TAILCALL_HANDLER(ZEND_OPCODE_HANDLER_ARGS);\n");
                         out($f,"static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_HALT_TAILCALL_HANDLER(ZEND_OPCODE_HANDLER_ARGS);\n");

--- a/Zend/zend_vm_gen.php
+++ b/Zend/zend_vm_gen.php
@@ -1867,10 +1867,12 @@ function gen_executor_code($f, $spec, $kind, $prolog, &$switch_labels = array())
         out($f, "#pragma push_macro(\"ZEND_VM_INTERRUPT\")\n");
         out($f, "#undef  ZEND_VM_INTERRUPT\n");
         out($f, "#define ZEND_VM_CONTINUE(handler) return opline\n");
-        out($f, "#if !(defined(ZEND_VM_FP_GLOBAL_REG) && defined(ZEND_VM_IP_GLOBAL_REG)) && ZEND_VM_KIND != ZEND_VM_KIND_TAILCALL\n");
-        out($f, "# define ZEND_VM_INTERRUPT()      return zend_interrupt(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU);\n");
-        out($f, "#else\n");
+        out($f, "#if ZEND_VM_KIND == ZEND_VM_KIND_TAILCALL\n");
+        out($f, "# define ZEND_VM_INTERRUPT()      SAVE_OPLINE(); return &call_interrupt_op;\n");
+        out($f, "#elif defined(ZEND_VM_FP_GLOBAL_REG) && defined(ZEND_VM_IP_GLOBAL_REG)\n");
         out($f, "# define ZEND_VM_INTERRUPT()      return zend_interrupt_helper".($spec?"_SPEC":"")."(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU);\n");
+        out($f, "#else\n");
+        out($f, "# define ZEND_VM_INTERRUPT()      return zend_interrupt(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU);\n");
         out($f, "#endif\n");
         out($f, $delayed_helpers);
         out($f, "#pragma pop_macro(\"ZEND_VM_INTERRUPT\")\n");

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -78,6 +78,7 @@ int zend_jit_profile_counter_rid = -1;
 int16_t zend_jit_hot_counters[ZEND_HOT_COUNTERS_COUNT];
 
 const zend_op *zend_jit_halt_op = NULL;
+const zend_op *zend_jit_interrupt_op = NULL;
 #ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
 static int zend_write_protect = 1;
 #endif
@@ -3777,6 +3778,7 @@ int zend_jit_check_support(void)
 void zend_jit_startup(void *buf, size_t size, bool reattached)
 {
 	zend_jit_halt_op = zend_get_halt_op();
+	zend_jit_interrupt_op = zend_get_interrupt_op();
 	zend_jit_profile_counter_rid = zend_get_op_array_extension_handle(ACCELERATOR_PRODUCT_NAME);
 
 #ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP

--- a/ext/opcache/jit/zend_jit_internal.h
+++ b/ext/opcache/jit/zend_jit_internal.h
@@ -177,6 +177,7 @@ typedef struct _zend_jit_op_array_hot_extension {
 	zend_jit_hash((op_array)->opcodes)
 
 extern const zend_op *zend_jit_halt_op;
+extern const zend_op *zend_jit_interrupt_op;
 
 #ifdef HAVE_GCC_GLOBAL_REGS
 # define EXECUTE_DATA_D                       void

--- a/ext/opcache/jit/zend_jit_vm_helpers.c
+++ b/ext/opcache/jit/zend_jit_vm_helpers.c
@@ -1072,6 +1072,11 @@ zend_jit_trace_stop ZEND_FASTCALL zend_jit_trace_execute(zend_execute_data  *ex,
 		if (UNEXPECTED(opline == zend_jit_halt_op)) {
 #else
 		opline = handler(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU);
+# if ZEND_VM_KIND == ZEND_VM_KIND_TAILCALL
+		while (UNEXPECTED(opline == zend_jit_interrupt_op)) {
+			opline = zend_vm_handle_interrupt(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU);
+		}
+# endif
 		if (UNEXPECTED(((uintptr_t)opline & ~ZEND_VM_ENTER_BIT) == 0)) {
 #endif
 			if (prev_opline->opcode == ZEND_YIELD || prev_opline->opcode == ZEND_YIELD_FROM) {

--- a/ext/zend_test/object_handlers.c
+++ b/ext/zend_test/object_handlers.c
@@ -232,6 +232,44 @@ ZEND_METHOD(NumericCastableNoOperations, __construct)
 	ZVAL_COPY(OBJ_PROP_NUM(Z_OBJ_P(ZEND_THIS), 0), n);
 }
 
+static zend_class_entry *vm_interrupt_comparable_ce;
+static zend_object_handlers vm_interrupt_comparable_object_handlers;
+
+static zend_object* vm_interrupt_comparable_object_create_ex(zend_class_entry* ce, zend_long l) {
+	zend_object *obj = zend_objects_new(ce);
+	object_properties_init(obj, ce);
+	obj->handlers = &vm_interrupt_comparable_object_handlers;
+	ZVAL_LONG(OBJ_PROP_NUM(obj, 0), l);
+	return obj;
+}
+
+static zend_object *vm_interrupt_comparable_object_create(zend_class_entry *ce)
+{
+	return vm_interrupt_comparable_object_create_ex(ce, 0);
+}
+
+static int vm_interrupt_comparable_compare(zval *op1, zval *op2)
+{
+	ZEND_COMPARE_OBJECTS_FALLBACK(op1, op2);
+
+	zend_atomic_bool_store_ex(&EG(vm_interrupt), true);
+
+	return ZEND_THREEWAY_COMPARE(
+		Z_LVAL_P(OBJ_PROP_NUM(Z_OBJ_P(op1), 0)),
+		Z_LVAL_P(OBJ_PROP_NUM(Z_OBJ_P(op2), 0)));
+}
+
+ZEND_METHOD(VmInterruptComparable, __construct)
+{
+	zend_long l;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_LONG(l)
+	ZEND_PARSE_PARAMETERS_END();
+
+	ZVAL_LONG(OBJ_PROP_NUM(Z_OBJ_P(ZEND_THIS), 0), l);
+}
+
 static zend_class_entry *dimension_handlers_no_ArrayAccess_ce;
 static zend_object_handlers dimension_handlers_no_ArrayAccess_object_handlers;
 
@@ -301,6 +339,11 @@ void zend_test_object_handlers_init(void)
 	numeric_castable_no_operation_ce->create_object = numeric_castable_no_operation_object_create;
 	memcpy(&numeric_castable_no_operation_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	numeric_castable_no_operation_object_handlers.cast_object = numeric_castable_no_operation_cast_object;
+
+	vm_interrupt_comparable_ce = register_class_VmInterruptComparable();
+	vm_interrupt_comparable_ce->create_object = vm_interrupt_comparable_object_create;
+	memcpy(&vm_interrupt_comparable_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+	vm_interrupt_comparable_object_handlers.compare = vm_interrupt_comparable_compare;
 
 	dimension_handlers_no_ArrayAccess_ce = register_class_DimensionHandlersNoArrayAccess();
 	dimension_handlers_no_ArrayAccess_ce->create_object = dimension_handlers_no_ArrayAccess_object_create;

--- a/ext/zend_test/object_handlers.stub.php
+++ b/ext/zend_test/object_handlers.stub.php
@@ -23,6 +23,11 @@ final class NumericCastableNoOperations {
     public function __construct(int|float $val) {}
 }
 
+final class VmInterruptComparable {
+    private int $val;
+    public function __construct(int $val) {}
+}
+
 class DimensionHandlersNoArrayAccess {
     public bool $read = false;
     public bool $write = false;

--- a/ext/zend_test/object_handlers_arginfo.h
+++ b/ext/zend_test/object_handlers_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 81be60f2c465ffe5c036739d072ab80d9c388907 */
+ * Stub hash: 1a70ed60c5af38539b1222a979f97fddf7d1826e */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DoOperationNoCast___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, val, IS_LONG, 0)
@@ -15,10 +15,13 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_NumericCastableNoOperations___construct, 0,
 	ZEND_ARG_TYPE_MASK(0, val, MAY_BE_LONG|MAY_BE_DOUBLE, NULL)
 ZEND_END_ARG_INFO()
 
+#define arginfo_class_VmInterruptComparable___construct arginfo_class_DoOperationNoCast___construct
+
 static ZEND_METHOD(DoOperationNoCast, __construct);
 static ZEND_METHOD(LongCastableNoOperations, __construct);
 static ZEND_METHOD(FloatCastableNoOperations, __construct);
 static ZEND_METHOD(NumericCastableNoOperations, __construct);
+static ZEND_METHOD(VmInterruptComparable, __construct);
 
 static const zend_function_entry class_DoOperationNoCast_methods[] = {
 	ZEND_ME(DoOperationNoCast, __construct, arginfo_class_DoOperationNoCast___construct, ZEND_ACC_PUBLIC)
@@ -37,6 +40,11 @@ static const zend_function_entry class_FloatCastableNoOperations_methods[] = {
 
 static const zend_function_entry class_NumericCastableNoOperations_methods[] = {
 	ZEND_ME(NumericCastableNoOperations, __construct, arginfo_class_NumericCastableNoOperations___construct, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+static const zend_function_entry class_VmInterruptComparable_methods[] = {
+	ZEND_ME(VmInterruptComparable, __construct, arginfo_class_VmInterruptComparable___construct, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
@@ -99,6 +107,22 @@ static zend_class_entry *register_class_NumericCastableNoOperations(void)
 	ZVAL_UNDEF(&property_val_default_value);
 	zend_string *property_val_name = zend_string_init("val", sizeof("val") - 1, 1);
 	zend_declare_typed_property(class_entry, property_val_name, &property_val_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_DOUBLE));
+	zend_string_release(property_val_name);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_VmInterruptComparable(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_CLASS_ENTRY(ce, "VmInterruptComparable", class_VmInterruptComparable_methods);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+
+	zval property_val_default_value;
+	ZVAL_UNDEF(&property_val_default_value);
+	zend_string *property_val_name = zend_string_init("val", sizeof("val") - 1, 1);
+	zend_declare_typed_property(class_entry, property_val_name, &property_val_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_val_name);
 
 	return class_entry;

--- a/ext/zend_test/tests/observer_vm_interrupt_tailcall_helper.phpt
+++ b/ext/zend_test/tests/observer_vm_interrupt_tailcall_helper.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Observer: VM interrupt during tailcall helper dispatch
+--DESCRIPTION--
+This exercises a VM interrupt raised while an opcode handler dispatches to an
+extra-argument helper. On the tailcall VM, the helper may return an opline
+tagged with ZEND_VM_ENTER_BIT; treating that tagged value as a zend_op * before
+tailcalling the next handler can crash.
+--EXTENSIONS--
+zend_test
+--INI--
+opcache.jit=0
+zend_test.observer.set_vm_interrupt_on_begin=1
+--FILE--
+<?php
+function trigger(VmInterruptComparable $left, VmInterruptComparable $right): object
+{
+    if ($left < $right) {
+        return new Exception();
+    }
+    return new stdClass();
+}
+
+echo get_class(trigger(new VmInterruptComparable(2), new VmInterruptComparable(1))), "\n";
+?>
+--EXPECT--
+stdClass


### PR DESCRIPTION
In the new tailcall VM, if a  call like `ZEND_VM_DISPATCH_TO_HELPER(...) ` uses a helper like `zend_is_smaller_helper_SPEC_TAILCALL()`, and during that helper `EG(vm_interrupt)` gets set, then it will return the current opline tagged with `ZEND_VM_ENTER_BIT`. But the `ZEND_VM_DISPATCH_TO_HELPER` macro directly dereferenced the tagged pointer.

This PR changes the macro to check for a tagged pointer, and returns instead of doing the tailcall as the outer executor will handle the `ZEND_VM_ENTER_BIT`.

To reproduce this, I piggy-backed on the vm_interrupt machinery in zend_test I just added in #21910. It uses a compare handler on `class VmInterruptComparable` to deterministically set the `EG(vm_interrupt)`.