### PR TITLE
fix(macOS): SEGV proc_open on macOS 15

### DIFF
--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -45,10 +45,31 @@
 #define USE_POSIX_SPAWN
 
 /* The non-_np variant is in macOS 26 (and _np deprecated) */
-#ifdef HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR
+#if defined(__APPLE__) && defined(HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR) && defined(HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NP)
+static inline int php_posix_spawn_file_actions_addchdir(posix_spawn_file_actions_t *actions, const char *path)
+{
+/* The standardized symbol is weak-linked when building with a newer SDK. */
+# if defined(__clang__)
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Wunguarded-availability-new"
+# endif
+	if (posix_spawn_file_actions_addchdir != NULL) {
+		return posix_spawn_file_actions_addchdir(actions, path);
+	}
+# if defined(__clang__)
+#  pragma clang diagnostic pop
+# endif
+
+	return posix_spawn_file_actions_addchdir_np(actions, path);
+}
+#define POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR php_posix_spawn_file_actions_addchdir
+#define POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NAME "posix_spawn_file_actions_addchdir"
+#elif defined(HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR)
 #define POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR posix_spawn_file_actions_addchdir
+#define POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NAME "posix_spawn_file_actions_addchdir"
 #else
 #define POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR posix_spawn_file_actions_addchdir_np
+#define POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NAME "posix_spawn_file_actions_addchdir_np"
 #endif
 #endif
 
@@ -1401,7 +1422,7 @@ PHP_FUNCTION(proc_open)
 	if (cwd) {
 		r = POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR(&factions, cwd);
 		if (r != 0) {
-			php_error_docref(NULL, E_WARNING, ZEND_TOSTR(POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR) "() failed: %s", strerror(r));
+			php_error_docref(NULL, E_WARNING, POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NAME "() failed: %s", strerror(r));
 		}
 	}
 

--- a/ext/standard/tests/general_functions/proc_open_cwd_basic.phpt
+++ b/ext/standard/tests/general_functions/proc_open_cwd_basic.phpt
@@ -1,0 +1,38 @@
+--TEST--
+proc_open() with cwd changes child working directory
+--SKIPIF--
+<?php
+if (!function_exists("proc_open")) echo "skip proc_open() is not available";
+?>
+--FILE--
+<?php
+$php = getenv('TEST_PHP_EXECUTABLE') ?: PHP_BINARY;
+$cwd = __DIR__ . DIRECTORY_SEPARATOR . 'proc_open_cwd_basic';
+@mkdir($cwd);
+
+$descriptors = [
+	1 => ['pipe', 'w'],
+	2 => ['pipe', 'w'],
+];
+$proc = proc_open([$php, '-n', '-r', 'echo basename(getcwd()), "\n";'], $descriptors, $pipes, $cwd);
+
+var_dump(is_resource($proc));
+echo stream_get_contents($pipes[1]);
+echo stream_get_contents($pipes[2]);
+fclose($pipes[1]);
+fclose($pipes[2]);
+var_dump(proc_close($proc));
+
+rmdir($cwd);
+?>
+--CLEAN--
+<?php
+$cwd = __DIR__ . DIRECTORY_SEPARATOR . 'proc_open_cwd_basic';
+if (is_dir($cwd)) {
+	rmdir($cwd);
+}
+?>
+--EXPECT--
+bool(true)
+proc_open_cwd_basic
+int(0)


### PR DESCRIPTION
Building `master` on macOS 15 causes a segfault in `proc_open` and crashes the process.

As a workaround, use the `_np` variant on older macOS and suppress the deprecation warnings.

```
$ PATH="/opt/homebrew/opt/bison/bin:/opt/homebrew/opt/re2c/bin:$PATH" ./buildconf --force
$ PATH="/opt/homebrew/opt/bison/bin:/opt/homebrew/opt/re2c/bin:$PATH" ./configure --disable-all --disable-phpdbg --disable-cgi --disable-fpm --enable-cli
$ PATH="/opt/homebrew/opt/bison/bin:/opt/homebrew/opt/re2c/bin:$PATH" make -j10
$ ./sapi/cli/php run-tests.php ext/standard/tests/general_functions/proc_open_cwd_basic.phpt

=====================================================================
PHP         : /Users/g-kudo/Developments/zeriyoshi-php-src/sapi/cli/php 
PHP_SAPI    : cli
PHP_VERSION : 8.6.0-dev
ZEND_VERSION: 4.6.0-dev
PHP_OS      : Darwin - Darwin MA-391.local 24.6.0 Darwin Kernel Version 24.6.0: Mon Jan 19 22:01:41 PST 2026; root:xnu-11417.140.69.708.3~1/RELEASE_ARM64_T8132 arm64
INI actual  : /Users/g-kudo/Developments/zeriyoshi-php-src
More .INIs  :   
CWD         : /Users/g-kudo/Developments/zeriyoshi-php-src
Extra dirs  : 
VALGRIND    : Not used
=====================================================================
Running selected tests.
Segmentation fault: 11     ./sapi/cli/php run-tests.php ext/standard/tests/general_functions/proc_open_cwd_basic.phpt
```
