### PR TITLE
Release Process: Add commands for merge up

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -301,10 +301,19 @@ slightly different steps. We'll call attention where the steps differ.
    > Only release tags should have version numbers in these files that do not
    > end in `-dev` (e.g., `8.1.7`, `8.1.7RC1`, `8.2.0alpha1`, etc.).
 
-    Do not forget to merge up PHP-X.Y all the way to master. When resolving
-    the conflicts, ignore the changes from PHP-X.Y in higher branches. It
-    means using something like `git checkout --ours .` when on PHP.X.Y+1 or
-    master after the merge resulting in the conflicts.
+    Do not forget to merge up PHP-X.Y all the way to master.
+
+    ```shell
+    git switch PHP-X.Y+1 # starting from your release branch
+    git merge PHP-X.Y
+    # repeat             # Merge up all the way
+    git switch master
+    git merge PHP-X.Y    # latest release branch
+    ```
+
+    When resolving the conflicts, ignore the changes from PHP-X.Y in higher
+    branches. It means using something like `git checkout --ours .` when on
+    PHP.X.Y+1 or master after the merge resulting in the conflicts.
 
     Be sure to set up a merge driver for the NEWS file as described in
     the [Git FAQ page on the PHP wiki][gitfaq-mandatory].

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -312,10 +312,16 @@ slightly different steps. We'll call attention where the steps differ.
     ```
 
     When resolving the conflicts, ignore the changes from PHP-X.Y in higher
-    branches. It means using something like `git checkout --ours .` when on
-    PHP.X.Y+1 or master after the merge resulting in the conflicts.
+    branches when on PHP.X.Y+1 or master after the merge resulting in the
+    conflicts.
 
-    Be sure to set up a merge driver for the NEWS file as described in
+    ```
+    git checkout --ours main/php_version.h Zend/zend.h configure.ac
+    git add main/php_version.h Zend/zend.h configure.ac
+    git merge --continue
+    ```
+    
+    Be sure to set up a merge driver for the `NEWS` file as described in
     the [Git FAQ page on the PHP wiki][gitfaq-mandatory].
 
 11. Push the changes to the `php-src`.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -315,7 +315,7 @@ slightly different steps. We'll call attention where the steps differ.
     branches when on PHP.X.Y+1 or master after the merge resulting in the
     conflicts.
 
-    ```
+    ```shell
     git checkout --ours main/php_version.h Zend/zend.h configure.ac
     git add main/php_version.h Zend/zend.h configure.ac
     git merge --continue

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -308,7 +308,7 @@ slightly different steps. We'll call attention where the steps differ.
     git merge PHP-X.Y
     # repeat             # Merge up all the way
     git switch master
-    git merge PHP-X.Y    # latest release branch
+    git merge PHP-X.Y+n  # latest release branch
     ```
 
     When resolving the conflicts, ignore the changes from PHP-X.Y in higher


### PR DESCRIPTION
We list all other commands RMs are expected to run explicitly.

While the merge up is common for RMs that regularly contribute code to PHP, it's not for others.

Adding this here should help people who follow the docs not forget about it.