### PR TITLE
ext/intl: use PATTERN constant name in dateformat errors

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,8 +8,9 @@ PHP                                                                        NEWS
     and IntlGregorianCalendar date/time construction. (Weilin Du)
   . Expose Spoofchecker restriction-level APIs on all supported ICU
     versions. (Weilin Du)
-  . Fix SpoofChecker::setAllowedChars() to report PHP constant names
-    instead of ICU USET_* names in invalid pattern option errors.
+  . Fix SpoofChecker::setAllowedChars() and IntlDateFormatter::__construct()
+    to report PHP constant names instead of ICU constant names in
+    user-visible error messages.
     (Weilin Du)
 
 - MySQLnd:

--- a/UPGRADING
+++ b/UPGRADING
@@ -92,8 +92,9 @@ PHP 8.4 UPGRADE NOTES
       - ValueError if the integer index does not fit in a signed 32 bit integer
     . IntlDateFormatter::__construct() throws a ValueError if the locale is invalid.
     . NumberFormatter::__construct() throws a ValueError if the locale is invalid.
-    . SpoofChecker::setAllowedChars() now reports PHP constant names instead
-      of ICU USET_* names in invalid pattern option errors.
+    . SpoofChecker::setAllowedChars() and IntlDateFormatter::__construct()
+      now report PHP constant names instead of ICU constant names in
+      user-visible error messages.
   . MBString:
     . mb_encode_numericentity() and mb_decode_numericentity() now check that
       the $map is only composed of integers, if not a ValueError is thrown.

--- a/ext/intl/dateformat/dateformat_create.cpp
+++ b/ext/intl/dateformat/dateformat_create.cpp
@@ -103,7 +103,7 @@ static zend_result datefmt_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handlin
 		return FAILURE;
 	}
 	if (date_type == UDAT_PATTERN && time_type != UDAT_PATTERN) {
-		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "datefmt_create: time format must be UDAT_PATTERN if date format is UDAT_PATTERN", 0);
+		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "datefmt_create: time format must be IntlDateFormatter::PATTERN if date format is IntlDateFormatter::PATTERN", 0);
 		return FAILURE;
 	}
 

--- a/ext/intl/tests/gh12243.phpt
+++ b/ext/intl/tests/gh12243.phpt
@@ -1,5 +1,5 @@
 --TEST--
-GitHub #12043 segfault with IntlDateFormatter::dateType where it equals to UDAT_PATTERN (icu 50) but
+GitHub #12043 segfault with IntlDateFormatter::dateType where it equals to IntlDateFormatter::PATTERN (icu 50) but
 IntldateFormatter::timeType needs to be set as such.
 --EXTENSIONS--
 intl
@@ -21,4 +21,4 @@ try {
 
 ?>
 --EXPECT--
-datefmt_create: time format must be UDAT_PATTERN if date format is UDAT_PATTERN: U_ILLEGAL_ARGUMENT_ERROR
+datefmt_create: time format must be IntlDateFormatter::PATTERN if date format is IntlDateFormatter::PATTERN: U_ILLEGAL_ARGUMENT_ERROR


### PR DESCRIPTION
Fix the error message of IntlDateFormatter::_construct() which demonstrates an ICU API instead of PHP API, similar to [php/php-src#22044 (comment)](https://github.com/php/php-src/pull/22044#issuecomment-4467262042)