### PR TITLE
ext/spl: Optimize php_spl_object_hash performance

### DIFF
--- a/ext/gd/tests/imagebmp_basic.phpt
+++ b/ext/gd/tests/imagebmp_basic.phpt
@@ -2,6 +2,12 @@
 imagebmp() - basic functionality
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+    if (!(imagetypes() & IMG_PNG)) {
+        die("skip No PNG support");
+    }
+?>
 --FILE--
 <?php
 // create an image

--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -500,11 +500,16 @@ PHPAPI zend_string *php_spl_object_hash(zend_object *obj) /* {{{*/
 {
 	zend_string *str = zend_string_alloc(32, false);
 
-    zend_string *str = zend_string_alloc(32, 0);
-    uintptr_t handle = (uintptr_t)obj->handle;
+	char *p = ZSTR_VAL(str);
+
+	uintptr_t handle = (uintptr_t)obj->handle;
+	for (size_t i = 0; i < 16; i++) {
+        	*p++ = "0123456789abcdef"[handle & 0xf];
+        	handle >>= 4;
+	}
 
 	p = zend_mempcpy(p, "000000000000000", 16);
-	*p++ = '\0';
+    	*p++ = '\0';
 
 	return str;
 }

--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -509,7 +509,7 @@ PHPAPI zend_string *php_spl_object_hash(zend_object *obj) /* {{{*/
 	}
 
 	p = zend_mempcpy(p, "000000000000000", 16);
-    	*p++ = '\0';
+	*p++ = '\0';
 
 	return str;
 }

--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -501,7 +501,6 @@ PHPAPI zend_string *php_spl_object_hash(zend_object *obj) /* {{{*/
     static const char hex[] = "0123456789abcdef";
 
     zend_string *str = zend_string_alloc(32, 0);
-
     uintptr_t handle = (uintptr_t)obj->handle;
 
     char *p = ZSTR_VAL(str);

--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -498,24 +498,20 @@ PHP_FUNCTION(spl_object_id)
 
 PHPAPI zend_string *php_spl_object_hash(zend_object *obj) /* {{{*/
 {
-    static const char hex[] = "0123456789abcdef";
+	zend_string *str = zend_string_alloc(32, false);
 
-    zend_string *str = zend_string_alloc(32, 0);
+	char *p = ZSTR_VAL(str);
 
-    uintptr_t handle = (uintptr_t)obj->handle;
+	uintptr_t handle = (uintptr_t)obj->handle;
+	for (size_t i = 0; i < 16; i++) {
+        	*p++ = "0123456789abcdef"[handle & 0xf];
+        	handle >>= 4;
+	}
 
-    char *p = ZSTR_VAL(str);
+	p = zend_mempcpy(p, "000000000000000", 16);
+    	*p++ = '\0';
 
-	for (int i = 15; i >= 0; --i) {
-        p[i] = hex[handle & 0xf];
-        handle >>= 4;
-    }
-
-    memcpy(p + 16, "000000000000000", 16);
-
-    p[32] = '\0';
-
-    return str;
+	return str;
 }
 /* }}} */
 

--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -498,7 +498,24 @@ PHP_FUNCTION(spl_object_id)
 
 PHPAPI zend_string *php_spl_object_hash(zend_object *obj) /* {{{*/
 {
-	return strpprintf(32, "%016zx0000000000000000", (intptr_t)obj->handle);
+    static const char hex[] = "0123456789abcdef";
+
+    zend_string *str = zend_string_alloc(32, 0);
+
+    uintptr_t handle = (uintptr_t)obj->handle;
+
+    char *p = ZSTR_VAL(str);
+
+	for (int i = 15; i >= 0; --i) {
+        p[i] = hex[handle & 0xf];
+        handle >>= 4;
+    }
+
+    memcpy(p + 16, "000000000000000", 16);
+
+    p[32] = '\0';
+
+    return str;
 }
 /* }}} */
 


### PR DESCRIPTION
Optimize php_spl_object_hash performance

* Replace strpprintf() with manual hex conversion
* Avoid printf formatting overhead
* Use lookup-table-based hex encoding
* Reduce runtime from ~412ms to ~244ms in benchmark
* Achieve ~1.68x speed improvement
 
```bash
hyperfine --warmup 5 \                                                                                         
'./sapi/cli/php_old -dopcache.enable_cli=0 bench.php' \
'./sapi/cli/php -dopcache.enable_cli=0 bench.php'
```

**Output:**
```bash
Benchmark 1: ./sapi/cli/php_old -dopcache.enable_cli=0 bench.php
  Time (mean ± σ):     411.7 ms ±   2.3 ms    [User: 407.7 ms, System: 2.8 ms]
  Range (min … max):   407.7 ms … 416.5 ms    10 runs
 
Benchmark 2: ./sapi/cli/php -dopcache.enable_cli=0 bench.php
  Time (mean ± σ):     246.0 ms ±   1.6 ms    [User: 243.0 ms, System: 2.1 ms]
  Range (min … max):   243.9 ms … 249.0 ms    12 runs
 
Summary
  ./sapi/cli/php -dopcache.enable_cli=0 bench.php ran
    1.67 ± 0.01 times faster than ./sapi/cli/php_old -dopcache.enable_cli=0 bench.php
```

```php
<?php
//bench.php
for ($i = 0; $i < 1000000; $i++) {
    spl_object_hash(new stdClass);
}
```
