### PR TITLE
Add `BackedEnum::values()` method to retrieve backing values as an array

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,7 @@ PHP                                                                        NEWS
     initialization). (Arnaud)
   . Enabled the TAILCALL VM on Windows when compiling with Clang >= 19 x86_64.
     (henderkes)
+  . Added BackedEnum::values() method. (duiliofanton)
 
 - BCMath:
   . Added NUL-byte validation to BCMath functions. (jorgsowa)

--- a/Zend/tests/enum/backed_enum_values.phpt
+++ b/Zend/tests/enum/backed_enum_values.phpt
@@ -1,0 +1,65 @@
+--TEST--
+BackedEnum::values() returns array of backing values
+--FILE--
+<?php
+
+enum Status: string {
+    case ACTIVE = 'active';
+    case INACTIVE = 'inactive';
+}
+
+enum HttpStatus: int {
+    case OK = 200;
+    case NOT_FOUND = 404;
+    case SERVER_ERROR = 500;
+}
+
+enum UnitOnly {
+    case A;
+    case B;
+}
+
+// Test string-backed enum
+echo "String-backed:\n";
+var_dump(Status::values());
+
+// Test int-backed enum
+echo "Int-backed:\n";
+var_dump(HttpStatus::values());
+
+// Verify it replaces boilerplate array_column(Status::cases(), 'value')
+echo "Equivalence with array_column:\n";
+var_dump(Status::values() === array_column(Status::cases(), 'value'));
+var_dump(HttpStatus::values() === array_column(HttpStatus::cases(), 'value'));
+
+// Verify UnitEnum doesn't have values() method
+echo "UnitEnum error:\n";
+try {
+    UnitOnly::values();
+} catch (Error $e) {
+    echo $e->getMessage() . "\n";
+}
+
+?>
+--EXPECTF--
+String-backed:
+array(2) {
+  [0]=>
+  string(6) "active"
+  [1]=>
+  string(8) "inactive"
+}
+Int-backed:
+array(3) {
+  [0]=>
+  int(200)
+  [1]=>
+  int(404)
+  [2]=>
+  int(500)
+}
+Equivalence with array_column:
+bool(true)
+bool(true)
+UnitEnum error:
+Call to undefined method UnitOnly::values()

--- a/Zend/zend_enum.c
+++ b/Zend/zend_enum.c
@@ -297,6 +297,33 @@ static ZEND_NAMED_FUNCTION(zend_enum_cases_func)
 	} ZEND_HASH_FOREACH_END();
 }
 
+static ZEND_NAMED_FUNCTION(zend_enum_values_func)
+{
+	zend_class_entry *ce = execute_data->func->common.scope;
+	zend_class_constant *c;
+
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	array_init(return_value);
+
+	ZEND_HASH_MAP_FOREACH_PTR(CE_CONSTANTS_TABLE(ce), c) {
+		if (!(ZEND_CLASS_CONST_FLAGS(c) & ZEND_CLASS_CONST_IS_CASE)) {
+			continue;
+		}
+		zval *zv = &c->value;
+		if (Z_TYPE_P(zv) == IS_CONSTANT_AST) {
+			if (zval_update_constant_ex(zv, c->ce) == FAILURE) {
+				RETURN_THROWS();
+			}
+		}
+		zend_object *case_obj = Z_OBJ_P(zv);
+		zval *value_prop = zend_read_property_ex(case_obj->ce, case_obj, ZSTR_KNOWN(ZEND_STR_VALUE), 1, &EG(uninitialized_zval));
+		zval value_copy;
+		ZVAL_COPY(&value_copy, value_prop);
+		zend_hash_next_index_insert_new(Z_ARRVAL_P(return_value), &value_copy);
+	} ZEND_HASH_FOREACH_END();
+}
+
 ZEND_API zend_result zend_enum_get_case_by_value(zend_object **result, zend_class_entry *ce, zend_long long_key, zend_string *string_key, bool try_from)
 {
 	if (ce->type == ZEND_USER_CLASS && !(ce->ce_flags & ZEND_ACC_CONSTANTS_UPDATED)) {
@@ -479,6 +506,14 @@ void zend_enum_register_funcs(zend_class_entry *ce)
 		try_from_function->required_num_args = 1;
 		try_from_function->arg_info = zarginfo_class_BackedEnum_tryFrom + 1;
 		zend_enum_register_func(ce, ZEND_STR_TRYFROM_LOWERCASE, try_from_function);
+
+		zend_internal_function *values_function = zend_arena_calloc(&CG(arena), sizeof(zend_internal_function), 1);
+		values_function->handler = zend_enum_values_func;
+		values_function->function_name = ZSTR_KNOWN(ZEND_STR_VALUES);
+		values_function->fn_flags = fn_flags;
+		values_function->doc_comment = NULL;
+		values_function->arg_info = zarginfo_class_UnitEnum_cases + 1;
+		zend_enum_register_func(ce, ZEND_STR_VALUES, values_function);
 	}
 }
 

--- a/Zend/zend_enum.stub.php
+++ b/Zend/zend_enum.stub.php
@@ -12,4 +12,6 @@ interface BackedEnum extends UnitEnum
     public static function from(int|string $value): static;
 
     public static function tryFrom(int|string $value): ?static;
+
+    public static function values(): array;
 }

--- a/Zend/zend_enum_arginfo.h
+++ b/Zend/zend_enum_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit zend_enum.stub.php instead.
- * Stub hash: 7092f1d4ba651f077cff37050899f090f00abf22 */
+ * Stub hash: 317eb8453e43958d391c4a0b4a01f9d34f00ab93 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_UnitEnum_cases, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -12,6 +12,8 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_BackedEnum_tryFrom, 0, 1, 
 	ZEND_ARG_TYPE_MASK(0, value, MAY_BE_LONG|MAY_BE_STRING, NULL)
 ZEND_END_ARG_INFO()
 
+#define arginfo_class_BackedEnum_values arginfo_class_UnitEnum_cases
+
 
 static const zend_function_entry class_UnitEnum_methods[] = {
 	ZEND_RAW_FENTRY("cases", NULL, arginfo_class_UnitEnum_cases, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_ABSTRACT, NULL, NULL)
@@ -21,6 +23,7 @@ static const zend_function_entry class_UnitEnum_methods[] = {
 static const zend_function_entry class_BackedEnum_methods[] = {
 	ZEND_RAW_FENTRY("from", NULL, arginfo_class_BackedEnum_from, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_ABSTRACT, NULL, NULL)
 	ZEND_RAW_FENTRY("tryFrom", NULL, arginfo_class_BackedEnum_tryFrom, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+	ZEND_RAW_FENTRY("values", NULL, arginfo_class_BackedEnum_values, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_ABSTRACT, NULL, NULL)
 	ZEND_FE_END
 };
 

--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -639,6 +639,7 @@ default: ZEND_UNREACHABLE();
 	_(ZEND_STR_SLEEP,                  "__sleep") \
 	_(ZEND_STR_WAKEUP,                 "__wakeup") \
 	_(ZEND_STR_CASES,                  "cases") \
+	_(ZEND_STR_VALUES,                 "values") \
 	_(ZEND_STR_FROM,                   "from") \
 	_(ZEND_STR_TRYFROM,                "tryFrom") \
 	_(ZEND_STR_TRYFROM_LOWERCASE,      "tryfrom") \

--- a/ext/reflection/tests/ReflectionEnum_toString_backed_int.phpt
+++ b/ext/reflection/tests/ReflectionEnum_toString_backed_int.phpt
@@ -43,7 +43,7 @@ Enum [ <user> enum MyBool: int implements MyStringable, UnitEnum, BackedEnum ] {
   - Static properties [0] {
   }
 
-  - Static methods [3] {
+  - Static methods [4] {
     Method [ <internal, prototype UnitEnum> static public method cases ] {
 
       - Parameters [0] {
@@ -65,6 +65,13 @@ Enum [ <user> enum MyBool: int implements MyStringable, UnitEnum, BackedEnum ] {
         Parameter #0 [ <required> string|int $value ]
       }
       - Return [ ?static ]
+    }
+
+    Method [ <internal, prototype BackedEnum> static public method values ] {
+
+      - Parameters [0] {
+      }
+      - Return [ array ]
     }
   }
 
@@ -99,7 +106,7 @@ Enum [ <user> enum MyBool: int implements MyStringable, UnitEnum, BackedEnum ] {
   - Static properties [0] {
   }
 
-  - Static methods [3] {
+  - Static methods [4] {
     Method [ <internal, prototype UnitEnum> static public method cases ] {
 
       - Parameters [0] {
@@ -121,6 +128,13 @@ Enum [ <user> enum MyBool: int implements MyStringable, UnitEnum, BackedEnum ] {
         Parameter #0 [ <required> string|int $value ]
       }
       - Return [ ?static ]
+    }
+
+    Method [ <internal, prototype BackedEnum> static public method values ] {
+
+      - Parameters [0] {
+      }
+      - Return [ array ]
     }
   }
 

--- a/ext/reflection/tests/ReflectionEnum_toString_backed_string.phpt
+++ b/ext/reflection/tests/ReflectionEnum_toString_backed_string.phpt
@@ -43,7 +43,7 @@ Enum [ <user> enum MyBool: string implements MyStringable, UnitEnum, BackedEnum 
   - Static properties [0] {
   }
 
-  - Static methods [3] {
+  - Static methods [4] {
     Method [ <internal, prototype UnitEnum> static public method cases ] {
 
       - Parameters [0] {
@@ -65,6 +65,13 @@ Enum [ <user> enum MyBool: string implements MyStringable, UnitEnum, BackedEnum 
         Parameter #0 [ <required> string|int $value ]
       }
       - Return [ ?static ]
+    }
+
+    Method [ <internal, prototype BackedEnum> static public method values ] {
+
+      - Parameters [0] {
+      }
+      - Return [ array ]
     }
   }
 
@@ -99,7 +106,7 @@ Enum [ <user> enum MyBool: string implements MyStringable, UnitEnum, BackedEnum 
   - Static properties [0] {
   }
 
-  - Static methods [3] {
+  - Static methods [4] {
     Method [ <internal, prototype UnitEnum> static public method cases ] {
 
       - Parameters [0] {
@@ -121,6 +128,13 @@ Enum [ <user> enum MyBool: string implements MyStringable, UnitEnum, BackedEnum 
         Parameter #0 [ <required> string|int $value ]
       }
       - Return [ ?static ]
+    }
+
+    Method [ <internal, prototype BackedEnum> static public method values ] {
+
+      - Parameters [0] {
+      }
+      - Return [ array ]
     }
   }
 


### PR DESCRIPTION
# Proposal

Add a new static method to `BackedEnum`:

```php
BackedEnum::values(): array
```

The method returns all backing values from the enum cases.

Example:

```php
enum Status: string
{
    case ACTIVE = 'active';
    case INACTIVE = 'inactive';
}

Status::values();
```

Result:

```php
['active', 'inactive']
```

Integer backed enum:

```php
enum HttpStatus: int
{
    case OK = 200;
    case NOT_FOUND = 404;
}

HttpStatus::values();
```

Result:

```php
[200, 404]
```

This provides a simple and direct way to retrieve enum backing values without requiring additional array transformations.

Currently this typically requires:

```php
array_column(Status::cases(), 'value');
```

The proposed API makes the intent explicit and easier to read:

```php
Status::values();
```

The method would only exist on `BackedEnum`, since `UnitEnum` cases do not contain backing values.

---

## Rationale

The proposal intentionally keeps the scope minimal.

`cases()` already provides access to enum case objects and names when needed.
The goal of `values()` is specifically to provide direct access to backing values for `BackedEnum`, which is currently a very common operation that requires additional array transformations.

This proposal does not introduce a generic collection-style API for enums.
Methods such as `map()`, `filter()`, `keys()`, or similar helpers are outside the scope of this RFC.

`values()` addresses a single focused use case:

```php
Status::values();
```

which is currently commonly written as:

```php
array_column(Status::cases(), 'value');
```

The intention is to provide a clearer and more direct API for retrieving enum backing values only.