### PR TITLE
sapi/cli/tests/php_cli_server_ipv6_error_message.phpt: captures IO

### DIFF
--- a/sapi/cli/tests/php_cli_server_ipv6_error_message.phpt
+++ b/sapi/cli/tests/php_cli_server_ipv6_error_message.phpt
@@ -5,6 +5,9 @@ IPv6 address error message formatting
 if (substr(PHP_OS, 0, 3) == 'WIN') {
     die("skip not for Windows");
 }
+if (getenv("SKIP_IO_CAPTURE_TESTS")) {
+    die("skip I/O capture test");
+}
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
Skip this test if `SKIP_IO_CAPTURE_TESTS=1` is set in the environment. It tries to capture stdout/stderr, and can produce different results when automated.

CC: @alexandre-daubois 