### PR TITLE
ext/gmp: Emit deprecation for precision-losing float RHS in ** / << / >>

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,10 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 8.4.22
 
+- GMP:
+  . GMP exponentiation and shift operators now emit a deprecation warning
+    when converting a float right operand to int loses precision. (Weilin Du)
+
 - Opcache:
   . Fixed tracing JIT crash when a VM interrupt is handled during an observed
     user function call. (Levi Morrison)

--- a/UPGRADING
+++ b/UPGRADING
@@ -522,6 +522,11 @@ PHP 8.4 UPGRADE NOTES
     deprecated. Use either IntlGregorianCalendar::createFromDate() or
     IntlGregorianCalendar::createFromDateTime() instead.
 
+- GMP:
+  . The shift (<<, >>) and exponentiation (**) operators on GMP objects now
+    emit a deprecation warning when converting a float right operand to int
+    loses precision.
+
 - LDAP:
   . Calling ldap_connect() with more than 2 arguments is deprecated. Use
     ldap_connect_wallet() instead.

--- a/UPGRADING
+++ b/UPGRADING
@@ -81,6 +81,10 @@ PHP 8.4 UPGRADE NOTES
   . Gettext:
     . bind_textdomain_codeset, textdomain and d(*)gettext functions now throw an exception
       if the domain argument is empty.
+  . GMP:
+    . The shift (<<, >>) and exponentiation (**) operators on GMP objects now
+      emit a deprecation warning when converting a float right operand to int
+      loses precision.
   . Intl:
     . resourcebundle_get(), ResourceBundle::get(), and accessing offsets on a
       ResourceBundle object now throw:
@@ -521,11 +525,6 @@ PHP 8.4 UPGRADE NOTES
     IntlGregorianCalendar::__construct() with more than 2 arguments is
     deprecated. Use either IntlGregorianCalendar::createFromDate() or
     IntlGregorianCalendar::createFromDateTime() instead.
-
-- GMP:
-  . The shift (<<, >>) and exponentiation (**) operators on GMP objects now
-    emit a deprecation warning when converting a float right operand to int
-    loses precision.
 
 - LDAP:
   . Calling ldap_connect() with more than 2 arguments is deprecated. Use

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -347,14 +347,14 @@ static zend_result shift_operator_helper(gmp_binary_ui_op_t op, zval *return_val
 
 	if (UNEXPECTED(Z_TYPE_P(op2) != IS_LONG)) {
 		if (UNEXPECTED(!IS_GMP(op2))) {
-			// For PHP 8.3 and up use zend_try_get_long()
 			switch (Z_TYPE_P(op2)) {
 				case IS_DOUBLE:
-					shift = zval_get_long(op2);
-					if (UNEXPECTED(EG(exception))) {
+					bool failed;
+					shift = zval_try_get_long(op2, &failed);
+					if (UNEXPECTED(failed)) {
 						return FAILURE;
-					}
 					break;
+				}
 				case IS_STRING:
 					if (is_numeric_str_function(Z_STR_P(op2), &shift, NULL) != IS_LONG) {
 						goto valueof_op_failure;

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -353,8 +353,8 @@ static zend_result shift_operator_helper(gmp_binary_ui_op_t op, zval *return_val
 					shift = zval_try_get_long(op2, &failed);
 					if (UNEXPECTED(failed)) {
 						return FAILURE;
+					}
 					break;
-				}
 				case IS_STRING:
 					if (is_numeric_str_function(Z_STR_P(op2), &shift, NULL) != IS_LONG) {
 						goto valueof_op_failure;

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -347,9 +347,9 @@ static zend_result shift_operator_helper(gmp_binary_ui_op_t op, zval *return_val
 
 	if (UNEXPECTED(Z_TYPE_P(op2) != IS_LONG)) {
 		if (UNEXPECTED(!IS_GMP(op2))) {
+			bool failed;
 			switch (Z_TYPE_P(op2)) {
 				case IS_DOUBLE:
-					bool failed;
 					shift = zval_try_get_long(op2, &failed);
 					if (UNEXPECTED(failed)) {
 						return FAILURE;

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -347,14 +347,15 @@ static zend_result shift_operator_helper(gmp_binary_ui_op_t op, zval *return_val
 
 	if (UNEXPECTED(Z_TYPE_P(op2) != IS_LONG)) {
 		if (UNEXPECTED(!IS_GMP(op2))) {
-			// For PHP 8.3 and up use zend_try_get_long()
 			switch (Z_TYPE_P(op2)) {
-				case IS_DOUBLE:
-					shift = zval_get_long(op2);
-					if (UNEXPECTED(EG(exception))) {
+				case IS_DOUBLE: {
+					bool failed;
+					shift = zval_try_get_long(op2, &failed);
+					if (UNEXPECTED(failed)) {
 						return FAILURE;
 					}
 					break;
+				}
 				case IS_STRING:
 					if (is_numeric_str_function(Z_STR_P(op2), &shift, NULL) != IS_LONG) {
 						goto valueof_op_failure;

--- a/ext/gmp/tests/overloading_with_float_fractional.phpt
+++ b/ext/gmp/tests/overloading_with_float_fractional.phpt
@@ -100,6 +100,8 @@ object(GMP)#2 (1) {
   ["num"]=>
   string(1) "0"
 }
+
+Deprecated: Implicit conversion from float 42.5 to int loses precision in %s on line %d
 object(GMP)#2 (1) {
   ["num"]=>
   string(69) "150130937545296572356771972164254457814047970568738777235893533016064"
@@ -122,10 +124,14 @@ object(GMP)#2 (1) {
   ["num"]=>
   string(1) "0"
 }
+
+Deprecated: Implicit conversion from float 42.5 to int loses precision in %s on line %d
 object(GMP)#2 (1) {
   ["num"]=>
   string(15) "184717953466368"
 }
+
+Deprecated: Implicit conversion from float 42.5 to int loses precision in %s on line %d
 object(GMP)#2 (1) {
   ["num"]=>
   string(1) "0"


### PR DESCRIPTION
I found this TODO message in the code base
```
For PHP 8.3 and up use zend_try_get_long()
```
Ah, so using zend_try_long() here will cause some precision loss and should be fixed after 8.3. So I created this PR targeting 8.4. I don't sure if this worth a NEWS entry. Also may need to merge this PR to other branches since I don't have access :)

cc @Girgias