### PR TITLE
ext/pcre: fix duplicate MARK key in matches array

### DIFF
--- a/ext/pcre/php_pcre.c
+++ b/ext/pcre/php_pcre.c
@@ -1079,7 +1079,7 @@ static void populate_subpat_array(
 	/* Add MARK, if available */
 	if (mark) {
 		ZVAL_STRING(&val, (char *)mark);
-		zend_hash_str_add_new(subpats_ht, ZEND_STRL("MARK"), &val);
+		zend_hash_str_update(subpats_ht, ZEND_STRL("MARK"), &val);
 	}
 }
 

--- a/ext/pcre/tests/mark_named_collision.phpt
+++ b/ext/pcre/tests/mark_named_collision.phpt
@@ -1,0 +1,15 @@
+--TEST--
+preg_match: (*MARK:name) directive does not collide with named group called MARK
+--FILE--
+<?php
+preg_match('/(?P<MARK>[abc])(*MARK:value)/', "abc", $m);
+echo "count: ", count($m), "\n";
+echo "MARK: ", $m['MARK'], "\n";
+echo "json: ", json_encode($m), "\n";
+echo "keys: ", implode(',', array_keys($m)), "\n";
+?>
+--EXPECT--
+count: 3
+MARK: value
+json: {"0":"a","MARK":"value","1":"a"}
+keys: 0,MARK,1


### PR DESCRIPTION
Regression from d6cc31cf9538: populate_subpat_array() now uses zend_hash_str_add_new for the (*MARK:name) directive, which skips the duplicate-key check. When a named capture is also called MARK, two buckets land in $matches.

Repro: `preg_match('/(?P<MARK>[abc])(*MARK:value)/', "abc", $m);`. Master gives count($m)==4 with a duplicate JSON key; PHP-8.4 gives 3. Restore the directive-overwrites-capture behavior that add_assoc_string_ex provided before the refactor.
