### PR TITLE
ext/session: prevent creation of fixed sid in php_session_rfc1867

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,11 @@ PHP                                                                        NEWS
 ?? ??? ????, PHP 8.4.26
 
 
+- Session:
+  . Fixed session upload progress to respect session.use_only_cookies.
+    (jorgsowa)
+
+
 27 Aug 2026, PHP 8.4.25
 
 - Core:

--- a/NEWS
+++ b/NEWS
@@ -242,6 +242,10 @@ PHP                                                                        NEWS
   . Preserve class-name case in ReflectionClass::getProperty() error messages
     and autoloading. (jorgsowa)
 
+- Session:
+  . Fixed session upload progress to respect session.use_only_cookies.
+    (jorgsowa)
+
 - Sqlite:
   . Fix error checks for column retrieval. (ndossche)
 

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -1673,8 +1673,8 @@ PHPAPI zend_result php_session_start(void) /* {{{ */
 	 * Cookies are preferred, because initially cookie and get
 	 * variables will be available.
 	 * URL/POST session ID may be used when use_only_cookies=Off.
-	 * session.use_strice_mode=On prevents session adoption.
-	 * Session based file upload progress uses non-cookie ID.
+	 * session.use_strict_mode=On prevents session adoption.
+	 * Session based file upload progress respects use_only_cookies.
 	 */
 
 	if (!PS(id)) {
@@ -3228,7 +3228,7 @@ static zend_result php_session_rfc1867_callback(unsigned int event, void *event_
 			multipart_event_start *data = (multipart_event_start *) event_data;
 			progress = ecalloc(1, sizeof(php_session_rfc1867_progress));
 			progress->content_length = data->content_length;
-			progress->sname_len  = strlen(PS(session_name));
+			progress->sname_len = strlen(PS(session_name));
 			PS(rfc1867_progress) = progress;
 		}
 		break;
@@ -3250,7 +3250,7 @@ static zend_result php_session_rfc1867_callback(unsigned int event, void *event_
 			if (data->name && data->value && value_len) {
 				size_t name_len = strlen(data->name);
 
-				if (name_len == progress->sname_len && memcmp(data->name, PS(session_name), name_len) == 0) {
+				if (!PS(use_only_cookies) && name_len == progress->sname_len && memcmp(data->name, PS(session_name), name_len) == 0) {
 					zval_ptr_dtor(&progress->sid);
 					ZVAL_STRINGL(&progress->sid, (*data->value), value_len);
 				} else if (name_len == strlen(PS(rfc1867_name)) && memcmp(data->name, PS(rfc1867_name), name_len + 1) == 0) {

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -1675,8 +1675,8 @@ PHPAPI zend_result php_session_start(void) /* {{{ */
 	 * Cookies are preferred, because initially cookie and get
 	 * variables will be available.
 	 * URL/POST session ID may be used when use_only_cookies=Off.
-	 * session.use_strice_mode=On prevents session adoption.
-	 * Session based file upload progress uses non-cookie ID.
+	 * session.use_strict_mode=On prevents session adoption.
+	 * Session based file upload progress respects use_only_cookies.
 	 */
 
 	if (!PS(id)) {
@@ -3231,7 +3231,7 @@ static zend_result php_session_rfc1867_callback(unsigned int event, void *event_
 			multipart_event_start *data = (multipart_event_start *) event_data;
 			progress = ecalloc(1, sizeof(php_session_rfc1867_progress));
 			progress->content_length = data->content_length;
-			progress->sname_len  = strlen(PS(session_name));
+			progress->sname_len = strlen(PS(session_name));
 			PS(rfc1867_progress) = progress;
 		}
 		break;
@@ -3253,7 +3253,7 @@ static zend_result php_session_rfc1867_callback(unsigned int event, void *event_
 			if (data->name && data->value && value_len) {
 				size_t name_len = strlen(data->name);
 
-				if (name_len == progress->sname_len && memcmp(data->name, PS(session_name), name_len) == 0) {
+				if (!PS(use_only_cookies) && name_len == progress->sname_len && memcmp(data->name, PS(session_name), name_len) == 0) {
 					zval_ptr_dtor(&progress->sid);
 					ZVAL_STRINGL(&progress->sid, (*data->value), value_len);
 				} else if (name_len == strlen(PS(rfc1867_name)) && memcmp(data->name, PS(rfc1867_name), name_len + 1) == 0) {

--- a/ext/session/tests/rfc1867_sid_post_use_only_cookies.phpt
+++ b/ext/session/tests/rfc1867_sid_post_use_only_cookies.phpt
@@ -1,0 +1,44 @@
+--TEST--
+session rfc1867 upload progress does not use form SID when use_only_cookies=1
+--INI--
+file_uploads=1
+upload_max_filesize=1024
+session.save_path=
+session.name=PHPSESSID
+session.use_strict_mode=0
+session.use_cookies=1
+session.use_only_cookies=1
+session.upload_progress.enabled=1
+session.upload_progress.cleanup=0
+session.upload_progress.prefix=upload_progress_
+session.upload_progress.name=PHP_SESSION_UPLOAD_PROGRESS
+session.upload_progress.freq=0
+session.save_handler=files
+--EXTENSIONS--
+session
+--SKIPIF--
+<?php include('skipif.inc'); ?>
+--POST_RAW--
+Content-Type: multipart/form-data; boundary=---------------------------20896060251896012921717172737
+-----------------------------20896060251896012921717172737
+Content-Disposition: form-data; name="PHPSESSID"
+
+rfc1867-sid-post-use-only-cookies
+-----------------------------20896060251896012921717172737
+Content-Disposition: form-data; name="PHP_SESSION_UPLOAD_PROGRESS"
+
+rfc1867_sid_post_use_only_cookies.php
+-----------------------------20896060251896012921717172737
+Content-Disposition: form-data; name="file1"; filename="file1.txt"
+
+1
+-----------------------------20896060251896012921717172737--
+--FILE--
+<?php
+session_id("rfc1867-sid-post-use-only-cookies");
+session_start();
+var_dump(isset($_SESSION["upload_progress_" . basename(__FILE__)]));
+session_destroy();
+?>
+--EXPECT--
+bool(false)


### PR DESCRIPTION
The RFC1867 multipart callback captures the session ID from form data to identify which session to write the upload progress to. When `session.use_only_cookies=1` this capture was not guarded, allowing the session ID to be accepted from a form field despite the setting's documented contract of "only accept session ID from cookies."

`php_session_rfc1867_early_find_sid()` already guards $_GET lookup behind `use_only_cookies`, but the form field capture in `MULTIPART_EVENT_FORMDATA` had no such guard.

This commit adds the missing check so that when `use_only_cookies=1` and no cookie is present, the form-supplied session ID is ignored and the upload progress is written to a randomly generated session instead.

I don't know if this is a security fix, so I point to the 8.4 branch.