### PR TITLE
Fix GH-22112: assertion when error handler throws during NaN coercion

### DIFF
--- a/Zend/tests/type_coercion/gh22112.phpt
+++ b/Zend/tests/type_coercion/gh22112.phpt
@@ -1,0 +1,35 @@
+--TEST--
+GH-22112 (Assertion failure when error handler throws during NaN to bool/string coercion at function entry)
+--FILE--
+<?php
+
+set_error_handler(function ($errno, $errstr) {
+    throw new Exception($errstr);
+});
+
+function take_bool(bool $v) {
+    echo "take_bool entered\n";
+}
+
+function take_string(string $v) {
+    echo "take_string entered\n";
+}
+
+$nan = fdiv(0, 0);
+
+try {
+    take_bool($nan);
+} catch (Exception $e) {
+    echo "bool: ", $e->getMessage(), "\n";
+}
+
+try {
+    take_string($nan);
+} catch (Exception $e) {
+    echo "string: ", $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+bool: unexpected NAN value was coerced to bool
+string: unexpected NAN value was coerced to string

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -537,6 +537,9 @@ ZEND_API bool ZEND_FASTCALL zend_parse_arg_bool_weak(const zval *arg, bool *dest
 			return 0;
 		}
 		*dest = zend_is_true(arg);
+		if (UNEXPECTED(EG(exception))) {
+			return 0;
+		}
 	} else {
 		return 0;
 	}
@@ -762,6 +765,9 @@ ZEND_API bool ZEND_FASTCALL zend_parse_arg_str_weak(zval *arg, zend_string **des
 			return 0;
 		}
 		convert_to_string(arg);
+		if (UNEXPECTED(EG(exception))) {
+			return 0;
+		}
 		*dest = Z_STR_P(arg);
 	} else if (UNEXPECTED(Z_TYPE_P(arg) == IS_OBJECT)) {
 		zend_object *zobj = Z_OBJ_P(arg);


### PR DESCRIPTION
Recv-arg verification for a userland function asserts `!EG(exception)` after a successful weak coercion. `zend_parse_arg_bool_weak` and `zend_parse_arg_str_weak` returned success without checking whether the NaN-coerced-to-bool/string warning had triggered a throw from the user error handler. Mirror the post-warning check in `zend_parse_arg_long_weak`.

Fixes #22112
