### PR TITLE
ext/gd/tests/gh17349.phpt: require PNG support

### DIFF
--- a/ext/gd/tests/gh17349.phpt
+++ b/ext/gd/tests/gh17349.phpt
@@ -2,6 +2,12 @@
 GH-17349 (Tiled truecolor filling looses single color transparency)
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+    if (!(imagetypes() & IMG_PNG)) {
+        die("skip No PNG support");
+    }
+?>
 --FILE--
 <?php
 require_once __DIR__ . "/func.inc";


### PR DESCRIPTION
This test loads a PNG image, so if an external libgd is being used, it has to support PNG.