### PR TITLE
Fix GH-22060: UAF in class-autoloader dispatch on self-unregister

### DIFF
--- a/Zend/zend_autoload.c
+++ b/Zend/zend_autoload.c
@@ -63,7 +63,21 @@ ZEND_API zend_class_entry *zend_perform_class_autoload(zend_string *class_name, 
 		if (!func_info) {
 			break;
 		}
+		zend_object *guard_object = func_info->object;
+		zend_object *guard_closure = func_info->closure;
+		if (guard_object) {
+			GC_ADDREF(guard_object);
+		}
+		if (guard_closure) {
+			GC_ADDREF(guard_closure);
+		}
 		zend_call_known_fcc(func_info, /* retval */ NULL, /* param_count */ 1, /* params */ &zname, /* named_params */ NULL);
+		if (guard_object) {
+			OBJ_RELEASE(guard_object);
+		}
+		if (guard_closure) {
+			OBJ_RELEASE(guard_closure);
+		}
 
 		if (EG(exception)) {
 			return NULL;

--- a/ext/spl/tests/autoloading/gh22060.phpt
+++ b/ext/spl/tests/autoloading/gh22060.phpt
@@ -1,0 +1,27 @@
+--TEST--
+GH-22060 (Class autoloader $this freed via spl_autoload_unregister during dispatch)
+--FILE--
+<?php
+
+class Loader {
+    public string $data = "loader-data";
+
+    public function load(string $class): void {
+        spl_autoload_unregister([$this, 'load']);
+        echo $this->data, "\n";
+    }
+}
+
+$obj = new Loader();
+spl_autoload_register([$obj, 'load']);
+unset($obj);
+
+try {
+    new NonExistentClass42();
+} catch (\Throwable $e) {
+    echo $e::class, ": ", $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+loader-data
+Error: Class "NonExistentClass42" not found


### PR DESCRIPTION
A method-bound autoloader registered as `[$obj, 'load']` can call `spl_autoload_unregister([$this, 'load'])` from inside its own callback. The hash entry's destructor releases the last ref on the object, frees it, and the rest of the PHP body (e.g. `echo $this->data`) reads freed memory. The dispatch loop in `zend_perform_class_autoload` calls `zend_call_known_fcc(func_info, ...)`, but `zend_call_function` reads `fci_cache->object` into `EX(This)` without bumping the refcount; the call convention is that the caller holds the ref, and here the only ref was the hash entry's.

Fix pins `object` and `closure` across the call with `GC_ADDREF`/`OBJ_RELEASE`. The pointers are saved locally before the call so the releases work even when `func_info` itself is freed mid-call by self-unregister.
