### PR TITLE
ext/intl: Fix argument position for uninitialized calendar arguments

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,9 @@ PHP                                                                        NEWS
   . Fix incorrect argument positions in out-of-bounds errors for
     IntlCalendar::set(), IntlCalendar::setDate(), IntlCalendar::setDateTime(),
     and IntlGregorianCalendar date/time construction. (Weilin Du)
+  . Fix incorrect argument positions for uninitialized calendar arguments in
+    IntlCalendar::equals(), ::before(), ::after(), and ::isEquivalentTo().
+    (Weilin Du)
   . Expose Spoofchecker restriction-level APIs on all supported ICU
     versions. (Weilin Du)
   . Fix SpoofChecker::setAllowedChars() to report PHP constant names

--- a/ext/intl/calendar/calendar_methods.cpp
+++ b/ext/intl/calendar/calendar_methods.cpp
@@ -345,7 +345,7 @@ static void _php_intlcal_before_after(
 
 	when_co = Z_INTL_CALENDAR_P(when_object);
 	if (when_co->ucal == NULL) {
-		zend_argument_error(NULL, 2, "is uninitialized");
+		zend_argument_error(NULL, hasThis() ? 1 : 2, "is uninitialized");
 		RETURN_THROWS();
 	}
 
@@ -774,7 +774,7 @@ U_CFUNC PHP_FUNCTION(intlcal_is_equivalent_to)
 
 	other_co = Z_INTL_CALENDAR_P(other_object);
 	if (other_co->ucal == NULL) {
-		zend_argument_error(NULL, 2, "is uninitialized");
+		zend_argument_error(NULL, hasThis() ? 1 : 2, "is uninitialized");
 		RETURN_THROWS();
 	}
 
@@ -912,7 +912,7 @@ U_CFUNC PHP_FUNCTION(intlcal_equals)
 	CALENDAR_METHOD_FETCH_OBJECT;
 	other_co = Z_INTL_CALENDAR_P(other_object);
 	if (other_co->ucal == NULL) {
-		zend_argument_error(NULL, 2, "is uninitialized");
+		zend_argument_error(NULL, hasThis() ? 1 : 2, "is uninitialized");
 		RETURN_THROWS();
 	}
 

--- a/ext/intl/tests/calendar_uninitialized_argument_position.phpt
+++ b/ext/intl/tests/calendar_uninitialized_argument_position.phpt
@@ -1,0 +1,36 @@
+--TEST--
+IntlCalendar methods report the correct argument position for uninitialized calendar arguments
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+
+$calendar = IntlGregorianCalendar::createFromDate(2024, 0, 1);
+$uninitialized = (new ReflectionClass(IntlGregorianCalendar::class))->newInstanceWithoutConstructor();
+
+foreach (['equals', 'before', 'after', 'isEquivalentTo'] as $method) {
+    try {
+        $calendar->$method($uninitialized);
+    } catch (Error $e) {
+        echo $method, ': ', $e->getMessage(), PHP_EOL;
+    }
+}
+
+foreach (['intlcal_equals', 'intlcal_before', 'intlcal_after', 'intlcal_is_equivalent_to'] as $function) {
+    try {
+        $function($calendar, $uninitialized);
+    } catch (Error $e) {
+        echo $function, ': ', $e->getMessage(), PHP_EOL;
+    }
+}
+
+?>
+--EXPECT--
+equals: IntlCalendar::equals(): Argument #1 ($other) is uninitialized
+before: IntlCalendar::before(): Argument #1 ($other) is uninitialized
+after: IntlCalendar::after(): Argument #1 ($other) is uninitialized
+isEquivalentTo: IntlCalendar::isEquivalentTo(): Argument #1 ($other) is uninitialized
+intlcal_equals: intlcal_equals(): Argument #2 ($other) is uninitialized
+intlcal_before: intlcal_before(): Argument #2 ($other) is uninitialized
+intlcal_after: intlcal_after(): Argument #2 ($other) is uninitialized
+intlcal_is_equivalent_to: intlcal_is_equivalent_to(): Argument #2 ($other) is uninitialized


### PR DESCRIPTION
Found when looking at the code base.   `IntlCalendar::equals()`, `IntlCalendar::before()`, `IntlCalendar::after()`, and `IntlCalendar::isEquivalentTo()` currently report the second parameter position used by the procedural API, even when called as methods. That is, the argument position will be error by -1.

```php
  <?php

  $cal = IntlGregorianCalendar::createFromDate(2024, 0, 1);
  $uninit = (new ReflectionClass(IntlGregorianCalendar::class))
      ->newInstanceWithoutConstructor();

  try {
      $cal->equals($uninit);
  } catch (Error $e) {
      echo $e->getMessage(), PHP_EOL;
  }

  try {
      intlcal_equals($cal, $uninit);
  } catch (Error $e) {
      echo $e->getMessage(), PHP_EOL;
  }
```

Resulted in:
```
  IntlCalendar::equals(): Argument #2 ($other) is uninitialized
  intlcal_equals(): Argument #2 ($other) is uninitialized
```
But I expeected:
```
  IntlCalendar::equals(): Argument #1 ($other) is uninitialized
  intlcal_equals(): Argument #2 ($other) is uninitialized
```
See https://3v4l.org/tQdYo#v8.4.18

Ah, ideally in the future maybe we can refactor this whole parameter logic.