### PR TITLE
ext/intl: Use ICU U16_APPEND_UNSAFE macro for UTF-16 surrogate pair encoding

### DIFF
--- a/ext/intl/converter/converter.cpp
+++ b/ext/intl/converter/converter.cpp
@@ -167,9 +167,9 @@ static void php_converter_append_toUnicode_target(zval *val, UConverterToUnicode
 			if (lval > 0xFFFF) {
 				/* Supplemental planes U+010000 - U+10FFFF */
 				if (TARGET_CHECK(args, 2)) {
-					/* TODO: Find the ICU call which does this properly */
-					*(args->target++) = (UChar)(((lval - 0x10000) >> 10)   | 0xD800);
-					*(args->target++) = (UChar)(((lval - 0x10000) & 0x3FF) | 0xDC00);
+					int32_t offset = 0;
+					U16_APPEND_UNSAFE(args->target, offset, lval);
+					args->target += offset;
 				}
 				return;
 			}


### PR DESCRIPTION
Use [U16_APPEND_UNSAFE](https://unicode-org.github.io/icu-docs/apidoc/dev/icu4c/utf16_8h.html#aea8253343c96066779cd3383080cafa8) for UTF-16 surrogate pair encoding instead of manually operating pointers.

Small clean-ups :) 