### PR TITLE
openssl: fix memory leaks when session callback returns wrong type

### DIFF
--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -1634,13 +1634,12 @@ static SSL_SESSION *php_openssl_session_get_cb(SSL *ssl, const unsigned char *se
 				SSL_SESSION_up_ref(obj->session);
 				session = obj->session;
 			}
-			zval_ptr_dtor(&retval);
 		} else if (Z_TYPE(retval) != IS_NULL) {
 			zend_type_error("session_get_cb return type must be null or OpenSSLSession");
-			return NULL;
 		}
 	}
 
+	zval_ptr_dtor(&retval);
 	zval_ptr_dtor(&args[1]);
 
 	*copy = 0;


### PR DESCRIPTION
Introduced in b1242c32bcaff0b4766eaca7e1846c80687f7006

Found by a static-dynamic analyser I'm developing.