### PR TITLE
Refactor: Reuse existing Zend parameter error helpers for standard error paths

### DIFF
--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -970,7 +970,7 @@ ZEND_FUNCTION(method_exists)
 			RETURN_FALSE;
 		}
 	} else {
-		zend_argument_type_error(1, "must be of type object|string, %s given", zend_zval_value_name(klass));
+		zend_wrong_parameter_type_error(1, Z_EXPECTED_OBJECT_OR_STRING, klass);
 		RETURN_THROWS();
 	}
 
@@ -1024,7 +1024,7 @@ static void _property_exists(zval *return_value, const zval *object, zend_string
 	} else if (Z_TYPE_P(object) == IS_OBJECT) {
 		ce = Z_OBJCE_P(object);
 	} else {
-		zend_argument_type_error(1, "must be of type object|string, %s given", zend_zval_value_name(object));
+		zend_wrong_parameter_type_error(1, Z_EXPECTED_OBJECT_OR_STRING, object);
 		RETURN_THROWS();
 	}
 

--- a/ext/dom/token_list.c
+++ b/ext/dom/token_list.c
@@ -484,7 +484,7 @@ static bool dom_validate_tokens_varargs(const zval *args, uint32_t argc)
 {
 	for (uint32_t i = 0; i < argc; i++) {
 		if (Z_TYPE(args[i]) != IS_STRING) {
-			zend_argument_type_error(i + 1, "must be of type string, %s given", zend_zval_value_name(&args[i]));
+			zend_wrong_parameter_type_error(i + 1, Z_EXPECTED_STRING, &args[i]);
 			return false;
 		}
 

--- a/ext/dom/xml_document.c
+++ b/ext/dom/xml_document.c
@@ -145,7 +145,7 @@ static void load_from_helper(INTERNAL_FUNCTION_PARAMETERS, int mode)
 	}
 
 	if (!source_len) {
-		zend_argument_value_error(1, "must not be empty");
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -1112,12 +1112,12 @@ PHP_FUNCTION(hash_equals)
 
 	/* We only allow comparing string to prevent unexpected results. */
 	if (Z_TYPE_P(known_zval) != IS_STRING) {
-		zend_argument_type_error(1, "must be of type string, %s given", zend_zval_value_name(known_zval));
+		zend_wrong_parameter_type_error(1, Z_EXPECTED_STRING, known_zval);
 		RETURN_THROWS();
 	}
 
 	if (Z_TYPE_P(user_zval) != IS_STRING) {
-		zend_argument_type_error(2, "must be of type string, %s given", zend_zval_value_name(user_zval));
+		zend_wrong_parameter_type_error(2, Z_EXPECTED_STRING, user_zval);
 		RETURN_THROWS();
 	}
 

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -1179,7 +1179,7 @@ PHP_METHOD(PDOStatement, fetchAll)
 			zend_class_entry *fetch_class = NULL;
 			if (arg2) {
 				if (Z_TYPE_P(arg2) != IS_STRING) {
-					zend_argument_type_error(2, "must be of type string, %s given", zend_zval_value_name(arg2));
+					zend_wrong_parameter_type_error(2, Z_EXPECTED_STRING, arg2);
 					RETURN_THROWS();
 				}
 				fetch_class = zend_lookup_class(Z_STR_P(arg2));
@@ -1228,7 +1228,7 @@ PHP_METHOD(PDOStatement, fetchAll)
 			if (arg2) {
 				// Reuse convert_to_long(arg2); ?
 				if (Z_TYPE_P(arg2) != IS_LONG) {
-					zend_argument_type_error(2, "must be of type int, %s given", zend_zval_value_name(arg2));
+					zend_wrong_parameter_type_error(2, Z_EXPECTED_LONG, arg2);
 					RETURN_THROWS();
 				}
 				if (Z_LVAL_P(arg2) < 0) {
@@ -1698,7 +1698,7 @@ bool pdo_stmt_setup_fetch_mode(pdo_stmt_t *stmt, zend_long mode, uint32_t mode_a
 					return false;
 				}
 				if (Z_TYPE(args[0]) != IS_STRING) {
-					zend_argument_type_error(arg1_arg_num, "must be of type string, %s given", zend_zval_value_name(&args[0]));
+					zend_wrong_parameter_type_error(arg1_arg_num, Z_EXPECTED_STRING, &args[0]);
 					return false;
 				}
 				cep = zend_lookup_class(Z_STR(args[0]));
@@ -1710,8 +1710,7 @@ bool pdo_stmt_setup_fetch_mode(pdo_stmt_t *stmt, zend_long mode, uint32_t mode_a
 				/* TODO: Improve logic? */
 				if (variadic_num_args == 2) {
 					if (Z_TYPE(args[1]) != IS_NULL && Z_TYPE(args[1]) != IS_ARRAY) {
-						zend_argument_type_error(constructor_arg_num, "must be of type ?array, %s given",
-							zend_zval_value_name(&args[1]));
+						zend_wrong_parameter_type_error(constructor_arg_num, Z_EXPECTED_ARRAY_OR_NULL, &args[1]);
 						return false;
 					}
 					if (Z_TYPE(args[1]) == IS_ARRAY && zend_hash_num_elements(Z_ARRVAL(args[1]))) {
@@ -1736,7 +1735,7 @@ bool pdo_stmt_setup_fetch_mode(pdo_stmt_t *stmt, zend_long mode, uint32_t mode_a
 				return false;
 			}
 			if (Z_TYPE(args[0]) != IS_OBJECT) {
-				zend_argument_type_error(arg1_arg_num, "must be of type object, %s given", zend_zval_value_name(&args[0]));
+				zend_wrong_parameter_type_error(arg1_arg_num, Z_EXPECTED_OBJECT, &args[0]);
 				return false;
 			}
 

--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -108,7 +108,7 @@ PHP_FUNCTION(class_parents)
 	}
 
 	if (Z_TYPE_P(obj) != IS_OBJECT && Z_TYPE_P(obj) != IS_STRING) {
-		zend_argument_type_error(1, "must be of type object|string, %s given", zend_zval_value_name(obj));
+		zend_wrong_parameter_type_error(1, Z_EXPECTED_OBJECT_OR_STRING, obj);
 		RETURN_THROWS();
 	}
 
@@ -141,7 +141,7 @@ PHP_FUNCTION(class_implements)
 		RETURN_THROWS();
 	}
 	if (Z_TYPE_P(obj) != IS_OBJECT && Z_TYPE_P(obj) != IS_STRING) {
-		zend_argument_type_error(1, "must be of type object|string, %s given", zend_zval_value_name(obj));
+		zend_wrong_parameter_type_error(1, Z_EXPECTED_OBJECT_OR_STRING, obj);
 		RETURN_THROWS();
 	}
 
@@ -170,7 +170,7 @@ PHP_FUNCTION(class_uses)
 		RETURN_THROWS();
 	}
 	if (Z_TYPE_P(obj) != IS_OBJECT && Z_TYPE_P(obj) != IS_STRING) {
-		zend_argument_type_error(1, "must be of type object|string, %s given", zend_zval_value_name(obj));
+		zend_wrong_parameter_type_error(1, Z_EXPECTED_OBJECT_OR_STRING, obj);
 		RETURN_THROWS();
 	}
 

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -1111,7 +1111,7 @@ PHP_FUNCTION(min)
 	/* mixed min ( array $values ) */
 	if (argc == 1) {
 		if (Z_TYPE(args[0]) != IS_ARRAY) {
-			zend_argument_type_error(1, "must be of type array, %s given", zend_zval_value_name(&args[0]));
+			zend_wrong_parameter_type_error(1, Z_EXPECTED_ARRAY, &args[0]);
 			RETURN_THROWS();
 		} else {
 			zval *result = zend_hash_minmax(Z_ARRVAL(args[0]), php_data_compare, 0);
@@ -1239,7 +1239,7 @@ PHP_FUNCTION(max)
 	/* mixed max ( array $values ) */
 	if (argc == 1) {
 		if (Z_TYPE(args[0]) != IS_ARRAY) {
-			zend_argument_type_error(1, "must be of type array, %s given", zend_zval_value_name(&args[0]));
+			zend_wrong_parameter_type_error(1, Z_EXPECTED_ARRAY, &args[0]);
 			RETURN_THROWS();
 		} else {
 			zval *result = zend_hash_minmax(Z_ARRVAL(args[0]), php_data_compare, 1);
@@ -4113,7 +4113,7 @@ static zend_always_inline void php_array_replace_wrapper(INTERNAL_FUNCTION_PARAM
 		zval *arg = args + i;
 
 		if (Z_TYPE_P(arg) != IS_ARRAY) {
-			zend_argument_type_error(i + 1, "must be of type array, %s given", zend_zval_value_name(arg));
+			zend_wrong_parameter_type_error(i + 1, Z_EXPECTED_ARRAY, arg);
 			RETURN_THROWS();
 		}
 	}
@@ -6685,7 +6685,7 @@ PHP_FUNCTION(array_map)
 
 	if (n_arrays == 1) {
 		if (Z_TYPE(arrays[0]) != IS_ARRAY) {
-			zend_argument_type_error(2, "must be of type array, %s given", zend_zval_value_name(&arrays[0]));
+			zend_wrong_parameter_type_error(2, Z_EXPECTED_ARRAY, &arrays[0]);
 			RETURN_THROWS();
 		}
 		const HashTable *input = Z_ARRVAL(arrays[0]);


### PR DESCRIPTION
Cleaning up the manually constructed standard parameter errors to use existing Zend helpers in bulk. This enhance readability and align with how those errors have been thrown in most places.