### PR TITLE
Preserve full XMM registers in Windows VM wrapper

### DIFF
--- a/Zend/asm/save_xmm_x86_64_ms_masm.asm
+++ b/Zend/asm/save_xmm_x86_64_ms_masm.asm
@@ -9,34 +9,34 @@ EXTERN execute_ex_real:PROC
 ; save the preserved registers when re-entering the VM from JIT code.
 ; See GH-18136.
 execute_ex PROC EXPORT FRAME
-    ; 10 floating points numbers
+    ; 10 XMM registers
     ; 32 bytes shadow space
     ; 8 bytes to align after the return address
-    sub rsp, 8*10 + 32 + 8
-    .allocstack 8*10 + 32 + 8
+    sub rsp, 16*10 + 32 + 8
+    .allocstack 16*10 + 32 + 8
     .endprolog
-    movsd qword ptr [rsp + 32 + 8*0], xmm6
-    movsd qword ptr [rsp + 32 + 8*1], xmm7
-    movsd qword ptr [rsp + 32 + 8*2], xmm8
-    movsd qword ptr [rsp + 32 + 8*3], xmm9
-    movsd qword ptr [rsp + 32 + 8*4], xmm10
-    movsd qword ptr [rsp + 32 + 8*5], xmm11
-    movsd qword ptr [rsp + 32 + 8*6], xmm12
-    movsd qword ptr [rsp + 32 + 8*7], xmm13
-    movsd qword ptr [rsp + 32 + 8*8], xmm14
-    movsd qword ptr [rsp + 32 + 8*9], xmm15
+    movaps xmmword ptr [rsp + 32 + 16*0], xmm6
+    movaps xmmword ptr [rsp + 32 + 16*1], xmm7
+    movaps xmmword ptr [rsp + 32 + 16*2], xmm8
+    movaps xmmword ptr [rsp + 32 + 16*3], xmm9
+    movaps xmmword ptr [rsp + 32 + 16*4], xmm10
+    movaps xmmword ptr [rsp + 32 + 16*5], xmm11
+    movaps xmmword ptr [rsp + 32 + 16*6], xmm12
+    movaps xmmword ptr [rsp + 32 + 16*7], xmm13
+    movaps xmmword ptr [rsp + 32 + 16*8], xmm14
+    movaps xmmword ptr [rsp + 32 + 16*9], xmm15
     call execute_ex_real
-    movsd xmm6, qword ptr [rsp + 32 + 8*0]
-    movsd xmm7, qword ptr [rsp + 32 + 8*1]
-    movsd xmm8, qword ptr [rsp + 32 + 8*2]
-    movsd xmm9, qword ptr [rsp + 32 + 8*3]
-    movsd xmm10, qword ptr [rsp + 32 + 8*4]
-    movsd xmm11, qword ptr [rsp + 32 + 8*5]
-    movsd xmm12, qword ptr [rsp + 32 + 8*6]
-    movsd xmm13, qword ptr [rsp + 32 + 8*7]
-    movsd xmm14, qword ptr [rsp + 32 + 8*8]
-    movsd xmm15, qword ptr [rsp + 32 + 8*9]
-    add rsp, 8*10 + 32 + 8
+    movaps xmm6, xmmword ptr [rsp + 32 + 16*0]
+    movaps xmm7, xmmword ptr [rsp + 32 + 16*1]
+    movaps xmm8, xmmword ptr [rsp + 32 + 16*2]
+    movaps xmm9, xmmword ptr [rsp + 32 + 16*3]
+    movaps xmm10, xmmword ptr [rsp + 32 + 16*4]
+    movaps xmm11, xmmword ptr [rsp + 32 + 16*5]
+    movaps xmm12, xmmword ptr [rsp + 32 + 16*6]
+    movaps xmm13, xmmword ptr [rsp + 32 + 16*7]
+    movaps xmm14, xmmword ptr [rsp + 32 + 16*8]
+    movaps xmm15, xmmword ptr [rsp + 32 + 16*9]
+    add rsp, 16*10 + 32 + 8
     ret
 execute_ex ENDP
 


### PR DESCRIPTION
We do PGO-optimized builds for Windows releases. In our builds CI, some recorded-error tests are failing on the master branch:
https://github.com/shivammathur/php-windows-builder/actions/runs/25329578176/job/74262237899#step:6:197
https://github.com/shivammathur/php-windows-builder/actions/runs/25329578176/job/74262237943#step:6:477

After checking the trace from the build, `orig_errors_buf` in `zend.c` was stored in XMM6 in the PGO build, but the Windows VM wrapper was only preserving half of the XMM registers when execution re-entered the VM:
https://github.com/php/php-src/blob/b5b2c5dfb847d0f85e51ebd2448db4627cf14266/Zend/zend.c#L1581

So the lower half was restored correctly, but the upper half, which contained the pointer to the recorded errors array, was lost. That left `EG(errors)` in an invalid state with a non-zero size but a null errors pointer.

This fixes the wrapper to save and restore the full XMM6-XMM15 registers.