### PR TITLE
ext/pcntl: Ensure `$array` is a list array in `pcntl_exec`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -85,6 +85,10 @@ PHP                                                                        NEWS
     list of candidate encodings (with 200,000+ entries). (Jordi Kroon)
   . mbregex has been deprecated. (youkidearitai)
 
+- PCNTL:
+  . pcntl_exec() now throws a ValueError if the $args array is not a list
+    array. (Weilin Du)
+
 - Mysqli:
   . Added mysqli_quote_string() and mysqli::quote_string(). (Kamil Tekiela)
 

--- a/UPGRADING
+++ b/UPGRADING
@@ -37,6 +37,8 @@ PHP 8.6 UPGRADE NOTES
 - PCNTL:
   . pcntl_alarm() now raises a ValueError if the seconds argument is
     lower than zero or greater than platform's UINT_MAX.
+  . pcntl_exec() now raises a ValueError if the $args argument is not a list
+    array.
 
 - PCRE:
   . preg_grep() now returns false instead of a partial array when a PCRE

--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -675,7 +675,11 @@ PHP_FUNCTION(pcntl_exec)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (args != NULL) {
-		// TODO Check array is a list?
+		if (!zend_array_is_list(Z_ARRVAL_P(args))) {
+			zend_argument_value_error(2, "must be a list array");
+			RETURN_THROWS();
+		}
+
 		/* Build argument list */
 		SEPARATE_ARRAY(args);
 		const HashTable *args_ht = Z_ARRVAL_P(args);

--- a/ext/pcntl/tests/pcntl_exec_list_args.phpt
+++ b/ext/pcntl/tests/pcntl_exec_list_args.phpt
@@ -1,0 +1,14 @@
+--TEST--
+pcntl_exec(): Argument array must be a list
+--EXTENSIONS--
+pcntl
+--FILE--
+<?php
+try {
+    pcntl_exec('cmd', ['opt' => '-n']);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+ValueError: pcntl_exec(): Argument #2 ($args) must be a list array


### PR DESCRIPTION
Don't sure if this requires a RFC. I think with the TODO message this could be a decided behavior.