### PR TITLE
Fix GH-21583: Make empty SimpleXML elements cast to false

### DIFF
--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -1839,12 +1839,7 @@ static zend_result sxe_object_cast_ex(zend_object *readobj, zval *writeobj, int 
 	sxe = php_sxe_fetch_object(readobj);
 
 	if (type == _IS_BOOL) {
-		node = php_sxe_get_first_node_non_destructive(sxe, NULL);
-		if (node) {
-			ZVAL_TRUE(writeobj);
-		} else {
-			ZVAL_BOOL(writeobj, !sxe_prop_is_empty(readobj));
-		}
+		ZVAL_BOOL(writeobj, !sxe_prop_is_empty(readobj));
 		return SUCCESS;
 	}
 

--- a/ext/simplexml/tests/000.phpt
+++ b/ext/simplexml/tests/000.phpt
@@ -221,7 +221,7 @@ object(SimpleXMLElement)#%d (1) {
 }
 ===sxe->elem11->elem111->elem1111
 bool(true)
-bool(true)
+bool(false)
 int(1)
 object(SimpleXMLElement)#%d (0) {
 }

--- a/ext/simplexml/tests/gh21583.phpt
+++ b/ext/simplexml/tests/gh21583.phpt
@@ -1,0 +1,31 @@
+--TEST--
+GH-21583 (empty SimpleXML child element casts to false)
+--EXTENSIONS--
+simplexml
+--FILE--
+<?php
+
+$xml = simplexml_load_string(<<<XML
+<root>
+    <empty/>
+    <with-text>content</with-text>
+    <with-attribute value="1"/>
+    <with-child><child/></with-child>
+</root>
+XML);
+
+var_dump((bool) $xml->empty);
+var_dump((bool) $xml->missing);
+var_dump((bool) $xml->{"with-text"});
+var_dump((bool) $xml->{"with-attribute"});
+var_dump((bool) $xml->{"with-child"});
+var_dump((bool) simplexml_load_string('<root/>'));
+
+?>
+--EXPECT--
+bool(false)
+bool(false)
+bool(true)
+bool(true)
+bool(true)
+bool(false)


### PR DESCRIPTION
Fixes GH-21583.

SimpleXML boolean casts currently return `true` as soon as a node exists. That skips the existing emptiness check, so an empty element like `<bar/>` casts to `true` even though the documented boolean-cast behavior says empty SimpleXML elements without attributes are false.

Use the same emptiness check for boolean casts that SimpleXML already uses elsewhere. Elements with text, attributes, or children still cast to `true`; empty elements without attributes now cast to `false`.

Tests run:

```
sapi/cli/php run-tests.php -q ext/simplexml/tests/gh21583.phpt
sapi/cli/php run-tests.php -q ext/simplexml/tests
git diff --check
```
