### PR TITLE
[ext/standard] Specialize min()/max() for long arrays

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -1095,6 +1095,69 @@ static int php_data_compare(const void *f, const void *s) /* {{{ */
 }
 /* }}} */
 
+static zend_always_inline bool php_array_minmax_long(HashTable *array, zval *return_value, bool max) /* {{{ */
+{
+	zval *entry, *result = NULL;
+	zend_long result_lval;
+	bool long_mode = true;
+
+	ZEND_HASH_FOREACH_VAL(array, entry) {
+		zval *value = entry;
+		zend_long value_lval;
+
+		ZVAL_DEREF(value);
+		if (!result) {
+			if (Z_TYPE_P(value) != IS_LONG) {
+				return false;
+			}
+
+			result = value;
+			result_lval = Z_LVAL_P(value);
+			continue;
+		}
+
+		if (long_mode && EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+			value_lval = Z_LVAL_P(value);
+			if (max) {
+				if (result_lval < value_lval) {
+					result = value;
+					result_lval = value_lval;
+				}
+			} else {
+				if (result_lval > value_lval) {
+					result = value;
+					result_lval = value_lval;
+				}
+			}
+			continue;
+		}
+
+		long_mode = false;
+
+		if (max) {
+			if (php_data_compare(result, value) < 0) {
+				result = value;
+			}
+		} else {
+			if (php_data_compare(result, value) > 0) {
+				result = value;
+			}
+		}
+	} ZEND_HASH_FOREACH_END();
+
+	if (!result) {
+		return false;
+	}
+
+	if (long_mode) {
+		ZVAL_LONG(return_value, result_lval);
+	} else {
+		ZVAL_COPY_DEREF(return_value, result);
+	}
+	return true;
+}
+/* }}} */
+
 /* {{{
  * proto mixed min(array values)
  * proto mixed min(mixed arg1 [, mixed arg2 [, mixed ...]])
@@ -1114,7 +1177,12 @@ PHP_FUNCTION(min)
 			zend_argument_type_error(1, "must be of type array, %s given", zend_zval_value_name(&args[0]));
 			RETURN_THROWS();
 		} else {
-			zval *result = zend_hash_minmax(Z_ARRVAL(args[0]), php_data_compare, 0);
+			HashTable *array = Z_ARRVAL(args[0]);
+			if (php_array_minmax_long(array, return_value, false)) {
+				return;
+			}
+
+			zval *result = zend_hash_minmax(array, php_data_compare, 0);
 			if (result) {
 				RETURN_COPY_DEREF(result);
 			} else {
@@ -1242,7 +1310,12 @@ PHP_FUNCTION(max)
 			zend_argument_type_error(1, "must be of type array, %s given", zend_zval_value_name(&args[0]));
 			RETURN_THROWS();
 		} else {
-			zval *result = zend_hash_minmax(Z_ARRVAL(args[0]), php_data_compare, 1);
+			HashTable *array = Z_ARRVAL(args[0]);
+			if (php_array_minmax_long(array, return_value, true)) {
+				return;
+			}
+
+			zval *result = zend_hash_minmax(array, php_data_compare, 1);
 			if (result) {
 				RETURN_COPY_DEREF(result);
 			} else {

--- a/ext/standard/tests/array/min_max_array_long_fast_path.phpt
+++ b/ext/standard/tests/array/min_max_array_long_fast_path.phpt
@@ -1,0 +1,44 @@
+--TEST--
+min() and max() array long fast path preserves comparison behavior
+--FILE--
+<?php
+
+$cases = [];
+
+$cases["packed"] = [4, 1, 7, -3, 2];
+
+$sparse = [4, 1, 7];
+unset($sparse[1]);
+$sparse[5] = -2;
+$cases["sparse"] = $sparse;
+
+$a = 4;
+$b = 9;
+$cases["refs"] = [&$a, &$b, 3];
+
+$cases["first non-long"] = ["5", 3, 4];
+$cases["fallback after longs"] = [5, 4, "3", 2];
+
+foreach ($cases as $name => $values) {
+    echo "-- $name --\n";
+    var_dump(min($values));
+    var_dump(max($values));
+}
+
+?>
+--EXPECT--
+-- packed --
+int(-3)
+int(7)
+-- sparse --
+int(-2)
+int(7)
+-- refs --
+int(3)
+int(9)
+-- first non-long --
+int(3)
+string(1) "5"
+-- fallback after longs --
+int(2)
+int(5)


### PR DESCRIPTION
## Summary

This specializes the array-form `min()` / `max()` path for arrays whose first value is `IS_LONG`.

The fast path compares `IS_LONG` values directly. If the array is empty or the first value is not `IS_LONG`, execution falls back to the existing `zend_hash_minmax()` path. If a non-`IS_LONG` value is encountered after a long prefix, comparison switches back to the existing `php_data_compare()` semantics for the rest of the scan.

For arrays that remain all-long, the result is returned directly with `ZVAL_LONG()`, avoiding generic comparison dispatch and zval copy/deref overhead on the hot path.

Float fast paths were intentionally not added: local benchmarks showed no meaningful win, and adding extra type dispatch would increase complexity for little benefit.

## Benchmark

Local CLI build:

- `Debug Build => no`
- `--disable-all --enable-cli`
- opcache/JIT disabled
- separate baseline and patched CLI binaries
- `n=10000`
- each case processes roughly 20M elements total
- 6 alternating baseline/current batches
- each batch reports median of 7 runs
- table shows the median across batches

| Case | Baseline | Patched | Result |
|:--|--:|--:|--:|
| `min()` packed long desc | 73.673 ms | 25.309 ms | 3.02x faster |
| `max()` packed long asc | 73.826 ms | 25.165 ms | 2.94x faster |
| `min()` hash long | 74.676 ms | 25.659 ms | 3.02x faster |
| `min()` mixed long-prefix | 74.130 ms | 24.826 ms | 2.94x faster |
| `min()` mixed non-long first | 74.254 ms | 75.981 ms | +2.3% overhead |
| `min()` floats | 108.886 ms | 109.369 ms | +0.4% overhead |
| `min()` strings | 470.430 ms | 452.911 ms | within noise |

Across the repeated batches, long-array and long-prefix mixed cases were roughly 3x faster. First-non-long, float, and string fallback cases stayed within noise to small overhead.

## Testing

- `./sapi/cli/php run-tests.php -q ext/standard/tests/array/min_max_array_long_fast_path.phpt ext/standard/tests/array/min.phpt ext/standard/tests/array/max.phpt ext/standard/tests/array/min_basic.phpt ext/standard/tests/array/max_basic.phpt ext/standard/tests/array/min_basiclong_64bit.phpt ext/standard/tests/array/max_basiclong_64bit.phpt ext/standard/tests/array/min_int_float_optimisation.phpt ext/standard/tests/array/max_int_float_optimisation.phpt`
- `./sapi/cli/php run-tests.php -q ext/standard/tests/array`

Full array test result:

- 858 tests
- 846 passed
- 12 skipped
- 0 failed
- 0 warned

Differential behavior hash against baseline:

`2d53aa26b0e8da297a97d311a9cb71c86f195b53b25295541ccc06f4996b9303`
