### PR TITLE
openssl: Add error checks for CMS_get1_certs() and CMS_get1_crls()

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -6677,6 +6677,10 @@ PHP_FUNCTION(openssl_cms_read)
 		case NID_pkcs7_signedAndEnveloped:
 			certs = CMS_get1_certs(cms);
 			crls = CMS_get1_crls(cms);
+			if ((!certs || !crls) && ERR_peek_error() != 0) {
+				php_openssl_store_errors();
+				goto clean_exit;
+			}
 			break;
 		default:
 			break;


### PR DESCRIPTION
These allocate new stacks and add the certificates to those as clones. So these aren't trivial refcount increases and might fail. Unfortunately, an empty stack also results in a NULL return, so to distinguish an empty stack from a failure we check the error stack.

Note: this was found by an experimental static-dynamic hybrid analyser I'm developing.