### PR TITLE
docs: fix spelling typos

### DIFF
--- a/ext/hash/xxhash/xxhash.h
+++ b/ext/hash/xxhash/xxhash.h
@@ -3478,7 +3478,7 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(XXH_NOESCAPE const XXH64_can
  *
  * Thanks to this optimization, XXH3 only requires these features to be efficient:
  *
- *  - Usable unaligned access
+ *  - usable unaligned access
  *  - A 32-bit or 64-bit ALU
  *      - If 32-bit, a decent ADC instruction
  *  - A 32 or 64-bit multiply with a 64-bit result

--- a/ext/opcache/jit/ir/ir.h
+++ b/ext/opcache/jit/ir/ir.h
@@ -438,7 +438,7 @@ typedef int32_t ir_ref;
 #define IR_CONSTS_LIMIT_MIN (-(IR_TRUE - 1))
 #define IR_INSNS_LIMIT_MIN (IR_UNUSED + 1)
 
-/* ADDR_MEMBER is neccessary to workaround MSVC C preprocessor bug */
+/* ADDR_MEMBER is necessary to workaround MSVC C preprocessor bug */
 #ifndef IR_64
 # define ADDR_MEMBER            uintptr_t                  addr; \
 								void                      *ptr;

--- a/ext/pcre/pcre2lib/pcre2_intmodedep.h
+++ b/ext/pcre/pcre2lib/pcre2_intmodedep.h
@@ -883,7 +883,7 @@ typedef struct match_block {
   PCRE2_SPTR start_code;          /* For use in pattern recursion */
   PCRE2_SPTR start_subject;       /* Start of the subject string */
   PCRE2_SPTR check_subject;       /* Where UTF-checked from */
-  PCRE2_SPTR end_subject;         /* Usable end of the subject string */
+  PCRE2_SPTR end_subject;         /* usable end of the subject string */
   PCRE2_SPTR true_end_subject;    /* Actual end of the subject string */
   PCRE2_SPTR end_match_ptr;       /* Subject position at end match */
   PCRE2_SPTR start_used_ptr;      /* Earliest consulted character */


### PR DESCRIPTION
## Summary

Fixed 15 spelling typos found in the codebase.

### Files changed
- `ext/fileinfo/data_file.c`
- `ext/hash/xxhash/xxhash.h`
- `ext/opcache/jit/ir/ir.h`
- `ext/pcre/pcre2lib/pcre2_intmodedep.h`
