### PR TITLE
ext/gmp: Emit deprecation for precision-losing float RHS in ** / << / >>

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -51,6 +51,8 @@ PHP                                                                        NEWS
   . gmp_fact() reject values larger than unsigned long. (David Carlier)
   . gmp_pow/binomial/root/rootrem and shift/pow operators reject values
     larger than unsigned long. (David Carlier)
+  . GMP exponentiation and shift operators now emit a deprecation warning
+    when converting a float right operand to int loses precision. (Weilin Du)
 
 - Hash:
   . Upgrade xxHash to 0.8.2. (timwolla)

--- a/UPGRADING
+++ b/UPGRADING
@@ -174,6 +174,11 @@ PHP 8.6 UPGRADE NOTES
 4. Deprecated Functionality
 ========================================
 
+- New warnings and exceptions:
+  . The shift (<<, >>) and exponentiation (**) operators on GMP objects now
+    emit a deprecation warning when converting a float right operand to int
+    loses precision.
+
 - Mbstring:
   . Mbregex has been deprecated, because the underlying Oniguruma library
     is no longer maintained.

--- a/UPGRADING
+++ b/UPGRADING
@@ -174,7 +174,7 @@ PHP 8.6 UPGRADE NOTES
 4. Deprecated Functionality
 ========================================
 
-- New warnings and exceptions:
+- GMP
   . The shift (<<, >>) and exponentiation (**) operators on GMP objects now
     emit a deprecation warning when converting a float right operand to int
     loses precision.

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -332,11 +332,11 @@ static zend_result shift_operator_helper(gmp_binary_ui_op_t op, zval *return_val
 
 	if (UNEXPECTED(Z_TYPE_P(op2) != IS_LONG)) {
 		if (UNEXPECTED(!IS_GMP(op2))) {
-			// For PHP 8.3 and up use zend_try_get_long()
+			bool failed;
 			switch (Z_TYPE_P(op2)) {
 				case IS_DOUBLE:
-					shift = zval_get_long(op2);
-					if (UNEXPECTED(EG(exception))) {
+					shift = zval_try_get_long(op2, &failed);
+					if (UNEXPECTED(failed)) {
 						return FAILURE;
 					}
 					break;

--- a/ext/gmp/tests/overloading_with_float_fractional.phpt
+++ b/ext/gmp/tests/overloading_with_float_fractional.phpt
@@ -100,6 +100,8 @@ object(GMP)#2 (1) {
   ["num"]=>
   string(1) "0"
 }
+
+Deprecated: Implicit conversion from float 42.5 to int loses precision in %s on line %d
 object(GMP)#2 (1) {
   ["num"]=>
   string(69) "150130937545296572356771972164254457814047970568738777235893533016064"
@@ -122,10 +124,14 @@ object(GMP)#2 (1) {
   ["num"]=>
   string(1) "0"
 }
+
+Deprecated: Implicit conversion from float 42.5 to int loses precision in %s on line %d
 object(GMP)#2 (1) {
   ["num"]=>
   string(15) "184717953466368"
 }
+
+Deprecated: Implicit conversion from float 42.5 to int loses precision in %s on line %d
 object(GMP)#2 (1) {
   ["num"]=>
   string(1) "0"


### PR DESCRIPTION
#21935 targeting the master branch