### PR TITLE
ext/pgsql: route pg_copy_from table_name through build_tablename

### DIFF
--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -273,6 +273,60 @@ static void pgsql_lob_free_obj(zend_object *obj)
 
 /* Compatibility definitions */
 
+static zend_result build_tablename(smart_str *querystr, PGconn *pg_link, const zend_string *table);
+
+static bool pgsql_copy_table_name_is_simple(const char *s, size_t len)
+{
+	if (len == 0) {
+		return false;
+	}
+	size_t i = 0;
+	if (!(isalpha((unsigned char) s[i]) || s[i] == '_')) {
+		return false;
+	}
+	i++;
+	while (i < len && (isalnum((unsigned char) s[i]) || s[i] == '_')) {
+		i++;
+	}
+	if (i == len) {
+		return true;
+	}
+	if (s[i] != '.') {
+		return false;
+	}
+	i++;
+	if (i >= len || !(isalpha((unsigned char) s[i]) || s[i] == '_')) {
+		return false;
+	}
+	i++;
+	while (i < len && (isalnum((unsigned char) s[i]) || s[i] == '_')) {
+		i++;
+	}
+	return i == len;
+}
+
+static bool pgsql_copy_query_form_balanced(const char *s, size_t len)
+{
+	if (len < 2 || s[0] != '(' || s[len - 1] != ')') {
+		return false;
+	}
+	int depth = 0;
+	for (size_t i = 0; i < len; i++) {
+		if (s[i] == '(') {
+			depth++;
+		} else if (s[i] == ')') {
+			depth--;
+			if (depth < 0) {
+				return false;
+			}
+			if (depth == 0 && i != len - 1) {
+				return false;
+			}
+		}
+	}
+	return depth == 0;
+}
+
 static zend_string *_php_pgsql_trim_message(const char *message)
 {
 	size_t i = strlen(message);
@@ -3347,9 +3401,8 @@ PHP_FUNCTION(pg_copy_to)
 	pgsql_link_handle *link;
 	zend_string *table_name;
 	zend_string *pg_delimiter = NULL;
-	char *pg_null_as = "\\\\N";
-	size_t pg_null_as_len = 0;
-	char *query;
+	char *pg_null_as = "\\N";
+	size_t pg_null_as_len = sizeof("\\N") - 1;
 	PGconn *pgsql;
 	PGresult *pgsql_result;
 	ExecStatusType status;
@@ -3373,14 +3426,55 @@ PHP_FUNCTION(pg_copy_to)
 		zend_argument_value_error(3, "must be one character");
 		RETURN_THROWS();
 	}
+	bool is_query_form = ZSTR_LEN(table_name) > 0 && ZSTR_VAL(table_name)[0] == '(';
+	if (is_query_form) {
+		if (!pgsql_copy_query_form_balanced(ZSTR_VAL(table_name), ZSTR_LEN(table_name))) {
+			php_error_docref(NULL, E_WARNING, "Invalid query source '%s': must be a single balanced parenthesised expression", ZSTR_VAL(table_name));
+			RETURN_FALSE;
+		}
+	} else if (!pgsql_copy_table_name_is_simple(ZSTR_VAL(table_name), ZSTR_LEN(table_name))) {
+		php_error_docref(NULL, E_WARNING, "Invalid table_name '%s': must be a plain identifier or schema.table", ZSTR_VAL(table_name));
+		RETURN_FALSE;
+	}
 
-	spprintf(&query, 0, "COPY %s TO STDOUT DELIMITER E'%c' NULL AS E'%s'", ZSTR_VAL(table_name), *ZSTR_VAL(pg_delimiter), pg_null_as);
+	smart_str querystr = {0};
+	smart_str_appends(&querystr, "COPY ");
+	if (is_query_form) {
+		smart_str_appendc(&querystr, '(');
+		smart_str_append(&querystr, table_name);
+		smart_str_appendc(&querystr, ')');
+	} else if (build_tablename(&querystr, pgsql, table_name) == FAILURE) {
+		smart_str_free(&querystr);
+		RETURN_FALSE;
+	}
+
+	char *escaped_delimiter = PQescapeLiteral(pgsql, ZSTR_VAL(pg_delimiter), 1);
+	if (!escaped_delimiter) {
+		zend_string *msgbuf = _php_pgsql_trim_message(PQerrorMessage(pgsql));
+		php_error_docref(NULL, E_WARNING, "Failed to escape delimiter '%c': %s", *ZSTR_VAL(pg_delimiter), ZSTR_VAL(msgbuf));
+		zend_string_release(msgbuf);
+		smart_str_free(&querystr);
+		RETURN_FALSE;
+	}
+	char *escaped_null_as = PQescapeLiteral(pgsql, pg_null_as, pg_null_as_len);
+	if (!escaped_null_as) {
+		zend_string *msgbuf = _php_pgsql_trim_message(PQerrorMessage(pgsql));
+		php_error_docref(NULL, E_WARNING, "Failed to escape null_as '%s': %s", pg_null_as, ZSTR_VAL(msgbuf));
+		zend_string_release(msgbuf);
+		PQfreemem(escaped_delimiter);
+		smart_str_free(&querystr);
+		RETURN_FALSE;
+	}
+	smart_str_append_printf(&querystr, " TO STDOUT DELIMITER %s NULL AS %s", escaped_delimiter, escaped_null_as);
+	smart_str_0(&querystr);
+	PQfreemem(escaped_delimiter);
+	PQfreemem(escaped_null_as);
 
 	while ((pgsql_result = PQgetResult(pgsql))) {
 		PQclear(pgsql_result);
 	}
-	pgsql_result = PQexec(pgsql, query);
-	efree(query);
+	pgsql_result = PQexec(pgsql, ZSTR_VAL(querystr.s));
+	smart_str_free(&querystr);
 
 	if (pgsql_result) {
 		status = PQresultStatus(pgsql_result);
@@ -3462,9 +3556,8 @@ PHP_FUNCTION(pg_copy_from)
 	zval *value;
 	zend_string *table_name;
 	zend_string *pg_delimiter = NULL;
-	char *pg_null_as = "\\\\N";
-	size_t pg_null_as_len;
-	char *query;
+	char *pg_null_as = "\\N";
+	size_t pg_null_as_len = sizeof("\\N") - 1;
 	PGconn *pgsql;
 	PGresult *pgsql_result;
 	ExecStatusType status;
@@ -3488,14 +3581,46 @@ PHP_FUNCTION(pg_copy_from)
 		zend_argument_value_error(4, "must be one character");
 		RETURN_THROWS();
 	}
+	if (!pgsql_copy_table_name_is_simple(ZSTR_VAL(table_name), ZSTR_LEN(table_name))) {
+		php_error_docref(NULL, E_WARNING, "Invalid table_name '%s': must be a plain identifier or schema.table", ZSTR_VAL(table_name));
+		RETURN_FALSE;
+	}
 
-	spprintf(&query, 0, "COPY %s FROM STDIN DELIMITER E'%c' NULL AS E'%s'", ZSTR_VAL(table_name), *ZSTR_VAL(pg_delimiter), pg_null_as);
+	smart_str querystr = {0};
+	smart_str_appends(&querystr, "COPY ");
+	if (build_tablename(&querystr, pgsql, table_name) == FAILURE) {
+		smart_str_free(&querystr);
+		RETURN_FALSE;
+	}
+
+	char *escaped_delimiter = PQescapeLiteral(pgsql, ZSTR_VAL(pg_delimiter), 1);
+	if (!escaped_delimiter) {
+		zend_string *msgbuf = _php_pgsql_trim_message(PQerrorMessage(pgsql));
+		php_error_docref(NULL, E_WARNING, "Failed to escape delimiter '%c': %s", *ZSTR_VAL(pg_delimiter), ZSTR_VAL(msgbuf));
+		zend_string_release(msgbuf);
+		smart_str_free(&querystr);
+		RETURN_FALSE;
+	}
+	char *escaped_null_as = PQescapeLiteral(pgsql, pg_null_as, pg_null_as_len);
+	if (!escaped_null_as) {
+		zend_string *msgbuf = _php_pgsql_trim_message(PQerrorMessage(pgsql));
+		php_error_docref(NULL, E_WARNING, "Failed to escape null_as '%s': %s", pg_null_as, ZSTR_VAL(msgbuf));
+		zend_string_release(msgbuf);
+		PQfreemem(escaped_delimiter);
+		smart_str_free(&querystr);
+		RETURN_FALSE;
+	}
+	smart_str_append_printf(&querystr, " FROM STDIN DELIMITER %s NULL AS %s", escaped_delimiter, escaped_null_as);
+	smart_str_0(&querystr);
+	PQfreemem(escaped_delimiter);
+	PQfreemem(escaped_null_as);
+
 	while ((pgsql_result = PQgetResult(pgsql))) {
 		PQclear(pgsql_result);
 	}
-	pgsql_result = PQexec(pgsql, query);
+	pgsql_result = PQexec(pgsql, ZSTR_VAL(querystr.s));
 
-	efree(query);
+	smart_str_free(&querystr);
 
 	if (pgsql_result) {
 		status = PQresultStatus(pgsql_result);
@@ -5563,7 +5688,7 @@ static bool do_exec(smart_str *querystr, ExecStatusType expect, PGconn *pg_link,
 }
 /* }}} */
 
-static inline zend_result build_tablename(smart_str *querystr, PGconn *pg_link, const zend_string *table) /* {{{ */
+static zend_result build_tablename(smart_str *querystr, PGconn *pg_link, const zend_string *table) /* {{{ */
 {
 	/* schema.table should be "schema"."table" */
 	const char *dot = memchr(ZSTR_VAL(table), '.', ZSTR_LEN(table));
@@ -5574,7 +5699,9 @@ static inline zend_result build_tablename(smart_str *querystr, PGconn *pg_link, 
 	} else {
 		char *escaped = PQescapeIdentifier(pg_link, ZSTR_VAL(table), len);
 		if (escaped == NULL) {
-			php_error_docref(NULL, E_NOTICE, "Failed to escape table name '%s'", ZSTR_VAL(table));
+			zend_string *msgbuf = _php_pgsql_trim_message(PQerrorMessage(pg_link));
+			php_error_docref(NULL, E_WARNING, "Failed to escape table name '%s': %s", ZSTR_VAL(table), ZSTR_VAL(msgbuf));
+			zend_string_release(msgbuf);
 			return FAILURE;
 		}
 		smart_str_appends(querystr, escaped);
@@ -5590,7 +5717,9 @@ static inline zend_result build_tablename(smart_str *querystr, PGconn *pg_link, 
 		} else {
 			char *escaped = PQescapeIdentifier(pg_link, after_dot, len);
 			if (escaped == NULL) {
-				php_error_docref(NULL, E_NOTICE, "Failed to escape table name '%s'", ZSTR_VAL(table));
+				zend_string *msgbuf = _php_pgsql_trim_message(PQerrorMessage(pg_link));
+				php_error_docref(NULL, E_WARNING, "Failed to escape table name '%s': %s", ZSTR_VAL(table), ZSTR_VAL(msgbuf));
+				zend_string_release(msgbuf);
 				return FAILURE;
 			}
 			smart_str_appendc(querystr, '.');

--- a/ext/pgsql/tests/ghsa-hrwm-9436-5mv3.phpt
+++ b/ext/pgsql/tests/ghsa-hrwm-9436-5mv3.phpt
@@ -42,7 +42,7 @@ bool(false)
 Notice: pg_insert(): String value escaping failed for PostgreSQL 'text' (bar) in %s on line %d
 bool(false)
 
-Notice: pg_insert(): Failed to escape table name 'ABC%s';' in %s on line %d
+Warning: pg_insert(): Failed to escape table name 'ABC%s';': %s in %s on line %d
 bool(false)
 
 Notice: pg_insert(): Failed to escape field 'ABC%s';' in %s on line %d

--- a/ext/pgsql/tests/pg_copy_default_null_marker.phpt
+++ b/ext/pgsql/tests/pg_copy_default_null_marker.phpt
@@ -1,0 +1,52 @@
+--TEST--
+pg_copy_to() / pg_copy_from() default null marker round-trip
+--EXTENSIONS--
+pgsql
+--SKIPIF--
+<?php include("inc/skipif.inc"); ?>
+--FILE--
+<?php
+
+include('inc/config.inc');
+
+$db = pg_connect($conn_str);
+pg_query($db, 'DROP TABLE IF EXISTS pg_copy_default_null');
+pg_query($db, 'CREATE TABLE pg_copy_default_null (id int, v text)');
+pg_query($db, "INSERT INTO pg_copy_default_null VALUES (1, 'hello'), (2, NULL)");
+
+$rows = pg_copy_to($db, 'pg_copy_default_null');
+var_dump($rows);
+
+pg_query($db, 'DELETE FROM pg_copy_default_null');
+var_dump(pg_copy_from($db, 'pg_copy_default_null', $rows));
+var_dump(pg_fetch_all(pg_query($db, 'SELECT v FROM pg_copy_default_null ORDER BY id')));
+
+?>
+--CLEAN--
+<?php
+include('inc/config.inc');
+$db = pg_connect($conn_str);
+pg_query($db, 'DROP TABLE IF EXISTS pg_copy_default_null');
+?>
+--EXPECT--
+array(2) {
+  [0]=>
+  string(8) "1	hello
+"
+  [1]=>
+  string(5) "2	\N
+"
+}
+bool(true)
+array(2) {
+  [0]=>
+  array(1) {
+    ["v"]=>
+    string(5) "hello"
+  }
+  [1]=>
+  array(1) {
+    ["v"]=>
+    NULL
+  }
+}

--- a/ext/pgsql/tests/pg_copy_from_null_as_escape.phpt
+++ b/ext/pgsql/tests/pg_copy_from_null_as_escape.phpt
@@ -1,0 +1,43 @@
+--TEST--
+pg_copy_from() escapes the null_as argument
+--EXTENSIONS--
+pgsql
+--SKIPIF--
+<?php include("inc/skipif.inc"); ?>
+--FILE--
+<?php
+
+include('inc/config.inc');
+
+$db = pg_connect($conn_str);
+pg_query($db, 'DROP TABLE IF EXISTS pg_copy_null_as_target');
+pg_query($db, 'DROP TABLE IF EXISTS pg_copy_null_as_injected');
+pg_query($db, 'CREATE TABLE pg_copy_null_as_target (v text)');
+
+$evil = "X'; CREATE TABLE pg_copy_null_as_injected (v text); --";
+var_dump(pg_copy_from($db, 'pg_copy_null_as_target', ["row\n"], "\t", $evil));
+
+$r = pg_query($db, "SELECT 1 FROM pg_tables WHERE tablename = 'pg_copy_null_as_injected'");
+var_dump(pg_num_rows($r));
+
+$r = pg_query($db, 'SELECT v FROM pg_copy_null_as_target ORDER BY v');
+var_dump(pg_fetch_all($r));
+
+?>
+--CLEAN--
+<?php
+include('inc/config.inc');
+$db = pg_connect($conn_str);
+pg_query($db, 'DROP TABLE IF EXISTS pg_copy_null_as_target');
+pg_query($db, 'DROP TABLE IF EXISTS pg_copy_null_as_injected');
+?>
+--EXPECT--
+bool(true)
+int(0)
+array(1) {
+  [0]=>
+  array(1) {
+    ["v"]=>
+    string(3) "row"
+  }
+}

--- a/ext/pgsql/tests/pg_copy_from_table_name_escape.phpt
+++ b/ext/pgsql/tests/pg_copy_from_table_name_escape.phpt
@@ -1,0 +1,36 @@
+--TEST--
+pg_copy_from() escapes the table name argument
+--EXTENSIONS--
+pgsql
+--SKIPIF--
+<?php include("inc/skipif.inc"); ?>
+--FILE--
+<?php
+
+include('inc/config.inc');
+
+$db = pg_connect($conn_str);
+pg_query($db, 'DROP TABLE IF EXISTS pg_copy_from_target');
+pg_query($db, 'CREATE TABLE pg_copy_from_target (v text)');
+pg_query($db, 'DROP TABLE IF EXISTS pg_copy_from_other');
+pg_query($db, 'CREATE TABLE pg_copy_from_other (v text)');
+
+$evil = "pg_copy_from_other FROM STDIN --";
+var_dump(pg_copy_from($db, $evil, ["redirected\n"]));
+
+$rows = pg_fetch_all(pg_query($db, 'SELECT v FROM pg_copy_from_other')) ?: [];
+var_dump($rows);
+
+?>
+--CLEAN--
+<?php
+include('inc/config.inc');
+$db = pg_connect($conn_str);
+pg_query($db, 'DROP TABLE IF EXISTS pg_copy_from_target');
+pg_query($db, 'DROP TABLE IF EXISTS pg_copy_from_other');
+?>
+--EXPECTF--
+Warning: pg_copy_from(): Invalid table_name 'pg_copy_from_other FROM STDIN --': must be a plain identifier or schema.table in %s on line %d
+bool(false)
+array(0) {
+}

--- a/ext/pgsql/tests/pg_copy_table_name_validation.phpt
+++ b/ext/pgsql/tests/pg_copy_table_name_validation.phpt
@@ -1,0 +1,121 @@
+--TEST--
+pg_copy_to() / pg_copy_from() accept only plain identifier or schema.table
+--EXTENSIONS--
+pgsql
+--SKIPIF--
+<?php include("inc/skipif.inc"); ?>
+--FILE--
+<?php
+
+include('inc/config.inc');
+
+$db = pg_connect($conn_str);
+pg_query($db, 'DROP SCHEMA IF EXISTS copyv_schema CASCADE');
+pg_query($db, 'DROP TABLE IF EXISTS pg_copy_v_plain');
+pg_query($db, 'CREATE TABLE pg_copy_v_plain (v text)');
+pg_query($db, 'CREATE SCHEMA copyv_schema');
+pg_query($db, 'CREATE TABLE copyv_schema.t (v text)');
+
+echo "--- accepted: plain identifier ---\n";
+var_dump(pg_copy_from($db, 'pg_copy_v_plain', ["a\n"]));
+var_dump(pg_copy_to($db, 'pg_copy_v_plain'));
+
+echo "--- accepted: schema.table ---\n";
+var_dump(pg_copy_from($db, 'copyv_schema.t', ["b\n"]));
+var_dump(pg_copy_to($db, 'copyv_schema.t'));
+
+echo "--- rejected: column list ---\n";
+var_dump(pg_copy_from($db, 'pg_copy_v_plain (v)', ["c\n"]));
+var_dump(pg_copy_to($db, 'pg_copy_v_plain (v)'));
+
+echo "--- rejected: ONLY ---\n";
+var_dump(pg_copy_from($db, 'ONLY pg_copy_v_plain', ["d\n"]));
+var_dump(pg_copy_to($db, 'ONLY pg_copy_v_plain'));
+
+echo "--- rejected: quoted identifier ---\n";
+var_dump(pg_copy_from($db, '"pg_copy_v_plain"', ["e\n"]));
+var_dump(pg_copy_to($db, '"pg_copy_v_plain"'));
+
+echo "--- rejected: quoted name with literal dot ---\n";
+var_dump(pg_copy_from($db, '"my.table"', ["f\n"]));
+var_dump(pg_copy_to($db, '"my.table"'));
+
+echo "--- rejected: leading digit ---\n";
+var_dump(pg_copy_from($db, '1pg_copy_v_plain', ["g\n"]));
+
+echo "--- rejected: trailing dot ---\n";
+var_dump(pg_copy_from($db, 'pg_copy_v_plain.', ["h\n"]));
+
+echo "--- rejected: empty ---\n";
+var_dump(pg_copy_from($db, '', ["i\n"]));
+
+echo "--- final row counts ---\n";
+var_dump(pg_num_rows(pg_query($db, 'SELECT * FROM pg_copy_v_plain')));
+var_dump(pg_num_rows(pg_query($db, 'SELECT * FROM copyv_schema.t')));
+
+?>
+--CLEAN--
+<?php
+include('inc/config.inc');
+$db = pg_connect($conn_str);
+pg_query($db, 'DROP SCHEMA IF EXISTS copyv_schema CASCADE');
+pg_query($db, 'DROP TABLE IF EXISTS pg_copy_v_plain');
+?>
+--EXPECTF--
+--- accepted: plain identifier ---
+bool(true)
+array(1) {
+  [0]=>
+  string(2) "a
+"
+}
+--- accepted: schema.table ---
+bool(true)
+array(1) {
+  [0]=>
+  string(2) "b
+"
+}
+--- rejected: column list ---
+
+Warning: pg_copy_from(): Invalid table_name 'pg_copy_v_plain (v)': must be a plain identifier or schema.table in %s on line %d
+bool(false)
+
+Warning: pg_copy_to(): Invalid table_name 'pg_copy_v_plain (v)': must be a plain identifier or schema.table in %s on line %d
+bool(false)
+--- rejected: ONLY ---
+
+Warning: pg_copy_from(): Invalid table_name 'ONLY pg_copy_v_plain': must be a plain identifier or schema.table in %s on line %d
+bool(false)
+
+Warning: pg_copy_to(): Invalid table_name 'ONLY pg_copy_v_plain': must be a plain identifier or schema.table in %s on line %d
+bool(false)
+--- rejected: quoted identifier ---
+
+Warning: pg_copy_from(): Invalid table_name '"pg_copy_v_plain"': must be a plain identifier or schema.table in %s on line %d
+bool(false)
+
+Warning: pg_copy_to(): Invalid table_name '"pg_copy_v_plain"': must be a plain identifier or schema.table in %s on line %d
+bool(false)
+--- rejected: quoted name with literal dot ---
+
+Warning: pg_copy_from(): Invalid table_name '"my.table"': must be a plain identifier or schema.table in %s on line %d
+bool(false)
+
+Warning: pg_copy_to(): Invalid table_name '"my.table"': must be a plain identifier or schema.table in %s on line %d
+bool(false)
+--- rejected: leading digit ---
+
+Warning: pg_copy_from(): Invalid table_name '1pg_copy_v_plain': must be a plain identifier or schema.table in %s on line %d
+bool(false)
+--- rejected: trailing dot ---
+
+Warning: pg_copy_from(): Invalid table_name 'pg_copy_v_plain.': must be a plain identifier or schema.table in %s on line %d
+bool(false)
+--- rejected: empty ---
+
+Warning: pg_copy_from(): Invalid table_name '': must be a plain identifier or schema.table in %s on line %d
+bool(false)
+--- final row counts ---
+int(1)
+int(1)

--- a/ext/pgsql/tests/pg_copy_to_query_injection.phpt
+++ b/ext/pgsql/tests/pg_copy_to_query_injection.phpt
@@ -1,0 +1,66 @@
+--TEST--
+pg_copy_to() (query) source form: parens-wrap, already-parenthesised, and statement-injection rejection
+--EXTENSIONS--
+pgsql
+--SKIPIF--
+<?php include("inc/skipif.inc"); ?>
+--FILE--
+<?php
+
+include('inc/config.inc');
+
+$db = pg_connect($conn_str);
+pg_query($db, 'DROP TABLE IF EXISTS pg_copy_to_qsource');
+pg_query($db, 'DROP TABLE IF EXISTS pg_copy_to_qinjected');
+pg_query($db, 'CREATE TABLE pg_copy_to_qsource (v text)');
+pg_query($db, "INSERT INTO pg_copy_to_qsource VALUES ('a'), ('b')");
+
+var_dump(pg_copy_to($db, '(SELECT v FROM pg_copy_to_qsource ORDER BY v)'));
+
+var_dump(pg_copy_to($db, '((SELECT v FROM pg_copy_to_qsource ORDER BY v))'));
+
+$evil = '(SELECT 1); DROP TABLE pg_copy_to_qsource; --';
+var_dump(pg_copy_to($db, $evil));
+
+$wrapper_close = '(SELECT 1)); DROP TABLE pg_copy_to_qsource; --';
+var_dump(pg_copy_to($db, $wrapper_close));
+
+$r = pg_query($db, "SELECT 1 FROM pg_tables WHERE tablename = 'pg_copy_to_qsource'");
+var_dump(pg_num_rows($r));
+
+$r = pg_query($db, "SELECT 1 FROM pg_tables WHERE tablename = 'pg_copy_to_qinjected'");
+var_dump(pg_num_rows($r));
+
+?>
+--CLEAN--
+<?php
+include('inc/config.inc');
+$db = pg_connect($conn_str);
+pg_query($db, 'DROP TABLE IF EXISTS pg_copy_to_qsource');
+pg_query($db, 'DROP TABLE IF EXISTS pg_copy_to_qinjected');
+?>
+--EXPECTF--
+array(2) {
+  [0]=>
+  string(2) "a
+"
+  [1]=>
+  string(2) "b
+"
+}
+array(2) {
+  [0]=>
+  string(2) "a
+"
+  [1]=>
+  string(2) "b
+"
+}
+
+Warning: pg_copy_to(): Invalid query source '(SELECT 1); DROP TABLE pg_copy_to_qsource; --': must be a single balanced parenthesised expression in %s on line %d
+bool(false)
+
+Warning: pg_copy_to(): Invalid query source '(SELECT 1)); DROP TABLE pg_copy_to_qsource; --': must be a single balanced parenthesised expression in %s on line %d
+bool(false)
+int(1)
+int(0)

--- a/ext/pgsql/tests/pg_copy_to_table_name_escape.phpt
+++ b/ext/pgsql/tests/pg_copy_to_table_name_escape.phpt
@@ -1,0 +1,34 @@
+--TEST--
+pg_copy_to() escapes the table name argument
+--EXTENSIONS--
+pgsql
+--SKIPIF--
+<?php include("inc/skipif.inc"); ?>
+--FILE--
+<?php
+
+include('inc/config.inc');
+
+$db = pg_connect($conn_str);
+pg_query($db, 'DROP TABLE IF EXISTS pg_copy_to_source');
+pg_query($db, 'DROP TABLE IF EXISTS pg_copy_to_injected');
+pg_query($db, 'CREATE TABLE pg_copy_to_source (v text)');
+
+$evil = "pg_copy_to_source; CREATE TABLE pg_copy_to_injected (v text); --";
+var_dump(pg_copy_to($db, $evil));
+
+$r = pg_query($db, "SELECT 1 FROM pg_tables WHERE tablename = 'pg_copy_to_injected'");
+var_dump(pg_num_rows($r));
+
+?>
+--CLEAN--
+<?php
+include('inc/config.inc');
+$db = pg_connect($conn_str);
+pg_query($db, 'DROP TABLE IF EXISTS pg_copy_to_source');
+pg_query($db, 'DROP TABLE IF EXISTS pg_copy_to_injected');
+?>
+--EXPECTF--
+Warning: pg_copy_to(): Invalid table_name 'pg_copy_to_source; CREATE TABLE pg_copy_to_injected (v text); --': must be a plain identifier or schema.table in %s on line %d
+bool(false)
+int(0)


### PR DESCRIPTION
Add the table validation added in bug #62978 (which fixed pg_insert, pg_update, pg_select, pg_delete) but missed pg_copy_from. Not updating pg_copy_to since it allows (query) for the table name per ext/pgsql/tests/06_bug73498.phpt.
