### PR TITLE
Fix imprecise %s placeholders in phpt test expectations

### DIFF
--- a/Zend/tests/attributes/008_wrong_attribution.phpt
+++ b/Zend/tests/attributes/008_wrong_attribution.phpt
@@ -7,4 +7,4 @@ Attributes: Prevent Attribute on non classes
 function foo() {}
 ?>
 --EXPECTF--
-Fatal error: Attribute "Attribute" cannot target function (allowed targets: class) in %s
+Fatal error: Attribute "Attribute" cannot target function (allowed targets: class) in %s on line %d

--- a/Zend/tests/attributes/010_unsupported_const_expression.phpt
+++ b/Zend/tests/attributes/010_unsupported_const_expression.phpt
@@ -8,4 +8,4 @@ class C1 { }
 
 ?>
 --EXPECTF--
-Fatal error: Constant expression contains invalid operations in %s
+Fatal error: Constant expression contains invalid operations in %s on line %d

--- a/Zend/tests/attributes/016_custom_attribute_validation.phpt
+++ b/Zend/tests/attributes/016_custom_attribute_validation.phpt
@@ -10,4 +10,4 @@ function foo() {
 }
 ?>
 --EXPECTF--
-Fatal error: Only classes can be marked with #[ZendTestAttribute] in %s
+Fatal error: Only classes can be marked with #[ZendTestAttribute] in %s on line %d

--- a/Zend/tests/attributes/024_internal_target_validation.phpt
+++ b/Zend/tests/attributes/024_internal_target_validation.phpt
@@ -8,4 +8,4 @@ function a1() { }
 
 ?>
 --EXPECTF--
-Fatal error: Attribute "Attribute" cannot target function (allowed targets: class) in %s
+Fatal error: Attribute "Attribute" cannot target function (allowed targets: class) in %s on line %d

--- a/Zend/tests/attributes/025_internal_repeatable_validation.phpt
+++ b/Zend/tests/attributes/025_internal_repeatable_validation.phpt
@@ -9,4 +9,4 @@ class A1 { }
 
 ?>
 --EXPECTF--
-Fatal error: Attribute "Attribute" must not be repeated in %s
+Fatal error: Attribute "Attribute" must not be repeated in %s on line %d

--- a/Zend/tests/attributes/deprecated/functions/001.phpt
+++ b/Zend/tests/attributes/deprecated/functions/001.phpt
@@ -55,17 +55,17 @@ new Constructor();
 
 ?>
 --EXPECTF--
-Deprecated: Function test() is deprecated in %s
+Deprecated: Function test() is deprecated in %s on line %d
 
 Deprecated: Function test2() is deprecated, use test() instead in %s on line %d
 
 Deprecated: Function test() is deprecated in %s on line %d
 
-Deprecated: Method Clazz::test() is deprecated in %s
+Deprecated: Method Clazz::test() is deprecated in %s on line %d
 
-Deprecated: Method Clazz::test2() is deprecated, use test() instead in %s
+Deprecated: Method Clazz::test2() is deprecated, use test() instead in %s on line %d
 
-Deprecated: Method Clazz::test() is deprecated in %s
+Deprecated: Method Clazz::test() is deprecated in %s on line %d
 
 Deprecated: Function {closure:%s:%d}() is deprecated in %s on line %d
 

--- a/Zend/tests/attributes/deprecated/functions/magic_call.phpt
+++ b/Zend/tests/attributes/deprecated/functions/magic_call.phpt
@@ -19,6 +19,6 @@ Clazz::test2();
 
 ?>
 --EXPECTF--
-Deprecated: Method Clazz::test() is deprecated in %s
+Deprecated: Method Clazz::test() is deprecated in %s on line %d
 
 Deprecated: Method Clazz::test2() is deprecated, due to some reason in %s on line %d

--- a/Zend/tests/autoload/bug39003.phpt
+++ b/Zend/tests/autoload/bug39003.phpt
@@ -20,7 +20,7 @@ test($obj);
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: test(): Argument #1 ($object) must be of type OtherClassName, ClassName given, called in %s:%d
+Fatal error: Uncaught TypeError: test(): Argument #1 ($object) must be of type OtherClassName, ClassName given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(%d): test(Object(ClassName))
 #1 {main}

--- a/Zend/tests/backtrace/debug_backtrace_with_include_and_this.phpt
+++ b/Zend/tests/backtrace/debug_backtrace_with_include_and_this.phpt
@@ -33,7 +33,7 @@ try {
 ERR#2: include(class://non.existent.Class): Failed to open stream: "CLWrapper::stream_open" call failed @ include
 ERR#2: include(): Failed opening 'class://non.existent.Class' for inclusion (include_path='%s') @ include
 
-Fatal error: Uncaught Exception: Failed loading class://non.existent.Class in %s
+Fatal error: Uncaught Exception: Failed loading class://non.existent.Class in %s:%d
 Stack trace:
 #0 %s(%d): CL->load('class://non.exi...')
 #1 {main}

--- a/Zend/tests/bug73954.phpt
+++ b/Zend/tests/bug73954.phpt
@@ -16,7 +16,7 @@ takes_int(log(tan(3.14)));
 float(NAN)
 bool(true)
 
-Fatal error: Uncaught TypeError: takes_int(): Argument #1 ($int) must be of type int, float given, called in %s:%d
+Fatal error: Uncaught TypeError: takes_int(): Argument #1 ($int) must be of type int, float given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(9): takes_int(NAN)
 #1 {main}

--- a/Zend/tests/closures/closure_027.phpt
+++ b/Zend/tests/closures/closure_027.phpt
@@ -30,7 +30,7 @@ NULL
 Warning: Undefined variable $y in %s on line %d
 Exception: Too few arguments to function {closure:%s:%d}(), 0 passed in %s on line %d and exactly 1 expected
 
-Fatal error: Uncaught TypeError: test(): Argument #1 ($a) must be of type Closure, stdClass given, called in %s:%d
+Fatal error: Uncaught TypeError: test(): Argument #1 ($a) must be of type Closure, stdClass given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(%d): test(Object(stdClass))
 #1 {main}

--- a/Zend/tests/exceptions/bug48228.phpt
+++ b/Zend/tests/exceptions/bug48228.phpt
@@ -23,7 +23,7 @@ $l_aa=new aa();
 $l_aa->dosome();
 ?>
 --EXPECTF--
-Fatal error: Uncaught Exception in %s
+Fatal error: Uncaught Exception in %s:%d
 Stack trace:
 #0 %s(%d): do_throw()
 #1 %s(%d): aa->dosome()

--- a/Zend/tests/exceptions/bug48408.phpt
+++ b/Zend/tests/exceptions/bug48408.phpt
@@ -22,7 +22,7 @@ catch(Exception $e){
 }
 ?>
 --EXPECTF--
-Fatal error: Uncaught Exception in %s
+Fatal error: Uncaught Exception in %s:%d
 Stack trace:
 #0 %s(%d): C->generate(0)
 #1 {main}

--- a/Zend/tests/exceptions/exception_017.phpt
+++ b/Zend/tests/exceptions/exception_017.phpt
@@ -28,7 +28,7 @@ Error: Cannot call abstract method C::foo() in %s:%d
 Stack trace:
 #0 {main}
 
-TypeError: foo(): Argument #1 ($x) must be of type callable, string given, called in %s:%d
+TypeError: foo(): Argument #1 ($x) must be of type callable, string given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(%d): foo('C::foo')
 #1 {main}

--- a/Zend/tests/falsetoarray.phpt
+++ b/Zend/tests/falsetoarray.phpt
@@ -119,76 +119,76 @@ unset($a[0]);
 --EXPECTF--
 [001]
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 [002]
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 
 Function
 [003]
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 [004]
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 [005]
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 [006]
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 
 Properties
 [007]
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 [008]
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 [009]
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 [010]
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 [011]
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 [012]
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 [013]
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 
 Destructuring
 [014]
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 [015]
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 [016]
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 [017]
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 [018]
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 [019]
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 [020]
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 [021]
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 [022]
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 [023]
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d

--- a/Zend/tests/generators/generator_with_type_check.phpt
+++ b/Zend/tests/generators/generator_with_type_check.phpt
@@ -6,7 +6,7 @@ function gen(array $a) { yield; }
 gen(42);
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: gen(): Argument #1 ($a) must be of type array, int given, called in %s:%d
+Fatal error: Uncaught TypeError: gen(): Argument #1 ($a) must be of type array, int given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %sgenerator_with_type_check.php(3): gen(42)
 #1 {main}

--- a/Zend/tests/indexing_001.phpt
+++ b/Zend/tests/indexing_001.phpt
@@ -68,7 +68,7 @@ int(1)
 Cannot use a scalar value as an array
 bool(true)
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 array(1) {
   ["foo"]=>
   array(1) {
@@ -105,7 +105,7 @@ int(1)
 Cannot use a scalar value as an array
 bool(true)
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 array(1) {
   ["foo"]=>
   &array(1) {
@@ -137,7 +137,7 @@ int(1)
 Cannot use a scalar value as an array
 bool(true)
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 array(1) {
   [0]=>
   array(1) {
@@ -170,7 +170,7 @@ int(1)
 Cannot use a scalar value as an array
 bool(true)
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 array(1) {
   [0]=>
   &array(1) {

--- a/Zend/tests/inheritance/abstract_inheritance_003.phpt
+++ b/Zend/tests/inheritance/abstract_inheritance_003.phpt
@@ -9,4 +9,4 @@ abstract class B extends A { abstract function bar($x); }
 echo "DONE";
 ?>
 --EXPECTF--
-Fatal error: Declaration of B::bar($x) must be compatible with A::bar($x, $y = 0) in %s
+Fatal error: Declaration of B::bar($x) must be compatible with A::bar($x, $y = 0) in %s on line %d

--- a/Zend/tests/inheritance/bug73987_1.phpt
+++ b/Zend/tests/inheritance/bug73987_1.phpt
@@ -15,4 +15,4 @@ class B extends A {
 
 ?>
 --EXPECTF--
-Fatal error: Declaration of B::example(): string must be compatible with A::example(): int in %s
+Fatal error: Declaration of B::example(): string must be compatible with A::example(): int in %s on line %d

--- a/Zend/tests/inheritance/bug73987_3.phpt
+++ b/Zend/tests/inheritance/bug73987_3.phpt
@@ -17,4 +17,4 @@ class C extends B {
 
 ?>
 --EXPECTF--
-Fatal error: Declaration of C::example(): string must be compatible with B::example(): int in %s
+Fatal error: Declaration of C::example(): string must be compatible with B::example(): int in %s on line %d

--- a/Zend/tests/namespaces/bug42802.phpt
+++ b/Zend/tests/namespaces/bug42802.phpt
@@ -38,7 +38,7 @@ ok
 ok
 ok
 
-Fatal error: Uncaught TypeError: foo\test5(): Argument #1 ($bar) must be of type bar, foo\bar given, called in %s:%d
+Fatal error: Uncaught TypeError: foo\test5(): Argument #1 ($bar) must be of type bar, foo\bar given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(%d): foo\test5(Object(foo\bar))
 #1 {main}

--- a/Zend/tests/namespaces/ns_071.phpt
+++ b/Zend/tests/namespaces/ns_071.phpt
@@ -18,7 +18,7 @@ new bar(new \stdclass);
 --EXPECTF--
 NULL
 
-Fatal error: Uncaught TypeError: foo\bar::__construct(): Argument #1 ($x) must be of type ?array, stdClass given, called in %s:%d
+Fatal error: Uncaught TypeError: foo\bar::__construct(): Argument #1 ($x) must be of type ?array, stdClass given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(%d): foo\bar->__construct(Object(stdClass))
 #1 {main}

--- a/Zend/tests/namespaces/ns_072.phpt
+++ b/Zend/tests/namespaces/ns_072.phpt
@@ -30,7 +30,7 @@ object(foo\test)#%d (0) {
 }
 NULL
 
-Fatal error: Uncaught TypeError: foo\bar::__construct(): Argument #1 ($x) must be of type ?foo\foo, stdClass given, called in %s:%d
+Fatal error: Uncaught TypeError: foo\bar::__construct(): Argument #1 ($x) must be of type ?foo\foo, stdClass given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(%d): foo\bar->__construct(Object(stdClass))
 #1 {main}

--- a/Zend/tests/object_types/type_hint_in_class_method.phpt
+++ b/Zend/tests/object_types/type_hint_in_class_method.phpt
@@ -12,7 +12,7 @@ $one->a(new One());
 $one->a(123);
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: One::a(): Argument #1 ($obj) must be of type object, int given, called in %s:%d
+Fatal error: Uncaught TypeError: One::a(): Argument #1 ($obj) must be of type object, int given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(9): One->a(123)
 #1 {main}

--- a/Zend/tests/object_types/type_hint_in_function.phpt
+++ b/Zend/tests/object_types/type_hint_in_function.phpt
@@ -10,7 +10,7 @@ a(new A());
 a(123);
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: a(): Argument #1 ($obj) must be of type object, int given, called in %s:%d
+Fatal error: Uncaught TypeError: a(): Argument #1 ($obj) must be of type object, int given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(7): a(123)
 #1 {main}

--- a/Zend/tests/objects/objects_022.phpt
+++ b/Zend/tests/objects/objects_022.phpt
@@ -36,7 +36,7 @@ object(bar)#%d (0) {
 object(baz)#%d (0) {
 }
 
-Fatal error: Uncaught TypeError: foo::testFoo(): Argument #1 ($obj) must be of type foo, stdClass given, called in %s:%d
+Fatal error: Uncaught TypeError: foo::testFoo(): Argument #1 ($obj) must be of type foo, stdClass given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(%d): foo->testFoo(Object(stdClass))
 #1 {main}

--- a/Zend/tests/parameter_default_values/bug68446.phpt
+++ b/Zend/tests/parameter_default_values/bug68446.phpt
@@ -32,7 +32,7 @@ array(1) {
   int(1)
 }
 
-Fatal error: Uncaught TypeError: a(): Argument #1 ($a) must be of type array, null given, called in %s:%d
+Fatal error: Uncaught TypeError: a(): Argument #1 ($a) must be of type array, null given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(%d): a(NULL)
 #1 {main}

--- a/Zend/tests/traits/bug74269.phpt
+++ b/Zend/tests/traits/bug74269.phpt
@@ -14,4 +14,4 @@ class PropertiesExample
 }
 ?>
 --EXPECTF--
-Fatal error: PropertiesExample and PropertiesTrait define the same property ($same) in the composition of PropertiesExample. However, the definition differs and is considered incompatible. Class was composed in %s
+Fatal error: PropertiesExample and PropertiesTrait define the same property ($same) in the composition of PropertiesExample. However, the definition differs and is considered incompatible. Class was composed in %s on line %d

--- a/Zend/tests/type_declarations/array_001.phpt
+++ b/Zend/tests/type_declarations/array_001.phpt
@@ -12,7 +12,7 @@ foo(123);
 --EXPECTF--
 3
 
-Fatal error: Uncaught TypeError: foo(): Argument #1 ($a) must be of type array, int given, called in %s:%d
+Fatal error: Uncaught TypeError: foo(): Argument #1 ($a) must be of type array, int given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(%d): foo(123)
 #1 {main}

--- a/Zend/tests/type_declarations/callable/callable_001.phpt
+++ b/Zend/tests/type_declarations/callable/callable_001.phpt
@@ -36,7 +36,7 @@ array(2) {
   string(3) "foo"
 }
 
-Fatal error: Uncaught TypeError: foo(): Argument #1 ($bar) must be of type callable, array given, called in %s:%d
+Fatal error: Uncaught TypeError: foo(): Argument #1 ($bar) must be of type callable, array given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(%d): foo(Array)
 #1 {main}

--- a/Zend/tests/type_declarations/dnf_types/variance/valid9.phpt
+++ b/Zend/tests/type_declarations/dnf_types/variance/valid9.phpt
@@ -15,4 +15,4 @@ class Test2 extends Test {
 ?>
 ===DONE===
 --EXPECTF--
-Fatal error: Could not check compatibility between Test2::method2(): (X&MyIterator)|int and Test::method2(): Traversable|array|int, because class X is not available in %s
+Fatal error: Could not check compatibility between Test2::method2(): (X&MyIterator)|int and Test::method2(): Traversable|array|int, because class X is not available in %s on line %d

--- a/Zend/tests/type_declarations/explicit_weak_include_strict.phpt
+++ b/Zend/tests/type_declarations/explicit_weak_include_strict.phpt
@@ -11,7 +11,7 @@ require 'weak_include_strict_2.inc';
 // calls within that file should stay strict, despite being included by weak file
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: takes_int(): Argument #1 ($x) must be of type int, float given, called in %s:%d
+Fatal error: Uncaught TypeError: takes_int(): Argument #1 ($x) must be of type int, float given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(%d): takes_int(1.0)
 #1 %s(%d): require('%s')

--- a/Zend/tests/type_declarations/inexistent_class_hint_with_scalar_arg.phpt
+++ b/Zend/tests/type_declarations/inexistent_class_hint_with_scalar_arg.phpt
@@ -8,7 +8,7 @@ foo(null);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: foo(): Argument #1 ($ex) must be of type bar, null given, called in %s:%d
+Fatal error: Uncaught TypeError: foo(): Argument #1 ($ex) must be of type bar, null given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(%d): foo(NULL)
 #1 {main}

--- a/Zend/tests/type_declarations/scalar_constant_defaults_error.phpt
+++ b/Zend/tests/type_declarations/scalar_constant_defaults_error.phpt
@@ -13,7 +13,7 @@ var_dump(int_val());
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: int_val(): Argument #1 ($a) must be of type int, string given, called in %s:%d
+Fatal error: Uncaught TypeError: int_val(): Argument #1 ($a) must be of type int, string given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(%d): int_val()
 #1 {main}

--- a/Zend/tests/type_declarations/strict_call_weak.phpt
+++ b/Zend/tests/type_declarations/strict_call_weak.phpt
@@ -13,7 +13,7 @@ require 'strict_call_weak_2.inc';
 function_declared_in_weak_mode(1.0);
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: function_declared_in_weak_mode(): Argument #1 ($x) must be of type int, float given, called in %s:%d
+Fatal error: Uncaught TypeError: function_declared_in_weak_mode(): Argument #1 ($x) must be of type int, float given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(%d): function_declared_in_weak_mode(1.0)
 #1 {main}

--- a/Zend/tests/type_declarations/strict_call_weak_explicit.phpt
+++ b/Zend/tests/type_declarations/strict_call_weak_explicit.phpt
@@ -13,7 +13,7 @@ require 'strict_call_weak_explicit_2.inc';
 function_declared_in_weak_mode(1.0);
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: function_declared_in_weak_mode(): Argument #1 ($x) must be of type int, float given, called in %s:%d
+Fatal error: Uncaught TypeError: function_declared_in_weak_mode(): Argument #1 ($x) must be of type int, float given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(%d): function_declared_in_weak_mode(1.0)
 #1 {main}

--- a/Zend/tests/type_declarations/weak_include_strict.phpt
+++ b/Zend/tests/type_declarations/weak_include_strict.phpt
@@ -11,7 +11,7 @@ require 'weak_include_strict_2.inc';
 // calls within that file should stay strict, despite being included by weak file
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: takes_int(): Argument #1 ($x) must be of type int, float given, called in %s:%d
+Fatal error: Uncaught TypeError: takes_int(): Argument #1 ($x) must be of type int, float given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(%d): takes_int(1.0)
 #1 %s(%d): require('%s')

--- a/Zend/tests/typehints/bug43332_1.phpt
+++ b/Zend/tests/typehints/bug43332_1.phpt
@@ -13,7 +13,7 @@ $foo->bar($foo); // Ok!
 $foo->bar(new \stdclass); // Error, ok!
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: foobar\foo::bar(): Argument #1 ($a) must be of type foobar\foo, stdClass given, called in %s:%d
+Fatal error: Uncaught TypeError: foobar\foo::bar(): Argument #1 ($a) must be of type foobar\foo, stdClass given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(%d): foobar\foo->bar(Object(stdClass))
 #1 {main}

--- a/Zend/tests/typehints/or_null.phpt
+++ b/Zend/tests/typehints/or_null.phpt
@@ -192,35 +192,35 @@ try {
 
 ?>
 --EXPECTF--
-TypeError: unloadedClass(): Argument #1 ($param) must be of type ?I\Dont\Exist, stdClass given, called in %s:%d
+TypeError: unloadedClass(): Argument #1 ($param) must be of type ?I\Dont\Exist, stdClass given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(%d): unloadedClass(Object(stdClass))
 #1 {main}
-TypeError: loadedClass(): Argument #1 ($param) must be of type ?RealClass, stdClass given, called in %s:%d
+TypeError: loadedClass(): Argument #1 ($param) must be of type ?RealClass, stdClass given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(%d): loadedClass(Object(stdClass))
 #1 {main}
-TypeError: loadedInterface(): Argument #1 ($param) must be of type ?RealInterface, stdClass given, called in %s:%d
+TypeError: loadedInterface(): Argument #1 ($param) must be of type ?RealInterface, stdClass given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(%d): loadedInterface(Object(stdClass))
 #1 {main}
-TypeError: unloadedClass(): Argument #1 ($param) must be of type ?I\Dont\Exist, int given, called in %s:%d
+TypeError: unloadedClass(): Argument #1 ($param) must be of type ?I\Dont\Exist, int given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(%d): unloadedClass(1)
 #1 {main}
-TypeError: loadedClass(): Argument #1 ($param) must be of type ?RealClass, int given, called in %s:%d
+TypeError: loadedClass(): Argument #1 ($param) must be of type ?RealClass, int given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(%d): loadedClass(1)
 #1 {main}
-TypeError: loadedInterface(): Argument #1 ($param) must be of type ?RealInterface, int given, called in %s:%d
+TypeError: loadedInterface(): Argument #1 ($param) must be of type ?RealInterface, int given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(%d): loadedInterface(1)
 #1 {main}
-TypeError: callableF(): Argument #1 ($param) must be of type ?callable, int given, called in %s:%d
+TypeError: callableF(): Argument #1 ($param) must be of type ?callable, int given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(%d): callableF(1)
 #1 {main}
-TypeError: intF(): Argument #1 ($param) must be of type ?int, stdClass given, called in %s:%d
+TypeError: intF(): Argument #1 ($param) must be of type ?int, stdClass given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(%d): intF(Object(stdClass))
 #1 {main}

--- a/Zend/tests/unset/unset_non_array.phpt
+++ b/Zend/tests/unset/unset_non_array.phpt
@@ -96,7 +96,7 @@ try {
 --EXPECTF--
 Warning: Undefined variable $x in %s on line %d
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 Cannot unset offset in a non-array variable
 Cannot unset offset in a non-array variable
 Cannot unset offset in a non-array variable
@@ -105,7 +105,7 @@ Cannot use object of type stdClass as array
 
 Warning: Undefined variable $x in %s on line %d
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 Cannot unset offset in a non-array variable
 Cannot unset offset in a non-array variable
 Cannot unset offset in a non-array variable

--- a/Zend/tests/variadic/typehint_error.phpt
+++ b/Zend/tests/variadic/typehint_error.phpt
@@ -33,7 +33,7 @@ array(3) {
   }
 }
 
-Fatal error: Uncaught TypeError: test(): Argument #3 must be of type array, int given, called in %s:%d
+Fatal error: Uncaught TypeError: test(): Argument #3 must be of type array, int given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s(%d): test(Array, Array, 2)
 #1 {main}

--- a/ext/bcmath/tests/number/cast_warning.phpt
+++ b/ext/bcmath/tests/number/cast_warning.phpt
@@ -9,6 +9,6 @@ $num = new BcMath\Number(1);
 (float) $num;
 ?>
 --EXPECTF--
-Warning: Object of class BcMath\Number could not be converted to int in %s
+Warning: Object of class BcMath\Number could not be converted to int in %s on line %d
 
-Warning: Object of class BcMath\Number could not be converted to float in %s
+Warning: Object of class BcMath\Number could not be converted to float in %s on line %d

--- a/ext/bcmath/tests/number/class_extends_error.phpt
+++ b/ext/bcmath/tests/number/class_extends_error.phpt
@@ -10,4 +10,4 @@ class Child extends \BcMath\Number{}
 $child = new Child(1);
 ?>
 --EXPECTF--
-Fatal error: Class Child cannot extend final class BcMath\Number in %s
+Fatal error: Class Child cannot extend final class BcMath\Number in %s on line %d

--- a/ext/bcmath/tests/number/construct_float.phpt
+++ b/ext/bcmath/tests/number/construct_float.phpt
@@ -8,7 +8,7 @@ $num = new BcMath\Number(0.1234);
 var_dump($num);
 ?>
 --EXPECTF--
-Deprecated: Implicit conversion from float 0.1234 to int loses precision in %s
+Deprecated: Implicit conversion from float 0.1234 to int loses precision in %s on line %d
 object(BcMath\Number)#1 (2) {
   ["value"]=>
   string(1) "0"

--- a/ext/bcmath/tests/number/methods/calc_methods_num_arg_error.phpt
+++ b/ext/bcmath/tests/number/methods/calc_methods_num_arg_error.phpt
@@ -45,10 +45,10 @@ other object:
 BcMath\Number::add(): Argument #1 ($num) must be of type int, string, or BcMath\Number, stdClass given
 float:
 
-Deprecated: Implicit conversion from float 0.1 to int loses precision in %s
+Deprecated: Implicit conversion from float 0.1 to int loses precision in %s on line %d
 null:
 
-Deprecated: BcMath\Number::add(): Passing null to parameter #1 ($num) of type BcMath\Number|string|int is deprecated in %s
+Deprecated: BcMath\Number::add(): Passing null to parameter #1 ($num) of type BcMath\Number|string|int is deprecated in %s on line %d
 
 ========== sub ==========
 non number str:
@@ -59,10 +59,10 @@ other object:
 BcMath\Number::sub(): Argument #1 ($num) must be of type int, string, or BcMath\Number, stdClass given
 float:
 
-Deprecated: Implicit conversion from float 0.1 to int loses precision in %s
+Deprecated: Implicit conversion from float 0.1 to int loses precision in %s on line %d
 null:
 
-Deprecated: BcMath\Number::sub(): Passing null to parameter #1 ($num) of type BcMath\Number|string|int is deprecated in %s
+Deprecated: BcMath\Number::sub(): Passing null to parameter #1 ($num) of type BcMath\Number|string|int is deprecated in %s on line %d
 
 ========== mul ==========
 non number str:
@@ -73,10 +73,10 @@ other object:
 BcMath\Number::mul(): Argument #1 ($num) must be of type int, string, or BcMath\Number, stdClass given
 float:
 
-Deprecated: Implicit conversion from float 0.1 to int loses precision in %s
+Deprecated: Implicit conversion from float 0.1 to int loses precision in %s on line %d
 null:
 
-Deprecated: BcMath\Number::mul(): Passing null to parameter #1 ($num) of type BcMath\Number|string|int is deprecated in %s
+Deprecated: BcMath\Number::mul(): Passing null to parameter #1 ($num) of type BcMath\Number|string|int is deprecated in %s on line %d
 
 ========== div ==========
 non number str:
@@ -87,11 +87,11 @@ other object:
 BcMath\Number::div(): Argument #1 ($num) must be of type int, string, or BcMath\Number, stdClass given
 float:
 
-Deprecated: Implicit conversion from float 0.1 to int loses precision in %s
+Deprecated: Implicit conversion from float 0.1 to int loses precision in %s on line %d
 Division by zero
 null:
 
-Deprecated: BcMath\Number::div(): Passing null to parameter #1 ($num) of type BcMath\Number|string|int is deprecated in %s
+Deprecated: BcMath\Number::div(): Passing null to parameter #1 ($num) of type BcMath\Number|string|int is deprecated in %s on line %d
 Division by zero
 
 ========== mod ==========
@@ -103,11 +103,11 @@ other object:
 BcMath\Number::mod(): Argument #1 ($num) must be of type int, string, or BcMath\Number, stdClass given
 float:
 
-Deprecated: Implicit conversion from float 0.1 to int loses precision in %s
+Deprecated: Implicit conversion from float 0.1 to int loses precision in %s on line %d
 Modulo by zero
 null:
 
-Deprecated: BcMath\Number::mod(): Passing null to parameter #1 ($num) of type BcMath\Number|string|int is deprecated in %s
+Deprecated: BcMath\Number::mod(): Passing null to parameter #1 ($num) of type BcMath\Number|string|int is deprecated in %s on line %d
 Modulo by zero
 
 ========== pow ==========
@@ -119,7 +119,7 @@ other object:
 BcMath\Number::pow(): Argument #1 ($exponent) must be of type int, string, or BcMath\Number, stdClass given
 float:
 
-Deprecated: Implicit conversion from float 0.1 to int loses precision in %s
+Deprecated: Implicit conversion from float 0.1 to int loses precision in %s on line %d
 null:
 
-Deprecated: BcMath\Number::pow(): Passing null to parameter #1 ($exponent) of type BcMath\Number|string|int is deprecated in %s
+Deprecated: BcMath\Number::pow(): Passing null to parameter #1 ($exponent) of type BcMath\Number|string|int is deprecated in %s on line %d

--- a/ext/bcmath/tests/number/methods/calc_methods_scale_arg_error.phpt
+++ b/ext/bcmath/tests/number/methods/calc_methods_scale_arg_error.phpt
@@ -41,7 +41,7 @@ other object:
 BcMath\Number::add(): Argument #2 ($scale) must be of type ?int, stdClass given
 float:
 
-Deprecated: Implicit conversion from float 0.1 to int loses precision in %s
+Deprecated: Implicit conversion from float 0.1 to int loses precision in %s on line %d
 
 ========== sub ==========
 array:
@@ -50,7 +50,7 @@ other object:
 BcMath\Number::sub(): Argument #2 ($scale) must be of type ?int, stdClass given
 float:
 
-Deprecated: Implicit conversion from float 0.1 to int loses precision in %s
+Deprecated: Implicit conversion from float 0.1 to int loses precision in %s on line %d
 
 ========== mul ==========
 array:
@@ -59,7 +59,7 @@ other object:
 BcMath\Number::mul(): Argument #2 ($scale) must be of type ?int, stdClass given
 float:
 
-Deprecated: Implicit conversion from float 0.1 to int loses precision in %s
+Deprecated: Implicit conversion from float 0.1 to int loses precision in %s on line %d
 
 ========== div ==========
 array:
@@ -68,7 +68,7 @@ other object:
 BcMath\Number::div(): Argument #2 ($scale) must be of type ?int, stdClass given
 float:
 
-Deprecated: Implicit conversion from float 0.1 to int loses precision in %s
+Deprecated: Implicit conversion from float 0.1 to int loses precision in %s on line %d
 
 ========== mod ==========
 array:
@@ -77,7 +77,7 @@ other object:
 BcMath\Number::mod(): Argument #2 ($scale) must be of type ?int, stdClass given
 float:
 
-Deprecated: Implicit conversion from float 0.1 to int loses precision in %s
+Deprecated: Implicit conversion from float 0.1 to int loses precision in %s on line %d
 
 ========== pow ==========
 array:
@@ -86,4 +86,4 @@ other object:
 BcMath\Number::pow(): Argument #2 ($scale) must be of type ?int, stdClass given
 float:
 
-Deprecated: Implicit conversion from float 0.1 to int loses precision in %s
+Deprecated: Implicit conversion from float 0.1 to int loses precision in %s on line %d

--- a/ext/bcmath/tests/number/methods/compare_arg_error.phpt
+++ b/ext/bcmath/tests/number/methods/compare_arg_error.phpt
@@ -35,8 +35,8 @@ BcMath\Number::compare(): Argument #1 ($num) must be of type int, string, or BcM
 
 float:
 
-Deprecated: Implicit conversion from float 0.1 to int loses precision in %s
+Deprecated: Implicit conversion from float 0.1 to int loses precision in %s on line %d
 
 null:
 
-Deprecated: BcMath\Number::compare(): Passing null to parameter #1 ($num) of type BcMath\Number|string|int is deprecated in %s
+Deprecated: BcMath\Number::compare(): Passing null to parameter #1 ($num) of type BcMath\Number|string|int is deprecated in %s on line %d

--- a/ext/bcmath/tests/number/methods/powmod_arg_error.phpt
+++ b/ext/bcmath/tests/number/methods/powmod_arg_error.phpt
@@ -46,10 +46,10 @@ other object:
 BcMath\Number::powmod(): Argument #1 ($exponent) must be of type int, string, or BcMath\Number, stdClass given
 float:
 
-Deprecated: Implicit conversion from float 0.1 to int loses precision in %s
+Deprecated: Implicit conversion from float 0.1 to int loses precision in %s on line %d
 null:
 
-Deprecated: BcMath\Number::powmod(): Passing null to parameter #1 ($exponent) of type BcMath\Number|string|int is deprecated in %s
+Deprecated: BcMath\Number::powmod(): Passing null to parameter #1 ($exponent) of type BcMath\Number|string|int is deprecated in %s on line %d
 
 ========== check 2nd arg ==========
 non number str:
@@ -60,9 +60,9 @@ other object:
 BcMath\Number::powmod(): Argument #2 ($modulus) must be of type int, string, or BcMath\Number, stdClass given
 float:
 
-Deprecated: Implicit conversion from float 0.1 to int loses precision in %s
+Deprecated: Implicit conversion from float 0.1 to int loses precision in %s on line %d
 Modulo by zero
 null:
 
-Deprecated: BcMath\Number::powmod(): Passing null to parameter #2 ($modulus) of type BcMath\Number|string|int is deprecated in %s
+Deprecated: BcMath\Number::powmod(): Passing null to parameter #2 ($modulus) of type BcMath\Number|string|int is deprecated in %s on line %d
 Modulo by zero

--- a/ext/bcmath/tests/number/operators/calc_float.phpt
+++ b/ext/bcmath/tests/number/operators/calc_float.phpt
@@ -14,14 +14,14 @@ $num % 1.01;
 $num ** 1.01;
 ?>
 --EXPECTF--
-Deprecated: Implicit conversion from float 1.01 to int loses precision in %s
+Deprecated: Implicit conversion from float 1.01 to int loses precision in %s on line %d
 
-Deprecated: Implicit conversion from float 1.01 to int loses precision in %s
+Deprecated: Implicit conversion from float 1.01 to int loses precision in %s on line %d
 
-Deprecated: Implicit conversion from float 1.01 to int loses precision in %s
+Deprecated: Implicit conversion from float 1.01 to int loses precision in %s on line %d
 
-Deprecated: Implicit conversion from float 1.01 to int loses precision in %s
+Deprecated: Implicit conversion from float 1.01 to int loses precision in %s on line %d
 
-Deprecated: Implicit conversion from float 1.01 to int loses precision in %s
+Deprecated: Implicit conversion from float 1.01 to int loses precision in %s on line %d
 
-Deprecated: Implicit conversion from float 1.01 to int loses precision in %s
+Deprecated: Implicit conversion from float 1.01 to int loses precision in %s on line %d

--- a/ext/bcmath/tests/number/operators/calc_undef.phpt
+++ b/ext/bcmath/tests/number/operators/calc_undef.phpt
@@ -43,20 +43,20 @@ try {
 }
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef in %s
+Warning: Undefined variable $undef in %s on line %d
 Unsupported operand types: BcMath\Number + null
 
-Warning: Undefined variable $undef in %s
+Warning: Undefined variable $undef in %s on line %d
 Unsupported operand types: BcMath\Number - null
 
-Warning: Undefined variable $undef in %s
+Warning: Undefined variable $undef in %s on line %d
 Unsupported operand types: BcMath\Number * null
 
-Warning: Undefined variable $undef in %s
+Warning: Undefined variable $undef in %s on line %d
 Unsupported operand types: BcMath\Number / null
 
-Warning: Undefined variable $undef in %s
+Warning: Undefined variable $undef in %s on line %d
 Unsupported operand types: BcMath\Number % null
 
-Warning: Undefined variable $undef in %s
+Warning: Undefined variable $undef in %s on line %d
 Unsupported operand types: BcMath\Number ** null

--- a/ext/bcmath/tests/number/properties_unknown.phpt
+++ b/ext/bcmath/tests/number/properties_unknown.phpt
@@ -26,11 +26,11 @@ try {
 var_dump(isset($num->foo));
 ?>
 --EXPECTF--
-Warning: Undefined property: BcMath\Number::$foo in %s
+Warning: Undefined property: BcMath\Number::$foo in %s on line %d
 NULL
 Cannot create dynamic property BcMath\Number::$foo
 
-Warning: Undefined property: BcMath\Number::$foo in %s
+Warning: Undefined property: BcMath\Number::$foo in %s on line %d
 NULL
 Cannot create dynamic property BcMath\Number::$bar
 bool(false)

--- a/ext/bz2/tests/bz2_filter_write_seek_modes.phpt
+++ b/ext/bz2/tests/bz2_filter_write_seek_modes.phpt
@@ -49,6 +49,6 @@ bool(true)
 bool(true)
 bool(true)
 
-Warning: stream_filter_append(): "write_seek_mode" filter parameter must be one of "preserve", "reset", or "strict" in %s
+Warning: stream_filter_append(): "write_seek_mode" filter parameter must be one of "preserve", "reset", or "strict" in %s on line %d
 
-Warning: stream_filter_append(): Unable to create or locate filter "bzip2.compress" in %s
+Warning: stream_filter_append(): Unable to create or locate filter "bzip2.compress" in %s on line %d

--- a/ext/date/tests/DateTime_modify_invalid_format.phpt
+++ b/ext/date/tests/DateTime_modify_invalid_format.phpt
@@ -13,6 +13,6 @@ try {
 
 ?>
 --EXPECTF--
-Warning: date_modify(): Failed to parse time string () at position 0 ( ): Empty string in %s
+Warning: date_modify(): Failed to parse time string () at position 0 ( ): Empty string in %s on line %d
 bool(false)
 DateMalformedStringException: DateTime::modify(): Failed to parse time string () at position 0 ( ): Empty string

--- a/ext/date/tests/bug50055-001.phpt
+++ b/ext/date/tests/bug50055-001.phpt
@@ -23,8 +23,8 @@ date_sub($ds2, $i);
 2010-03-07T13:21:38+0000
 2010-04-20T13:21:38+0000
 
-Warning: date_sub(): Only non-special relative time specifications are supported for subtraction in %s
+Warning: date_sub(): Only non-special relative time specifications are supported for subtraction in %s on line %d
 2010-03-07T13:21:38+0000
 2010-02-16T13:21:38+0000
 
-Warning: date_sub(): Only non-special relative time specifications are supported for subtraction in %s
+Warning: date_sub(): Only non-special relative time specifications are supported for subtraction in %s on line %d

--- a/ext/date/tests/date_interval_create_from_date_string_broken.phpt
+++ b/ext/date/tests/date_interval_create_from_date_string_broken.phpt
@@ -6,5 +6,5 @@ $i = date_interval_create_from_date_string("foobar");
 var_dump($i);
 ?>
 --EXPECTF--
-Warning: date_interval_create_from_date_string(): Unknown or bad format (foobar) at position 0 (f): The timezone could not be found in the database in %s
+Warning: date_interval_create_from_date_string(): Unknown or bad format (foobar) at position 0 (f): The timezone could not be found in the database in %s on line %d
 bool(false)

--- a/ext/date/tests/date_interval_create_from_date_string_nullparam.phpt
+++ b/ext/date/tests/date_interval_create_from_date_string_nullparam.phpt
@@ -10,5 +10,5 @@ var_dump($i);
 --EXPECTF--
 Deprecated: date_interval_create_from_date_string(): Passing null to parameter #1 ($datetime) of type string is deprecated in %s on line %d
 
-Warning: date_interval_create_from_date_string(): Unknown or bad format () at position 0 ( ): Empty string in %s
+Warning: date_interval_create_from_date_string(): Unknown or bad format () at position 0 ( ): Empty string in %s on line %d
 bool(false)

--- a/ext/enchant/tests/broker_free.phpt
+++ b/ext/enchant/tests/broker_free.phpt
@@ -19,5 +19,5 @@ echo "OK\n";
 --EXPECTF--
 OK
 
-Deprecated: Function enchant_broker_free() is deprecated since 8.0, as EnchantBroker objects are freed automatically in %s
+Deprecated: Function enchant_broker_free() is deprecated since 8.0, as EnchantBroker objects are freed automatically in %s on line %d
 OK

--- a/ext/enchant/tests/broker_free_dict.phpt
+++ b/ext/enchant/tests/broker_free_dict.phpt
@@ -49,6 +49,6 @@ OK
 OK
 NULL
 
-Deprecated: Function enchant_broker_free_dict() is deprecated since 8.0, as EnchantDictionary objects are freed automatically in %s
+Deprecated: Function enchant_broker_free_dict() is deprecated since 8.0, as EnchantDictionary objects are freed automatically in %s on line %d
 OK
 OK

--- a/ext/enchant/tests/bug53070.phpt
+++ b/ext/enchant/tests/bug53070.phpt
@@ -13,16 +13,16 @@ var_dump(enchant_broker_get_dict_path($broker, ENCHANT_MYSPELL));
 var_dump(enchant_broker_get_dict_path($broker, ENCHANT_ISPELL));
 ?>
 --EXPECTF--
-Deprecated: Constant ENCHANT_MYSPELL is deprecated in %s
+Deprecated: Constant ENCHANT_MYSPELL is deprecated in %s on line %d
 
-Deprecated: Function enchant_broker_get_dict_path() is deprecated since 8.0 in %s
+Deprecated: Function enchant_broker_get_dict_path() is deprecated since 8.0 in %s on line %d
 
 Warning: enchant_broker_get_dict_path(): dict_path not set in %s on line %d
 bool(false)
 
-Deprecated: Constant ENCHANT_ISPELL is deprecated in %s
+Deprecated: Constant ENCHANT_ISPELL is deprecated in %s on line %d
 
-Deprecated: Function enchant_broker_get_dict_path() is deprecated since 8.0 in %s
+Deprecated: Function enchant_broker_get_dict_path() is deprecated since 8.0 in %s on line %d
 
 Warning: enchant_broker_get_dict_path(): dict_path not set in %s on line %d
 bool(false)

--- a/ext/enchant/tests/enchant_broker_set_dict_path.phpt
+++ b/ext/enchant/tests/enchant_broker_set_dict_path.phpt
@@ -50,13 +50,13 @@ if (is_object($broker)) {
 --EXPECTF--
 OK
 
-Deprecated: Function enchant_broker_set_dict_path() is deprecated since 8.0 in %s
+Deprecated: Function enchant_broker_set_dict_path() is deprecated since 8.0 in %s on line %d
 OK
 
-Deprecated: Function enchant_broker_set_dict_path() is deprecated since 8.0 in %s
+Deprecated: Function enchant_broker_set_dict_path() is deprecated since 8.0 in %s on line %d
 OK
 
-Deprecated: Function enchant_broker_get_dict_path() is deprecated since 8.0 in %s
+Deprecated: Function enchant_broker_get_dict_path() is deprecated since 8.0 in %s on line %d
 
-Deprecated: Function enchant_broker_get_dict_path() is deprecated since 8.0 in %s
+Deprecated: Function enchant_broker_get_dict_path() is deprecated since 8.0 in %s on line %d
 OK

--- a/ext/mbstring/tests/base64_encoding.phpt
+++ b/ext/mbstring/tests/base64_encoding.phpt
@@ -31,21 +31,21 @@ testConversion(str_repeat("ABCDEFGHIJ", 20), "QUJDREVGR0hJSkFCQ0RFRkdISUpBQkNERU
 echo "Done!\n";
 ?>
 --EXPECTF--
-Deprecated: mb_convert_encoding(): Handling Base64 via mbstring is deprecated; use base64_encode/base64_decode instead in %s
+Deprecated: mb_convert_encoding(): Handling Base64 via mbstring is deprecated; use base64_encode/base64_decode instead in %s on line %d
 
-Deprecated: mb_convert_encoding(): Handling Base64 via mbstring is deprecated; use base64_encode/base64_decode instead in %s
+Deprecated: mb_convert_encoding(): Handling Base64 via mbstring is deprecated; use base64_encode/base64_decode instead in %s on line %d
 
-Deprecated: mb_convert_encoding(): Handling Base64 via mbstring is deprecated; use base64_encode/base64_decode instead in %s
+Deprecated: mb_convert_encoding(): Handling Base64 via mbstring is deprecated; use base64_encode/base64_decode instead in %s on line %d
 
-Deprecated: mb_convert_encoding(): Handling Base64 via mbstring is deprecated; use base64_encode/base64_decode instead in %s
+Deprecated: mb_convert_encoding(): Handling Base64 via mbstring is deprecated; use base64_encode/base64_decode instead in %s on line %d
 
-Deprecated: mb_convert_encoding(): Handling Base64 via mbstring is deprecated; use base64_encode/base64_decode instead in %s
+Deprecated: mb_convert_encoding(): Handling Base64 via mbstring is deprecated; use base64_encode/base64_decode instead in %s on line %d
 
-Deprecated: mb_convert_encoding(): Handling Base64 via mbstring is deprecated; use base64_encode/base64_decode instead in %s
+Deprecated: mb_convert_encoding(): Handling Base64 via mbstring is deprecated; use base64_encode/base64_decode instead in %s on line %d
 
-Deprecated: mb_convert_encoding(): Handling Base64 via mbstring is deprecated; use base64_encode/base64_decode instead in %s
+Deprecated: mb_convert_encoding(): Handling Base64 via mbstring is deprecated; use base64_encode/base64_decode instead in %s on line %d
 
-Deprecated: mb_convert_encoding(): Handling Base64 via mbstring is deprecated; use base64_encode/base64_decode instead in %s
+Deprecated: mb_convert_encoding(): Handling Base64 via mbstring is deprecated; use base64_encode/base64_decode instead in %s on line %d
 
-Deprecated: mb_convert_encoding(): Handling Base64 via mbstring is deprecated; use base64_encode/base64_decode instead in %s
+Deprecated: mb_convert_encoding(): Handling Base64 via mbstring is deprecated; use base64_encode/base64_decode instead in %s on line %d
 Done!

--- a/ext/mbstring/tests/htmlent_encoding.phpt
+++ b/ext/mbstring/tests/htmlent_encoding.phpt
@@ -54,15 +54,15 @@ convertFromEntities("&A", "&&#x41;");
 echo "Done!\n";
 ?>
 --EXPECTF--
-Deprecated: mb_convert_encoding(): Handling HTML entities via mbstring is deprecated; use htmlspecialchars, htmlentities, or mb_encode_numericentity/mb_decode_numericentity instead in %s
+Deprecated: mb_convert_encoding(): Handling HTML entities via mbstring is deprecated; use htmlspecialchars, htmlentities, or mb_encode_numericentity/mb_decode_numericentity instead in %s on line %d
 
-Deprecated: mb_convert_encoding(): Handling HTML entities via mbstring is deprecated; use htmlspecialchars, htmlentities, or mb_encode_numericentity/mb_decode_numericentity instead in %s
+Deprecated: mb_convert_encoding(): Handling HTML entities via mbstring is deprecated; use htmlspecialchars, htmlentities, or mb_encode_numericentity/mb_decode_numericentity instead in %s on line %d
 
-Deprecated: mb_convert_encoding(): Handling HTML entities via mbstring is deprecated; use htmlspecialchars, htmlentities, or mb_encode_numericentity/mb_decode_numericentity instead in %s
+Deprecated: mb_convert_encoding(): Handling HTML entities via mbstring is deprecated; use htmlspecialchars, htmlentities, or mb_encode_numericentity/mb_decode_numericentity instead in %s on line %d
 
-Deprecated: mb_convert_encoding(): Handling HTML entities via mbstring is deprecated; use htmlspecialchars, htmlentities, or mb_encode_numericentity/mb_decode_numericentity instead in %s
+Deprecated: mb_convert_encoding(): Handling HTML entities via mbstring is deprecated; use htmlspecialchars, htmlentities, or mb_encode_numericentity/mb_decode_numericentity instead in %s on line %d
 
-Deprecated: mb_convert_encoding(): Handling HTML entities via mbstring is deprecated; use htmlspecialchars, htmlentities, or mb_encode_numericentity/mb_decode_numericentity instead in %s
+Deprecated: mb_convert_encoding(): Handling HTML entities via mbstring is deprecated; use htmlspecialchars, htmlentities, or mb_encode_numericentity/mb_decode_numericentity instead in %s on line %d
 
-Deprecated: mb_convert_encoding(): Handling HTML entities via mbstring is deprecated; use htmlspecialchars, htmlentities, or mb_encode_numericentity/mb_decode_numericentity instead in %s
+Deprecated: mb_convert_encoding(): Handling HTML entities via mbstring is deprecated; use htmlspecialchars, htmlentities, or mb_encode_numericentity/mb_decode_numericentity instead in %s on line %d
 Done!

--- a/ext/mbstring/tests/qprint_encoding.phpt
+++ b/ext/mbstring/tests/qprint_encoding.phpt
@@ -29,11 +29,11 @@ testConversion("***,*-S,\xac,,\xb7,l,,,,\xb6UTF7,\xb5\xb5\xb5\xb5\xb5\xb5K\xb5\x
 echo "Done!\n";
 ?>
 --EXPECTF--
-Deprecated: mb_convert_encoding(): Handling QPrint via mbstring is deprecated; use quoted_printable_encode/quoted_printable_decode instead in %s
+Deprecated: mb_convert_encoding(): Handling QPrint via mbstring is deprecated; use quoted_printable_encode/quoted_printable_decode instead in %s on line %d
 
-Deprecated: mb_convert_encoding(): Handling QPrint via mbstring is deprecated; use quoted_printable_encode/quoted_printable_decode instead in %s
+Deprecated: mb_convert_encoding(): Handling QPrint via mbstring is deprecated; use quoted_printable_encode/quoted_printable_decode instead in %s on line %d
 
-Deprecated: mb_convert_encoding(): Handling QPrint via mbstring is deprecated; use quoted_printable_encode/quoted_printable_decode instead in %s
+Deprecated: mb_convert_encoding(): Handling QPrint via mbstring is deprecated; use quoted_printable_encode/quoted_printable_decode instead in %s on line %d
 
-Deprecated: mb_convert_encoding(): Handling QPrint via mbstring is deprecated; use quoted_printable_encode/quoted_printable_decode instead in %s
+Deprecated: mb_convert_encoding(): Handling QPrint via mbstring is deprecated; use quoted_printable_encode/quoted_printable_decode instead in %s on line %d
 Done!

--- a/ext/mysqli/tests/070.phpt
+++ b/ext/mysqli/tests/070.phpt
@@ -17,6 +17,6 @@ require_once 'skipifconnectfailure.inc';
 ?>
 --EXPECTF--
 
-Deprecated: Method mysqli::ping() is deprecated since 8.4, because the reconnect feature has been removed in PHP 8.2 and this method is now redundant in %s
+Deprecated: Method mysqli::ping() is deprecated since 8.4, because the reconnect feature has been removed in PHP 8.2 and this method is now redundant in %s on line %d
 bool(true)
 done!

--- a/ext/mysqli/tests/071.phpt
+++ b/ext/mysqli/tests/071.phpt
@@ -40,10 +40,10 @@ require_once 'skipifconnectfailure.inc';
 --EXPECTF--
 bool(true)
 
-Deprecated: Method mysqli::kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s
+Deprecated: Method mysqli::kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s on line %d
 bool(false)
 bool(true)
 
-Deprecated: Method mysqli::kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s
+Deprecated: Method mysqli::kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s on line %d
 bool(false)
 done!

--- a/ext/mysqli/tests/bug38003.phpt
+++ b/ext/mysqli/tests/bug38003.phpt
@@ -17,7 +17,7 @@ $DB = new DB();
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Call to private DB::__construct() from global scope in %s
+Fatal error: Uncaught Error: Call to private DB::__construct() from global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s

--- a/ext/mysqli/tests/deprecated_constants.phpt
+++ b/ext/mysqli/tests/deprecated_constants.phpt
@@ -16,22 +16,22 @@ echo constant('MYSQLI_IS_MARIADB')."\n";
 ?>
 --EXPECTF--
 
-Deprecated: Constant MYSQLI_NO_DATA is deprecated since 8.1, as it was unused in %s
+Deprecated: Constant MYSQLI_NO_DATA is deprecated since 8.1, as it was unused in %s on line %d
 %i
 
-Deprecated: Constant MYSQLI_DATA_TRUNCATED is deprecated since 8.1, as it was unused in %s
+Deprecated: Constant MYSQLI_DATA_TRUNCATED is deprecated since 8.1, as it was unused in %s on line %d
 %i
 
-Deprecated: Constant MYSQLI_SERVER_QUERY_NO_GOOD_INDEX_USED is deprecated since 8.1, as it was unused in %s
+Deprecated: Constant MYSQLI_SERVER_QUERY_NO_GOOD_INDEX_USED is deprecated since 8.1, as it was unused in %s on line %d
 %i
 
-Deprecated: Constant MYSQLI_SERVER_QUERY_NO_INDEX_USED is deprecated since 8.1, as it was unused in %s
+Deprecated: Constant MYSQLI_SERVER_QUERY_NO_INDEX_USED is deprecated since 8.1, as it was unused in %s on line %d
 %i
 
-Deprecated: Constant MYSQLI_SERVER_QUERY_WAS_SLOW is deprecated since 8.1, as it was unused in %s
+Deprecated: Constant MYSQLI_SERVER_QUERY_WAS_SLOW is deprecated since 8.1, as it was unused in %s on line %d
 %i
 
-Deprecated: Constant MYSQLI_SERVER_PS_OUT_PARAMS is deprecated since 8.1, as it was unused in %s
+Deprecated: Constant MYSQLI_SERVER_PS_OUT_PARAMS is deprecated since 8.1, as it was unused in %s on line %d
 %i
 
-Deprecated: Constant MYSQLI_IS_MARIADB is deprecated since 8.2, as it is always false in %s
+Deprecated: Constant MYSQLI_IS_MARIADB is deprecated since 8.2, as it is always false in %s on line %d

--- a/ext/mysqli/tests/gh8978.phpt
+++ b/ext/mysqli/tests/gh8978.phpt
@@ -24,6 +24,6 @@ try {
 echo 'done!';
 ?>
 --EXPECTF--
-Warning: failed loading cafile stream: `x509.ca' in %s
+Warning: failed loading cafile stream: `x509.ca' in %s on line %d
 Cannot connect to MySQL using SSL
 done!

--- a/ext/mysqli/tests/mysqli_get_info_deprecations.phpt
+++ b/ext/mysqli/tests/mysqli_get_info_deprecations.phpt
@@ -24,9 +24,9 @@ print "done!";
 ?>
 --EXPECTF--
 
-Deprecated: Method mysqli::get_client_info() is deprecated since 8.1, use mysqli_get_client_info() instead in %s
+Deprecated: Method mysqli::get_client_info() is deprecated since 8.1, use mysqli_get_client_info() instead in %s on line %d
 client_info = '%s'
 
-Deprecated: mysqli_get_client_info(): Passing connection object as an argument is deprecated in %s
+Deprecated: mysqli_get_client_info(): Passing connection object as an argument is deprecated in %s on line %d
 client_info = '%s'
 done!

--- a/ext/mysqli/tests/mysqli_insert_id_variation.phpt
+++ b/ext/mysqli/tests/mysqli_insert_id_variation.phpt
@@ -101,5 +101,5 @@ if (!mysqli_query($link, "DROP TABLE IF EXISTS test_insert_id_var"))
 mysqli_close($link);
 ?>
 --EXPECTF--
-Deprecated: Method mysqli::ping() is deprecated since 8.4, because the reconnect feature has been removed in PHP 8.2 and this method is now redundant in %s
+Deprecated: Method mysqli::ping() is deprecated since 8.4, because the reconnect feature has been removed in PHP 8.2 and this method is now redundant in %s on line %d
 DONE

--- a/ext/mysqli/tests/mysqli_kill.phpt
+++ b/ext/mysqli/tests/mysqli_kill.phpt
@@ -71,10 +71,10 @@ require_once 'skipifconnectfailure.inc';
 ?>
 --EXPECTF--
 
-Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s
+Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s on line %d
 mysqli_kill(): Argument #2 ($process_id) must be greater than 0
 
-Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s
+Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s on line %d
 string(%d) "%s"
 bool(false)
 object(mysqli)#%d (%d) {
@@ -126,13 +126,13 @@ object(mysqli)#%d (%d) {
   int(0)
 }
 
-Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s
+Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s on line %d
 mysqli_kill(): Argument #2 ($process_id) must be greater than 0
 array(1) {
   ["id"]=>
   string(1) "1"
 }
 
-Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s
+Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s on line %d
 mysqli_kill(): Argument #2 ($process_id) must be greater than 0
 done!

--- a/ext/mysqli/tests/mysqli_ping.phpt
+++ b/ext/mysqli/tests/mysqli_ping.phpt
@@ -38,12 +38,12 @@ require_once 'skipifconnectfailure.inc';
 ?>
 --EXPECTF--
 
-Deprecated: Function mysqli_ping() is deprecated since 8.4, because the reconnect feature has been removed in PHP 8.2 and this function is now redundant in %s
+Deprecated: Function mysqli_ping() is deprecated since 8.4, because the reconnect feature has been removed in PHP 8.2 and this function is now redundant in %s on line %d
 bool(true)
 
-Deprecated: Function mysqli_ping() is deprecated since 8.4, because the reconnect feature has been removed in PHP 8.2 and this function is now redundant in %s
+Deprecated: Function mysqli_ping() is deprecated since 8.4, because the reconnect feature has been removed in PHP 8.2 and this function is now redundant in %s on line %d
 bool(true)
 
-Deprecated: Function mysqli_ping() is deprecated since 8.4, because the reconnect feature has been removed in PHP 8.2 and this function is now redundant in %s
+Deprecated: Function mysqli_ping() is deprecated since 8.4, because the reconnect feature has been removed in PHP 8.2 and this function is now redundant in %s on line %d
 mysqli object is already closed
 done!

--- a/ext/mysqli/tests/mysqli_report.phpt
+++ b/ext/mysqli/tests/mysqli_report.phpt
@@ -305,7 +305,7 @@ Warning: mysqli_multi_query(): (%d/%d): You have an error in your SQL syntax; ch
 
 Warning: mysqli_query(): (%d/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'FOO' at line 1 in %s on line %d
 
-Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s
+Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s on line %d
 mysqli_kill(): Argument #2 ($process_id) must be greater than 0
 
 Warning: mysqli_prepare(): (%d/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'FOO' at line 1 in %s on line %d
@@ -324,16 +324,16 @@ Warning: mysqli_next_result(): (%s/%d): You have an error in your SQL syntax; ch
 
 Warning: mysqli_store_result(): (%s/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'FOO' at line 1 in %s on line %d
 
-Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s
+Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s on line %d
 mysqli_kill(): Argument #2 ($process_id) must be greater than 0
 
 Warning: mysqli_stmt_prepare(): (%d/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'FOO' at line 1 in %s on line %d
 
-Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s
+Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s on line %d
 
-Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s
+Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s on line %d
 
-Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s
+Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s on line %d
 [013] Access denied for user '%s'@'%s'%r( \(using password: \w+\)){0,1}%r
 [016] Access denied for user '%s'@'%s'%r( \(using password: \w+\)){0,1}%r
 done!

--- a/ext/opcache/tests/jit/assign_dim_002.phpt
+++ b/ext/opcache/tests/jit/assign_dim_002.phpt
@@ -182,7 +182,7 @@ array(1) {
 Cannot use a scalar value as an array
 int(1)
 
-Deprecated: Automatic conversion of false to array is deprecated in %s
+Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 int(1)
 array(1) {
   [2]=>

--- a/ext/openssl/tests/gh19245.phpt
+++ b/ext/openssl/tests/gh19245.phpt
@@ -47,7 +47,7 @@ ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
 
 ?>
 --EXPECTF--
-PHP Warning:  stream_socket_accept(): Path for local_cert in ssl stream context option must not contain any null bytes in %s
-PHP Warning:  stream_socket_accept(): Unable to get real path of certificate file `%scert.crt' in %s
-PHP Warning:  stream_socket_accept(): Failed to enable crypto in %s
-PHP Warning:  stream_socket_accept(): Accept failed: Cannot enable crypto in %s
+PHP Warning:  stream_socket_accept(): Path for local_cert in ssl stream context option must not contain any null bytes in %s on line %d
+PHP Warning:  stream_socket_accept(): Unable to get real path of certificate file `%scert.crt' in %s on line %d
+PHP Warning:  stream_socket_accept(): Failed to enable crypto in %s on line %d
+PHP Warning:  stream_socket_accept(): Accept failed: Cannot enable crypto in %s on line %d

--- a/ext/openssl/tests/gh9310.phpt
+++ b/ext/openssl/tests/gh9310.phpt
@@ -176,31 +176,31 @@ $baseDir = __DIR__ . '/gh9310';
 @rmdir($baseDir);
 ?>
 --EXPECTF--
-PHP Warning:  stream_socket_accept(): Path for local_cert in ssl stream context option must not contain any null bytes in %s
-PHP Warning:  stream_socket_accept(): Unable to get real path of certificate file `%scert.crt' in %s
-PHP Warning:  stream_socket_accept(): Failed to enable crypto in %s
+PHP Warning:  stream_socket_accept(): Path for local_cert in ssl stream context option must not contain any null bytes in %s on line %d
+PHP Warning:  stream_socket_accept(): Unable to get real path of certificate file `%scert.crt' in %s on line %d
+PHP Warning:  stream_socket_accept(): Failed to enable crypto in %s on line %d
 PHP Warning:  stream_socket_accept(): Accept failed: %s
-PHP Warning:  stream_socket_accept(): Path for local_pk in ssl stream context option must not contain any null bytes in %s
-PHP Warning:  stream_socket_accept(): Unable to get real path of private key file `%sprivate.key' in %s
-PHP Warning:  stream_socket_accept(): Failed to enable crypto in %s
+PHP Warning:  stream_socket_accept(): Path for local_pk in ssl stream context option must not contain any null bytes in %s on line %d
+PHP Warning:  stream_socket_accept(): Unable to get real path of private key file `%sprivate.key' in %s on line %d
+PHP Warning:  stream_socket_accept(): Failed to enable crypto in %s on line %d
 PHP Warning:  stream_socket_accept(): Accept failed: %s
-PHP Warning:  stream_socket_accept(): open_basedir restriction in effect. File(%sgh9310.crt) is not within the allowed path(s): (%sgh9310) in %s
-PHP Warning:  stream_socket_accept(): Unable to get real path of certificate file `%sgh9310.crt' in %s
-PHP Warning:  stream_socket_accept(): Failed to enable crypto in %s
+PHP Warning:  stream_socket_accept(): open_basedir restriction in effect. File(%sgh9310.crt) is not within the allowed path(s): (%sgh9310) in %s on line %d
+PHP Warning:  stream_socket_accept(): Unable to get real path of certificate file `%sgh9310.crt' in %s on line %d
+PHP Warning:  stream_socket_accept(): Failed to enable crypto in %s on line %d
 PHP Warning:  stream_socket_accept(): Accept failed: %s
-PHP Warning:  stream_socket_accept(): open_basedir restriction in effect. File(%sgh9310.key) is not within the allowed path(s): (%sgh9310) in %s
-PHP Warning:  stream_socket_accept(): Unable to get real path of private key file `%sgh9310.key' in %s
-PHP Warning:  stream_socket_accept(): Failed to enable crypto in %s
+PHP Warning:  stream_socket_accept(): open_basedir restriction in effect. File(%sgh9310.key) is not within the allowed path(s): (%sgh9310) in %s on line %d
+PHP Warning:  stream_socket_accept(): Unable to get real path of private key file `%sgh9310.key' in %s on line %d
+PHP Warning:  stream_socket_accept(): Failed to enable crypto in %s on line %d
 PHP Warning:  stream_socket_accept(): Accept failed: %s
-PHP Warning:  stream_socket_accept(): open_basedir restriction in effect. File(%sgh9310_sni_cs.pem.tmp) is not within the allowed path(s): (%sgh9310) in %s
-PHP Warning:  stream_socket_accept(): Failed setting local cert chain file `%sgh9310_sni_cs.pem.tmp'; file not found in %s
-PHP Warning:  stream_socket_accept(): Failed to enable crypto in %s
+PHP Warning:  stream_socket_accept(): open_basedir restriction in effect. File(%sgh9310_sni_cs.pem.tmp) is not within the allowed path(s): (%sgh9310) in %s on line %d
+PHP Warning:  stream_socket_accept(): Failed setting local cert chain file `%sgh9310_sni_cs.pem.tmp'; file not found in %s on line %d
+PHP Warning:  stream_socket_accept(): Failed to enable crypto in %s on line %d
 PHP Warning:  stream_socket_accept(): Accept failed: %s
-PHP Warning:  stream_socket_accept(): open_basedir restriction in effect. File(%sgh9310_sni_uk_key.pem.tmp) is not within the allowed path(s): (%sgh9310) in %s
-PHP Warning:  stream_socket_accept(): Failed setting local private key file `%sgh9310_sni_uk_key.pem.tmp';  could not open file in %s
-PHP Warning:  stream_socket_accept(): Failed to enable crypto in %s
+PHP Warning:  stream_socket_accept(): open_basedir restriction in effect. File(%sgh9310_sni_uk_key.pem.tmp) is not within the allowed path(s): (%sgh9310) in %s on line %d
+PHP Warning:  stream_socket_accept(): Failed setting local private key file `%sgh9310_sni_uk_key.pem.tmp';  could not open file in %s on line %d
+PHP Warning:  stream_socket_accept(): Failed to enable crypto in %s on line %d
 PHP Warning:  stream_socket_accept(): Accept failed: %s
-PHP Warning:  stream_socket_accept(): open_basedir restriction in effect. File(%sgh9310_sni_us_cert.pem.tmp) is not within the allowed path(s): (%sgh9310) in %s
-PHP Warning:  stream_socket_accept(): Failed setting local cert chain file `%sgh9310_sni_us_cert.pem.tmp'; could not open file in %s
-PHP Warning:  stream_socket_accept(): Failed to enable crypto in %s
+PHP Warning:  stream_socket_accept(): open_basedir restriction in effect. File(%sgh9310_sni_us_cert.pem.tmp) is not within the allowed path(s): (%sgh9310) in %s on line %d
+PHP Warning:  stream_socket_accept(): Failed setting local cert chain file `%sgh9310_sni_us_cert.pem.tmp'; could not open file in %s on line %d
+PHP Warning:  stream_socket_accept(): Failed to enable crypto in %s on line %d
 PHP Warning:  stream_socket_accept(): Accept failed: %s

--- a/ext/pcntl/tests/pcntl_getpriority_error.phpt
+++ b/ext/pcntl/tests/pcntl_getpriority_error.phpt
@@ -33,4 +33,4 @@ pcntl_getpriority(-1, PRIO_PROCESS);
 --EXPECTF--
 pcntl_getpriority(): Argument #2 ($mode) must be one of PRIO_PGRP, PRIO_USER, or PRIO_PROCESS
 
-Warning: pcntl_getpriority(): Error %d: No process was located using the given parameters in %s
+Warning: pcntl_getpriority(): Error %d: No process was located using the given parameters in %s on line %d

--- a/ext/pcntl/tests/pcntl_setpriority_error.phpt
+++ b/ext/pcntl/tests/pcntl_setpriority_error.phpt
@@ -32,4 +32,4 @@ pcntl_setpriority(0, -123);
 --EXPECTF--
 pcntl_setpriority(): Argument #3 ($mode) must be one of PRIO_PGRP, PRIO_USER, or PRIO_PROCESS
 
-Warning: pcntl_setpriority(): Error 3: No process was located using the given parameters in %s
+Warning: pcntl_setpriority(): Error 3: No process was located using the given parameters in %s on line %d

--- a/ext/pcntl/tests/pcntl_setpriority_error_darwin.phpt
+++ b/ext/pcntl/tests/pcntl_setpriority_error_darwin.phpt
@@ -46,4 +46,4 @@ pcntl_setpriority(): Argument #3 ($mode) must be one of PRIO_PGRP, PRIO_USER, PR
 pcntl_setpriority(): Argument #2 ($process_id) must be 0 (zero) if PRIO_DARWIN_THREAD is provided as second parameter
 pcntl_setpriority(): Argument #2 ($process_id) is not a valid process, process group, or user ID
 
-Warning: pcntl_setpriority(): Error 1: A process was located, but neither its effective nor real user ID matched the effective user ID of the caller in %s
+Warning: pcntl_setpriority(): Error 1: A process was located, but neither its effective nor real user ID matched the effective user ID of the caller in %s on line %d

--- a/ext/pcntl/tests/pcntl_setpriority_error_linux.phpt
+++ b/ext/pcntl/tests/pcntl_setpriority_error_linux.phpt
@@ -25,6 +25,6 @@ pcntl_setpriority(-1000, 0);
 
 ?>
 --EXPECTF--
-Warning: pcntl_setpriority(): Error 1: A process was located, but neither its effective nor real user ID matched the effective user ID of the caller in %s
+Warning: pcntl_setpriority(): Error 1: A process was located, but neither its effective nor real user ID matched the effective user ID of the caller in %s on line %d
 
 Warning: pcntl_setpriority(): Error 13: Only a super user may attempt to increase the process priority in %s on line %d

--- a/ext/pdo_mysql/tests/bug_38546.phpt
+++ b/ext/pdo_mysql/tests/bug_38546.phpt
@@ -227,7 +227,7 @@ Array
     [3] => 2
 )
 
-Warning: PDOStatement::execute(): SQLSTATE[%s]: %s: 1366 Incorrect integer value: 'true' for column %s at row 1 in %s
+Warning: PDOStatement::execute(): SQLSTATE[%s]: %s: 1366 Incorrect integer value: 'true' for column %s at row 1 in %s on line %d
 array(3) {
   [0]=>
   string(5) "%s"
@@ -248,7 +248,7 @@ Array
     [3] => 2
 )
 
-Warning: PDOStatement::execute(): SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'some_bool_2' cannot be null in %s
+Warning: PDOStatement::execute(): SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'some_bool_2' cannot be null in %s on line %d
 array(3) {
   [0]=>
   string(5) "23000"

--- a/ext/pdo_sqlite/tests/pdo_sqlite_filename_uri.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_filename_uri.phpt
@@ -42,7 +42,7 @@ int(0)
 int(0)
 int(0)
 
-Fatal error: Uncaught PDOException: SQLSTATE[HY000]: General error: 8 attempt to write a readonly database in %s
+Fatal error: Uncaught PDOException: SQLSTATE[HY000]: General error: 8 attempt to write a readonly database in %s:%d
 Stack trace:
 %s
 #1 {main}

--- a/ext/pdo_sqlite/tests/pdo_sqlite_open_flags.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_open_flags.phpt
@@ -26,7 +26,7 @@ if (file_exists($filename)) {
 --EXPECTF--
 int(0)
 
-Fatal error: Uncaught PDOException: SQLSTATE[HY000]: General error: 8 attempt to write a readonly database in %s
+Fatal error: Uncaught PDOException: SQLSTATE[HY000]: General error: 8 attempt to write a readonly database in %s:%d
 Stack trace:
 %s
 #1 {main}

--- a/ext/session/tests/user_session_module/bug60634_error_2.phpt
+++ b/ext/session/tests/user_session_module/bug60634_error_2.phpt
@@ -48,7 +48,7 @@ echo "um, hi\n";
 --EXPECTF--
 write: goodbye cruel world
 
-Fatal error: Uncaught Exception in %s
+Fatal error: Uncaught Exception in %s:%d
 Stack trace:
 #0 [internal function]: MySessionHandler->write('%s', '')
 #1 %s(%d): session_write_close()

--- a/ext/session/tests/user_session_module/bug60634_error_4.phpt
+++ b/ext/session/tests/user_session_module/bug60634_error_4.phpt
@@ -40,7 +40,7 @@ session_start();
 Deprecated: session_set_save_handler(): Providing individual callbacks instead of an object implementing SessionHandlerInterface is deprecated in %s on line %d
 write: goodbye cruel world
 
-Fatal error: Uncaught Exception in %s
+Fatal error: Uncaught Exception in %s:%d
 Stack trace:
 #0 [internal function]: write('%s', '')
 #1 {main}

--- a/ext/spl/tests/ArrayObject/bug70155.phpt
+++ b/ext/spl/tests/ArrayObject/bug70155.phpt
@@ -13,7 +13,7 @@ Deprecated: ArrayObject::unserialize(): Using an object as a backing array for A
 
 Deprecated: Creation of dynamic property ArrayObject::$0 is deprecated in %s on line %d
 
-Fatal error: Uncaught InvalidArgumentException: Overloaded object of type DateInterval is not compatible with ArrayObject in %s
+Fatal error: Uncaught InvalidArgumentException: Overloaded object of type DateInterval is not compatible with ArrayObject in %s:%d
 Stack trace:
 %s
 %s

--- a/ext/spl/tests/DirectoryIterator_getInode_error.phpt
+++ b/ext/spl/tests/DirectoryIterator_getInode_error.phpt
@@ -20,7 +20,7 @@ $fileInfo = new SplFileInfo('not_existing');
 var_dump($fileInfo->getInode());
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: SplFileInfo::getInode(): stat failed for %s in %s
+Fatal error: Uncaught RuntimeException: SplFileInfo::getInode(): stat failed for %s in %s:%d
 Stack trace:
 #0 %s: SplFileInfo->getInode()
 #1 {main}

--- a/ext/spl/tests/SplDoublyLinkedList_offsetGet_param_array.phpt
+++ b/ext/spl/tests/SplDoublyLinkedList_offsetGet_param_array.phpt
@@ -11,7 +11,7 @@ $get = $array->offsetGet( array( 'fail' ) );
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: SplDoublyLinkedList::offsetGet(): Argument #1 ($index) must be of type int, array given in %s
+Fatal error: Uncaught TypeError: SplDoublyLinkedList::offsetGet(): Argument #1 ($index) must be of type int, array given in %s:%d
 Stack trace:
 #0 %s
 #1 {main}

--- a/ext/spl/tests/SplDoublyLinkedList_offsetGet_param_string.phpt
+++ b/ext/spl/tests/SplDoublyLinkedList_offsetGet_param_string.phpt
@@ -11,7 +11,7 @@ $get = $array->offsetGet( 'fail' );
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: SplDoublyLinkedList::offsetGet(): Argument #1 ($index) must be of type int, string given in %s
+Fatal error: Uncaught TypeError: SplDoublyLinkedList::offsetGet(): Argument #1 ($index) must be of type int, string given in %s:%d
 Stack trace:
 #0 %s
 #1 {main}

--- a/ext/spl/tests/SplFileInfo_getGroup_error.phpt
+++ b/ext/spl/tests/SplFileInfo_getGroup_error.phpt
@@ -16,7 +16,7 @@ $fileInfo = new SplFileInfo('not_existing');
 var_dump($fileInfo->getGroup());
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: SplFileInfo::getGroup(): stat failed for not_existing in %s
+Fatal error: Uncaught RuntimeException: SplFileInfo::getGroup(): stat failed for not_existing in %s:%d
 Stack trace:
 #0 %s: SplFileInfo->getGroup()
 #1 {main}

--- a/ext/spl/tests/SplFileInfo_getInode_error.phpt
+++ b/ext/spl/tests/SplFileInfo_getInode_error.phpt
@@ -16,7 +16,7 @@ $fileInfo = new SplFileInfo('not_existing');
 var_dump($fileInfo->getInode());
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: SplFileInfo::getInode(): stat failed for not_existing in %s
+Fatal error: Uncaught RuntimeException: SplFileInfo::getInode(): stat failed for not_existing in %s:%d
 Stack trace:
 #0 %s: SplFileInfo->getInode()
 #1 {main}

--- a/ext/spl/tests/SplFileInfo_getOwner_error.phpt
+++ b/ext/spl/tests/SplFileInfo_getOwner_error.phpt
@@ -16,7 +16,7 @@ $fileInfo = new SplFileInfo('not_existing');
 var_dump($fileInfo->getOwner());
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: SplFileInfo::getOwner(): stat failed for not_existing in %s
+Fatal error: Uncaught RuntimeException: SplFileInfo::getOwner(): stat failed for not_existing in %s:%d
 Stack trace:
 #0 %s: SplFileInfo->getOwner()
 #1 {main}

--- a/ext/spl/tests/SplFileInfo_getPerms_error.phpt
+++ b/ext/spl/tests/SplFileInfo_getPerms_error.phpt
@@ -16,7 +16,7 @@ $fileInfo = new SplFileInfo('not_existing');
 var_dump($fileInfo->getPerms() == 0100557);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: SplFileInfo::getPerms(): stat failed for %s in %s
+Fatal error: Uncaught RuntimeException: SplFileInfo::getPerms(): stat failed for %s in %s:%d
 Stack trace:
 #0 %s: SplFileInfo->getPerms()
 #1 {main}

--- a/ext/spl/tests/bug52238.phpt
+++ b/ext/spl/tests/bug52238.phpt
@@ -15,7 +15,7 @@ class Foo implements IteratorAggregate
 var_dump(iterator_to_array(new Foo));
 ?>
 --EXPECTF--
-Fatal error: Uncaught Exception in %s
+Fatal error: Uncaught Exception in %s:%d
 Stack trace:
 #0 %s: Foo->bar()
 #1 [internal function]: Foo->getIterator()

--- a/ext/spl/tests/recursiveIteratorIterator_beginchildren_error.phpt
+++ b/ext/spl/tests/recursiveIteratorIterator_beginchildren_error.phpt
@@ -28,7 +28,7 @@ var_dump($recItIt2->next());
 --EXPECTF--
 NULL
 
-Fatal error: Uncaught Exception in %s
+Fatal error: Uncaught Exception in %s:%d
 Stack trace:
 #0 [internal function]: MyRecursiveIteratorIterator->beginchildren()
 #1 %s: RecursiveIteratorIterator->next()

--- a/ext/spl/tests/recursiveIteratorIterator_callHasChildren_error.phpt
+++ b/ext/spl/tests/recursiveIteratorIterator_callHasChildren_error.phpt
@@ -28,7 +28,7 @@ var_dump($recItIt2->next());
 --EXPECTF--
 NULL
 
-Fatal error: Uncaught Exception in %s
+Fatal error: Uncaught Exception in %s:%d
 Stack trace:
 #0 [internal function]: MyRecursiveIteratorIterator->callHasChildren()
 #1 %s: RecursiveIteratorIterator->next()

--- a/ext/spl/tests/recursiveIteratorIterator_endchildren_error.phpt
+++ b/ext/spl/tests/recursiveIteratorIterator_endchildren_error.phpt
@@ -36,7 +36,7 @@ b
 1
 2
 
-Fatal error: Uncaught Exception in %s
+Fatal error: Uncaught Exception in %s:%d
 Stack trace:
 #0 %s(%d): MyRecursiveIteratorIterator->endchildren()
 #1 {main}

--- a/ext/spl/tests/recursiveIteratorIterator_nextelement_error.phpt
+++ b/ext/spl/tests/recursiveIteratorIterator_nextelement_error.phpt
@@ -28,7 +28,7 @@ var_dump($recItIt->next());
 --EXPECTF--
 NULL
 
-Fatal error: Uncaught Exception in %s
+Fatal error: Uncaught Exception in %s:%d
 Stack trace:
 #0 [internal function]: MyRecursiveIteratorIterator->nextelement()
 #1 %s: RecursiveIteratorIterator->next()

--- a/ext/sqlite3/tests/sqlite3_enable_exceptions.phpt
+++ b/ext/sqlite3/tests/sqlite3_enable_exceptions.phpt
@@ -25,7 +25,7 @@ echo "Done\n";
 bool(false)
 no such table: non_existent_table
 
-Deprecated: SQLite3::enableExceptions(): Use of warnings for SQLite3 is deprecated in %s
+Deprecated: SQLite3::enableExceptions(): Use of warnings for SQLite3 is deprecated in %s on line %d
 bool(true)
 
 Warning: SQLite3::query(): no such table: non_existent_table in %s on line %d

--- a/ext/standard/tests/file/bug43353.phpt
+++ b/ext/standard/tests/file/bug43353.phpt
@@ -16,5 +16,5 @@ bool(false)
 bool(false)
 string(3) "foo"
 
-Warning: file_get_contents(datafoo:text/plain,foo): Failed to open stream: No such file or directory in %s
+Warning: file_get_contents(datafoo:text/plain,foo): Failed to open stream: No such file or directory in %s on line %d
 bool(false)

--- a/ext/standard/tests/file/bug45303.phpt
+++ b/ext/standard/tests/file/bug45303.phpt
@@ -9,5 +9,5 @@ var_dump(fseek($fd, 1024*1024, SEEK_SET));
 --EXPECTF--
 resource(%d) of type (stream)
 
-Warning: fseek(): Stream does not support seeking in %s
+Warning: fseek(): Stream does not support seeking in %s on line %d
 int(-1)

--- a/ext/standard/tests/file/userstreams_002.phpt
+++ b/ext/standard/tests/file/userstreams_002.phpt
@@ -53,35 +53,35 @@ bool(true)
 
 ------ stream_cast not implemented: -------
 
-Warning: stream_select(): test_wrapper_base::stream_cast is not implemented! in %s
+Warning: stream_select(): test_wrapper_base::stream_cast is not implemented! in %s on line %d
 
-Warning: stream_select(): Cannot represent a stream of type user-space as a select()able descriptor in %s
+Warning: stream_select(): Cannot represent a stream of type user-space as a select()able descriptor in %s on line %d
 No stream arrays were passed
 
 ------ return value is false: -------
 
-Warning: stream_select(): Cannot represent a stream of type user-space as a select()able descriptor in %s
+Warning: stream_select(): Cannot represent a stream of type user-space as a select()able descriptor in %s on line %d
 No stream arrays were passed
 
 ------ return value not a stream resource: -------
 
-Warning: stream_select(): test_wrapper::stream_cast must return a stream resource in %s
+Warning: stream_select(): test_wrapper::stream_cast must return a stream resource in %s on line %d
 
-Warning: stream_select(): Cannot represent a stream of type user-space as a select()able descriptor in %s
+Warning: stream_select(): Cannot represent a stream of type user-space as a select()able descriptor in %s on line %d
 No stream arrays were passed
 
 ------ return value is stream itself: -------
 
-Warning: stream_select(): test_wrapper::stream_cast must not return itself in %s
+Warning: stream_select(): test_wrapper::stream_cast must not return itself in %s on line %d
 
-Warning: stream_select(): Cannot represent a stream of type user-space as a select()able descriptor in %s
+Warning: stream_select(): Cannot represent a stream of type user-space as a select()able descriptor in %s on line %d
 No stream arrays were passed
 
 ------ return value cannot be casted: -------
 
-Warning: stream_select(): test_wrapper_base::stream_cast is not implemented! in %s
+Warning: stream_select(): test_wrapper_base::stream_cast is not implemented! in %s on line %d
 
-Warning: stream_select(): Cannot represent a stream of type user-space as a select()able descriptor in %s
+Warning: stream_select(): Cannot represent a stream of type user-space as a select()able descriptor in %s on line %d
 
-Warning: stream_select(): Cannot represent a stream of type user-space as a select()able descriptor in %s
+Warning: stream_select(): Cannot represent a stream of type user-space as a select()able descriptor in %s on line %d
 No stream arrays were passed

--- a/ext/standard/tests/file/userstreams_003.phpt
+++ b/ext/standard/tests/file/userstreams_003.phpt
@@ -95,7 +95,7 @@ bool(true)
 
 ------ stream_set_blocking - 4: -------
 
-Warning: stream_set_blocking(): test_wrapper_base::stream_set_option is not implemented! in %s
+Warning: stream_set_blocking(): test_wrapper_base::stream_set_option is not implemented! in %s on line %d
 bool(false)
 
 ------ stream_set_write_buffer - 1: -------

--- a/ext/standard/tests/file/userstreams_004.phpt
+++ b/ext/standard/tests/file/userstreams_004.phpt
@@ -43,7 +43,7 @@ bool(true)
 bool(true)
 ------ stream_lock not implemented: -------
 
-Warning: flock(): test_wrapper_base::stream_lock is not implemented! in %s
+Warning: flock(): test_wrapper_base::stream_lock is not implemented! in %s on line %d
 bool(false)
 ------ fclock(LOCK_SH): -------
 bool(true)

--- a/ext/standard/tests/filters/convert_filter_write_seek_modes.phpt
+++ b/ext/standard/tests/filters/convert_filter_write_seek_modes.phpt
@@ -48,14 +48,14 @@ bool(true)
 bool(true)
 bool(true)
 
-Warning: stream_filter_append(): "write_seek_mode" filter parameter must be one of "preserve", "reset", or "strict" in %s
+Warning: stream_filter_append(): "write_seek_mode" filter parameter must be one of "preserve", "reset", or "strict" in %s on line %d
 
-Warning: stream_filter_append(): Unable to create or locate filter "convert.base64-encode" in %s
+Warning: stream_filter_append(): Unable to create or locate filter "convert.base64-encode" in %s on line %d
 bool(true)
 bool(true)
 bool(true)
 bool(true)
 
-Warning: stream_filter_append(): "write_seek_mode" filter parameter must be one of "preserve", "reset", or "strict" in %s
+Warning: stream_filter_append(): "write_seek_mode" filter parameter must be one of "preserve", "reset", or "strict" in %s on line %d
 
-Warning: stream_filter_append(): Unable to create or locate filter "convert.quoted-printable-encode" in %s
+Warning: stream_filter_append(): Unable to create or locate filter "convert.quoted-printable-encode" in %s on line %d

--- a/ext/standard/tests/filters/filter_errors_convert_base64_decode.phpt
+++ b/ext/standard/tests/filters/filter_errors_convert_base64_decode.phpt
@@ -8,9 +8,9 @@ filter_errors_test('convert.base64-decode', '===');
 --EXPECTF--
 test filtering of buffered data
 
-Warning: stream_filter_append(): Stream filter (convert.base64-decode): invalid byte sequence in %s
+Warning: stream_filter_append(): Stream filter (convert.base64-decode): invalid byte sequence in %s on line %d
 
-Warning: stream_filter_append(): Filter failed to process pre-buffered data in %s
+Warning: stream_filter_append(): Filter failed to process pre-buffered data in %s on line %d
 test filtering of non buffered data
 
-Warning: stream_get_contents(): Stream filter (convert.base64-decode): invalid byte sequence in %s
+Warning: stream_get_contents(): Stream filter (convert.base64-decode): invalid byte sequence in %s on line %d

--- a/ext/standard/tests/filters/filter_errors_user.phpt
+++ b/ext/standard/tests/filters/filter_errors_user.phpt
@@ -91,66 +91,66 @@ test_filter0
 bool(true)
 test filtering of buffered data
 
-Warning: stream_filter_append(): Unprocessed filter buckets remaining on input brigade in %s
+Warning: stream_filter_append(): Unprocessed filter buckets remaining on input brigade in %s on line %d
 
-Warning: stream_filter_append(): Filter failed to process pre-buffered data in %s
+Warning: stream_filter_append(): Filter failed to process pre-buffered data in %s on line %d
 test filtering of non buffered data
 
-Warning: stream_get_contents(): Unprocessed filter buckets remaining on input brigade in %s
+Warning: stream_get_contents(): Unprocessed filter buckets remaining on input brigade in %s on line %d
 test_filter1
 bool(true)
 test filtering of buffered data
 
-Warning: stream_filter_append(): Filter failed to process pre-buffered data in %s
+Warning: stream_filter_append(): Filter failed to process pre-buffered data in %s on line %d
 test filtering of non buffered data
 test_filter2
 bool(true)
 test filtering of buffered data
 
-Warning: stream_filter_append(): Filter failed to process pre-buffered data in %s
+Warning: stream_filter_append(): Filter failed to process pre-buffered data in %s on line %d
 test filtering of non buffered data
 test_filter3
 bool(true)
 test filtering of buffered data
 
-Warning: stream_filter_append(): Unprocessed filter buckets remaining on input brigade in %s
+Warning: stream_filter_append(): Unprocessed filter buckets remaining on input brigade in %s on line %d
 
-Warning: stream_filter_append(): Filter failed to process pre-buffered data in %s
+Warning: stream_filter_append(): Filter failed to process pre-buffered data in %s on line %d
 test filtering of non buffered data
 
-Warning: stream_get_contents(): Unprocessed filter buckets remaining on input brigade in %s
+Warning: stream_get_contents(): Unprocessed filter buckets remaining on input brigade in %s on line %d
 test_filter4
 bool(true)
 test filtering of buffered data
 
-Warning: stream_filter_append(): Unprocessed filter buckets remaining on input brigade in %s
+Warning: stream_filter_append(): Unprocessed filter buckets remaining on input brigade in %s on line %d
 
-Warning: stream_filter_append(): Filter failed to process pre-buffered data in %s
+Warning: stream_filter_append(): Filter failed to process pre-buffered data in %s on line %d
 test filtering of non buffered data
 
-Warning: stream_get_contents(): Unprocessed filter buckets remaining on input brigade in %s
+Warning: stream_get_contents(): Unprocessed filter buckets remaining on input brigade in %s on line %d
 test append / read / remove
 test_filter0
 
-Warning: stream_get_contents(): Unprocessed filter buckets remaining on input brigade in %s
+Warning: stream_get_contents(): Unprocessed filter buckets remaining on input brigade in %s on line %d
 
-Warning: stream_filter_remove(): Unable to flush filter, not removing in %s
+Warning: stream_filter_remove(): Unable to flush filter, not removing in %s on line %d
 test_filter1
 
-Warning: stream_filter_remove(): Unable to flush filter, not removing in %s
+Warning: stream_filter_remove(): Unable to flush filter, not removing in %s on line %d
 test_filter2
 
-Warning: stream_filter_remove(): Unable to flush filter, not removing in %s
+Warning: stream_filter_remove(): Unable to flush filter, not removing in %s on line %d
 test_filter3
 
-Warning: stream_get_contents(): Unprocessed filter buckets remaining on input brigade in %s
+Warning: stream_get_contents(): Unprocessed filter buckets remaining on input brigade in %s on line %d
 
-Warning: stream_filter_remove(): Unable to flush filter, not removing in %s
+Warning: stream_filter_remove(): Unable to flush filter, not removing in %s on line %d
 test_filter4
 
-Warning: stream_get_contents(): Unprocessed filter buckets remaining on input brigade in %s
+Warning: stream_get_contents(): Unprocessed filter buckets remaining on input brigade in %s on line %d
 
-Warning: stream_filter_remove(): Unable to flush filter, not removing in %s
+Warning: stream_filter_remove(): Unable to flush filter, not removing in %s on line %d
 test append all / read / remove all
 test_filter0
 test_filter1
@@ -158,17 +158,17 @@ test_filter2
 test_filter3
 test_filter4
 
-Warning: stream_get_contents(): Unprocessed filter buckets remaining on input brigade in %s
+Warning: stream_get_contents(): Unprocessed filter buckets remaining on input brigade in %s on line %d
 
-Warning: stream_filter_remove(): Unable to flush filter, not removing in %s
+Warning: stream_filter_remove(): Unable to flush filter, not removing in %s on line %d
 
-Warning: stream_filter_remove(): Unable to flush filter, not removing in %s
+Warning: stream_filter_remove(): Unable to flush filter, not removing in %s on line %d
 
-Warning: stream_filter_remove(): Unable to flush filter, not removing in %s
+Warning: stream_filter_remove(): Unable to flush filter, not removing in %s on line %d
 
-Warning: stream_filter_remove(): Unable to flush filter, not removing in %s
+Warning: stream_filter_remove(): Unable to flush filter, not removing in %s on line %d
 
-Warning: stream_filter_remove(): Unable to flush filter, not removing in %s
+Warning: stream_filter_remove(): Unable to flush filter, not removing in %s on line %d
 test append all / read / close
 test_filter0
 test_filter1
@@ -176,4 +176,4 @@ test_filter2
 test_filter3
 test_filter4
 
-Warning: stream_get_contents(): Unprocessed filter buckets remaining on input brigade in %s
+Warning: stream_get_contents(): Unprocessed filter buckets remaining on input brigade in %s on line %d

--- a/ext/standard/tests/filters/filter_errors_zlib_inflate.phpt
+++ b/ext/standard/tests/filters/filter_errors_zlib_inflate.phpt
@@ -12,7 +12,7 @@ test filtering of buffered data
 
 Notice: stream_filter_append(): zlib: data error in %s on line %d
 
-Warning: stream_filter_append(): Filter failed to process pre-buffered data in %s
+Warning: stream_filter_append(): Filter failed to process pre-buffered data in %s on line %d
 test filtering of non buffered data
 
 Notice: stream_get_contents(): zlib: data error in %s on line %d

--- a/ext/standard/tests/general_functions/proc_open_redirect.phpt
+++ b/ext/standard/tests/general_functions/proc_open_redirect.phpt
@@ -55,7 +55,7 @@ proc_close($proc);
 Missing redirection target
 Redirection target must be of type int, string given
 
-Warning: proc_open(): Redirection target 42 not found in %s
+Warning: proc_open(): Redirection target 42 not found in %s on line %d
 
 With pipe:
 array(1) {

--- a/ext/standard/tests/http/bug38802.phpt
+++ b/ext/standard/tests/http/bug38802.phpt
@@ -109,7 +109,7 @@ Connection: close
 "
 -- Test: fail after 2 redirections --
 
-Warning: fopen(http://%s:%d/foo/bar): Failed to open stream: Redirection limit reached, aborting in %s
+Warning: fopen(http://%s:%d/foo/bar): Failed to open stream: Redirection limit reached, aborting in %s on line %d
 bool(false)
 string(%d) "GET /foo/bar HTTP/1.1
 Host: %s:%d
@@ -122,7 +122,7 @@ Connection: close
 "
 -- Test: fail at first redirection --
 
-Warning: fopen(http://%s:%d/foo/bar): Failed to open stream: Redirection limit reached, aborting in %s
+Warning: fopen(http://%s:%d/foo/bar): Failed to open stream: Redirection limit reached, aborting in %s on line %d
 bool(false)
 string(%d) "GET /foo/bar HTTP/1.1
 Host: %s:%d
@@ -131,7 +131,7 @@ Connection: close
 "
 -- Test: fail at first redirection (2) --
 
-Warning: fopen(http://%s:%d/foo/bar): Failed to open stream: Redirection limit reached, aborting in %s
+Warning: fopen(http://%s:%d/foo/bar): Failed to open stream: Redirection limit reached, aborting in %s on line %d
 bool(false)
 string(%d) "GET /foo/bar HTTP/1.1
 Host: %s:%d

--- a/ext/standard/tests/http/bug47021.phpt
+++ b/ext/standard/tests/http/bug47021.phpt
@@ -75,22 +75,22 @@ echo "\n";
 Type='text/plain'
 Hello
 
-Warning: file_get_contents(http://%s:%d): Failed to open stream: HTTP invalid response format (no colon in header line)! in %s
+Warning: file_get_contents(http://%s:%d): Failed to open stream: HTTP invalid response format (no colon in header line)! in %s on line %d
 
 
 Type='text/plain'
 Hello
 
-Warning: file_get_contents(http://%s:%d): Failed to open stream: HTTP invalid response format (no colon in header line)! in %s
+Warning: file_get_contents(http://%s:%d): Failed to open stream: HTTP invalid response format (no colon in header line)! in %s on line %d
 
 
 Type='text/plain'
 Hello
 
-Warning: file_get_contents(http://%s:%d): Failed to open stream: HTTP invalid response format (no colon in header line)! in %s
+Warning: file_get_contents(http://%s:%d): Failed to open stream: HTTP invalid response format (no colon in header line)! in %s on line %d
 
 
 Type='text/plain'
 Hello
 
-Warning: file_get_contents(http://%s:%d): Failed to open stream: HTTP invalid response format (no colon in header line)! in %s
+Warning: file_get_contents(http://%s:%d): Failed to open stream: HTTP invalid response format (no colon in header line)! in %s on line %d

--- a/ext/standard/tests/http/ghsa-52jp-hrpf-2jff-002.phpt
+++ b/ext/standard/tests/http/ghsa-52jp-hrpf-2jff-002.phpt
@@ -45,7 +45,7 @@ ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
 --EXPECTF--
 Found the mime-type: text/html;
 
-Warning: file_get_contents(http://127.0.0.1:%d): Failed to open stream: HTTP Location header size is over the limit of 8182 bytes in %s
+Warning: file_get_contents(http://127.0.0.1:%d): Failed to open stream: HTTP Location header size is over the limit of 8182 bytes in %s on line %d
 string(0) ""
 array(2) {
   [0]=>

--- a/ext/standard/tests/http/ghsa-pcmh-g36c-qc44-001.phpt
+++ b/ext/standard/tests/http/ghsa-pcmh-g36c-qc44-001.phpt
@@ -41,7 +41,7 @@ ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
 --EXPECTF--
 Found the mime-type: text/html
 
-Warning: file_get_contents(http://127.0.0.1:%d): Failed to open stream: HTTP invalid response format (no colon in header line)! in %s
+Warning: file_get_contents(http://127.0.0.1:%d): Failed to open stream: HTTP invalid response format (no colon in header line)! in %s on line %d
 bool(false)
 array(2) {
   [0]=>

--- a/ext/standard/tests/http/ghsa-pcmh-g36c-qc44-002.phpt
+++ b/ext/standard/tests/http/ghsa-pcmh-g36c-qc44-002.phpt
@@ -41,7 +41,7 @@ ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
 --EXPECTF--
 Found the mime-type: text/html
 
-Warning: file_get_contents(http://127.0.0.1:%d): Failed to open stream: HTTP invalid response format (space in header name)! in %s
+Warning: file_get_contents(http://127.0.0.1:%d): Failed to open stream: HTTP invalid response format (space in header name)! in %s on line %d
 bool(false)
 array(2) {
   [0]=>

--- a/ext/standard/tests/http/ghsa-v8xr-gpvj-cx9g-004.phpt
+++ b/ext/standard/tests/http/ghsa-v8xr-gpvj-cx9g-004.phpt
@@ -40,7 +40,7 @@ ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
 ?>
 --EXPECTF--
 
-Warning: file_get_contents(http://127.0.0.1:%d): Failed to open stream: HTTP invalid response format (folding header at the start)! in %s
+Warning: file_get_contents(http://127.0.0.1:%d): Failed to open stream: HTTP invalid response format (folding header at the start)! in %s on line %d
 bool(false)
 array(1) {
   [0]=>

--- a/ext/standard/tests/http/ghsa-v8xr-gpvj-cx9g-005.phpt
+++ b/ext/standard/tests/http/ghsa-v8xr-gpvj-cx9g-005.phpt
@@ -40,7 +40,7 @@ ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
 ?>
 --EXPECTF--
 
-Warning: file_get_contents(http://127.0.0.1:%d): Failed to open stream: HTTP invalid header name (cannot start with CR character)! in %s
+Warning: file_get_contents(http://127.0.0.1:%d): Failed to open stream: HTTP invalid header name (cannot start with CR character)! in %s on line %d
 bool(false)
 array(1) {
   [0]=>

--- a/ext/standard/tests/network/ghsa-3cr5-j632-f35r.phpt
+++ b/ext/standard/tests/network/ghsa-3cr5-j632-f35r.phpt
@@ -17,5 +17,5 @@ fclose($server);
 ?>
 --EXPECTF--
 
-Warning: fsockopen(): Unable to connect to localhost:%d (The hostname must not contain null bytes) in %s
+Warning: fsockopen(): Unable to connect to localhost:%d (The hostname must not contain null bytes) in %s on line %d
 bool(false)

--- a/ext/standard/tests/streams/ghsa-3cr5-j632-f35r.phpt
+++ b/ext/standard/tests/streams/ghsa-3cr5-j632-f35r.phpt
@@ -22,5 +22,5 @@ fclose($server);
 ?>
 --EXPECTF--
 
-Warning: stream_socket_client(): Unable to connect to tcp://localhost\0.example.com:%d (The hostname must not contain null bytes) in %s
+Warning: stream_socket_client(): Unable to connect to tcp://localhost\0.example.com:%d (The hostname must not contain null bytes) in %s on line %d
 bool(false)

--- a/ext/standard/tests/streams/stream_select_null_usec.phpt
+++ b/ext/standard/tests/streams/stream_select_null_usec.phpt
@@ -28,7 +28,7 @@ array(1) {
 }
 
 
-Fatal error: Uncaught ValueError: stream_select(): Argument #5 ($microseconds) must be null when argument #4 ($seconds) is null in %s
+Fatal error: Uncaught ValueError: stream_select(): Argument #5 ($microseconds) must be null when argument #4 ($seconds) is null in %s:%d
 Stack trace:
 #0 %s stream_select(Array, NULL, NULL, NULL, 1)
 #1 {main}

--- a/ext/standard/tests/strings/implode_variation.phpt
+++ b/ext/standard/tests/strings/implode_variation.phpt
@@ -208,9 +208,9 @@ Warning: Array to string conversion in %s on line %d
 string(27) "ArrayTESTArrayTESTPHPTEST50"
 implode(): Argument #1 ($separator) must be of type string, array given
 
-Warning: Array to string conversion in %s
+Warning: Array to string conversion in %s on line %d
 
-Warning: Array to string conversion in %s
+Warning: Array to string conversion in %s on line %d
 string(18) "Array2Array2PHP250"
 
 *** Testing implode() on objects ***

--- a/ext/zend_test/tests/observer_types_01.phpt
+++ b/ext/zend_test/tests/observer_types_01.phpt
@@ -27,12 +27,12 @@ foo(42);
   <Error::getTraceAsString>
   </Error::getTraceAsString:'#0 %s(%d): foo(42)
 #1 {main}'>
-</Error::__toString:'TypeError: foo(): Argument #1 ($a) must be of type array, int given, called in %s:%d
+</Error::__toString:'TypeError: foo(): Argument #1 ($a) must be of type array, int given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s%eobserver_types_%d.php(%d): foo(42)
 #1 {main}'>
 
-Fatal error: Uncaught TypeError: foo(): Argument #1 ($a) must be of type array, int given, called in %s:%d
+Fatal error: Uncaught TypeError: foo(): Argument #1 ($a) must be of type array, int given, called in %s on line %d and defined in %s:%d
 Stack trace:
 #0 %s%eobserver_types_%d.php(%d): foo(42)
 #1 {main}

--- a/ext/zip/tests/bug53885.phpt
+++ b/ext/zip/tests/bug53885.phpt
@@ -19,5 +19,5 @@ $fname = __DIR__."/test53885.zip";
 @unlink($fname);
 ?>
 --EXPECTF--
-Deprecated: ZipArchive::open(): Using empty file as ZipArchive is deprecated in %s
+Deprecated: ZipArchive::open(): Using empty file as ZipArchive is deprecated in %s on line %d
 ==DONE==

--- a/ext/zip/tests/bug80833.phpt
+++ b/ext/zip/tests/bug80833.phpt
@@ -54,5 +54,5 @@ string(22) "This is a test string."
 string(22) "This is a test string."
 string(28) "This is another test string."
 
-Warning: stream_get_contents(): Zip stream error: Containing zip archive was closed in %s
+Warning: stream_get_contents(): Zip stream error: Containing zip archive was closed in %s on line %d
 string(0) ""

--- a/ext/zip/tests/oo_cancel.phpt
+++ b/ext/zip/tests/oo_cancel.phpt
@@ -42,7 +42,7 @@ $file = $dirname . '__tmp_oo_cancel.zip';
 bool(true)
 bool(true)
 
-Warning: ZipArchive::close(): Operation cancelled in %s
+Warning: ZipArchive::close(): Operation cancelled in %s on line %d
 bool(false)
 bool(true)
 string(19) "Operation cancelled"

--- a/ext/zip/tests/oo_stream_seek.phpt
+++ b/ext/zip/tests/oo_stream_seek.phpt
@@ -66,7 +66,7 @@ int(2)
 + ZipArchive::getStream no supported
 resource(%d) of type (stream)
 
-Warning: fseek(): %s does not support seeking in %s
+Warning: fseek(): %s does not support seeking in %s on line %d
 int(-1)
 string(2) "en"
 + Zip Stream

--- a/ext/zlib/tests/zlib_filter_write_seek_modes.phpt
+++ b/ext/zlib/tests/zlib_filter_write_seek_modes.phpt
@@ -66,13 +66,13 @@ fclose($fp);
 bool(true)
 bool(true)
 
-Warning: fseek(): Stream filter zlib.deflate is seekable only to start position in %s
+Warning: fseek(): Stream filter zlib.deflate is seekable only to start position in %s on line %d
 bool(false)
 bool(true)
 bool(true)
 bool(true)
 bool(true)
 
-Warning: stream_filter_append(): "write_seek_mode" filter parameter must be one of "preserve", "reset", or "strict" in %s
+Warning: stream_filter_append(): "write_seek_mode" filter parameter must be one of "preserve", "reset", or "strict" in %s on line %d
 
-Warning: stream_filter_append(): Unable to create or locate filter "zlib.deflate" in %s
+Warning: stream_filter_append(): Unable to create or locate filter "zlib.deflate" in %s on line %d

--- a/tests/basic/rfc1867_garbled_mime_headers.phpt
+++ b/tests/basic/rfc1867_garbled_mime_headers.phpt
@@ -16,7 +16,7 @@ var_dump($_FILES);
 var_dump($_POST);
 ?>
 --EXPECTF--
-Warning: PHP Request Startup: File Upload Mime headers garbled in %s
+Warning: PHP Request Startup: File Upload Mime headers garbled in %s on line %d
 array(0) {
 }
 array(0) {

--- a/tests/basic/rfc1867_invalid_boundary.phpt
+++ b/tests/basic/rfc1867_invalid_boundary.phpt
@@ -15,7 +15,7 @@ var_dump($_FILES);
 var_dump($_POST);
 ?>
 --EXPECTF--
-Warning: PHP Request Startup: Invalid boundary in multipart/form-data POST data in %s
+Warning: PHP Request Startup: Invalid boundary in multipart/form-data POST data in %s on line %d
 array(0) {
 }
 array(0) {

--- a/tests/basic/rfc1867_missing_boundary.phpt
+++ b/tests/basic/rfc1867_missing_boundary.phpt
@@ -15,7 +15,7 @@ var_dump($_FILES);
 var_dump($_POST);
 ?>
 --EXPECTF--
-Warning: PHP Request Startup: Missing boundary in multipart/form-data POST data in %s
+Warning: PHP Request Startup: Missing boundary in multipart/form-data POST data in %s on line %d
 array(0) {
 }
 array(0) {

--- a/tests/basic/rfc1867_post_max_size.phpt
+++ b/tests/basic/rfc1867_post_max_size.phpt
@@ -15,7 +15,7 @@ var_dump($_FILES);
 var_dump($_POST);
 ?>
 --EXPECTF--
-Warning: PHP Request Startup: POST Content-Length of 168 bytes exceeds the limit of 1 bytes in %s
+Warning: PHP Request Startup: POST Content-Length of 168 bytes exceeds the limit of 1 bytes in %s on line %d
 array(0) {
 }
 array(0) {

--- a/tests/lang/033.phpt
+++ b/tests/lang/033.phpt
@@ -38,9 +38,9 @@ switch ($a):
 endswitch;
 ?>
 --EXPECTF--
-Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in %s
+Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in %s on line %d
 
-Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in %s
+Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in %s on line %d
 If: 11
 While: 12346789
 For: 0123401234


### PR DESCRIPTION
In `--EXPECTF--` sections, `%s` placeholders were being used to match more than just file paths, inadvertently absorbing line number information and making the assertions weaker than intended.