### PR TITLE
ext/standard: Reject null bytes in parse_str()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -189,6 +189,8 @@ PHP                                                                        NEWS
     (Weilin Du)
   . getenv() and putenv() now raises a ValueError when the first argument
     contains null bytes. (Weilin Du)
+  . parse_str() now raises a ValueError when the $string argument contains
+    null bytes. (Weilin Du)
   . proc_open() now raises a ValueError when the $cwd argument contains
     null bytes. (Weilin Du)
 

--- a/UPGRADING
+++ b/UPGRADING
@@ -97,6 +97,8 @@ PHP 8.6 UPGRADE NOTES
     argument value is passed.
   . getenv() and putenv() now raises a ValueError when the first argument
     contains null bytes.
+  . parse_str() now raises a ValueError when the $string argument contains
+    null bytes.
   . linkinfo() now raises a ValueError when the $path argument is empty.
   . pathinfo() now raises a ValueError when an invalid $flag
     argument value is passed.

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -5012,7 +5012,7 @@ PHP_FUNCTION(parse_str)
 	size_t arglen;
 
 	ZEND_PARSE_PARAMETERS_START(2, 2)
-		Z_PARAM_STRING(arg, arglen)
+		Z_PARAM_PATH(arg, arglen)
 		Z_PARAM_ZVAL(arrayArg)
 	ZEND_PARSE_PARAMETERS_END();
 

--- a/ext/standard/tests/strings/parse_str_null_bytes.phpt
+++ b/ext/standard/tests/strings/parse_str_null_bytes.phpt
@@ -1,0 +1,14 @@
+--TEST--
+parse_str() rejects null bytes
+--FILE--
+<?php
+
+try {
+    parse_str("a=1\0&b=2", $result);
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+parse_str(): Argument #1 ($string) must not contain any null bytes


### PR DESCRIPTION
```php
<?php
parse_str("a=1\0&b=2", $result);
print_r($result);
```
resulted in
```
Array
(
    [a] => 1
)
```
reproduce: https://3v4l.org/UF6Pu#v
This might be the last important occurrence in the standard extension :) 