### PR TITLE
Fix GH-22000: ext/reflection: if __isset is a reference, resolve it in ReflectionProperty::isReadable()

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -6732,7 +6732,6 @@ handle_magic_get:
 					ZVAL_STR(&member, ref->unmangled_name);
 					zend_call_known_instance_method_with_1_params(ce->__isset, obj, return_value, &member);
 
-					// if it's a reference, unwrap
 					if (Z_TYPE_P(return_value) == IS_REFERENCE) {
 						zend_unwrap_reference(return_value);
 					}

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -6731,7 +6731,12 @@ handle_magic_get:
 					zval member;
 					ZVAL_STR(&member, ref->unmangled_name);
 					zend_call_known_instance_method_with_1_params(ce->__isset, obj, return_value, &member);
-					zend_unwrap_reference(return_value);
+
+					// if it's a reference, unwrap
+					if (Z_TYPE_P(return_value) == IS_REFERENCE) {
+						zend_unwrap_reference(return_value);
+					}
+
 					*guard &= ~ZEND_GUARD_PROPERTY_ISSET;
 					OBJ_RELEASE(obj);
 					return;

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -6724,6 +6724,11 @@ ZEND_METHOD(ReflectionProperty, isReadable)
 handle_magic_get:
 		if (ce->__get) {
 			if (obj && ce->__isset) {
+				if (ce->__isset->common.fn_flags & ZEND_ACC_RETURN_REFERENCE) {
+					zend_throw_exception(reflection_exception_ptr, "__isset should not return a reference", 0);
+					RETURN_THROWS();
+				}
+
 				uint32_t *guard = zend_get_property_guard(obj, ref->unmangled_name);
 				if (!((*guard) & ZEND_GUARD_PROPERTY_ISSET)) {
 					GC_ADDREF(obj);

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -6724,12 +6724,6 @@ ZEND_METHOD(ReflectionProperty, isReadable)
 handle_magic_get:
 		if (ce->__get) {
 			if (obj && ce->__isset) {
-				if (ce->__isset->common.fn_flags & ZEND_ACC_RETURN_REFERENCE) {
-					//php_error_docref(NULL, E_WARNING, "__isset unexpectedly returned a reference!");
-					zend_error(E_WARNING, "__isset unexpectedly returned a reference!");
-					RETURN_FALSE;
-				}
-
 				uint32_t *guard = zend_get_property_guard(obj, ref->unmangled_name);
 				if (!((*guard) & ZEND_GUARD_PROPERTY_ISSET)) {
 					GC_ADDREF(obj);
@@ -6737,6 +6731,7 @@ handle_magic_get:
 					zval member;
 					ZVAL_STR(&member, ref->unmangled_name);
 					zend_call_known_instance_method_with_1_params(ce->__isset, obj, return_value, &member);
+					zend_unwrap_reference(return_value);
 					*guard &= ~ZEND_GUARD_PROPERTY_ISSET;
 					OBJ_RELEASE(obj);
 					return;

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -6725,8 +6725,9 @@ handle_magic_get:
 		if (ce->__get) {
 			if (obj && ce->__isset) {
 				if (ce->__isset->common.fn_flags & ZEND_ACC_RETURN_REFERENCE) {
-					zend_throw_exception(reflection_exception_ptr, "__isset should not return a reference", 0);
-					RETURN_THROWS();
+					//php_error_docref(NULL, E_WARNING, "__isset unexpectedly returned a reference!");
+					zend_error(E_WARNING, "__isset unexpectedly returned a reference!");
+					RETURN_FALSE;
 				}
 
 				uint32_t *guard = zend_get_property_guard(obj, ref->unmangled_name);

--- a/ext/reflection/tests/gh22000.phpt
+++ b/ext/reflection/tests/gh22000.phpt
@@ -1,0 +1,39 @@
+--TEST--
+GH-22000 - Ensure __isset is not returning a reference in ReflectionProperty::isReadable()
+--FILE--
+<?php
+class TestClass {
+    public int $a;
+    public int $b;
+    public int $c;
+
+    public function __construct() {
+        unset($this->b);
+        unset($this->c);
+    }
+
+    public function &__isset($name) {
+        return $name === 'c';
+    }
+
+    public function __get($name) {}
+}
+
+
+function test($class) {
+    try {
+        $rc = new ReflectionClass($class);
+        foreach ($rc->getProperties() as $rp) {
+            echo $rp->getName() . ' from global: ';
+            var_dump($rp->isReadable(null, new $class));
+        }
+    } catch(\Exception $ex) {
+        echo $ex->getMessage();
+    }
+}
+
+test('TestClass');
+?>
+--EXPECTF--
+a from global: bool(false)
+b from global: __isset should not return a reference

--- a/ext/reflection/tests/gh22000.phpt
+++ b/ext/reflection/tests/gh22000.phpt
@@ -2,8 +2,8 @@
 GH-22000 - Ensure __isset is not returning a reference in ReflectionProperty::isReadable()
 --FILE--
 <?php
-class TestClass {
-    public int $a;
+class TestClass1 {
+    public int $a = 1;
     public int $b;
     public int $c;
 
@@ -12,8 +12,25 @@ class TestClass {
         unset($this->c);
     }
 
+    public function __isset($name) {
+        return $name === 'b';
+    }
+
+    public function __get($name) {}
+}
+
+class TestClass2 {
+    public int $d;
+    public int $e;
+    public int $f;
+
+    public function __construct() {
+        unset($this->e);
+        unset($this->f);
+    }
+
     public function &__isset($name) {
-        return $name === 'c';
+        return $name === 'f';
     }
 
     public function __get($name) {}
@@ -28,13 +45,17 @@ function test($class) {
     }
 }
 
-test('TestClass');
+test('TestClass1');
+test('TestClass2');
 ?>
 --EXPECTF--
-a from global:bool(false)
-b from global:
-Notice: Only variable references should be returned by reference in /home/zaaarf/dev/irl/c/php/ext/reflection/tests/gh22000.php on line 13
+a from global:bool(true)
+b from global:bool(true)
+c from global:bool(false)
+d from global:bool(false)
+e from global:
+Notice: Only variable references should be returned by reference in %s%eext%ereflection%etests%egh22000.php on line %d
 bool(false)
-c from global:
-Notice: Only variable references should be returned by reference in /home/zaaarf/dev/irl/c/php/ext/reflection/tests/gh22000.php on line 13
+f from global:
+Notice: Only variable references should be returned by reference in %s%eext%ereflection%etests%egh22000.php on line %d
 bool(true)

--- a/ext/reflection/tests/gh22000.phpt
+++ b/ext/reflection/tests/gh22000.phpt
@@ -33,9 +33,8 @@ test('TestClass');
 --EXPECTF--
 a from global:bool(false)
 b from global:
-Warning: __isset unexpectedly returned a reference! in %s%eext%ereflection%etests%egh22000.php on line %d
+Notice: Only variable references should be returned by reference in /home/zaaarf/dev/irl/c/php/ext/reflection/tests/gh22000.php on line 13
 bool(false)
 c from global:
-Warning: __isset unexpectedly returned a reference! in %s%eext%ereflection%etests%egh22000.php on line %d
-bool(false)
-
+Notice: Only variable references should be returned by reference in /home/zaaarf/dev/irl/c/php/ext/reflection/tests/gh22000.php on line 13
+bool(true)

--- a/ext/reflection/tests/gh22000.phpt
+++ b/ext/reflection/tests/gh22000.phpt
@@ -33,9 +33,9 @@ test('TestClass');
 --EXPECTF--
 a from global:bool(false)
 b from global:
-Warning: __isset unexpectedly returned a reference! in %s/ext/reflection/tests/gh22000.php on line %d
+Warning: __isset unexpectedly returned a reference! in %s%eext%ereflection%etests%egh22000.php on line %d
 bool(false)
 c from global:
-Warning: __isset unexpectedly returned a reference! in %s/ext/reflection/tests/gh22000.php on line %d
+Warning: __isset unexpectedly returned a reference! in %s%eext%ereflection%etests%egh22000.php on line %d
 bool(false)
 

--- a/ext/reflection/tests/gh22000.phpt
+++ b/ext/reflection/tests/gh22000.phpt
@@ -1,5 +1,5 @@
 --TEST--
-GH-22000 - Ensure __isset is supported by ReflectionProperty::isReadable()
+GH-22000 - Ensure __isset returning a reference is supported by ReflectionProperty::isReadable()
 --FILE--
 <?php
 class TestClass1 {

--- a/ext/reflection/tests/gh22000.phpt
+++ b/ext/reflection/tests/gh22000.phpt
@@ -1,5 +1,5 @@
 --TEST--
-GH-22000 - Ensure __isset is not returning a reference in ReflectionProperty::isReadable()
+GH-22000 - Ensure __isset is supported by ReflectionProperty::isReadable()
 --FILE--
 <?php
 class TestClass1 {
@@ -54,8 +54,8 @@ b from global:bool(true)
 c from global:bool(false)
 d from global:bool(false)
 e from global:
-Notice: Only variable references should be returned by reference in %s%eext%ereflection%etests%egh22000.php on line %d
+Notice: Only variable references should be returned by reference in %s on line %d
 bool(false)
 f from global:
-Notice: Only variable references should be returned by reference in %s%eext%ereflection%etests%egh22000.php on line %d
+Notice: Only variable references should be returned by reference in %s on line %d
 bool(true)

--- a/ext/reflection/tests/gh22000.phpt
+++ b/ext/reflection/tests/gh22000.phpt
@@ -21,19 +21,21 @@ class TestClass {
 
 
 function test($class) {
-    try {
-        $rc = new ReflectionClass($class);
-        foreach ($rc->getProperties() as $rp) {
-            echo $rp->getName() . ' from global: ';
-            var_dump($rp->isReadable(null, new $class));
-        }
-    } catch(\Exception $ex) {
-        echo $ex->getMessage();
+    $rc = new ReflectionClass($class);
+    foreach ($rc->getProperties() as $rp) {
+        echo $rp->getName() . ' from global:';
+        var_dump($rp->isReadable(null, new $class));
     }
 }
 
 test('TestClass');
 ?>
 --EXPECTF--
-a from global: bool(false)
-b from global: __isset should not return a reference
+a from global:bool(false)
+b from global:
+Warning: __isset unexpectedly returned a reference! in %s/ext/reflection/tests/gh22000.php on line %d
+bool(false)
+c from global:
+Warning: __isset unexpectedly returned a reference! in %s/ext/reflection/tests/gh22000.php on line %d
+bool(false)
+


### PR DESCRIPTION
#22000 outlines a problem that happens in the new-ish 8.6 methods introduced by [this RFC](https://wiki.php.net/rfc/isreadable-iswriteable) (hence why I'm submitting this against `master`).

They call `__isset`, but if the implementer made `__isset` return a reference, the call breaks and fails an assertion. I am pretty sure this qualifies as an unrecoverable state, so I just added a check before calling it that ensures that `__isset` does not return a reference, throwing an exception if that's the case so at least the user gets a graceful exit.

If this is recoverable, please do leave me a comment on how you envision it, and I'll make it happen.

~~Not sure if this bug warrants a dedicated test, but if it does, leave me a comment and I'll add it.~~ added test

I should add that this is kind of a dirty fix that addresses the situation in a single case; we should probably look towards forbidding magic methods from returning references altogether, but maybe there's some valid niche use case that I can't envision.