### PR TITLE
Fix GH-22121: double-free in gdImageSetStyle() after overflow early return

### DIFF
--- a/ext/gd/libgd/gd.c
+++ b/ext/gd/libgd/gd.c
@@ -2854,11 +2854,11 @@ int gdCompareInt (const void *a, const void *b)
 
 void gdImageSetStyle (gdImagePtr im, int *style, int noOfPixels)
 {
-	if (im->style) {
-		gdFree(im->style);
-	}
 	if (overflow2(sizeof (int), noOfPixels)) {
 		return;
+	}
+	if (im->style) {
+		gdFree(im->style);
 	}
 	im->style = (int *) gdMalloc(sizeof(int) * noOfPixels);
 	memcpy(im->style, style, sizeof(int) * noOfPixels);


### PR DESCRIPTION
`gdImageSetStyle` (ext/gd/libgd/gd.c:2880) frees `im->style` before calling `overflow2()`. When the overflow check trips and the function returns, `im->style` is left dangling and the next `gdImageSetStyle`, `gdImageDestroy`, or `gdImageSetPixel` `gdStyled`/`gdStyledBrushed` dispatch frees or dereferences it.

Move the overflow check above the free to match upstream libgd (`libgd/libgd` src/gd.c::gdImageSetStyle), which has always had the check first. The divergence was an oversight in 77ba2483d9 when the overflow check was ported from libgd 2.0.29.

Fixes #22121
