### PR TITLE
ext/openssl: Match IPv6 IPADDR SAN when connecting to bracketed URI

### DIFF
--- a/ext/openssl/tests/peer_verification_ipv6_san.phpt
+++ b/ext/openssl/tests/peer_verification_ipv6_san.phpt
@@ -1,0 +1,64 @@
+--TEST--
+Peer verification matches an IPADDR SAN when connecting to a bracketed IPv6 URI
+--EXTENSIONS--
+openssl
+--SKIPIF--
+<?php
+if (!function_exists("proc_open")) die("skip no proc_open");
+$probe = @stream_socket_server("tcp://[::1]:0", $errno, $errstr);
+if (!$probe) die("skip IPv6 loopback not available");
+fclose($probe);
+?>
+--FILE--
+<?php
+$certFile = __DIR__ . DIRECTORY_SEPARATOR . 'peer_verification_ipv6_san.pem.tmp';
+$cacertFile = __DIR__ . DIRECTORY_SEPARATOR . 'peer_verification_ipv6_san-ca.pem.tmp';
+
+$serverCode = <<<'CODE'
+    $serverUri = "ssl://[::1]:0";
+    $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
+    $serverCtx = stream_context_create(['ssl' => [
+        'local_cert' => '%s'
+    ]]);
+
+    $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
+    phpt_notify_server_start($server);
+
+    $client = @stream_socket_accept($server, 3);
+    if ($client) {
+        fwrite($client, "HELLO\n");
+    }
+CODE;
+$serverCode = sprintf($serverCode, $certFile);
+
+$clientCode = <<<'CODE'
+    $serverUri = "ssl://{{ ADDR }}";
+    $clientFlags = STREAM_CLIENT_CONNECT;
+    $clientCtx = stream_context_create(['ssl' => [
+        'cafile' => '%s',
+    ]]);
+
+    $client = @stream_socket_client($serverUri, $errno, $errstr, 3, $clientFlags, $clientCtx);
+    if (!$client) {
+        echo "connect failed: $errstr\n";
+        return;
+    }
+    echo trim(fread($client, 16)), "\n";
+CODE;
+$clientCode = sprintf($clientCode, $cacertFile);
+
+include 'CertificateGenerator.inc';
+$certificateGenerator = new CertificateGenerator();
+$certificateGenerator->saveCaCert($cacertFile);
+$certificateGenerator->saveNewCertAsFileWithKey('ipv6-san', $certFile, null, 'IP:::1');
+
+include 'ServerClientTestCase.inc';
+ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . DIRECTORY_SEPARATOR . 'peer_verification_ipv6_san.pem.tmp');
+@unlink(__DIR__ . DIRECTORY_SEPARATOR . 'peer_verification_ipv6_san-ca.pem.tmp');
+?>
+--EXPECT--
+HELLO

--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -2760,6 +2760,13 @@ static char *php_openssl_get_url_name(const char *resourcename,
 		return NULL;
 	}
 
+	if (resourcenamelen >= 2 && resourcename[0] == '[') {
+		const char *end = memchr(resourcename, ']', resourcenamelen);
+		if (end != NULL && end > resourcename + 1) {
+			return pestrndup(resourcename + 1, end - resourcename - 1, is_persistent);
+		}
+	}
+
 	url = php_url_parse_ex(resourcename, resourcenamelen);
 	if (!url) {
 		return NULL;
@@ -2773,6 +2780,11 @@ static char *php_openssl_get_url_name(const char *resourcename,
 		/* skip trailing dots */
 		while (len && host[len-1] == '.') {
 			--len;
+		}
+
+		if (len >= 2 && host[0] == '[' && host[len-1] == ']') {
+			host += 1;
+			len -= 2;
 		}
 
 		if (len) {


### PR DESCRIPTION
Default-config TLS client cannot match an IPADDR SAN entry covering an IPv6 literal because `php_openssl_get_url_name()` returns NULL for resourcenames of the form `[::1]:port`. `php_url_parse_ex()` cannot extract a host from a bracketed hostport when no scheme is present, so `url_name` ends up unset, the SAN matcher's `inet_pton(AF_INET6, ...)` call never happens, and `verify_peer_name` rejects every legitimate IPv6 target.

Handle the bare `[host]:port` shape before `php_url_parse_ex()` and strip surrounding brackets on the parse path for callers that pass a full `ssl://[::1]:port` URL. The SAN matcher now sees `::1` and the 16-byte IPADDR SAN comparison body runs.

Covered by `ext/openssl/tests/peer_verification_ipv6_san.phpt`.
