### PR TITLE
[skip ci] Add classification section to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,13 +19,16 @@ are not limited to):
 - Invocation of specially crafted, malicious code intended to cause memory
   violations. This commonly includes malicious error handlers, destructors or
   `__toString()` functions. PHP does not offer sandboxing, and the execution of
-  untrusted code is always considered unsafe.
+  untrusted code is always considered unsafe. Such issues are bugs, but not
+  security issues. They may still be reported, though please avoid reporting
+  the known issues.
 
 - Passing malicious arguments to functions clearly not intended to receive
   unsanitized values, e.g. `mysqli_query()`. `escapeshellarg()` on the other
   hand should clearly be hardened against unsafe inputs.
 
-- The use of legacy APIs or settings known to be insecure.
+- The use of legacy APIs or settings known to be insecure, particularly those
+  documented as such, or those with a secure alternative.
 
 - The use of FFI.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,6 +11,26 @@ Vulnerability reports remain private until published. When published, you will
 be credited as a contributor, and your contribution will reflect the MITRE
 Credit System.
 
+# Classification
+
+Issues commonly reported that are _not_ considered security issues include (but
+are not limited to):
+
+- Invocation of specially crafted, malicious code intended to cause memory
+  violations. This commonly includes malicious error handlers, destructors or
+  `__toString()` functions. PHP does not offer sandboxing, and the execution of
+  untrusted code is always considered unsafe.
+
+- Passing malicious arguments to functions clearly not intended to receive
+  unsanitized values, e.g. `mysqli_query()`. `escapeshellarg()` on the other
+  hand should clearly be hardened against unsafe inputs.
+
+- The use of legacy APIs or settings known to be insecure.
+
+- The use of FFI.
+
+- `open_basedir` or `disable_functions` bypasses.
+
 # Vulnerability Policy
 
 Our full policy is described at


### PR DESCRIPTION
According to Volker, AI models respect this file when evaluating security issues. While we do link to php/policies:security-classification.rst, this clearly isn't enough to stop the frequent false-positive reports.

I copied any relevant items from security-classification.rst, but also reworded the first one to something much more explicit.