### PR TITLE
ext/Intl: Fix out-of-bounds argument positions in calendar date/time APIs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,8 +4,8 @@ PHP                                                                        NEWS
 
 - Intl:
   . Fix incorrect argument positions in out-of-bounds errors for
-    IntlCalendar::set() and IntlGregorianCalendar date/time construction.
-    (Weilin Du)
+    IntlCalendar::set(), IntlCalendar::setDate(), IntlCalendar::setDateTime(),
+    and IntlGregorianCalendar date/time construction. (Weilin Du)
 
 - MySQLnd:
   . Fix persistent free of non-persistent connect_attr key (David Carlier).

--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,11 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 8.4.22
 
+- Intl:
+  . Fix incorrect argument positions in out-of-bounds errors for
+    IntlCalendar::set() and IntlGregorianCalendar date/time construction.
+    (Weilin Du)
+
 - MySQLnd:
   . Fix persistent free of non-persistent connect_attr key (David Carlier).
 

--- a/UPGRADING
+++ b/UPGRADING
@@ -82,6 +82,9 @@ PHP 8.4 UPGRADE NOTES
     . bind_textdomain_codeset, textdomain and d(*)gettext functions now throw an exception
       if the domain argument is empty.
   . Intl:
+    . IntlCalendar::set(), IntlCalendar::setDate(), IntlCalendar::setDateTime(),
+      and IntlGregorianCalendar date/time construction now report the correct
+      argument position for out-of-bounds integer values.
     . resourcebundle_get(), ResourceBundle::get(), and accessing offsets on a
       ResourceBundle object now throw:
       - TypeError for invalid offset types

--- a/ext/intl/calendar/calendar_methods.cpp
+++ b/ext/intl/calendar/calendar_methods.cpp
@@ -427,18 +427,10 @@ U_CFUNC PHP_METHOD(IntlCalendar, setDate)
 		RETURN_THROWS();
 	}
 
-	if (UNEXPECTED(year < INT32_MIN || year > INT32_MAX)) {
-		zend_argument_value_error(1, "must be between %d and %d", INT32_MIN, INT32_MAX);
-		RETURN_THROWS();
-	}
-	if (UNEXPECTED(month < INT32_MIN || month > INT32_MAX)) {
-		zend_argument_value_error(2, "must be between %d and %d", INT32_MIN, INT32_MAX);
-		RETURN_THROWS();
-	}
-	if (UNEXPECTED(day < INT32_MIN || day > INT32_MAX)) {
-		zend_argument_value_error(3, "must be between %d and %d", INT32_MIN, INT32_MAX);
-		RETURN_THROWS();
-	}
+	/* These method-only APIs parse the object first, so the API argument positions are offset by +1. */
+	ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(year, 2);
+	ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(month, 3);
+	ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(day, 4);
 
 	CALENDAR_METHOD_FETCH_OBJECT;
 
@@ -459,36 +451,19 @@ U_CFUNC PHP_METHOD(IntlCalendar, setDateTime)
 		RETURN_THROWS();
 	}
 
-	if (UNEXPECTED(year < INT32_MIN || year > INT32_MAX)) {
-		zend_argument_value_error(1, "must be between %d and %d", INT32_MIN, INT32_MAX);
-		RETURN_THROWS();
-	}
-	if (UNEXPECTED(month < INT32_MIN || month > INT32_MAX)) {
-		zend_argument_value_error(2, "must be between %d and %d", INT32_MIN, INT32_MAX);
-		RETURN_THROWS();
-	}
-	if (UNEXPECTED(day < INT32_MIN || day > INT32_MAX)) {
-		zend_argument_value_error(3, "must be between %d and %d", INT32_MIN, INT32_MAX);
-		RETURN_THROWS();
-	}
-	if (UNEXPECTED(hour < INT32_MIN || hour > INT32_MAX)) {
-		zend_argument_value_error(4, "must be between %d and %d", INT32_MIN, INT32_MAX);
-		RETURN_THROWS();
-	}
-	if (UNEXPECTED(minute < INT32_MIN || minute > INT32_MAX)) {
-		zend_argument_value_error(5, "must be between %d and %d", INT32_MIN, INT32_MAX);
-		RETURN_THROWS();
-	}
+	/* These method-only APIs parse the object first, so the API argument positions are offset by +1. */
+	ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(year, 2);
+	ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(month, 3);
+	ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(day, 4);
+	ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(hour, 5);
+	ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(minute, 6);
 
 	CALENDAR_METHOD_FETCH_OBJECT;
 
 	if (second_is_null) {
 		co->ucal->set((int32_t) year, (int32_t) month, (int32_t) day, (int32_t) hour, (int32_t) minute);
 	} else {
-		if (UNEXPECTED(second < INT32_MIN || second > INT32_MAX)) {
-			zend_argument_value_error(6, "must be between %d and %d", INT32_MIN, INT32_MAX);
-			RETURN_THROWS();
-		}
+		ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(second, 7);
 		co->ucal->set((int32_t) year, (int32_t) month, (int32_t) day, (int32_t) hour, (int32_t) minute, (int32_t) second);
 	}
 }

--- a/ext/intl/calendar/calendar_methods.cpp
+++ b/ext/intl/calendar/calendar_methods.cpp
@@ -427,9 +427,18 @@ U_CFUNC PHP_METHOD(IntlCalendar, setDate)
 		RETURN_THROWS();
 	}
 
-	ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(year, 1);
-	ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(month, 2);
-	ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(day, 3);
+	if (UNEXPECTED(year < INT32_MIN || year > INT32_MAX)) {
+		zend_argument_value_error(1, "must be between %d and %d", INT32_MIN, INT32_MAX);
+		RETURN_THROWS();
+	}
+	if (UNEXPECTED(month < INT32_MIN || month > INT32_MAX)) {
+		zend_argument_value_error(2, "must be between %d and %d", INT32_MIN, INT32_MAX);
+		RETURN_THROWS();
+	}
+	if (UNEXPECTED(day < INT32_MIN || day > INT32_MAX)) {
+		zend_argument_value_error(3, "must be between %d and %d", INT32_MIN, INT32_MAX);
+		RETURN_THROWS();
+	}
 
 	CALENDAR_METHOD_FETCH_OBJECT;
 
@@ -450,18 +459,36 @@ U_CFUNC PHP_METHOD(IntlCalendar, setDateTime)
 		RETURN_THROWS();
 	}
 
-	ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(year, 1);
-	ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(month, 2);
-	ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(day, 3);
-	ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(hour, 4);
-	ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(minute, 5);
+	if (UNEXPECTED(year < INT32_MIN || year > INT32_MAX)) {
+		zend_argument_value_error(1, "must be between %d and %d", INT32_MIN, INT32_MAX);
+		RETURN_THROWS();
+	}
+	if (UNEXPECTED(month < INT32_MIN || month > INT32_MAX)) {
+		zend_argument_value_error(2, "must be between %d and %d", INT32_MIN, INT32_MAX);
+		RETURN_THROWS();
+	}
+	if (UNEXPECTED(day < INT32_MIN || day > INT32_MAX)) {
+		zend_argument_value_error(3, "must be between %d and %d", INT32_MIN, INT32_MAX);
+		RETURN_THROWS();
+	}
+	if (UNEXPECTED(hour < INT32_MIN || hour > INT32_MAX)) {
+		zend_argument_value_error(4, "must be between %d and %d", INT32_MIN, INT32_MAX);
+		RETURN_THROWS();
+	}
+	if (UNEXPECTED(minute < INT32_MIN || minute > INT32_MAX)) {
+		zend_argument_value_error(5, "must be between %d and %d", INT32_MIN, INT32_MAX);
+		RETURN_THROWS();
+	}
 
 	CALENDAR_METHOD_FETCH_OBJECT;
 
 	if (second_is_null) {
 		co->ucal->set((int32_t) year, (int32_t) month, (int32_t) day, (int32_t) hour, (int32_t) minute);
 	} else {
-		ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(second, 6);
+		if (UNEXPECTED(second < INT32_MIN || second > INT32_MAX)) {
+			zend_argument_value_error(6, "must be between %d and %d", INT32_MIN, INT32_MAX);
+			RETURN_THROWS();
+		}
 		co->ucal->set((int32_t) year, (int32_t) month, (int32_t) day, (int32_t) hour, (int32_t) minute, (int32_t) second);
 	}
 }

--- a/ext/intl/calendar/calendar_methods.cpp
+++ b/ext/intl/calendar/calendar_methods.cpp
@@ -391,8 +391,8 @@ U_CFUNC PHP_FUNCTION(intlcal_set)
 	}
 
 	for (int i = 0; i < arg_num; i++) {
-		/* Arguments start at 1 */
-		ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(args[i], i + 1);
+		/* Count from intlcal_set($calendar, ...), so date/time arguments start at #2. */
+		ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(args[i], i + 2);
 	}
 
 	CALENDAR_METHOD_FETCH_OBJECT;

--- a/ext/intl/calendar/gregoriancalendar_methods.cpp
+++ b/ext/intl/calendar/gregoriancalendar_methods.cpp
@@ -178,7 +178,7 @@ static void _php_intlgregcal_constructor_body(
 	} else {
 		// From date/time (3, 5 or 6 arguments)
 		for (int i = 0; i < variant; i++) {
-			ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(largs[i], hasThis() ? (i-1) : i);
+			ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(largs[i], i + 1);
 		}
 
 		if (variant == 3) {

--- a/ext/intl/tests/calendar_set_date_out_of_bounds.phpt
+++ b/ext/intl/tests/calendar_set_date_out_of_bounds.phpt
@@ -1,0 +1,32 @@
+--TEST--
+IntlCalendar::setDate(): out-of-bounds arguments report correct positions
+--EXTENSIONS--
+intl
+--SKIPIF--
+<?php if (PHP_INT_SIZE != 8) die("skip: 64-bit only"); ?>
+--FILE--
+<?php
+$cal = IntlCalendar::createInstance();
+
+try {
+    $cal->setDate(99999999999, 1, 1);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    $cal->setDate(1, 99999999999, 1);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    $cal->setDate(1, 1, 99999999999);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+IntlCalendar::setDate(): Argument #1 ($year) must be between -2147483648 and 2147483647
+IntlCalendar::setDate(): Argument #2 ($month) must be between -2147483648 and 2147483647
+IntlCalendar::setDate(): Argument #3 ($dayOfMonth) must be between -2147483648 and 2147483647

--- a/ext/intl/tests/calendar_set_date_time_out_of_bounds.phpt
+++ b/ext/intl/tests/calendar_set_date_time_out_of_bounds.phpt
@@ -1,0 +1,53 @@
+--TEST--
+IntlCalendar::setDateTime(): out-of-bounds arguments report correct positions
+--EXTENSIONS--
+intl
+--SKIPIF--
+<?php if (PHP_INT_SIZE != 8) die("skip: 64-bit only"); ?>
+--FILE--
+<?php
+$cal = IntlCalendar::createInstance();
+
+try {
+    $cal->setDateTime(99999999999, 1, 1, 1, 1, 1);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    $cal->setDateTime(1, 99999999999, 1, 1, 1, 1);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    $cal->setDateTime(1, 1, 99999999999, 1, 1, 1);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    $cal->setDateTime(1, 1, 1, 99999999999, 1, 1);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    $cal->setDateTime(1, 1, 1, 1, 99999999999, 1);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    $cal->setDateTime(1, 1, 1, 1, 1, 99999999999);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+IntlCalendar::setDateTime(): Argument #1 ($year) must be between -2147483648 and 2147483647
+IntlCalendar::setDateTime(): Argument #2 ($month) must be between -2147483648 and 2147483647
+IntlCalendar::setDateTime(): Argument #3 ($dayOfMonth) must be between -2147483648 and 2147483647
+IntlCalendar::setDateTime(): Argument #4 ($hour) must be between -2147483648 and 2147483647
+IntlCalendar::setDateTime(): Argument #5 ($minute) must be between -2147483648 and 2147483647
+IntlCalendar::setDateTime(): Argument #6 ($second) must be between -2147483648 and 2147483647

--- a/ext/intl/tests/calendar_set_out_of_bounds.phpt
+++ b/ext/intl/tests/calendar_set_out_of_bounds.phpt
@@ -19,6 +19,24 @@ try {
 } catch (Throwable $e) {
     echo $e->getMessage(), "\n";
 }
+
+try {
+    $cal->set(1, 1, 1, 99999999999, 1);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    $cal->set(1, 1, 1, 1, 99999999999, 1);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    intlcal_set($cal, 1, 1, 1, 1, 1, 99999999999);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
 ?>
 --EXPECTF--
 Deprecated: Calling IntlCalendar::set() with more than 2 arguments is deprecated, use either IntlCalendar::setDate() or IntlCalendar::setDateTime() instead in %s on line %d
@@ -26,3 +44,12 @@ IntlCalendar::set(): Argument #1 ($year) must be between -2147483648 and 2147483
 
 Deprecated: Function intlcal_set() is deprecated since 8.4, use IntlCalendar::set(), IntlCalendar::setDate(), or IntlCalendar::setDateTime() instead in %s on line %d
 intlcal_set(): Argument #3 ($month) must be between -2147483648 and 2147483647
+
+Deprecated: Calling IntlCalendar::set() with more than 2 arguments is deprecated, use either IntlCalendar::setDate() or IntlCalendar::setDateTime() instead in %s on line %d
+IntlCalendar::set(): Argument #4 ($hour) must be between -2147483648 and 2147483647
+
+Deprecated: Calling IntlCalendar::set() with more than 2 arguments is deprecated, use either IntlCalendar::setDate() or IntlCalendar::setDateTime() instead in %s on line %d
+IntlCalendar::set(): Argument #5 ($minute) must be between -2147483648 and 2147483647
+
+Deprecated: Function intlcal_set() is deprecated since 8.4, use IntlCalendar::set(), IntlCalendar::setDate(), or IntlCalendar::setDateTime() instead in %s on line %d
+intlcal_set(): Argument #7 ($second) must be between -2147483648 and 2147483647

--- a/ext/intl/tests/calendar_set_out_of_bounds.phpt
+++ b/ext/intl/tests/calendar_set_out_of_bounds.phpt
@@ -1,0 +1,28 @@
+--TEST--
+IntlCalendar::set(): out-of-bounds date/time arguments report correct positions
+--EXTENSIONS--
+intl
+--SKIPIF--
+<?php if (PHP_INT_SIZE != 8) die("skip: 64-bit only"); ?>
+--FILE--
+<?php
+$cal = IntlCalendar::createInstance();
+
+try {
+    $cal->set(99999999999, 1, 1);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    intlcal_set($cal, 1, 99999999999, 1);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECTF--
+Deprecated: Calling IntlCalendar::set() with more than 2 arguments is deprecated, use either IntlCalendar::setDate() or IntlCalendar::setDateTime() instead in %s on line %d
+IntlCalendar::set(): Argument #1 ($year) must be between -2147483648 and 2147483647
+
+Deprecated: Function intlcal_set() is deprecated since 8.4, use IntlCalendar::set(), IntlCalendar::setDate(), or IntlCalendar::setDateTime() instead in %s on line %d
+intlcal_set(): Argument #3 ($month) must be between -2147483648 and 2147483647

--- a/ext/intl/tests/gregoriancalendar___construct_out_of_bounds.phpt
+++ b/ext/intl/tests/gregoriancalendar___construct_out_of_bounds.phpt
@@ -17,6 +17,24 @@ try {
 } catch (Throwable $e) {
     echo $e->getMessage(), "\n";
 }
+
+try {
+    new IntlGregorianCalendar(1, 1, 1, 99999999999, 1);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    new IntlGregorianCalendar(1, 1, 1, 1, 99999999999);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    intlgregcal_create_instance(1, 1, 1, 1, 1, 99999999999);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
 ?>
 --EXPECTF--
 Deprecated: Calling IntlGregorianCalendar::__construct() with more than 2 arguments is deprecated, use either IntlGregorianCalendar::createFromDate() or IntlGregorianCalendar::createFromDateTime() instead in %s on line %d
@@ -24,3 +42,12 @@ IntlGregorianCalendar::__construct(): Argument #1 ($timezoneOrYear) must be betw
 
 Deprecated: Function intlgregcal_create_instance() is deprecated since 8.4, use IntlGregorianCalendar::__construct(), IntlGregorianCalendar::createFromDate(), or IntlGregorianCalendar::createFromDateTime() instead in %s on line %d
 intlgregcal_create_instance(): Argument #2 ($localeOrMonth) must be between -2147483648 and 2147483647
+
+Deprecated: Calling IntlGregorianCalendar::__construct() with more than 2 arguments is deprecated, use either IntlGregorianCalendar::createFromDate() or IntlGregorianCalendar::createFromDateTime() instead in %s on line %d
+IntlGregorianCalendar::__construct(): Argument #4 ($hour) must be between -2147483648 and 2147483647
+
+Deprecated: Calling IntlGregorianCalendar::__construct() with more than 2 arguments is deprecated, use either IntlGregorianCalendar::createFromDate() or IntlGregorianCalendar::createFromDateTime() instead in %s on line %d
+IntlGregorianCalendar::__construct(): Argument #5 ($minute) must be between -2147483648 and 2147483647
+
+Deprecated: Function intlgregcal_create_instance() is deprecated since 8.4, use IntlGregorianCalendar::__construct(), IntlGregorianCalendar::createFromDate(), or IntlGregorianCalendar::createFromDateTime() instead in %s on line %d
+intlgregcal_create_instance(): Argument #6 ($second) must be between -2147483648 and 2147483647

--- a/ext/intl/tests/gregoriancalendar___construct_out_of_bounds.phpt
+++ b/ext/intl/tests/gregoriancalendar___construct_out_of_bounds.phpt
@@ -1,0 +1,26 @@
+--TEST--
+IntlGregorianCalendar::__construct(): out-of-bounds date/time arguments report correct positions
+--EXTENSIONS--
+intl
+--SKIPIF--
+<?php if (PHP_INT_SIZE != 8) die("skip: 64-bit only"); ?>
+--FILE--
+<?php
+try {
+    new IntlGregorianCalendar(99999999999, 1, 1);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    intlgregcal_create_instance(1, 99999999999, 1);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECTF--
+Deprecated: Calling IntlGregorianCalendar::__construct() with more than 2 arguments is deprecated, use either IntlGregorianCalendar::createFromDate() or IntlGregorianCalendar::createFromDateTime() instead in %s on line %d
+IntlGregorianCalendar::__construct(): Argument #1 ($timezoneOrYear) must be between -2147483648 and 2147483647
+
+Deprecated: Function intlgregcal_create_instance() is deprecated since 8.4, use IntlGregorianCalendar::__construct(), IntlGregorianCalendar::createFromDate(), or IntlGregorianCalendar::createFromDateTime() instead in %s on line %d
+intlgregcal_create_instance(): Argument #2 ($localeOrMonth) must be between -2147483648 and 2147483647


### PR DESCRIPTION
When I was looking at the new deprecation of IntlGregorianCalendar::__construct() with more than 2 arguments is deprecated, I find that the argument position in the overflow error is actually wrong. That is 
```php
<?php
try {
    new IntlGregorianCalendar(99999999999, 1, 1);
} catch (Throwable $e) {
    echo $e->getMessage(), "\n";
}
```
Will result in 
```
Deprecated: Calling IntlGregorianCalendar::__construct() with more than 2 arguments is deprecated, use either IntlGregorianCalendar::createFromDate() or IntlGregorianCalendar::createFromDateTime() instead in /in/dB6p5 on line 3
IntlGregorianCalendar::__construct(): Argument #-1 must be between -2147483648 and 2147483647
```
Which I expected the last line being
```
IntlGregorianCalendar::__construct(): Argument #1 must be between -2147483648 and 2147483647
```
Seems like in the case we don't need to use hasThis() because $this is impossible to exist. Just using i+1 here will be safe enough.

Edited: With further research, IntlCalendar::set also has this problem.

```php
<?php
$cal = IntlCalendar::createInstance();
try {
    $cal->set(99999999999, 1, 1);
} catch (Throwable $e) {
    echo $e->getMessage(), "\n";
}
```
Will return
```
IntlCalendar::set(): Argument #0 ($year) must be between -2147483648 and 2147483647
```
But I expected
```
IntlCalendar::set(): Argument #1 ($year) must be between -2147483648 and 2147483647
```
