### PR TITLE
ext/openssl: Reorder reneg rate-limit decay to avoid integer divide to zero

### DIFF
--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -1131,7 +1131,9 @@ static void php_openssl_limit_handshake_reneg(const SSL *ssl) /* {{{ */
 
 	elapsed_time = (now.tv_sec - sslsock->reneg->prev_handshake);
 	sslsock->reneg->prev_handshake = now.tv_sec;
-	sslsock->reneg->tokens -= (elapsed_time * (sslsock->reneg->limit / sslsock->reneg->window));
+	if (sslsock->reneg->window > 0) {
+		sslsock->reneg->tokens -= ((double)elapsed_time * (double)sslsock->reneg->limit) / (double)sslsock->reneg->window;
+	}
 
 	if (sslsock->reneg->tokens < 0) {
 		sslsock->reneg->tokens = 0;


### PR DESCRIPTION
`php_openssl_limit_handshake_reneg()` computes the bucket decay as `elapsed * (limit / window)`. Both operands are `zend_long`, so with the documented defaults `limit=2` and `window=300` the inner division truncates to 0 and the decay term collapses to 0 for every elapsed value. The leaky bucket stops leaking and the cap fires after exactly `limit` renegotiations regardless of how widely spaced in time, not "limit per window seconds" as documented.

Compute `(elapsed * limit) / window` so the truncation only applies once, after the multiply brings the operand into a useful range. Guard against `window <= 0` to keep the divide safe under user-supplied values that the existing init handler does not validate.

The existing `stream_server_reneg_limit.phpt` (which exercises the `limit=0` cap-fires-immediately path) continues to pass. A focused decay-arithmetic test requires `openssl s_client` reneg choreography across several wall-clock seconds; deferring unless reviewers want it.
