### PR TITLE
zlib: fix memory leak if {in,de}flate initialization fails and there is a dict

### DIFF
--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -908,6 +908,7 @@ PHP_FUNCTION(inflate_init)
 	}
 
 	if (inflateInit2(&ctx->Z, encoding) != Z_OK) {
+		efree(dict);
 		zval_ptr_dtor(return_value);
 		php_error_docref(NULL, E_WARNING, "Failed allocating zlib.inflate context");
 		RETURN_FALSE;
@@ -1158,6 +1159,7 @@ PHP_FUNCTION(deflate_init)
 	}
 
 	if (deflateInit2(&ctx->Z, level, Z_DEFLATED, encoding, memory, strategy) != Z_OK) {
+		efree(dict);
 		zval_ptr_dtor(return_value);
 		php_error_docref(NULL, E_WARNING, "Failed allocating zlib.deflate context");
 		RETURN_FALSE;


### PR DESCRIPTION
```
Direct leak of 52 byte(s) in 1 object(s) allocated from:
    #0 0x7ff90cd2c161 in malloc (/usr/lib/libasan.so.8+0x12c161) (BuildId: ee5fbab73143ab257a66a33afe0f038a4af7a74e)
    #1 0x55de10c9a468 in tracked_malloc /work/php-8.4/Zend/zend_alloc.c:2973
    #2 0x55de10c99443 in _emalloc /work/php-8.4/Zend/zend_alloc.c:2740
    #3 0x55de102deb86 in zlib_create_dictionary_string /work/php-8.4/ext/zlib/zlib.c:836
    #4 0x55de102e145a in zif_deflate_init /work/php-8.4/ext/zlib/zlib.c:1144
    #5 0x55de10dcac6c in ZEND_DO_ICALL_SPEC_RETVAL_USED_HANDLER /work/php-8.4/Zend/zend_vm_execute.h:1351
    #6 0x55de10f2d69d in execute_ex /work/php-8.4/Zend/zend_vm_execute.h:58907
    #7 0x55de10f41666 in zend_execute /work/php-8.4/Zend/zend_vm_execute.h:64334
    #8 0x55de110a6cf8 in zend_execute_script /work/php-8.4/Zend/zend.c:1934
    #9 0x55de10af0ddb in php_execute_script_ex /work/php-8.4/main/main.c:2577
    #10 0x55de10af128f in php_execute_script /work/php-8.4/main/main.c:2617
    #11 0x55de110ac5e1 in do_cli /work/php-8.4/sapi/cli/php_cli.c:935
    #12 0x55de110ae592 in main /work/php-8.4/sapi/cli/php_cli.c:1322
    #13 0x7ff90c027740  (/usr/lib/libc.so.6+0x27740) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #14 0x7ff90c027878 in __libc_start_main (/usr/lib/libc.so.6+0x27878) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #15 0x55de10005964 in _start (/work/php-8.4/sapi/cli/php+0x605964) (BuildId: 5f144db4e56ea623e070c56445fb1dfa3f8d085d)

SUMMARY: AddressSanitizer: 52 byte(s) leaked in 1 allocation(s).
```

Note: this was found by a hybrid static-dynamic analyzer I'm developing.