### PR TITLE
ext/intl: Delete outdated TODO message to support numeric-castable objects as date/time values in `IntlDateFormatter->format()`

### DIFF
--- a/ext/intl/common/common_date.cpp
+++ b/ext/intl/common/common_date.cpp
@@ -202,7 +202,6 @@ try_again:
 				}
 			}
 		} else {
-			/* TODO: try with cast(), get() to obtain a number */
 			intl_errors_set(err, U_ILLEGAL_ARGUMENT_ERROR,
 				"invalid object type for date/time "
 				"(only IntlCalendar and DateTimeInterface permitted)");


### PR DESCRIPTION
Allow `IntlDateFormatter->format()` to accept objects that support numeric casting, in addition to `IntlCalendar` and `DateTimeInterface` as per the TODO message.