### PR TITLE
Fix GH-22023 crash during ZTS thread startup

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -809,6 +809,7 @@ static void executor_globals_ctor(zend_executor_globals *executor_globals) /* {{
 	executor_globals->user_error_handler_error_reporting = 0;
 	ZVAL_UNDEF(&executor_globals->user_error_handler);
 	ZVAL_UNDEF(&executor_globals->user_exception_handler);
+	ZVAL_UNDEF(&executor_globals->last_fatal_error_backtrace);
 	executor_globals->in_autoload = NULL;
 	executor_globals->current_execute_data = NULL;
 	executor_globals->current_module = NULL;


### PR DESCRIPTION
Fixes GH-22023 by initializing `last_fatal_error_backtrace` in `executor_globals_ctor()`.

On Apache + ZTS, `zend_new_thread_end_handler()` may refresh INI caches before `init_executor()` runs for the new thread. If `session.use_trans_sid=1` triggers its startup deprecation in that window, `zend_error_zstr_at()` can destroy `EG(last_fatal_error_backtrace)` before it has been initialized, causing an access violation and Apache child restart.

This change makes the per-thread executor globals safe for that early warning path.