### PR TITLE
Zend: Fix string leak in zend_update_property_string{,l} on write failure

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -4984,8 +4984,8 @@ ZEND_API void zend_update_property_string(const zend_class_entry *scope, zend_ob
 	zval tmp;
 
 	ZVAL_STRING(&tmp, value);
-	Z_SET_REFCOUNT(tmp, 0);
 	zend_update_property(scope, object, name, name_length, &tmp);
+	zval_ptr_dtor(&tmp);
 }
 /* }}} */
 
@@ -4994,8 +4994,8 @@ ZEND_API void zend_update_property_stringl(const zend_class_entry *scope, zend_o
 	zval tmp;
 
 	ZVAL_STRINGL(&tmp, value, value_len);
-	Z_SET_REFCOUNT(tmp, 0);
 	zend_update_property(scope, object, name, name_length, &tmp);
+	zval_ptr_dtor(&tmp);
 }
 /* }}} */
 
@@ -5085,8 +5085,9 @@ ZEND_API zend_result zend_update_static_property_string(zend_class_entry *scope,
 	zval tmp;
 
 	ZVAL_STRING(&tmp, value);
-	Z_SET_REFCOUNT(tmp, 0);
-	return zend_update_static_property(scope, name, name_length, &tmp);
+	zend_result retval = zend_update_static_property(scope, name, name_length, &tmp);
+	zval_ptr_dtor(&tmp);
+	return retval;
 }
 /* }}} */
 
@@ -5095,8 +5096,9 @@ ZEND_API zend_result zend_update_static_property_stringl(zend_class_entry *scope
 	zval tmp;
 
 	ZVAL_STRINGL(&tmp, value, value_len);
-	Z_SET_REFCOUNT(tmp, 0);
-	return zend_update_static_property(scope, name, name_length, &tmp);
+	zend_result retval = zend_update_static_property(scope, name, name_length, &tmp);
+	zval_ptr_dtor(&tmp);
+	return retval;
 }
 /* }}} */
 


### PR DESCRIPTION
The four `zend_update_{,static_}property_string{,l}()` helpers set the local `tmp` zval refcount to 0 so the consume path can absorb the only reference. Every write-rejection path returns before that consume happens (readonly property, asymmetric visibility, type mismatch, missing static property, magic `__set` throw, type-check rejection on a typed static), and the local `zend_string` leaks at refcount 0. Reproduces as a 64-byte orphan under `--enable-debug` or ASan. Fix builds the zval at refcount 1 and `zval_ptr_dtor`s it after the write; the consumer's `Z_TRY_ADDREF_P` and the local dtor balance, slot end state matches the pre-patch value.

The memory leak here is demonstrated via test associated with PR #22040 
