### PR TITLE
ext/gd/tests/imagebmp_basic.phpt: require PNG support

### DIFF
--- a/ext/gd/tests/imagebmp_basic.phpt
+++ b/ext/gd/tests/imagebmp_basic.phpt
@@ -2,6 +2,12 @@
 imagebmp() - basic functionality
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+    if (!(imagetypes() & IMG_PNG)) {
+        die("skip No PNG support");
+    }
+?>
 --FILE--
 <?php
 // create an image


### PR DESCRIPTION
After https://github.com/php/php-src/commit/c1c6520c4f3, libgd needs PNG support to pass this test. Skip the test if we are using (external) libgd without it.