### PR TITLE
sqlite3: fix internal return type violation in escapeString()

### DIFF
--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -494,6 +494,9 @@ PHP_METHOD(SQLite3, escapeString)
 		if (ret) {
 			RETVAL_STRING(ret);
 			sqlite3_free(ret);
+		} else {
+			zend_throw_exception_ex(php_sqlite3_exception_ce, 0, "Unable to escape string");
+			RETURN_THROWS();
 		}
 	} else {
 		RETURN_EMPTY_STRING();


### PR DESCRIPTION
If this call fails due to an internal libsqlite3 error, then the function will return NULL (as that's the default value set by the VM). However, the function is marked with a non-nullable string return type. Therefore this will result in a type violation and a fatal error in debug mode.
Either we solve it by making the function nullable or throw. I chose the latter as it is less of a footgun.

Found by a static-dynamic analyser I'm developing.