### PR TITLE
ext/gd/tests: fixup gh16559.phpt and gh17349.phpt with external gd

### DIFF
--- a/ext/gd/tests/gh16559.phpt
+++ b/ext/gd/tests/gh16559.phpt
@@ -2,6 +2,13 @@
 GH-16559 (UBSan abort in ext/gd/libgd/gd_interpolation.c:1007)
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+    if (!GD_BUNDLED) {
+        /* external libgd bugs are not our problem */
+    	die("skip meaningful only for bundled libgd\n");
+    }
+?>
 --FILE--
 <?php
 $input = imagecreatefrompng(__DIR__ . '/gh10614.png');

--- a/ext/gd/tests/gh17349.phpt
+++ b/ext/gd/tests/gh17349.phpt
@@ -2,6 +2,12 @@
 GH-17349 (Tiled truecolor filling looses single color transparency)
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+    if (!(imagetypes() & IMG_PNG)) {
+        die("skip No PNG support");
+    }
+?>
 --FILE--
 <?php
 require_once __DIR__ . "/func.inc";


### PR DESCRIPTION
* gh16559.phpt is a test for a bugfix in the bundled libgd
* gh17349.phpt now loads a PNG image so an external libgd needs PNG support
