### PR TITLE
ext/standard: add `@compile-time-eval` to a few more functions

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -1938,9 +1938,13 @@ function base64_decode(string $string, bool $strict = false): string|false {}
 
 function constant(string $name): mixed {}
 
+/** @compile-time-eval */
 function ip2long(string $ip): int|false {}
 
-/** @refcount 1 */
+/**
+ * @compile-time-eval
+ * @refcount 1
+ */
 function long2ip(int $ip): string {}
 
 /**
@@ -2194,7 +2198,10 @@ function hrtime(bool $as_number = false): array|int|float|false {}
 
 /* md5.c */
 
-/** @refcount 1 */
+/**
+ * @compile-time-eval
+ * @refcount 1
+ */
 function md5(string $string, bool $binary = false): string {}
 
 /** @refcount 1 */
@@ -2214,7 +2221,10 @@ function getlastmod(): int|false {}
 
 /* sha1.c */
 
-/** @refcount 1 */
+/**
+ * @compile-time-eval
+ * @refcount 1
+ */
 function sha1(string $string, bool $binary = false): string {}
 
 /** @refcount 1 */
@@ -3099,6 +3109,7 @@ function iptcparse(string $iptc_block): array|false {}
 
 /* levenshtein.c */
 
+/** @compile-time-eval */
 function levenshtein(string $string1, string $string2, int $insertion_cost = 1, int $replacement_cost = 1, int $deletion_cost = 1): int {}
 
 /* link.c */

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit basic_functions.stub.php instead.
- * Stub hash: 36b71aa7bbfe478a5e4af400b2822a77067efa2f
+ * Stub hash: dee75a482f622e24c440adbf4327c3b0495a47de
  * Has decl header: yes */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
@@ -3015,8 +3015,8 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_RAW_FENTRY("base64_encode", zif_base64_encode, arginfo_base64_encode, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
 	ZEND_RAW_FENTRY("base64_decode", zif_base64_decode, arginfo_base64_decode, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
 	ZEND_FE(constant, arginfo_constant)
-	ZEND_FE(ip2long, arginfo_ip2long)
-	ZEND_FE(long2ip, arginfo_long2ip)
+	ZEND_RAW_FENTRY("ip2long", zif_ip2long, arginfo_ip2long, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
+	ZEND_RAW_FENTRY("long2ip", zif_long2ip, arginfo_long2ip, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
 	ZEND_FE(getenv, arginfo_getenv)
 #if defined(HAVE_PUTENV)
 	ZEND_FE(putenv, arginfo_putenv)
@@ -3105,14 +3105,14 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(ftok, arginfo_ftok)
 #endif
 	ZEND_FE(hrtime, arginfo_hrtime)
-	ZEND_FE(md5, arginfo_md5)
+	ZEND_RAW_FENTRY("md5", zif_md5, arginfo_md5, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
 	ZEND_FE(md5_file, arginfo_md5_file)
 	ZEND_FE(getmyuid, arginfo_getmyuid)
 	ZEND_FE(getmygid, arginfo_getmygid)
 	ZEND_FE(getmypid, arginfo_getmypid)
 	ZEND_FE(getmyinode, arginfo_getmyinode)
 	ZEND_FE(getlastmod, arginfo_getlastmod)
-	ZEND_FE(sha1, arginfo_sha1)
+	ZEND_RAW_FENTRY("sha1", zif_sha1, arginfo_sha1, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
 	ZEND_FE(sha1_file, arginfo_sha1_file)
 #if defined(HAVE_SYSLOG_H)
 	ZEND_FE(openlog, arginfo_openlog)
@@ -3333,7 +3333,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(php_ini_loaded_file, arginfo_php_ini_loaded_file)
 	ZEND_FE(iptcembed, arginfo_iptcembed)
 	ZEND_FE(iptcparse, arginfo_iptcparse)
-	ZEND_FE(levenshtein, arginfo_levenshtein)
+	ZEND_RAW_FENTRY("levenshtein", zif_levenshtein, arginfo_levenshtein, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
 #if (defined(HAVE_SYMLINK) || defined(PHP_WIN32))
 	ZEND_FE(readlink, arginfo_readlink)
 	ZEND_FE(linkinfo, arginfo_linkinfo)

--- a/ext/standard/basic_functions_decl.h
+++ b/ext/standard/basic_functions_decl.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit basic_functions.stub.php instead.
- * Stub hash: 36b71aa7bbfe478a5e4af400b2822a77067efa2f */
+ * Stub hash: dee75a482f622e24c440adbf4327c3b0495a47de */
 
-#ifndef ZEND_BASIC_FUNCTIONS_DECL_36b71aa7bbfe478a5e4af400b2822a77067efa2f_H
-#define ZEND_BASIC_FUNCTIONS_DECL_36b71aa7bbfe478a5e4af400b2822a77067efa2f_H
+#ifndef ZEND_BASIC_FUNCTIONS_DECL_dee75a482f622e24c440adbf4327c3b0495a47de_H
+#define ZEND_BASIC_FUNCTIONS_DECL_dee75a482f622e24c440adbf4327c3b0495a47de_H
 
 typedef enum zend_enum_SortDirection {
 	ZEND_ENUM_SortDirection_Ascending = 1,
@@ -20,4 +20,4 @@ typedef enum zend_enum_RoundingMode {
 	ZEND_ENUM_RoundingMode_PositiveInfinity = 8,
 } zend_enum_RoundingMode;
 
-#endif /* ZEND_BASIC_FUNCTIONS_DECL_36b71aa7bbfe478a5e4af400b2822a77067efa2f_H */
+#endif /* ZEND_BASIC_FUNCTIONS_DECL_dee75a482f622e24c440adbf4327c3b0495a47de_H */


### PR DESCRIPTION
`ip2long`, `long2ip`, `md5`, `sha1` and `levenshtein` are pure and deterministic, `@compile-time-eval` may be added to them?