### PR TITLE
standard: Fail unserialization when the `C` format is used for classes that are not `Serializable`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -21,6 +21,9 @@ PHP                                                                        NEWS
   . Deprecate specifying a nullable return type for __debugInfo(). (timwolla)
   . Fixed bug GH-22142 (Assertion failure in zendi_try_get_long() on IS_UNDEF).
     (David Carlier)
+  . Fixed bug GH-22046 (The unserialize function can lead to segfault when
+    non-Serializable internal classes are serialized back with the C format).
+    (kocsismate)
 
 - BCMath:
   . Added NUL-byte validation to BCMath functions. (jorgsowa)

--- a/ext/standard/tests/serialize/serialization_objects_009.phpt
+++ b/ext/standard/tests/serialize/serialization_objects_009.phpt
@@ -3,22 +3,24 @@ Custom unserialization of classes with no custom unserializer.
 --FILE--
 <?php
 $ser = 'C:1:"C":6:{dasdas}';
-$a = unserialize($ser);
-eval('class C {}');
-$b = unserialize($ser);
 
-var_dump($a, $b);
+try {
+    unserialize($ser);
+} catch (Throwable $e) {
+    echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+}
+
+eval('class C {}');
+
+try {
+    unserialize($ser);
+} catch (Throwable $e) {
+    echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+}
 
 echo "Done";
 ?>
---EXPECTF--
-Warning: Class __PHP_Incomplete_Class has no unserializer in %sserialization_objects_009.php on line %d
-
-Warning: Class C has no unserializer in %sserialization_objects_009.php on line %d
-object(__PHP_Incomplete_Class)#%d (1) {
-  ["__PHP_Incomplete_Class_Name"]=>
-  string(1) "C"
-}
-object(C)#%d (0) {
-}
+--EXPECT--
+Exception: Class __PHP_Incomplete_Class has no unserializer
+Exception: Class C has no unserializer
 Done

--- a/ext/standard/tests/serialize/serialization_objects_009.phpt
+++ b/ext/standard/tests/serialize/serialization_objects_009.phpt
@@ -3,24 +3,21 @@ Custom unserialization of classes with no custom unserializer.
 --FILE--
 <?php
 $ser = 'C:1:"C":6:{dasdas}';
-
-try {
-    unserialize($ser);
-} catch (Throwable $e) {
-    echo $e::class, ": ", $e->getMessage(), PHP_EOL;
-}
-
+$a = unserialize($ser);
 eval('class C {}');
+$b = unserialize($ser);
 
-try {
-    unserialize($ser);
-} catch (Throwable $e) {
-    echo $e::class, ": ", $e->getMessage(), PHP_EOL;
-}
-
+var_dump($a, $b);
 echo "Done";
 ?>
---EXPECT--
-Exception: Class __PHP_Incomplete_Class has no unserializer
-Exception: Class C has no unserializer
+--EXPECTF--
+Warning: Class __PHP_Incomplete_Class has no unserializer in %s on line %d
+
+Warning: unserialize(): Error at offset 11 of 18 bytes in %s on line %d
+
+Warning: Class C has no unserializer in %s on line %d
+
+Warning: unserialize(): Error at offset 11 of 18 bytes in %s on line %d
+bool(false)
+bool(false)
 Done

--- a/ext/standard/var_unserializer.re
+++ b/ext/standard/var_unserializer.re
@@ -769,7 +769,7 @@ static inline int object_custom(UNSERIALIZE_PARAMETER, zend_class_entry *ce)
 	}
 
 	if (ce->unserialize == NULL) {
-		zend_error(E_WARNING, "Class %s has no unserializer", ZSTR_VAL(ce->name));
+		zend_throw_exception_ex(NULL, 0,  "Class %s has no unserializer", ZSTR_VAL(ce->name));
 		object_init_ex(rval, ce);
 	} else if (ce->unserialize(rval, ce, (const unsigned char*)*p, datalen, (zend_unserialize_data *)var_hash) != SUCCESS) {
 		return 0;

--- a/ext/standard/var_unserializer.re
+++ b/ext/standard/var_unserializer.re
@@ -769,7 +769,7 @@ static inline int object_custom(UNSERIALIZE_PARAMETER, zend_class_entry *ce)
 	}
 
 	if (ce->unserialize == NULL) {
-		zend_throw_exception_ex(NULL, 0, "Class %s has no unserializer", ZSTR_VAL(ce->name));
+		zend_error(E_WARNING, "Class %s has no unserializer", ZSTR_VAL(ce->name));
 		return 0;
 	} else if (ce->unserialize(rval, ce, (const unsigned char*)*p, datalen, (zend_unserialize_data *)var_hash) != SUCCESS) {
 		return 0;

--- a/ext/standard/var_unserializer.re
+++ b/ext/standard/var_unserializer.re
@@ -769,8 +769,8 @@ static inline int object_custom(UNSERIALIZE_PARAMETER, zend_class_entry *ce)
 	}
 
 	if (ce->unserialize == NULL) {
-		zend_throw_exception_ex(NULL, 0,  "Class %s has no unserializer", ZSTR_VAL(ce->name));
-		object_init_ex(rval, ce);
+		zend_throw_exception_ex(NULL, 0, "Class %s has no unserializer", ZSTR_VAL(ce->name));
+		return 0;
 	} else if (ce->unserialize(rval, ce, (const unsigned char*)*p, datalen, (zend_unserialize_data *)var_hash) != SUCCESS) {
 		return 0;
 	}

--- a/ext/uri/tests/gh22046.phpt
+++ b/ext/uri/tests/gh22046.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-22046: The unserialize function with Uri\WhatWg\Url leads to NULL pointer dereference when object serialized back
+--FILE--
+<?php
+
+$payload = 'C:14:"Uri\WhatWg\Url":0:{}';
+try {
+    unserialize($payload);
+} catch (Throwable $e) {
+    echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+}
+
+$payload = 'C:15:"Uri\Rfc3986\Uri":0:{}';
+try {
+    unserialize($payload);
+} catch (Throwable $e) {
+    echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+}
+?>
+--EXPECT--
+Exception: Class Uri\WhatWg\Url has no unserializer
+Exception: Class Uri\Rfc3986\Uri has no unserializer

--- a/ext/uri/tests/gh22046.phpt
+++ b/ext/uri/tests/gh22046.phpt
@@ -1,22 +1,19 @@
 --TEST--
-GH-22046: The unserialize function with Uri\WhatWg\Url leads to NULL pointer dereference when object serialized back
+GH-22046: The unserialize function can lead to segfault when internal classes are serialized back with the unsupported C format
 --FILE--
 <?php
 
 $payload = 'C:14:"Uri\WhatWg\Url":0:{}';
-try {
-    unserialize($payload);
-} catch (Throwable $e) {
-    echo $e::class, ": ", $e->getMessage(), PHP_EOL;
-}
+unserialize($payload);
 
 $payload = 'C:15:"Uri\Rfc3986\Uri":0:{}';
-try {
-    unserialize($payload);
-} catch (Throwable $e) {
-    echo $e::class, ": ", $e->getMessage(), PHP_EOL;
-}
+unserialize($payload);
 ?>
---EXPECT--
-Exception: Class Uri\WhatWg\Url has no unserializer
-Exception: Class Uri\Rfc3986\Uri has no unserializer
+--EXPECTF--
+Warning: Class Uri\WhatWg\Url has no unserializer in %s on line %d
+
+Warning: unserialize(): Error at offset 25 of 26 bytes in %s on line %d
+
+Warning: Class Uri\Rfc3986\Uri has no unserializer in %s on line %d
+
+Warning: unserialize(): Error at offset 26 of 27 bytes in %s on line %d


### PR DESCRIPTION
Unserializing from the "C" format is explicitly disabled.

Fixes GH-22046.