### PR TITLE
Fix phar path fix overread from the latest refactoring

### DIFF
--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -2074,7 +2074,7 @@ zend_string* phar_fix_filepath(const char *path, size_t path_length, bool use_cw
 	size_t ptr_length;
 
 	if (use_cwd && PHAR_G(cwd_len) && path_length > 2 && path[0] == '.' && path[1] == '/') {
-		new_path = zend_string_alloc(path_length + path_length + 1, false);
+		new_path = zend_string_alloc(path_length + PHAR_G(cwd_len) + 1, false);
 		new_path_len = PHAR_G(cwd_len);
 		memcpy(ZSTR_VAL(new_path), PHAR_G(cwd), PHAR_G(cwd_len));
 	} else {


### PR DESCRIPTION
This is from unrelased refactoring: https://github.com/php/php-src/commit/e1c5049ed9bb6c62dc7ff59515ad8ab2e81a3fa6#diff-04979daf330cd412502ec8ebf4a363d608a73f034687a0dd07328fd0969f2813L2070-R2069 . It was a clear mistake that can lead to the over-read.