### PR TITLE
Fix GH-22071: JIT assertion on abstract static method call.

### DIFF
--- a/Zend/Optimizer/zend_optimizer.c
+++ b/Zend/Optimizer/zend_optimizer.c
@@ -945,7 +945,7 @@ zend_function *zend_optimizer_get_called_func(
 				if (ce) {
 					zend_string *func_name = Z_STR_P(CRT_CONSTANT(opline->op2) + 1);
 					zend_function *fbc = zend_hash_find_ptr(&ce->function_table, func_name);
-					if (fbc) {
+					if (fbc && !(fbc->common.fn_flags & ZEND_ACC_ABSTRACT)) {
 						bool is_public = (fbc->common.fn_flags & ZEND_ACC_PUBLIC) != 0;
 						bool same_scope = fbc->common.scope == op_array->scope;
 						if (is_public || same_scope) {

--- a/ext/opcache/tests/gh22071.phpt
+++ b/ext/opcache/tests/gh22071.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-22071: Assertion failure jit_CONST_FUNC_PROTO on abstract static method call
+--CREDITS--
+YuanchengJiang
+--EXTENSIONS--
+opcache
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit=1205
+opcache.jit_buffer_size=16M
+--FILE--
+<?php
+try {
+    $e = enum_exists('UnitEnum') ? UnitEnum::cases() : [];
+} catch (\Throwable $_e) {}
+echo "ok\n";
+?>
+--EXPECT--
+ok


### PR DESCRIPTION
The optimizer's ZEND_INIT_STATIC_METHOD_CALL handling returned the function entry even when the resolved method was abstract, leading the JIT to assert on a null address in jit_CONST_FUNC_PROTO when emitting a direct call (e.g. UnitEnum::cases()).