### PR TITLE
ext/session: add missing NEWS entries

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -156,6 +156,12 @@ PHP                                                                        NEWS
     (Girgias)
   . Null bytes in session.cookie_path, session.cookie_domain, and
     session.cache_limiter are now rejected with a warning. (jorgsowa)
+  . session.cookie_samesite now rejects invalid values with a warning; only
+    "Strict", "Lax", "None", or "" are accepted. (jorgsowa)
+  . session.cookie_lifetime now rejects non-integer and out-of-range values
+    with a warning. (jorgsowa)
+  . Session file GC now recursively cleans nested subdirectories when
+    session.save_path uses the dirdepth prefix. (jorgsowa)
   . Changed defaults of session.use_strict_mode (now 1), session.cookie_httponly
     (now 1) and session.cookie_samesite (now "Lax"). (jorgsowa)
 


### PR DESCRIPTION
Add NEWS entries for three ext/session changes that were never documented:
- SameSite cookie validation ([GH-21670](https://github.com/php/php-src/pull/21670))
- session.cookie_lifetime improved parsing ([GH-21704](https://github.com/php/php-src/pull/21704))
- Recursive GC cleanup for nested session directories ([GH-21491](https://github.com/php/php-src/pull/21491))