### PR TITLE
GH-22004: Fix TSSA of ZEND_FE_FETCH with key operand

### DIFF
--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -2315,6 +2315,9 @@ propagate_arg:
 				if (ssa_ops[idx].op2_use >= 0 && ssa_ops[idx].op2_def >= 0) {
 					ssa_var_info[ssa_ops[idx].op2_def] = ssa_var_info[ssa_ops[idx].op2_use];
 				}
+				if (ssa_ops[idx].result_use >= 0 && ssa_ops[idx].result_def >= 0) {
+					ssa_var_info[ssa_ops[idx].result_def] = ssa_var_info[ssa_ops[idx].result_use];
+				}
 			} else {
 				if (zend_update_type_info(op_array, tssa, script, (zend_op*)opline, ssa_ops + idx, ssa_opcodes, optimization_level) == FAILURE) {
 					// TODO:

--- a/ext/opcache/tests/jit/gh22004.phpt
+++ b/ext/opcache/tests/jit/gh22004.phpt
@@ -1,0 +1,63 @@
+--TEST--
+GH-22004: ZEND_FE_FETCH_R with key operand
+--CREDITS--
+YuanchengJiang
+--FILE--
+<?php
+
+function doRandom($iter) {
+    for ($i = 0; $i < $iter; $i++) {
+        $lines = [];
+        for ($j = 0; $j < $nLines; $j++) {
+            $lines[] = $line;
+        }
+        foreach ($lines as $i => $line) {
+        }
+    }
+}
+$iter = 20;
+doRandom($iter);
+
+?>
+==DONE==
+--EXPECTF--
+Warning: Undefined variable $nLines in %s on line %d
+
+Warning: Undefined variable $nLines in %s on line %d
+
+Warning: Undefined variable $nLines in %s on line %d
+
+Warning: Undefined variable $nLines in %s on line %d
+
+Warning: Undefined variable $nLines in %s on line %d
+
+Warning: Undefined variable $nLines in %s on line %d
+
+Warning: Undefined variable $nLines in %s on line %d
+
+Warning: Undefined variable $nLines in %s on line %d
+
+Warning: Undefined variable $nLines in %s on line %d
+
+Warning: Undefined variable $nLines in %s on line %d
+
+Warning: Undefined variable $nLines in %s on line %d
+
+Warning: Undefined variable $nLines in %s on line %d
+
+Warning: Undefined variable $nLines in %s on line %d
+
+Warning: Undefined variable $nLines in %s on line %d
+
+Warning: Undefined variable $nLines in %s on line %d
+
+Warning: Undefined variable $nLines in %s on line %d
+
+Warning: Undefined variable $nLines in %s on line %d
+
+Warning: Undefined variable $nLines in %s on line %d
+
+Warning: Undefined variable $nLines in %s on line %d
+
+Warning: Undefined variable $nLines in %s on line %d
+==DONE==


### PR DESCRIPTION
Fixes GH-22004.

During type inference of `foreach ($array as $key => $elem)`, in the case of loops that didn't iterate during tracing, we copy the use var info of `$elem` to the def, but we forgot `$key`.