### PR TITLE
Fixing memory leak in php_openssl_x509_fingerprint when getting mdtype with php_openssl_get_evp_md_by_name

### DIFF
--- a/ext/openssl/openssl_backend_common.c
+++ b/ext/openssl/openssl_backend_common.c
@@ -599,6 +599,7 @@ zend_string* php_openssl_x509_fingerprint(X509 *peer, const char *method, bool r
 	} else if (!X509_digest(peer, mdtype, md, &n)) {
 		php_openssl_store_errors();
 		php_error_docref(NULL, E_ERROR, "Could not generate signature");
+		php_openssl_release_evp_md(mdtype);
 		return NULL;
 	}
 
@@ -610,6 +611,7 @@ zend_string* php_openssl_x509_fingerprint(X509 *peer, const char *method, bool r
 		ZSTR_VAL(ret)[n * 2] = '\0';
 	}
 
+	php_openssl_release_evp_md(mdtype);
 	return ret;
 }
 

--- a/ext/openssl/openssl_backend_common.c
+++ b/ext/openssl/openssl_backend_common.c
@@ -597,9 +597,9 @@ zend_string* php_openssl_x509_fingerprint(X509 *peer, const char *method, bool r
 		php_error_docref(NULL, E_WARNING, "Unknown digest algorithm");
 		return NULL;
 	} else if (!X509_digest(peer, mdtype, md, &n)) {
+		php_openssl_release_evp_md(mdtype);
 		php_openssl_store_errors();
 		php_error_docref(NULL, E_ERROR, "Could not generate signature");
-		php_openssl_release_evp_md(mdtype);
 		return NULL;
 	}
 


### PR DESCRIPTION
```
=================================================================
==1179787==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 248 byte(s) in 1 object(s) allocated from:
    #0 0x7f7b98ee6f2b in malloc (/lib64/libasan.so.8+0xe6f2b) (BuildId: 25975f766867e9e604dc5a71a8befeaed3301942)
    #1 0x7f7b98538c3d in CRYPTO_malloc (/lib64/libcrypto.so.3+0x138c3d) (BuildId: e262d686339d2c1bdd0c1aaa7ceb157f208522ab)
    #2 0x7f7b98538f54 in CRYPTO_zalloc (/lib64/libcrypto.so.3+0x138f54) (BuildId: e262d686339d2c1bdd0c1aaa7ceb157f208522ab)
    #3 0x7f7b984ec4f7 in evp_md_from_algorithm.lto_priv.0 (/lib64/libcrypto.so.3+0xec4f7) (BuildId: e262d686339d2c1bdd0c1aaa7ceb157f208522ab)
    #4 0x7f7b984ff9e4 in construct_evp_method (/lib64/libcrypto.so.3+0xff9e4) (BuildId: e262d686339d2c1bdd0c1aaa7ceb157f208522ab)
    #5 0x7f7b9852cd01 in ossl_method_construct_this (/lib64/libcrypto.so.3+0x12cd01) (BuildId: e262d686339d2c1bdd0c1aaa7ceb157f208522ab)
    #6 0x7f7b9852cba4 in algorithm_do_this (/lib64/libcrypto.so.3+0x12cba4) (BuildId: e262d686339d2c1bdd0c1aaa7ceb157f208522ab)
    #7 0x7f7b9854ca83 in ossl_provider_doall_activated (/lib64/libcrypto.so.3+0x14ca83) (BuildId: e262d686339d2c1bdd0c1aaa7ceb157f208522ab)
    #8 0x7f7b98534a87 in ossl_method_construct.constprop.0 (/lib64/libcrypto.so.3+0x134a87) (BuildId: e262d686339d2c1bdd0c1aaa7ceb157f208522ab)
    #9 0x7f7b98501217 in inner_evp_generic_fetch.constprop.0 (/lib64/libcrypto.so.3+0x101217) (BuildId: e262d686339d2c1bdd0c1aaa7ceb157f208522ab)
    #10 0x7f7b984e87b1 in EVP_MD_fetch (/lib64/libcrypto.so.3+0xe87b1) (BuildId: e262d686339d2c1bdd0c1aaa7ceb157f208522ab)
    #11 0x0000005246ed in php_openssl_get_evp_md_by_name /home/jarne/ugent/mastersThesis/project/php/ext/openssl/openssl_backend_v3.c:737
    #12 0x00000051742d in php_openssl_x509_fingerprint /home/jarne/ugent/mastersThesis/project/php/ext/openssl/openssl_backend_common.c:596
    #13 0x0000005286f6 in php_openssl_x509_fingerprint_cmp /home/jarne/ugent/mastersThesis/project/php/ext/openssl/xp_ssl.c:359
    #14 0x000000528b18 in php_openssl_x509_fingerprint_match /home/jarne/ugent/mastersThesis/project/php/ext/openssl/xp_ssl.c:398
    #15 0x00000052aa68 in php_openssl_apply_peer_verification_policy /home/jarne/ugent/mastersThesis/project/php/ext/openssl/xp_ssl.c:611
    #16 0x0000005315c5 in php_openssl_enable_crypto /home/jarne/ugent/mastersThesis/project/php/ext/openssl/xp_ssl.c:1896
    #17 0x000000535710 in php_openssl_sockop_set_option /home/jarne/ugent/mastersThesis/project/php/ext/openssl/xp_ssl.c:2513
    #18 0x000001393b17 in _php_stream_set_option /home/jarne/ugent/mastersThesis/project/php/main/streams/streams.c:1466
    #19 0x00000139d6f1 in php_stream_xport_crypto_enable /home/jarne/ugent/mastersThesis/project/php/main/streams/transports.c:387
    #20 0x0000005359b1 in php_openssl_sockop_set_option /home/jarne/ugent/mastersThesis/project/php/ext/openssl/xp_ssl.c:2538
    #21 0x000001393b17 in _php_stream_set_option /home/jarne/ugent/mastersThesis/project/php/main/streams/streams.c:1466
    #22 0x00000139c68e in php_stream_xport_connect /home/jarne/ugent/mastersThesis/project/php/main/streams/transports.c:248
    #23 0x00000139b5aa in _php_stream_xport_create /home/jarne/ugent/mastersThesis/project/php/main/streams/transports.c:145
    #24 0x0000011bb404 in zif_stream_socket_client /home/jarne/ugent/mastersThesis/project/php/ext/standard/streamsfuncs.c:158
    #25 0x00000162e355 in ZEND_DO_ICALL_SPEC_RETVAL_USED_HANDLER /home/jarne/ugent/mastersThesis/project/php/Zend/zend_vm_execute.h:1421
    #26 0x00000179f32e in execute_ex /home/jarne/ugent/mastersThesis/project/php/Zend/zend_vm_execute.h:116431
    #27 0x0000017b361f in zend_execute /home/jarne/ugent/mastersThesis/project/php/Zend/zend_vm_execute.h:121914
    #28 0x00000195d600 in zend_execute_script /home/jarne/ugent/mastersThesis/project/php/Zend/zend.c:1977
    #29 0x00000132cb00 in php_execute_script_ex /home/jarne/ugent/mastersThesis/project/php/main/main.c:2641
```

Found by a static-dynamic analyzer looking for memory bugs in error-handling paths.