### PR TITLE
Fix Windows clang VM handler declaration

### DIFF
--- a/Zend/zend_vm.h
+++ b/Zend/zend_vm.h
@@ -41,7 +41,7 @@ void zend_vm_init(void);
 void zend_vm_dtor(void);
 
 #if ZEND_VM_KIND == ZEND_VM_KIND_TAILCALL
-const struct _zend_op *zend_vm_handle_interrupt(struct _zend_execute_data *execute_data, const struct _zend_op *opline);
+const struct _zend_op *ZEND_FASTCALL zend_vm_handle_interrupt(struct _zend_execute_data *execute_data, const struct _zend_op *opline);
 #endif
 
 END_EXTERN_C()


### PR DESCRIPTION
Follow up to GH-21922, this fixes the Windows clang build in the nightly CI run by matching the declaration of `zend_vm_handle_interrupt()` with its generated definition.

Logs: https://github.com/php/php-src/actions/runs/26200549586/job/77089519094