### PR TITLE
ext/XML: Improve invalid value handling for XML_OPTION_SKIP_TAGSTART

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -220,6 +220,11 @@ PHP                                                                        NEWS
   . Fixed bug #49874 (ftell() and fseek() inconsistency when using stream
     filters). (Jakub Zelenka)
 
+- XML:
+  . xml_parser_set_option() now reports invalid XML_OPTION_SKIP_TAGSTART
+    values more consistently and avoids an extra object-to-int conversion
+    warning for unsupported values. (Weilin Du)
+
 - Zip:
   . Fixed ZipArchive callback being called after executor has shut down.
     (ilutov)

--- a/UPGRADING
+++ b/UPGRADING
@@ -118,6 +118,11 @@ PHP 8.6 UPGRADE NOTES
   . proc_open() now raises a ValueError when the $cwd argument contains
     null bytes.
 
+- XML:
+  . xml_parser_set_option() now reports invalid XML_OPTION_SKIP_TAGSTART
+    values more consistently and no longer emits an extra object-to-int
+    conversion warning for unsupported values.
+
 - Zip:
   . ZipArchive::extractTo now raises a TypeError for the
     files argument if one or more of the entries is not

--- a/ext/xml/tests/xml_parser_set_option_errors.phpt
+++ b/ext/xml/tests/xml_parser_set_option_errors.phpt
@@ -38,6 +38,12 @@ xml_parser_set_option($xmlParser, XML_OPTION_SKIP_TAGSTART, []);
 
 xml_parser_set_option($xmlParser, XML_OPTION_SKIP_TAGSTART, new stdClass());
 
+var_dump(xml_parser_set_option($xmlParser, XML_OPTION_SKIP_TAGSTART, "123test"));
+var_dump(xml_parser_get_option($xmlParser, XML_OPTION_SKIP_TAGSTART));
+
+var_dump(xml_parser_set_option($xmlParser, XML_OPTION_SKIP_TAGSTART, 1.5));
+var_dump(xml_parser_get_option($xmlParser, XML_OPTION_SKIP_TAGSTART));
+
 echo "Encodings\n";
 try {
     xml_parser_set_option($xmlParser, XML_OPTION_TARGET_ENCODING, 'Invalid Encoding');
@@ -74,8 +80,12 @@ Warning: xml_parser_set_option(): Argument #3 ($value) must be between 0 and 214
 Warning: xml_parser_set_option(): Argument #3 ($value) must be of type string|int|bool, array given in %s on line %d
 
 Warning: xml_parser_set_option(): Argument #3 ($value) must be of type string|int|bool, stdClass given in %s on line %d
+bool(true)
+int(123)
 
-Warning: Object of class stdClass could not be converted to int in %s on line %d
+Warning: xml_parser_set_option(): Argument #3 ($value) must be of type string|int|bool, float given in %s on line %d
+bool(true)
+int(1)
 Encodings
 xml_parser_set_option(): Argument #3 ($value) is not a supported target encoding
 

--- a/ext/xml/xml.c
+++ b/ext/xml/xml.c
@@ -1588,7 +1588,17 @@ PHP_FUNCTION(xml_parser_set_option)
 		/* Integer option */
 		case PHP_XML_OPTION_SKIP_TAGSTART: {
 			/* The tag start offset is stored in an int */
-			/* TODO Improve handling of values? */
+			switch (Z_TYPE_P(value)) {
+				case IS_FALSE:
+				case IS_TRUE:
+				case IS_LONG:
+				case IS_DOUBLE:
+				case IS_STRING:
+					break;
+				default:
+					RETURN_FALSE;
+			}
+
 			zend_long value_long = zval_get_long(value);
 			if (value_long < 0 || value_long > INT_MAX) {
 				/* TODO Promote to ValueError in PHP 9.0 */


### PR DESCRIPTION
cleaning up implicit cast of `zval_get_long` in XML_OPTION_SKIP_TAGSTART

Types like stdClass or array will cause two warnings currently, which is duplication. For non-numeric string, the original behavior is silently convert it to long (0) and return false with no warning.

So one suggested practice is to check if the type is string|int|bool, if no raise a warning and ret false, if yes than go to `zval_try_get_long` and see if it is non-numeric string, if yes raise a warning and ret false.