### PR TITLE
Fixing memory leak in zif_openssl_seal and zif_openssl_open when fetching cipher with php_openssl_get_evp_cipher_by_name

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -4261,6 +4261,7 @@ PHP_FUNCTION(openssl_seal)
 
 	iv_len = EVP_CIPHER_iv_length(cipher);
 	if (!iv && iv_len > 0) {
+		php_openssl_release_evp_cipher(cipher);
 		zend_argument_value_error(6, "cannot be null for the chosen cipher algorithm");
 		RETURN_THROWS();
 	}
@@ -4347,6 +4348,7 @@ clean_exit:
 	efree(eks);
 	efree(eksl);
 	efree(pkeys);
+	php_openssl_release_evp_cipher(cipher);
 }
 /* }}} */
 
@@ -4423,6 +4425,7 @@ PHP_FUNCTION(openssl_open)
 	EVP_CIPHER_CTX_free(ctx);
 out_pkey:
 	EVP_PKEY_free(pkey);
+	php_openssl_release_evp_cipher(cipher);
 }
 /* }}} */
 


### PR DESCRIPTION
```
=================================================================
==1056242==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 296 byte(s) in 1 object(s) allocated from:
    #0 0x7f2db02e6f2b in malloc (/lib64/libasan.so.8+0xe6f2b) (BuildId: 25975f766867e9e604dc5a71a8befeaed3301942)
    #1 0x7f2daf938c3d in CRYPTO_malloc (/lib64/libcrypto.so.3+0x138c3d) (BuildId: e262d686339d2c1bdd0c1aaa7ceb157f208522ab)
    #2 0x7f2daf938f54 in CRYPTO_zalloc (/lib64/libcrypto.so.3+0x138f54) (BuildId: e262d686339d2c1bdd0c1aaa7ceb157f208522ab)
    #3 0x7f2daf906fa7 in evp_cipher_from_algorithm.lto_priv.0 (/lib64/libcrypto.so.3+0x106fa7) (BuildId: e262d686339d2c1bdd0c1aaa7ceb157f208522ab)
    #4 0x7f2daf8ff9e4 in construct_evp_method (/lib64/libcrypto.so.3+0xff9e4) (BuildId: e262d686339d2c1bdd0c1aaa7ceb157f208522ab)
    #5 0x7f2daf92cd01 in ossl_method_construct_this (/lib64/libcrypto.so.3+0x12cd01) (BuildId: e262d686339d2c1bdd0c1aaa7ceb157f208522ab)
    #6 0x7f2daf92cba4 in algorithm_do_this (/lib64/libcrypto.so.3+0x12cba4) (BuildId: e262d686339d2c1bdd0c1aaa7ceb157f208522ab)
    #7 0x7f2daf94ca83 in ossl_provider_doall_activated (/lib64/libcrypto.so.3+0x14ca83) (BuildId: e262d686339d2c1bdd0c1aaa7ceb157f208522ab)
    #8 0x7f2daf934a87 in ossl_method_construct.constprop.0 (/lib64/libcrypto.so.3+0x134a87) (BuildId: e262d686339d2c1bdd0c1aaa7ceb157f208522ab)
    #9 0x7f2daf901217 in inner_evp_generic_fetch.constprop.0 (/lib64/libcrypto.so.3+0x101217) (BuildId: e262d686339d2c1bdd0c1aaa7ceb157f208522ab)
    #10 0x7f2daf901651 in EVP_CIPHER_fetch (/lib64/libcrypto.so.3+0x101651) (BuildId: e262d686339d2c1bdd0c1aaa7ceb157f208522ab)
    #11 0x000000524949 in php_openssl_get_evp_cipher_by_name /home/jarne/ugent/mastersThesis/project/php/ext/openssl/openssl_backend_v3.c:799
    #12 0x00000050dc26 in zif_openssl_seal /home/jarne/ugent/mastersThesis/project/php/ext/openssl/openssl.c:4256
    #13 0x00000162e355 in ZEND_DO_ICALL_SPEC_RETVAL_USED_HANDLER /home/jarne/ugent/mastersThesis/project/php/Zend/zend_vm_execute.h:1421
    #14 0x00000179f32e in execute_ex /home/jarne/ugent/mastersThesis/project/php/Zend/zend_vm_execute.h:116431
    #15 0x0000017b361f in zend_execute /home/jarne/ugent/mastersThesis/project/php/Zend/zend_vm_execute.h:121914
    #16 0x00000195d600 in zend_execute_script /home/jarne/ugent/mastersThesis/project/php/Zend/zend.c:1977
    #17 0x00000132cb00 in php_execute_script_ex /home/jarne/ugent/mastersThesis/project/php/main/main.c:2641
    #18 0x00000132d16d in php_execute_script /home/jarne/ugent/mastersThesis/project/php/main/main.c:2681
    #19 0x00000196397a in do_cli /home/jarne/ugent/mastersThesis/project/php/sapi/cli/php_cli.c:951
    #20 0x000001966433 in main /home/jarne/ugent/mastersThesis/project/php/sapi/cli/php_cli.c:1374
    #21 0x7f2daf6105b4 in __libc_start_call_main (/lib64/libc.so.6+0x35b4) (BuildId: abd2a4d896fed122b3f7da571746f193feeb86a1)
    #22 0x7f2daf610667 in __libc_start_main@@GLIBC_2.34 (/lib64/libc.so.6+0x3667) (BuildId: abd2a4d896fed122b3f7da571746f193feeb86a1)
    #23 0x000000406074 in _start (/home/jarne/ugent/mastersThesis/project/php/sapi/cli/php+0x406074) (BuildId: 8bae4729394587767c8fe9f6181242bc24c687ed)
```

Found by a static-dynamic analyzer looking for memory bugs in error-handling paths.