### PR TITLE
Zend: Fix SIZEOF_POINTER_TYPE warnings in zend_observer.c

### DIFF
--- a/Zend/zend_observer.c
+++ b/Zend/zend_observer.c
@@ -167,7 +167,7 @@ static bool zend_observer_remove_handler(void **first_handler, const void *old_h
 				*next_handler = NULL;
 			} else {
 				if (cur_handler != last_handler) {
-					memmove(cur_handler, cur_handler + 1, sizeof(cur_handler) * (last_handler - cur_handler));
+					memmove(cur_handler, cur_handler + 1, sizeof(*cur_handler) * (last_handler - cur_handler));
 				}
 				*last_handler = NULL;
 				*next_handler = *cur_handler;
@@ -218,7 +218,7 @@ ZEND_API void zend_observer_add_end_handler(const zend_function *function, zend_
 	if (*end_handler != ZEND_OBSERVER_NOT_OBSERVED) {
 		// there's no space for new handlers, then it's forbidden to call this function
 		ZEND_ASSERT(end_handler[registered_observers - 1] == NULL);
-		memmove(end_handler + 1, end_handler, sizeof(end_handler) * (registered_observers - 1));
+		memmove(end_handler + 1, end_handler, sizeof(*end_handler) * (registered_observers - 1));
 	} else if (*begin_handler == ZEND_OBSERVER_NONE_OBSERVED) {
 		*begin_handler = ZEND_OBSERVER_NOT_OBSERVED;
 	}


### PR DESCRIPTION
This PR fixes two `SIZEOF_POINTER_TYPE` static analysis warnings in `Zend/zend_observer.c`.

- In `zend_observer_remove_handler()`, the `memmove()` size argument now uses `sizeof(void *)` instead of `sizeof(cur_handler)`.
- In `zend_observer_add_end_handler()`, the `memmove()` size argument now uses `sizeof(zend_observer_fcall_end_handler)` instead of `sizeof(end_handler)`.

This makes the byte count explicitly based on the moved element type rather than the pointer variable type.

No functional behavior change is intended.

Static analyzer findings addressed:
[SIZEOF_POINTER_TYPE zend_observer.c:[160:6].log](https://github.com/user-attachments/files/27808349/SIZEOF_POINTER_TYPE.zend_observer.c.160.6.log)
[SIZEOF_POINTER_TYPE zend_observer.c:[198:3].log](https://github.com/user-attachments/files/27808350/SIZEOF_POINTER_TYPE.zend_observer.c.198.3.log)
