### PR TITLE
Switch to VS18 for the master branch

### DIFF
--- a/.github/actions/setup-windows/action.yml
+++ b/.github/actions/setup-windows/action.yml
@@ -16,5 +16,6 @@ runs:
     - name: Setup PostgreSQL
       shell: pwsh
       run: |
-        Set-Service -Name "postgresql-x64-14" -StartupType manual -Status Running
+        $postgresService = if ($env:PHP_BUILD_CRT -eq "vs18") { "postgresql-x64-17" } else { "postgresql-x64-14" }
+        Set-Service -Name $postgresService -StartupType manual -Status Running
         pwsh -Command { $env:PGPASSWORD="root"; & "$env:PGBIN\psql" -U postgres -c "ALTER USER postgres WITH PASSWORD 'Password12!';" }

--- a/.github/matrix.php
+++ b/.github/matrix.php
@@ -153,9 +153,11 @@ function select_jobs($repository, $trigger, $nightly, $labels, $php_version, $re
             }
         }
         $jobs['WINDOWS']['matrix'] = ['include' => $matrix];
-        $jobs['WINDOWS']['config'] = version_compare($php_version, '8.4', '>=')
-            ? ['vs_crt_version' => 'vs17']
-            : ['vs_crt_version' => 'vs16'];
+        $jobs['WINDOWS']['config'] = match (true) {
+            version_compare($php_version, '8.6', '>=') => ['vs_crt_version' => 'vs18', 'runs_on' => 'windows-2025-vs2026'],
+            version_compare($php_version, '8.4', '>=') => ['vs_crt_version' => 'vs17', 'runs_on' => 'windows-2022'],
+            default => ['vs_crt_version' => 'vs16', 'runs_on' => 'windows-2022'],
+        };
     }
     if ($all_jobs || !$no_jobs || $test_freebsd) {
         $jobs['FREEBSD']['matrix'] = $all_variations && version_compare($php_version, '8.3', '>=')

--- a/.github/scripts/windows/find-vs-toolset.bat
+++ b/.github/scripts/windows/find-vs-toolset.bat
@@ -3,7 +3,7 @@
 setlocal enabledelayedexpansion
 
 if "%~1"=="" (
-  echo ERROR: Usage: %~nx0 [vc14^|vc15^|vs16^|vs17]
+  echo ERROR: Usage: %~nx0 [vc14^|vc15^|vs16^|vs17^|vs18]
   exit /b 1
 )
 
@@ -11,6 +11,7 @@ set "toolsets_vc14=14.0"
 set "toolsets_vc15="
 set "toolsets_vs16="
 set "toolsets_vs17="
+set "toolsets_vs18="
 
 
 for /f "usebackq tokens=*" %%I in (`vswhere.exe -latest -find "VC\Tools\MSVC"`) do set "MSVCDIR=%%I"
@@ -30,8 +31,10 @@ for /f "delims=" %%D in ('dir /b /ad "%MSVCDIR%"') do (
         set "toolsets_vc15=%%D"
       ) else if !min! LEQ 29 (
         set "toolsets_vs16=%%D"
-      ) else (
+      ) else if !min! LEQ 49 (
         set "toolsets_vs17=%%D"
+      ) else (
+        set "toolsets_vs18=%%D"
       )
     )
   )

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -941,12 +941,12 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(inputs.branch).jobs.WINDOWS.matrix }}
     name: "WINDOWS_${{ matrix.x64 && 'X64' || 'X86' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}${{ matrix.asan && '_ASAN' || ''}}${{ matrix.clang && '_CLANG' || ''}}"
-    runs-on: windows-2022
+    runs-on: ${{ fromJson(inputs.branch).jobs.WINDOWS.config.runs_on }}
     env:
       PHP_BUILD_CACHE_BASE_DIR: C:\build-cache
       PHP_BUILD_OBJ_DIR: C:\obj
       PHP_BUILD_CACHE_SDK_DIR: C:\build-cache\sdk
-      PHP_BUILD_SDK_BRANCH: php-sdk-2.5.0
+      PHP_BUILD_SDK_BRANCH: php-sdk-2.7.1
       PHP_BUILD_CRT: ${{ fromJson(inputs.branch).jobs.WINDOWS.config.vs_crt_version }}
       PLATFORM: ${{ matrix.x64 && 'x64' || 'x86' }}
       THREAD_SAFE: "${{ matrix.zts && '1' || '0' }}"

--- a/ext/com_dotnet/tests/variants.phpt
+++ b/ext/com_dotnet/tests/variants.phpt
@@ -43,7 +43,7 @@ foreach ($values as $t => $val) {
 
 echo "OK!";
 ?>
---EXPECT--
+--EXPECTF--
 --
 add: 84
 cat: 4242
@@ -142,8 +142,8 @@ mul: 0
 and: 0
 div:
 	variant_div(42, )
-	exception Division by zero
-	code 80020012
+	exception %s
+	code 800200%x
 
 eqv: -43
 idiv:
@@ -258,8 +258,8 @@ mul: 0
 and: 0
 div:
 	variant_div(3.5, )
-	exception Division by zero
-	code 80020012
+	exception %s
+	code 800200%x
 
 eqv: -5
 idiv:

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3101,8 +3101,8 @@ function toolset_get_compiler_name(short)
 
 		version = probe_binary(PHP_CL).substr(0, 5).replace('.', '');
 
-		if (version >= 1940) {
-			return name;
+		if (version >= 1950) {
+			name = short ? "VS18" : "Visual C++ 2026";
 		} else if (version >= 1930) {
 			name = short ? "VS17" : "Visual C++ 2022";
 		} else if (version >= 1920) {


### PR DESCRIPTION
For the next version PHP 8.6, we can switch to Visual Studio 2026 / VS18 for Windows builds, so this PR switches to VS18 for the master branch.

In prep for this, we have rebuilt and published all dependencies with VS18 and added support in `php/php-sdk-binary-tools`.

Ref:
- https://github.com/php/php-sdk-binary-tools/releases/tag/php-sdk-2.7.1
- https://github.com/winlibs/winlib-builder/pull/45
- https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-VS2026-Readme.md
- https://learn.microsoft.com/en-us/cpp/overview/compiler-versions?view=msvc-170
- https://learn.microsoft.com/en-us/windows/win32/api/oleauto/nf-oleauto-vardiv (for `ext/com_dotnet/tests/variants.phpt`)