### PR TITLE
Fix GH-19088: Make sscanf %c read whitespace

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -153,6 +153,9 @@ PHP 8.6 UPGRADE NOTES
   . Form feed (\f) is now added in the default trimmed characters of trim(),
     rtrim() and ltrim().
     RFC: https://wiki.php.net/rfc/trim_form_feed
+  . sscanf() and fscanf() %c conversions now correctly read whitespace
+    characters, restoring ANSI C behavior. Previously, they stopped at
+    whitespace.
   . array_filter() now raises a ValueError when an invalid $mode argument value
     is passed.
   . array_change_key_case() now raises a ValueError when an invalid $case

--- a/ext/standard/scanf.c
+++ b/ext/standard/scanf.c
@@ -833,7 +833,7 @@ literal:
 				end = string;
 				while (*end != '\0') {
 					sch = *end;
-					if (op == 's' && isspace((unsigned char) sch)) {
+					if (op == 's' && isspace( (unsigned char)sch ) ) {
 						break;
 					}
 					end++;

--- a/ext/standard/scanf.c
+++ b/ext/standard/scanf.c
@@ -777,7 +777,7 @@ literal:
 				break;
 
 			case 'c':
-				op = 's';
+				op = 'c';
 				flags |= SCAN_NOSKIP;
 				/*-cc-*/
 				if (0 == width) {
@@ -833,7 +833,7 @@ literal:
 				end = string;
 				while (*end != '\0') {
 					sch = *end;
-					if ( isspace( (unsigned char)sch ) ) {
+					if (op == 's' && isspace((unsigned char) sch)) {
 						break;
 					}
 					end++;

--- a/ext/standard/tests/file/fscanf_variation20.phpt
+++ b/ext/standard/tests/file/fscanf_variation20.phpt
@@ -710,15 +710,18 @@ bool(false)
 -- iteration 10 --
 array(1) {
   [0]=>
-  string(1) "0"
+  string(2) "0
+"
 }
 array(1) {
   [0]=>
-  string(1) "1"
+  string(2) "1
+"
 }
 array(1) {
   [0]=>
-  string(2) "-1"
+  string(3) "-1
+"
 }
 array(1) {
   [0]=>
@@ -750,7 +753,8 @@ array(1) {
 }
 array(1) {
   [0]=>
-  string(3) "250"
+  string(4) "250
+"
 }
 array(1) {
   [0]=>
@@ -766,11 +770,13 @@ array(1) {
 }
 array(1) {
   [0]=>
-  string(2) "83"
+  string(3) "83
+"
 }
 array(1) {
   [0]=>
-  string(1) "1"
+  string(2) "1
+"
 }
 array(1) {
   [0]=>
@@ -785,75 +791,93 @@ bool(false)
 -- iteration 11 --
 array(1) {
   [0]=>
-  string(1) "0"
+  string(2) "0
+"
 }
 array(1) {
   [0]=>
-  string(1) "1"
+  string(2) "1
+"
 }
 array(1) {
   [0]=>
-  string(2) "-1"
+  string(3) "-1
+"
 }
 array(1) {
   [0]=>
-  string(11) "-2147483648"
+  string(12) "-2147483648
+"
 }
 array(1) {
   [0]=>
-  string(11) "-2147483647"
+  string(12) "-2147483647
+"
 }
 array(1) {
   [0]=>
-  string(10) "2147483647"
+  string(11) "2147483647
+"
 }
 array(1) {
   [0]=>
-  string(10) "2147483640"
+  string(11) "2147483640
+"
 }
 array(1) {
   [0]=>
-  string(4) "4667"
+  string(5) "4667
+"
 }
 array(1) {
   [0]=>
-  string(4) "4779"
+  string(5) "4779
+"
 }
 array(1) {
   [0]=>
-  string(4) "4095"
+  string(5) "4095
+"
 }
 array(1) {
   [0]=>
-  string(3) "250"
+  string(4) "250
+"
 }
 array(1) {
   [0]=>
-  string(11) "-2147483648"
+  string(12) "-2147483648
+"
 }
 array(1) {
   [0]=>
-  string(10) "2147483647"
+  string(11) "2147483647
+"
 }
 array(1) {
   [0]=>
-  string(10) "2147483647"
+  string(11) "2147483647
+"
 }
 array(1) {
   [0]=>
-  string(2) "83"
+  string(3) "83
+"
 }
 array(1) {
   [0]=>
-  string(1) "1"
+  string(2) "1
+"
 }
 array(1) {
   [0]=>
-  string(11) "-2147483648"
+  string(12) "-2147483648
+"
 }
 array(1) {
   [0]=>
-  string(10) "2147483647"
+  string(11) "2147483647
+"
 }
 bool(false)
 

--- a/ext/standard/tests/file/fscanf_variation21.phpt
+++ b/ext/standard/tests/file/fscanf_variation21.phpt
@@ -633,7 +633,8 @@ array(1) {
 }
 array(1) {
   [0]=>
-  string(1) "0"
+  string(2) "0
+"
 }
 array(1) {
   [0]=>
@@ -641,7 +642,8 @@ array(1) {
 }
 array(1) {
   [0]=>
-  string(1) "1"
+  string(2) "1
+"
 }
 array(1) {
   [0]=>
@@ -661,7 +663,8 @@ array(1) {
 }
 array(1) {
   [0]=>
-  string(2) "10"
+  string(3) "10
+"
 }
 array(1) {
   [0]=>
@@ -672,63 +675,78 @@ bool(false)
 -- iteration 11 --
 array(1) {
   [0]=>
-  string(11) "-2147483649"
+  string(12) "-2147483649
+"
 }
 array(1) {
   [0]=>
-  string(10) "2147483648"
+  string(11) "2147483648
+"
 }
 array(1) {
   [0]=>
-  string(11) "-2147483649"
+  string(12) "-2147483649
+"
 }
 array(1) {
   [0]=>
-  string(11) "34359738369"
+  string(12) "34359738369
+"
 }
 array(1) {
   [0]=>
-  string(10) "2147483649"
+  string(11) "2147483649
+"
 }
 array(1) {
   [0]=>
-  string(11) "-2147483649"
+  string(12) "-2147483649
+"
 }
 array(1) {
   [0]=>
-  string(1) "0"
+  string(2) "0
+"
 }
 array(1) {
   [0]=>
-  string(4) "-0.1"
+  string(5) "-0.1
+"
 }
 array(1) {
   [0]=>
-  string(1) "1"
+  string(2) "1
+"
 }
 array(1) {
   [0]=>
-  string(6) "100000"
+  string(7) "100000
+"
 }
 array(1) {
   [0]=>
-  string(8) "-1000000"
+  string(9) "-1000000
+"
 }
 array(1) {
   [0]=>
-  string(9) "100000000"
+  string(10) "100000000
+"
 }
 array(1) {
   [0]=>
-  string(11) "-1000000000"
+  string(12) "-1000000000
+"
 }
 array(1) {
   [0]=>
-  string(2) "10"
+  string(3) "10
+"
 }
 array(1) {
   [0]=>
-  string(7) "1050000"
+  string(8) "1050000
+"
 }
 bool(false)
 

--- a/ext/standard/tests/file/fscanf_variation22.phpt
+++ b/ext/standard/tests/file/fscanf_variation22.phpt
@@ -76,7 +76,7 @@ $file_path = __DIR__;
 $filename = "$file_path/fscanf_variation22.tmp";
 unlink($filename);
 ?>
---EXPECT--
+--EXPECTF--
 *** Test fscanf(): different char format types with resource ***
 
 -- iteration 1 --
@@ -186,11 +186,13 @@ bool(false)
 -- iteration 11 --
 array(1) {
   [0]=>
-  string(8) "Resource"
+  string(%d) "Resource id #%d
+"
 }
 array(1) {
   [0]=>
-  string(8) "Resource"
+  string(%d) "Resource id #%d
+"
 }
 bool(false)
 

--- a/ext/standard/tests/file/fscanf_variation23.phpt
+++ b/ext/standard/tests/file/fscanf_variation23.phpt
@@ -557,51 +557,63 @@ bool(false)
 -- iteration 11 --
 array(1) {
   [0]=>
-  string(5) "Array"
+  string(6) "Array
+"
 }
 array(1) {
   [0]=>
-  string(5) "Array"
+  string(6) "Array
+"
 }
 array(1) {
   [0]=>
-  string(5) "Array"
+  string(6) "Array
+"
 }
 array(1) {
   [0]=>
-  string(5) "Array"
+  string(6) "Array
+"
 }
 array(1) {
   [0]=>
-  string(5) "Array"
+  string(6) "Array
+"
 }
 array(1) {
   [0]=>
-  string(5) "Array"
+  string(6) "Array
+"
 }
 array(1) {
   [0]=>
-  string(5) "Array"
+  string(6) "Array
+"
 }
 array(1) {
   [0]=>
-  string(5) "Array"
+  string(6) "Array
+"
 }
 array(1) {
   [0]=>
-  string(5) "Array"
+  string(6) "Array
+"
 }
 array(1) {
   [0]=>
-  string(5) "Array"
+  string(6) "Array
+"
 }
 array(1) {
   [0]=>
-  string(5) "Array"
+  string(6) "Array
+"
 }
 array(1) {
   [0]=>
-  string(5) "Array"
+  string(6) "Array
+"
 }
 bool(false)
 

--- a/ext/standard/tests/file/fscanf_variation24.phpt
+++ b/ext/standard/tests/file/fscanf_variation24.phpt
@@ -89,11 +89,13 @@ unlink($filename);
 -- iteration 1 --
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 array(1) {
   [0]=>
@@ -164,11 +166,13 @@ bool(false)
 -- iteration 2 --
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 array(1) {
   [0]=>
@@ -239,11 +243,13 @@ bool(false)
 -- iteration 3 --
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 array(1) {
   [0]=>
@@ -314,11 +320,13 @@ bool(false)
 -- iteration 4 --
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 array(1) {
   [0]=>
@@ -458,11 +466,13 @@ bool(false)
 -- iteration 6 --
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 array(1) {
   [0]=>
@@ -692,31 +702,38 @@ bool(false)
 -- iteration 10 --
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 array(1) {
   [0]=>
-  string(1) "0"
+  string(2) "0
+"
 }
 array(1) {
   [0]=>
-  string(1) "0"
+  string(2) "0
+"
 }
 array(1) {
   [0]=>
-  string(1) "1"
+  string(2) "1
+"
 }
 array(1) {
   [0]=>
-  string(1) "1"
+  string(2) "1
+"
 }
 array(1) {
   [0]=>
-  string(1) ""
+  string(2) "
+"
 }
 array(1) {
   [0]=>
@@ -724,11 +741,13 @@ array(1) {
 }
 array(1) {
   [0]=>
-  string(1) ""
+  string(2) "
+"
 }
 array(1) {
   [0]=>
-  string(3) "\01"
+  string(4) "\01
+"
 }
 array(1) {
   [0]=>
@@ -767,75 +786,93 @@ bool(false)
 -- iteration 11 --
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 array(1) {
   [0]=>
-  string(1) "0"
+  string(2) "0
+"
 }
 array(1) {
   [0]=>
-  string(1) "0"
+  string(2) "0
+"
 }
 array(1) {
   [0]=>
-  string(1) "1"
+  string(2) "1
+"
 }
 array(1) {
   [0]=>
-  string(1) "1"
+  string(2) "1
+"
 }
 array(1) {
   [0]=>
-  string(1) ""
+  string(2) "
+"
 }
 array(1) {
   [0]=>
-  string(4) "\x01"
+  string(5) "\x01
+"
 }
 array(1) {
   [0]=>
-  string(1) ""
+  string(2) "
+"
 }
 array(1) {
   [0]=>
-  string(3) "\01"
+  string(4) "\01
+"
 }
 array(1) {
   [0]=>
-  string(6) "string"
+  string(7) "string
+"
 }
 array(1) {
   [0]=>
-  string(6) "string"
+  string(7) "string
+"
 }
 array(1) {
   [0]=>
-  string(4) "true"
+  string(5) "true
+"
 }
 array(1) {
   [0]=>
-  string(5) "FALSE"
+  string(6) "FALSE
+"
 }
 array(1) {
   [0]=>
-  string(5) "false"
+  string(6) "false
+"
 }
 array(1) {
   [0]=>
-  string(4) "TRUE"
+  string(5) "TRUE
+"
 }
 array(1) {
   [0]=>
-  string(4) "NULL"
+  string(5) "NULL
+"
 }
 array(1) {
   [0]=>
-  string(4) "null"
+  string(5) "null
+"
 }
 bool(false)
 

--- a/ext/standard/tests/file/fscanf_variation25.phpt
+++ b/ext/standard/tests/file/fscanf_variation25.phpt
@@ -79,7 +79,8 @@ array(1) {
 }
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 array(1) {
   [0]=>
@@ -87,7 +88,8 @@ array(1) {
 }
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 bool(false)
 
@@ -98,7 +100,8 @@ array(1) {
 }
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 array(1) {
   [0]=>
@@ -106,7 +109,8 @@ array(1) {
 }
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 bool(false)
 
@@ -117,7 +121,8 @@ array(1) {
 }
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 array(1) {
   [0]=>
@@ -125,7 +130,8 @@ array(1) {
 }
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 bool(false)
 
@@ -136,7 +142,8 @@ array(1) {
 }
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 array(1) {
   [0]=>
@@ -144,7 +151,8 @@ array(1) {
 }
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 bool(false)
 
@@ -168,7 +176,8 @@ array(1) {
 }
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 array(1) {
   [0]=>
@@ -176,7 +185,8 @@ array(1) {
 }
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 bool(false)
 
@@ -216,38 +226,46 @@ bool(false)
 -- iteration 10 --
 array(1) {
   [0]=>
-  string(1) "1"
+  string(2) "1
+"
 }
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 array(1) {
   [0]=>
-  string(1) "1"
+  string(2) "1
+"
 }
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 bool(false)
 
 -- iteration 11 --
 array(1) {
   [0]=>
-  string(1) "1"
+  string(2) "1
+"
 }
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 array(1) {
   [0]=>
-  string(1) "1"
+  string(2) "1
+"
 }
 array(1) {
   [0]=>
-  string(0) ""
+  string(1) "
+"
 }
 bool(false)
 

--- a/ext/standard/tests/file/fscanf_variation26.phpt
+++ b/ext/standard/tests/file/fscanf_variation26.phpt
@@ -262,46 +262,56 @@ bool(false)
 -- iteration 10 --
 array(1) {
   [0]=>
-  string(1) "a"
+  string(2) "a
+"
 }
 array(1) {
   [0]=>
-  string(1) "a"
+  string(2) "a
+"
 }
 array(1) {
   [0]=>
-  string(2) "67"
+  string(3) "67
+"
 }
 array(1) {
   [0]=>
-  string(3) "-67"
+  string(4) "-67
+"
 }
 array(1) {
   [0]=>
-  string(2) "99"
+  string(3) "99
+"
 }
 bool(false)
 
 -- iteration 11 --
 array(1) {
   [0]=>
-  string(1) "a"
+  string(2) "a
+"
 }
 array(1) {
   [0]=>
-  string(1) "a"
+  string(2) "a
+"
 }
 array(1) {
   [0]=>
-  string(2) "67"
+  string(3) "67
+"
 }
 array(1) {
   [0]=>
-  string(3) "-67"
+  string(4) "-67
+"
 }
 array(1) {
   [0]=>
-  string(2) "99"
+  string(3) "99
+"
 }
 bool(false)
 

--- a/ext/standard/tests/strings/gh19088.phpt
+++ b/ext/standard/tests/strings/gh19088.phpt
@@ -10,6 +10,12 @@ var_dump($result, $char, $offset);
 
 var_dump(sscanf($string, '%3c%n'));
 
+$result = sscanf('hi world', '%5c', $a);
+var_dump($result, $a);
+
+$result = sscanf('a', '%5c', $a);
+var_dump($result, $a);
+
 ?>
 --EXPECT--
 int(2)
@@ -21,3 +27,7 @@ array(2) {
   [1]=>
   int(3)
 }
+int(1)
+string(5) "hi wo"
+int(1)
+string(1) "a"

--- a/ext/standard/tests/strings/gh19088.phpt
+++ b/ext/standard/tests/strings/gh19088.phpt
@@ -1,0 +1,23 @@
+--TEST--
+GH-19088 (sscanf %c conversion should read whitespace)
+--FILE--
+<?php
+
+$string = '     ';
+
+$result = sscanf($string, '%c%n', $char, $offset);
+var_dump($result, $char, $offset);
+
+var_dump(sscanf($string, '%3c%n'));
+
+?>
+--EXPECT--
+int(2)
+string(1) " "
+int(1)
+array(2) {
+  [0]=>
+  string(3) "   "
+  [1]=>
+  int(3)
+}


### PR DESCRIPTION
Fixes GH-19088.

`%c` disables the leading whitespace skip, but still uses the `%s` scan path, which stops at whitespace. That makes `sscanf('     ', '%c%n', ...)` assign an empty string and leave the offset at 0.

Keep `%c` separate from `%s` so it consumes the requested characters, including whitespace. The same scanner handles `fscanf()`, so its existing `%c` expectations are updated too.

This targets master (PHP 8.7), with an UPGRADING note for the behavior change.

Tested on a fresh PHP 8.7 debug build: 60 scanf tests passed; 8 tests skipped because they require a 32-bit platform.

```
sapi/cli/php run-tests.php -q ext/standard/tests/strings/*sscanf*.phpt ext/standard/tests/strings/gh19088.phpt ext/standard/tests/strings/bug21730.phpt ext/standard/tests/file/fscanf*.phpt
git diff --check
```
