### PR TITLE
Fix GH-19739: imageellipse/imagefilledellipse overflow.

### DIFF
--- a/ext/gd/libgd/gd.c
+++ b/ext/gd/libgd/gd.c
@@ -1775,6 +1775,9 @@ void gdImageEllipse(gdImagePtr im, int mx, int my, int w, int h, int c)
 
 	a=w>>1;
 	b=h>>1;
+	if (overflowMul3(a, b, b) || overflowMul3(b, a, a)) {
+		return;
+	}
 	gdImageSetPixel(im,mx+a, my, c);
 	gdImageSetPixel(im,mx-a, my, c);
 	mx1 = mx-a;my1 = my;
@@ -1816,7 +1819,9 @@ void gdImageFilledEllipse (gdImagePtr im, int mx, int my, int w, int h, int c)
 
 	a=w>>1;
 	b=h>>1;
-
+	if (overflowMul3(a, b, b) || overflowMul3(b, a, a)) {
+		return;
+	}
 	for (x = mx-a; x <= mx+a; x++) {
 		gdImageSetPixel(im, x, my, c);
 	}

--- a/ext/gd/libgd/gd_security.c
+++ b/ext/gd/libgd/gd_security.c
@@ -14,6 +14,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <limits.h>
 #include "gd.h"
 #include "gd_errors.h"
@@ -26,6 +27,23 @@ int overflow2(int a, int b)
 	}
 	if(a > INT_MAX / b) {
 		gd_error("Product of memory allocation multiplication would exceed INT_MAX, failing operation gracefully\n");
+		return 1;
+	}
+	return 0;
+}
+
+int overflowMul3(int a, int b, int c)
+{
+	if (a < 0 || b < 0 || c < 0) {
+		return 1;
+	}
+	if (a == 0 || b == 0 || c == 0) {
+		return 0;
+	}
+	if (a > INT_MAX / b) {
+		return 1;
+	}
+	if ((int64_t)a * b > INT64_MAX / c) {
 		return 1;
 	}
 	return 0;

--- a/ext/gd/libgd/gdhelpers.h
+++ b/ext/gd/libgd/gdhelpers.h
@@ -27,6 +27,7 @@ extern char *gd_strtok_r(char *s, char *sep, char **state);
 	netpbm fixes by Alan Cox. */
 
 int overflow2(int a, int b);
+int overflowMul3(int a, int b, int c);
 
 #ifdef ZTS
 #define gdMutexDeclare(x) MUTEX_T x

--- a/ext/gd/tests/gh19739.phpt
+++ b/ext/gd/tests/gh19739.phpt
@@ -1,0 +1,19 @@
+--TEST--
+GH-19739 (integer overflow in imageellipse / imagefilledellipse)
+--EXTENSIONS--
+gd
+--FILE--
+<?php
+$im = imagecreatetruecolor(400, 300);
+$color = imagecolorallocate($im, 150, 255, 0);
+
+var_dump(imageellipse($im, 64, 150, 2147483647, 2147483647, $color));
+var_dump(imagefilledellipse($im, 64, 150, 2147483647, 2147483647, $color));
+
+imagedestroy($im);
+echo "done" . PHP_EOL;
+?>
+--EXPECT--
+bool(true)
+bool(true)
+done

--- a/ext/gd/tests/gh19739.phpt
+++ b/ext/gd/tests/gh19739.phpt
@@ -10,7 +10,6 @@ $color = imagecolorallocate($im, 150, 255, 0);
 var_dump(imageellipse($im, 64, 150, 2147483647, 2147483647, $color));
 var_dump(imagefilledellipse($im, 64, 150, 2147483647, 2147483647, $color));
 
-imagedestroy($im);
 echo "done" . PHP_EOL;
 ?>
 --EXPECT--


### PR DESCRIPTION
Port the upstream libgd portable fix (overflowMul3) for the int64 overflow at r = a * bq when w/h reach near INT_MAX. Mirrors the upstream libgd commit 0057de6.