### PR TITLE
Change bless to clean up absolute paths

### DIFF
--- a/scripts/dev/bless_tests.php
+++ b/scripts/dev/bless_tests.php
@@ -74,6 +74,10 @@ function normalizeOutput(string $out): string {
         'Resource ID#%d used as offset, casting to integer (%d)',
         $out);
     $out = preg_replace('/string\(\d+\) "([^"]*%d)/', 'string(%d) "$1', $out);
+    // Inside of strings, replace absolute paths that have been truncated with
+    // any string. These tend to contain homedirs with usernames, not good.
+    $out = preg_replace("/'\\/.*\.\\.\\.'/", "'%s'", $out);
+    $out = preg_replace("/'file:\/\\/.*\.\\.\\.'/", "'%s'", $out);
     $out = str_replace("\0", '%0', $out);
     return $out;
 }

--- a/scripts/dev/bless_tests.php
+++ b/scripts/dev/bless_tests.php
@@ -76,8 +76,8 @@ function normalizeOutput(string $out): string {
     $out = preg_replace('/string\(\d+\) "([^"]*%d)/', 'string(%d) "$1', $out);
     // Inside of strings, replace absolute paths that have been truncated with
     // any string. These tend to contain homedirs with usernames, not good.
-    $out = preg_replace("/'\\/.*\.\\.\\.'/", "'%s'", $out);
-    $out = preg_replace("/'file:\/\\/.*\.\\.\\.'/", "'%s'", $out);
+    $out = preg_replace("/'(\/|[A-Z]:\\\\)\S+\\.\\.\\.'/", "'%s'", $out);
+    $out = preg_replace("/'file:(\/|[A-Z]:\\\\)\S+\\.\\.\\.'/", "'%s'", $out);
     $out = str_replace("\0", '%0', $out);
     return $out;
 }


### PR DESCRIPTION
User-specific absolute paths should be avoided in tests, since they aren't portable. Change bless to detect common places where this occurs and make it use %s in EXPECTF if so.

This was originally developed as part of GH-12276. While the approved RFC doesn't enable function parameters to be printed for tests, the functionality is generally useful.