### PR TITLE
ext/dba: end LMDB cursor iteration on write/delete

### DIFF
--- a/ext/dba/dba_lmdb.c
+++ b/ext/dba/dba_lmdb.c
@@ -172,6 +172,12 @@ DBA_UPDATE_FUNC(lmdb)
 	int rc;
 	MDB_val k, v;
 
+	if (LMDB_IT(cur)) {
+		mdb_cursor_close(LMDB_IT(cur));
+		LMDB_IT(cur) = NULL;
+		mdb_txn_abort(LMDB_IT(txn));
+	}
+
 	rc = mdb_txn_begin(LMDB_IT(env), NULL, 0, &LMDB_IT(txn));
 	if (rc) {
 		php_error_docref(NULL, E_WARNING, "%s", mdb_strerror(rc));
@@ -243,6 +249,12 @@ DBA_DELETE_FUNC(lmdb)
 	int rc;
 	MDB_val k;
 
+	if (LMDB_IT(cur)) {
+		mdb_cursor_close(LMDB_IT(cur));
+		LMDB_IT(cur) = NULL;
+		mdb_txn_abort(LMDB_IT(txn));
+	}
+
 	rc = mdb_txn_begin(LMDB_IT(env), NULL, 0, &LMDB_IT(txn));
 	if (rc) {
 		php_error_docref(NULL, E_WARNING, "%s", mdb_strerror(rc));
@@ -313,6 +325,10 @@ DBA_NEXTKEY_FUNC(lmdb)
 	int rc;
 	MDB_val k, v;
 	zend_string *ret = NULL;
+
+	if (!LMDB_IT(cur)) {
+		return NULL;
+	}
 
 	rc = mdb_txn_renew(LMDB_IT(txn));
 	if (rc) {

--- a/ext/dba/tests/dba_lmdb_nextkey_without_firstkey.phpt
+++ b/ext/dba/tests/dba_lmdb_nextkey_without_firstkey.phpt
@@ -1,0 +1,33 @@
+--TEST--
+DBA LMDB: dba_nextkey before dba_firstkey returns false
+--EXTENSIONS--
+dba
+--SKIPIF--
+<?php
+require_once __DIR__ . '/setup/setup_dba_tests.inc';
+check_skip('lmdb');
+?>
+--FILE--
+<?php
+require_once __DIR__ . '/setup/setup_dba_tests.inc';
+$db_file = __DIR__ . '/dba_lmdb_nextkey_without_firstkey.db';
+@unlink($db_file);
+@unlink($db_file . '-lock');
+
+$db = dba_open($db_file, 'cl', 'lmdb');
+var_dump(dba_nextkey($db));
+dba_replace('a', '1', $db);
+var_dump(dba_nextkey($db));
+dba_close($db);
+?>
+--CLEAN--
+<?php
+$db_file = __DIR__ . '/dba_lmdb_nextkey_without_firstkey.db';
+@unlink($db_file);
+@unlink($db_file . '-lock');
+@unlink($db_file . '.lck');
+?>
+--EXPECTF--
+Notice: dba_open(): Handler lmdb does locking internally in %s on line %d
+bool(false)
+bool(false)

--- a/ext/dba/tests/dba_lmdb_write_during_iteration.phpt
+++ b/ext/dba/tests/dba_lmdb_write_during_iteration.phpt
@@ -1,0 +1,51 @@
+--TEST--
+DBA LMDB: writes during cursor iteration end the iteration cleanly
+--EXTENSIONS--
+dba
+--SKIPIF--
+<?php
+require_once __DIR__ . '/setup/setup_dba_tests.inc';
+check_skip('lmdb');
+?>
+--FILE--
+<?php
+require_once __DIR__ . '/setup/setup_dba_tests.inc';
+$db_file = __DIR__ . '/dba_lmdb_write_during_iteration.db';
+@unlink($db_file);
+@unlink($db_file . '-lock');
+
+$db = dba_open($db_file, 'cl', 'lmdb');
+foreach (['a' => '1', 'b' => '2', 'c' => '3'] as $k => $v) {
+    dba_replace($k, $v, $db);
+}
+
+var_dump(dba_firstkey($db));
+var_dump(dba_nextkey($db));
+
+var_dump(dba_replace('d', '4', $db));
+var_dump(dba_nextkey($db));
+var_dump(dba_nextkey($db));
+
+var_dump(dba_firstkey($db));
+var_dump(dba_delete('a', $db));
+var_dump(dba_nextkey($db));
+
+dba_close($db);
+?>
+--CLEAN--
+<?php
+$db_file = __DIR__ . '/dba_lmdb_write_during_iteration.db';
+@unlink($db_file);
+@unlink($db_file . '-lock');
+@unlink($db_file . '.lck');
+?>
+--EXPECTF--
+Notice: dba_open(): Handler lmdb does locking internally in %s on line %d
+string(1) "a"
+string(1) "b"
+bool(true)
+bool(false)
+bool(false)
+string(1) "a"
+bool(true)
+bool(false)


### PR DESCRIPTION
dba_insert/replace/delete on an LMDB handler started a write txn into LMDB_IT(txn) while dba_firstkey's cursor was still bound to the read txn in that slot, so the next dba_nextkey renewed a freed handle. Close the cursor and abort the read txn before starting the write txn, and bail out of dba_nextkey when no cursor is open.
