### PR TITLE
Validate chunk extension in dechunk filter

### DIFF
--- a/ext/standard/filters.c
+++ b/ext/standard/filters.c
@@ -1781,7 +1781,8 @@ static const php_stream_filter_factory consumed_filter_factory = {
 typedef enum _php_chunked_filter_state {
 	CHUNK_SIZE_START,
 	CHUNK_SIZE,
-	CHUNK_SIZE_EXT,
+	CHUNK_MAYBE_EXT,
+	CHUNK_VALID_EXT,
 	CHUNK_SIZE_CR,
 	CHUNK_SIZE_LF,
 	CHUNK_BODY,
@@ -1820,7 +1821,7 @@ static size_t php_dechunk(char *buf, size_t len, php_chunked_filter_data *data)
 						data->state = CHUNK_ERROR;
 						break;
 					} else {
-						data->state = CHUNK_SIZE_EXT;
+						data->state = CHUNK_MAYBE_EXT;
 						break;
 					}
 					data->state = CHUNK_SIZE;
@@ -1831,7 +1832,34 @@ static size_t php_dechunk(char *buf, size_t len, php_chunked_filter_data *data)
 				} else if (p == end) {
 					return out_len;
 				}
-			case CHUNK_SIZE_EXT:
+				// intentional fallthrough: state is CHUNK_MAYBE_EXT if we get here
+				ZEND_FALLTHROUGH;
+			case CHUNK_MAYBE_EXT:
+				// end of size, but chunk-ext may follow
+				if (*p == '\r' || *p == '\n') {
+					data->state = CHUNK_SIZE_CR;
+					continue;
+				} else {
+					// we are not at the end of the line, so we expect a valid chunk-ext
+					// skip whitespace
+					while (p < end && (*p == ' ' || *p == '\t')) {
+						p++;
+					}
+					if (p == end) {
+						return out_len;
+					}
+
+					// semicolon indicates start of chunk-ext
+					if (*p == ';') {
+						data->state = CHUNK_VALID_EXT;
+					} else {
+						data->state = CHUNK_ERROR;
+						continue;
+					}
+				}
+				// intentional fallthrough: state is CHUNK_VALID_EXT if we get here
+				ZEND_FALLTHROUGH;
+			case CHUNK_VALID_EXT:
 				/* skip extension */
 				while (p < end && *p != '\r' && *p != '\n') {
 					p++;
@@ -1915,6 +1943,12 @@ static size_t php_dechunk(char *buf, size_t len, php_chunked_filter_data *data)
 				p = end;
 				continue;
 			case CHUNK_ERROR:
+				// Unable to parse, which means that this did not look like chunked encoding.
+				// If we haven't output anything yet, return the buffer unchanged
+				if (out_len == 0) {
+					return len;
+				}
+				// Otherwise, append the remaining buffer and return
 				if (p != out) {
 					memmove(out, p, end - p);
 				}

--- a/ext/standard/tests/filters/chunked_003.phpt
+++ b/ext/standard/tests/filters/chunked_003.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Chunked encoding (error handling)
+--SKIPIF--
+<?php
+$filters = stream_get_filters();
+if(! in_array( "dechunk", $filters )) die( "skip Chunked filter not available." );
+?>
+--INI--
+allow_url_fopen=1
+--FILE--
+<?php
+$streams = array(
+    "data://text/plain,apple",
+    "data://text/plain,mango",
+);
+foreach ($streams as $name) {
+    $fp = fopen($name, "r");
+    stream_filter_append($fp, "dechunk", STREAM_FILTER_READ);
+    var_dump(stream_get_contents($fp));
+    fclose($fp);
+}
+?>
+--EXPECT--
+string(5) "apple"
+string(5) "mango"

--- a/ext/standard/tests/filters/chunked_004.phpt
+++ b/ext/standard/tests/filters/chunked_004.phpt
@@ -1,0 +1,94 @@
+--TEST--
+Chunked encoding (multiple buckets)
+--SKIPIF--
+<?php
+$filters = stream_get_filters();
+if(! in_array( "dechunk", $filters )) die( "skip Chunked filter not available." );
+?>
+--INI--
+allow_url_fopen=1
+--FILE--
+<?php
+
+// Filter that splits each bucket in the input into two, with $chunkSize bytes in the first bucket.
+final class Splitter extends php_user_filter {
+    public static int $chunkSize;
+    function filter($in, $out, &$consumed, $closing): int {
+        while ($bucket = stream_bucket_make_writeable($in)) {
+            $head = substr($bucket->data, 0, self::$chunkSize);
+            $head_bucket = stream_bucket_new($this->stream, $head);
+            stream_bucket_append($out, $head_bucket);
+
+            $tail = substr($bucket->data, self::$chunkSize);
+            $tail_bucket = stream_bucket_new($this->stream, $tail);
+            stream_bucket_append($out, $tail_bucket);
+
+            $consumed += strlen($bucket->data);
+            return PSFS_PASS_ON;
+        }
+        return PSFS_FEED_ME;
+    }
+}
+stream_filter_register("Splitter", "Splitter");
+
+$testdata = "2;key=value\r\nte\r\n2\r\nst\r\n0\r\nTrailer: section\r\n\r\n";
+
+// Split test data on every possible position
+for ($i = 1; $i < strlen($testdata); $i++) {
+    Splitter::$chunkSize = $i;
+
+    $fp = fopen("data:text/plain,$testdata", "r");
+    stream_filter_append($fp, "Splitter", STREAM_FILTER_READ);
+    stream_filter_append($fp, "dechunk", STREAM_FILTER_READ);
+
+    var_dump(stream_get_contents($fp));
+    fclose($fp);
+}
+?>
+--EXPECT--
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"
+string(4) "test"


### PR DESCRIPTION
Chunked transfer encoding has a chunk-size field that can be optionally
followed by a chunk-ext field. This was already skipped by php_dechunk,
by skipping anything that was not a hex character. This changes
php_dechunk to be a little bit more strict in what it considers a
chunk-ext, and treat it as an error and stop decoding if the extension
does not start with optional whitespace and a semicolon.

The dechunk filter is used in some filter chain attacks as an oracle
that determines whether a string starts with a hex character. Anything
after the hex character would be interpreted as the chunk-ext. This
change make that a bit more narrow, also requiring a semicolon, thus
reducing the usefulness of the dechunk filter for attackers.

This only changes behavior on invalid chunked encoding; the happy flow
for valid chunked encoding remains unchanged.

The state CHUNK_SIZE_EXT is renamed to CHUNK_MAYBE_EXT, where the size
of the chunk is read and maybe followed by a chunk-ext. In
CHUNK_VALID_EXT we have detected the semicolon and just skip the rest of
the line.

https://github.com/php/php-src/issues/21983
https://httpwg.org/specs/rfc9112.html#chunked.encoding
