### PR TITLE
ext/Intl: fix IntlListFormatter object error state after format() failures.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -381,6 +381,8 @@ PHP                                                                        NEWS
     when pos.size < 2). (Oblivionsage)
 
 - Intl:
+  . Fixed IntlListFormatter::getErrorCode() and getErrorMessage() not
+    reflecting format() failures. (Weilin Du)
   . Fix leak in umsg_format_helper(). (ndossche)
 
 - LDAP:

--- a/UPGRADING
+++ b/UPGRADING
@@ -846,6 +846,9 @@ PHP 8.5 UPGRADE NOTES
     indicates more accurately which call site caused what error.
     Moreover, some ext/date exceptions have been wrapped inside a
     IntlException now.
+  . IntlListFormatter::getErrorCode() and getErrorMessage() now reflect
+    IntlListFormatter::format() failures.
+    (Weilin Du)
 
 - Lexbor:
   . An always enabled lexbor extension is added. It contains the lexbor

--- a/UPGRADING
+++ b/UPGRADING
@@ -848,7 +848,6 @@ PHP 8.5 UPGRADE NOTES
     IntlException now.
   . IntlListFormatter::getErrorCode() and getErrorMessage() now reflect
     IntlListFormatter::format() failures.
-    (Weilin Du)
 
 - Lexbor:
   . An always enabled lexbor extension is added. It contains the lexbor

--- a/ext/intl/listformatter/listformatter_class.c
+++ b/ext/intl/listformatter/listformatter_class.c
@@ -124,6 +124,8 @@ PHP_METHOD(IntlListFormatter, format)
         Z_PARAM_ARRAY_HT(ht)
     ZEND_PARSE_PARAMETERS_END();
 
+    intl_errors_reset(LISTFORMATTER_ERROR_P(obj));
+
     uint32_t count = zend_hash_num_elements(ht);
     if (count == 0) {
         RETURN_EMPTY_STRING();
@@ -154,7 +156,7 @@ PHP_METHOD(IntlListFormatter, format)
             }
             efree(items);
             efree(itemLengths);
-            intl_error_set(NULL, status, "Failed to convert string to UTF-16");
+            intl_errors_set(LISTFORMATTER_ERROR_P(obj), status, "Failed to convert string to UTF-16");
             RETURN_FALSE;
         }
         
@@ -170,7 +172,7 @@ PHP_METHOD(IntlListFormatter, format)
     resultLength = ulistfmt_format(LISTFORMATTER_OBJECT(obj), items, itemLengths, count, NULL, 0, &status);
 
     if (U_FAILURE(status) && status != U_BUFFER_OVERFLOW_ERROR) {
-        intl_error_set(NULL, status, "Failed to format list");
+        intl_errors_set(LISTFORMATTER_ERROR_P(obj), status, "Failed to format list");
         RETVAL_FALSE;
         goto cleanup;
     }
@@ -184,7 +186,7 @@ PHP_METHOD(IntlListFormatter, format)
         if (result) {
             efree(result);
         }
-        intl_error_set(NULL, status, "Failed to format list");
+        intl_errors_set(LISTFORMATTER_ERROR_P(obj), status, "Failed to format list");
         RETVAL_FALSE;
         goto cleanup;
     }
@@ -194,7 +196,7 @@ PHP_METHOD(IntlListFormatter, format)
     efree(result);
     
     if (!ret) {
-        intl_error_set(NULL, status, "Failed to convert result to UTF-8");
+        intl_errors_set(LISTFORMATTER_ERROR_P(obj), status, "Failed to convert result to UTF-8");
         RETVAL_FALSE;
     } else {
         RETVAL_NEW_STR(ret);

--- a/ext/intl/tests/listformatter/listformatter_get_error.phpt
+++ b/ext/intl/tests/listformatter/listformatter_get_error.phpt
@@ -1,0 +1,25 @@
+--TEST--
+IntlListFormatter getErrorCode()/getErrorMessage() reflect format() failures
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+
+$formatter = new IntlListFormatter('en_US');
+
+var_dump($formatter->format(["\x80"]));
+var_dump($formatter->getErrorCode() === U_INVALID_CHAR_FOUND);
+var_dump($formatter->getErrorMessage());
+
+var_dump($formatter->format(['a', 'b']));
+var_dump($formatter->getErrorCode() === U_ZERO_ERROR);
+var_dump($formatter->getErrorMessage());
+
+?>
+--EXPECT--
+bool(false)
+bool(true)
+string(85) "IntlListFormatter::format(): Failed to convert string to UTF-16: U_INVALID_CHAR_FOUND"
+string(7) "a and b"
+bool(true)
+string(12) "U_ZERO_ERROR"


### PR DESCRIPTION
This fixes:
```php
<?php

$formatter = new IntlListFormatter('en_US');

var_dump($formatter->format(["\x80"]));         // bool(false)
var_dump($formatter->getErrorCode());           // int(0)
var_dump($formatter->getErrorMessage());        // string(12) "U_ZERO_ERROR"

var_dump(intl_get_error_code());                // int(10)
var_dump(intl_get_error_message());             // string(...) "IntlListFormatter::format(): Failed to convert string to UTF-16: U_INVALID_CHAR_FOUND"
```
Which is because IntlListFormatter doesn't pass error status to object but only to global status. Not yet found similar bugs.

Targeting 8.5 as  IntlListFormatter is a new feature in 8.5.

To reproduce, see [sandbox](https://onlinephp.io?s=hZDda8IwEMDfBf-HowxMHqx2D2PUfSDasoKzEJc97IOQ2dgV0qQkmdufv3Yqs5axezqO-9397q5uq_eq3-v3zjbalNw5YeAalPiERDm5KKyLD3U0EIrR1QBPmv4tNyz7KCv0Cw5vdil69l6-LsfeK8YTOMRoBG9aS7Th0gr8B58LFxmjzUxnAh3TP3yhHBr_h94La3neomvUOlOoHAXnGDzKniKSsoiQlHitU-oFktWDmGgmsXXX4lglaLmcsGVX48TF9_1apvPlMNw_EYcQ80KKDJyGtVZbYdyebSr0IR4GFyFQliwfp4tkzmZ3U8LilC7n3jc%2C&v=8.5.6%2C8.4.21)