### PR TITLE
Fix compiler warning with glibc 2.43

### DIFF
--- a/ext/dba/libinifile/inifile.c
+++ b/ext/dba/libinifile/inifile.c
@@ -111,7 +111,7 @@ void inifile_free(inifile *dba, int persistent)
 key_type inifile_key_split(const char *group_name)
 {
 	key_type key;
-	char *name;
+	const char *name;
 
 	if (group_name[0] == '[' && (name = strchr(group_name, ']')) != NULL) {
 		key.group = estrndup(group_name+1, name - (group_name + 1));

--- a/ext/readline/readline_cli.c
+++ b/ext/readline/readline_cli.c
@@ -529,7 +529,8 @@ TODO:
 	} else if (text[0] == '#' && text[1] != '[') {
 		retval = cli_completion_generator_ini(text, textlen, &cli_completion_state);
 	} else {
-		char *lc_text, *class_name_end;
+		char *lc_text;
+		const char *class_name_end;
 		zend_string *class_name = NULL;
 		zend_class_entry *ce = NULL;
 


### PR DESCRIPTION
Fix compiler warnings with glibc 2.43 support of C23 const-preserving standard library macros: assignment discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers].

These are cases I didn't spot in https://github.com/php/php-src/pull/21950.