### PR TITLE
ext/intl: Expose Spoofchecker restriction-level APIs on all supported ICU versions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,11 @@ PHP                                                                        NEWS
   . Fix incorrect argument positions in out-of-bounds errors for
     IntlCalendar::set(), IntlCalendar::setDate(), IntlCalendar::setDateTime(),
     and IntlGregorianCalendar date/time construction. (Weilin Du)
+  . Expose Spoofchecker restriction-level APIs on all supported ICU
+    versions. (Weilin Du)
+  . Fix SpoofChecker::setAllowedChars() to report PHP constant names
+    instead of ICU USET_* names in invalid pattern option errors.
+    (Weilin Du)
 
 - MySQLnd:
   . Fix persistent free of non-persistent connect_attr key (David Carlier).
@@ -31,10 +36,6 @@ PHP                                                                        NEWS
   . Fixed ip2long() leading zeros handling inconsistency on AIX. (ayappanec)
 
 07 May 2026, PHP 8.4.21
-
-- Intl:
-  . Expose Spoofchecker restriction-level APIs on all supported ICU
-    versions. (Weilin Du)
 
 - Core:
   . Fixed bug GH-19983 (GC assertion failure with fibers, generators and

--- a/NEWS
+++ b/NEWS
@@ -32,6 +32,10 @@ PHP                                                                        NEWS
 
 07 May 2026, PHP 8.4.21
 
+- Intl:
+  . Expose Spoofchecker restriction-level APIs on all supported ICU
+    versions. (Weilin Du)
+
 - Core:
   . Fixed bug GH-19983 (GC assertion failure with fibers, generators and
     destructors). (iliaal)

--- a/UPGRADING
+++ b/UPGRADING
@@ -92,6 +92,8 @@ PHP 8.4 UPGRADE NOTES
       - ValueError if the integer index does not fit in a signed 32 bit integer
     . IntlDateFormatter::__construct() throws a ValueError if the locale is invalid.
     . NumberFormatter::__construct() throws a ValueError if the locale is invalid.
+    . SpoofChecker::setAllowedChars() now reports PHP constant names instead
+      of ICU USET_* names in invalid pattern option errors.
   . MBString:
     . mb_encode_numericentity() and mb_decode_numericentity() now check that
       the $map is only composed of integers, if not a ValueError is thrown.

--- a/ext/intl/spoofchecker/spoofchecker.stub.php
+++ b/ext/intl/spoofchecker/spoofchecker.stub.php
@@ -19,7 +19,6 @@ class Spoofchecker
     public const int INVISIBLE = UNKNOWN;
     /** @cvalue USPOOF_CHAR_LIMIT */
     public const int CHAR_LIMIT = UNKNOWN;
-#if U_ICU_VERSION_MAJOR_NUM >= 58
     /** @cvalue USPOOF_ASCII */
     public const int ASCII = UNKNOWN;
     /** @cvalue USPOOF_HIGHLY_RESTRICTIVE */
@@ -34,7 +33,6 @@ class Spoofchecker
     public const int SINGLE_SCRIPT_RESTRICTIVE = UNKNOWN;
     /** @cvalue USPOOF_MIXED_NUMBERS */
     public const int MIXED_NUMBERS = UNKNOWN;
-#endif
 #if U_ICU_VERSION_MAJOR_NUM >= 62
     /** @cvalue USPOOF_HIDDEN_OVERLAY */
     public const int HIDDEN_OVERLAY = UNKNOWN;
@@ -71,9 +69,7 @@ class Spoofchecker
     /** @tentative-return-type */
     public function setChecks(int $checks): void {}
 
-#if U_ICU_VERSION_MAJOR_NUM >= 58
     /** @tentative-return-type */
     public function setRestrictionLevel(int $level): void {}
-#endif
     public function setAllowedChars(string $pattern, int $patternOptions = 0): void {}
 }

--- a/ext/intl/spoofchecker/spoofchecker_arginfo.h
+++ b/ext/intl/spoofchecker/spoofchecker_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 4834be57a3f0cb74dbc4422e609846139f09f6cb */
+ * Stub hash: 4634f8ef9157fb3670a2ddc5e3246340660fc68c */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Spoofchecker___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -23,11 +23,9 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Spoofchecker_set
 	ZEND_ARG_TYPE_INFO(0, checks, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-#if U_ICU_VERSION_MAJOR_NUM >= 58
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Spoofchecker_setRestrictionLevel, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, level, IS_LONG, 0)
 ZEND_END_ARG_INFO()
-#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Spoofchecker_setAllowedChars, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, pattern, IS_STRING, 0)
@@ -39,9 +37,7 @@ ZEND_METHOD(Spoofchecker, isSuspicious);
 ZEND_METHOD(Spoofchecker, areConfusable);
 ZEND_METHOD(Spoofchecker, setAllowedLocales);
 ZEND_METHOD(Spoofchecker, setChecks);
-#if U_ICU_VERSION_MAJOR_NUM >= 58
 ZEND_METHOD(Spoofchecker, setRestrictionLevel);
-#endif
 ZEND_METHOD(Spoofchecker, setAllowedChars);
 
 static const zend_function_entry class_Spoofchecker_methods[] = {
@@ -50,9 +46,7 @@ static const zend_function_entry class_Spoofchecker_methods[] = {
 	ZEND_ME(Spoofchecker, areConfusable, arginfo_class_Spoofchecker_areConfusable, ZEND_ACC_PUBLIC)
 	ZEND_ME(Spoofchecker, setAllowedLocales, arginfo_class_Spoofchecker_setAllowedLocales, ZEND_ACC_PUBLIC)
 	ZEND_ME(Spoofchecker, setChecks, arginfo_class_Spoofchecker_setChecks, ZEND_ACC_PUBLIC)
-#if U_ICU_VERSION_MAJOR_NUM >= 58
 	ZEND_ME(Spoofchecker, setRestrictionLevel, arginfo_class_Spoofchecker_setRestrictionLevel, ZEND_ACC_PUBLIC)
-#endif
 	ZEND_ME(Spoofchecker, setAllowedChars, arginfo_class_Spoofchecker_setAllowedChars, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
@@ -105,62 +99,48 @@ static zend_class_entry *register_class_Spoofchecker(void)
 	zend_string *const_CHAR_LIMIT_name = zend_string_init_interned("CHAR_LIMIT", sizeof("CHAR_LIMIT") - 1, 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_LIMIT_name, &const_CHAR_LIMIT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_LIMIT_name);
-#if U_ICU_VERSION_MAJOR_NUM >= 58
 
 	zval const_ASCII_value;
 	ZVAL_LONG(&const_ASCII_value, USPOOF_ASCII);
 	zend_string *const_ASCII_name = zend_string_init_interned("ASCII", sizeof("ASCII") - 1, 1);
 	zend_declare_typed_class_constant(class_entry, const_ASCII_name, &const_ASCII_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ASCII_name);
-#endif
-#if U_ICU_VERSION_MAJOR_NUM >= 58
 
 	zval const_HIGHLY_RESTRICTIVE_value;
 	ZVAL_LONG(&const_HIGHLY_RESTRICTIVE_value, USPOOF_HIGHLY_RESTRICTIVE);
 	zend_string *const_HIGHLY_RESTRICTIVE_name = zend_string_init_interned("HIGHLY_RESTRICTIVE", sizeof("HIGHLY_RESTRICTIVE") - 1, 1);
 	zend_declare_typed_class_constant(class_entry, const_HIGHLY_RESTRICTIVE_name, &const_HIGHLY_RESTRICTIVE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_HIGHLY_RESTRICTIVE_name);
-#endif
-#if U_ICU_VERSION_MAJOR_NUM >= 58
 
 	zval const_MODERATELY_RESTRICTIVE_value;
 	ZVAL_LONG(&const_MODERATELY_RESTRICTIVE_value, USPOOF_MODERATELY_RESTRICTIVE);
 	zend_string *const_MODERATELY_RESTRICTIVE_name = zend_string_init_interned("MODERATELY_RESTRICTIVE", sizeof("MODERATELY_RESTRICTIVE") - 1, 1);
 	zend_declare_typed_class_constant(class_entry, const_MODERATELY_RESTRICTIVE_name, &const_MODERATELY_RESTRICTIVE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MODERATELY_RESTRICTIVE_name);
-#endif
-#if U_ICU_VERSION_MAJOR_NUM >= 58
 
 	zval const_MINIMALLY_RESTRICTIVE_value;
 	ZVAL_LONG(&const_MINIMALLY_RESTRICTIVE_value, USPOOF_MINIMALLY_RESTRICTIVE);
 	zend_string *const_MINIMALLY_RESTRICTIVE_name = zend_string_init_interned("MINIMALLY_RESTRICTIVE", sizeof("MINIMALLY_RESTRICTIVE") - 1, 1);
 	zend_declare_typed_class_constant(class_entry, const_MINIMALLY_RESTRICTIVE_name, &const_MINIMALLY_RESTRICTIVE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MINIMALLY_RESTRICTIVE_name);
-#endif
-#if U_ICU_VERSION_MAJOR_NUM >= 58
 
 	zval const_UNRESTRICTIVE_value;
 	ZVAL_LONG(&const_UNRESTRICTIVE_value, USPOOF_UNRESTRICTIVE);
 	zend_string *const_UNRESTRICTIVE_name = zend_string_init_interned("UNRESTRICTIVE", sizeof("UNRESTRICTIVE") - 1, 1);
 	zend_declare_typed_class_constant(class_entry, const_UNRESTRICTIVE_name, &const_UNRESTRICTIVE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_UNRESTRICTIVE_name);
-#endif
-#if U_ICU_VERSION_MAJOR_NUM >= 58
 
 	zval const_SINGLE_SCRIPT_RESTRICTIVE_value;
 	ZVAL_LONG(&const_SINGLE_SCRIPT_RESTRICTIVE_value, USPOOF_SINGLE_SCRIPT_RESTRICTIVE);
 	zend_string *const_SINGLE_SCRIPT_RESTRICTIVE_name = zend_string_init_interned("SINGLE_SCRIPT_RESTRICTIVE", sizeof("SINGLE_SCRIPT_RESTRICTIVE") - 1, 1);
 	zend_declare_typed_class_constant(class_entry, const_SINGLE_SCRIPT_RESTRICTIVE_name, &const_SINGLE_SCRIPT_RESTRICTIVE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SINGLE_SCRIPT_RESTRICTIVE_name);
-#endif
-#if U_ICU_VERSION_MAJOR_NUM >= 58
 
 	zval const_MIXED_NUMBERS_value;
 	ZVAL_LONG(&const_MIXED_NUMBERS_value, USPOOF_MIXED_NUMBERS);
 	zend_string *const_MIXED_NUMBERS_name = zend_string_init_interned("MIXED_NUMBERS", sizeof("MIXED_NUMBERS") - 1, 1);
 	zend_declare_typed_class_constant(class_entry, const_MIXED_NUMBERS_name, &const_MIXED_NUMBERS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MIXED_NUMBERS_name);
-#endif
 #if U_ICU_VERSION_MAJOR_NUM >= 62
 
 	zval const_HIDDEN_OVERLAY_value;

--- a/ext/intl/spoofchecker/spoofchecker_main.c
+++ b/ext/intl/spoofchecker/spoofchecker_main.c
@@ -206,9 +206,9 @@ PHP_METHOD(Spoofchecker, setAllowedChars)
 #endif
             pattern_option != (USET_IGNORE_SPACE|USET_CASE_INSENSITIVE) &&
             pattern_option != (USET_IGNORE_SPACE|USET_ADD_CASE_MAPPINGS)) {
-		zend_argument_value_error(2, "must be a valid pattern option, 0 or (SpoofChecker::IGNORE_SPACE|(<none> or SpoofChecker::USET_CASE_INSENSITIVE or SpoofChecker::USET_ADD_CASE_MAPPINGS"
+		zend_argument_value_error(2, "must be a valid pattern option, 0 or (SpoofChecker::IGNORE_SPACE|(<none> or SpoofChecker::CASE_INSENSITIVE or SpoofChecker::ADD_CASE_MAPPINGS"
 #if U_ICU_VERSION_MAJOR_NUM >= 73
-				" or SpoofChecker::USET_SIMPLE_CASE_INSENSITIVE"
+				" or SpoofChecker::SIMPLE_CASE_INSENSITIVE"
 #endif
 				"))"
 		);

--- a/ext/intl/spoofchecker/spoofchecker_main.c
+++ b/ext/intl/spoofchecker/spoofchecker_main.c
@@ -135,7 +135,6 @@ PHP_METHOD(Spoofchecker, setChecks)
 }
 /* }}} */
 
-#if U_ICU_VERSION_MAJOR_NUM >= 58
 /* TODO Document this method on PHP.net */
 /* {{{ Set the loosest restriction level allowed for strings. */
 PHP_METHOD(Spoofchecker, setRestrictionLevel)
@@ -164,7 +163,6 @@ PHP_METHOD(Spoofchecker, setRestrictionLevel)
 	uspoof_setRestrictionLevel(co->uspoof, (URestrictionLevel)level);
 }
 /* }}} */
-#endif
 
 PHP_METHOD(Spoofchecker, setAllowedChars)
 {

--- a/ext/intl/tests/spoofchecker_007.phpt
+++ b/ext/intl/tests/spoofchecker_007.phpt
@@ -4,12 +4,6 @@ spoofchecker with restriction level
 intl
 --SKIPIF--
 <?php if(!class_exists("Spoofchecker")) print 'skip'; ?>
-<?php
-    $r = new ReflectionClass("SpoofChecker");
-    if (false === $r->getConstant("SINGLE_SCRIPT_RESTRICTIVE")) {
-        die("skip Incompatible ICU version");
-    }
-?>
 --FILE--
 <?php
 

--- a/ext/intl/tests/spoofchecker_008.phpt
+++ b/ext/intl/tests/spoofchecker_008.phpt
@@ -39,6 +39,6 @@ try {
 bool(true)
 bool(false)
 bool(false)
-Spoofchecker::setAllowedChars(): Argument #2 ($patternOptions) must be a valid pattern option, 0 or (SpoofChecker::IGNORE_SPACE|(<none> or SpoofChecker::USET_CASE_INSENSITIVE%s))
+Spoofchecker::setAllowedChars(): Argument #2 ($patternOptions) must be a valid pattern option, 0 or (SpoofChecker::IGNORE_SPACE|(<none> or SpoofChecker::CASE_INSENSITIVE%s))
 Spoofchecker::setAllowedChars(): Argument #1 ($pattern) must be a valid regular expression character set pattern
 Spoofchecker::setAllowedChars(): Argument #1 ($pattern) must be a valid regular expression character set pattern

--- a/ext/intl/tests/spoofchecker_supported_icu57_apis.phpt
+++ b/ext/intl/tests/spoofchecker_supported_icu57_apis.phpt
@@ -8,12 +8,28 @@ intl
 <?php
 $r = new ReflectionClass("Spoofchecker");
 
-var_dump($r->getConstant("ASCII") !== false);
-var_dump($r->getConstant("SINGLE_SCRIPT_RESTRICTIVE") !== false);
-var_dump($r->getConstant("MIXED_NUMBERS") !== false);
+$ascii = $r->getConstant("ASCII");
+$singleScriptRestrictive = $r->getConstant("SINGLE_SCRIPT_RESTRICTIVE");
+$mixedNumbers = $r->getConstant("MIXED_NUMBERS");
+
+var_dump($ascii !== false);
+var_dump($singleScriptRestrictive !== false);
+var_dump($mixedNumbers !== false);
+var_dump(is_int($ascii));
+var_dump(is_int($singleScriptRestrictive));
+var_dump(is_int($mixedNumbers));
+var_dump($ascii !== $singleScriptRestrictive);
+var_dump($ascii !== $mixedNumbers);
+var_dump($singleScriptRestrictive !== $mixedNumbers);
 var_dump($r->hasMethod("setRestrictionLevel"));
 ?>
 --EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
 bool(true)
 bool(true)
 bool(true)

--- a/ext/intl/tests/spoofchecker_supported_icu57_apis.phpt
+++ b/ext/intl/tests/spoofchecker_supported_icu57_apis.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Spoofchecker exposes restriction-level APIs on all supported ICU versions
+--EXTENSIONS--
+intl
+--SKIPIF--
+<?php if (!class_exists("Spoofchecker")) print 'skip'; ?>
+--FILE--
+<?php
+$r = new ReflectionClass("Spoofchecker");
+
+var_dump($r->getConstant("ASCII") !== false);
+var_dump($r->getConstant("SINGLE_SCRIPT_RESTRICTIVE") !== false);
+var_dump($r->getConstant("MIXED_NUMBERS") !== false);
+var_dump($r->hasMethod("setRestrictionLevel"));
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/ext/intl/tests/spoofchecker_unknown_restriction_level.phpt
+++ b/ext/intl/tests/spoofchecker_unknown_restriction_level.phpt
@@ -5,8 +5,6 @@ intl
 --SKIPIF--
 <?php
 if (!class_exists("Spoofchecker")) print 'skip';
-
-if (!method_exists(new Spoofchecker(), 'setRestrictionLevel')) print 'skip ICU version < 58';
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
  Those constants (functions) are made out of the version guard of ICU >= 58 in this PR.
  - Spoofchecker::ASCII
  - Spoofchecker::HIGHLY_RESTRICTIVE
  - Spoofchecker::MODERATELY_RESTRICTIVE
  - Spoofchecker::MINIMALLY_RESTRICTIVE
  - Spoofchecker::UNRESTRICTIVE
  - Spoofchecker::SINGLE_SCRIPT_RESTRICTIVE
  - Spoofchecker::MIXED_NUMBERS
  - Spoofchecker::setRestrictionLevel()
 
 Fixes #22053