### PR TITLE
Fix GH-22122: UAF in SQLite3/Pdo\Sqlite authorizer when callback releases it

### DIFF
--- a/ext/pdo_sqlite/sqlite_driver.c
+++ b/ext/pdo_sqlite/sqlite_driver.c
@@ -859,7 +859,19 @@ static int authorizer(void *autharg, int access_type, const char *arg1, const ch
 
 	int authreturn = SQLITE_DENY;
 
+	zend_object *saved_obj = db_obj->authorizer_fcc.object;
+	zend_object *saved_closure = db_obj->authorizer_fcc.closure;
+	zend_fcc_addref(&db_obj->authorizer_fcc);
+
 	zend_call_known_fcc(&db_obj->authorizer_fcc, &retval, /* argc */ 5, argv, /* named_params */ NULL);
+
+	if (saved_obj) {
+		OBJ_RELEASE(saved_obj);
+	}
+	if (saved_closure) {
+		OBJ_RELEASE(saved_closure);
+	}
+
 	if (Z_ISUNDEF(retval)) {
 		ZEND_ASSERT(EG(exception));
 	} else {

--- a/ext/pdo_sqlite/tests/gh22122.phpt
+++ b/ext/pdo_sqlite/tests/gh22122.phpt
@@ -1,0 +1,40 @@
+--TEST--
+GH-22122 (Use-after-free in Pdo\Sqlite authorizer when callback releases the authorizer)
+--EXTENSIONS--
+pdo_sqlite
+--FILE--
+<?php
+$db = Pdo\Sqlite::connect('sqlite::memory:');
+
+class Auth {
+    public string $state = "alive";
+
+    public function authorize(int $action, ...$args): int {
+        global $db;
+        $db->setAuthorizer(null);
+        echo "method: ", $this->state, "\n";
+        return Pdo\Sqlite::OK;
+    }
+}
+$auth = new Auth();
+$db->setAuthorizer([$auth, 'authorize']);
+unset($auth);
+$db->exec('SELECT 1');
+
+$capture = "closure-alive";
+$closure = function (int $action, ...$args) use (&$capture, $db): int {
+    $db->setAuthorizer(null);
+    echo "closure: ", $capture, "\n";
+    return Pdo\Sqlite::OK;
+};
+$db->setAuthorizer($closure);
+unset($closure);
+$db->exec('SELECT 2');
+
+$db->exec('SELECT 3');
+echo "post-disable query ok\n";
+?>
+--EXPECT--
+method: alive
+closure: closure-alive
+post-disable query ok

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -2197,9 +2197,21 @@ static int php_sqlite3_authorizer(void *autharg, int action, const char *arg1, c
 
 	int authreturn = SQLITE_DENY;
 
+	zend_object *saved_obj = db_obj->authorizer_fcc.object;
+	zend_object *saved_closure = db_obj->authorizer_fcc.closure;
+	zend_fcc_addref(&db_obj->authorizer_fcc);
+
 	zend_call_known_fcc(&db_obj->authorizer_fcc, &retval, /* argc */ 5, argv, /* named_params */ NULL);
+
+	if (saved_obj) {
+		OBJ_RELEASE(saved_obj);
+	}
+	if (saved_closure) {
+		OBJ_RELEASE(saved_closure);
+	}
+
 	if (Z_ISUNDEF(retval)) {
-		php_sqlite3_error(db_obj, 0, "An error occurred while invoking the authorizer callback");
+		ZEND_ASSERT(EG(exception));
 	} else {
 		if (Z_TYPE(retval) != IS_LONG) {
 			php_sqlite3_error(db_obj, 0, "The authorizer callback returned an invalid type: expected int");

--- a/ext/sqlite3/tests/gh22122.phpt
+++ b/ext/sqlite3/tests/gh22122.phpt
@@ -1,0 +1,54 @@
+--TEST--
+GH-22122 (Use-after-free in SQLite3 authorizer when callback releases the authorizer)
+--EXTENSIONS--
+sqlite3
+--FILE--
+<?php
+$db = new SQLite3(':memory:');
+
+/* Method receiver - the reported UAF shape. */
+class Auth {
+    public string $state = "alive";
+
+    public function authorize(int $action, ...$args): int {
+        global $db;
+        $db->setAuthorizer(null);
+        echo "method: ", $this->state, "\n";
+        return SQLite3::OK;
+    }
+}
+$auth = new Auth();
+$db->setAuthorizer([$auth, 'authorize']);
+unset($auth);
+$db->exec('SELECT 1');
+
+/* Closure receiver - exercises the saved_closure release path. */
+$capture = "closure-alive";
+$closure = function (int $action, ...$args) use (&$capture, $db): int {
+    $db->setAuthorizer(null);
+    echo "closure: ", $capture, "\n";
+    return SQLite3::OK;
+};
+$db->setAuthorizer($closure);
+unset($closure);
+$db->exec('SELECT 2');
+
+/* Confirm the authorizer was actually disabled by the callback (setAuthorizer null). */
+$db->exec('SELECT 3');
+echo "post-disable query ok\n";
+
+/* Throwing callback should propagate the user's exception without redundant warnings. */
+$db->setAuthorizer(function () { throw new RuntimeException("from authorizer"); });
+try {
+    @$db->exec('SELECT 4');
+} catch (RuntimeException $e) {
+    echo "throw: ", $e->getMessage(), "\n";
+}
+echo "done\n";
+?>
+--EXPECT--
+method: alive
+closure: closure-alive
+post-disable query ok
+throw: from authorizer
+done


### PR DESCRIPTION
`zend_call_known_fcc` does not addref `fcc->object`/`fcc->closure`. When the authorizer callback invokes `$db->setAuthorizer(null)`, `zend_fcc_dtor` releases the bound `$this` and the object is freed mid-call; the method body then dereferences freed memory. Snapshot `object` and `closure` before the call, addref via `zend_fcc_addref`, release the snapshots after. Saved pointers are required because the callback can replace `db_obj->authorizer_fcc`.

Same fix applied to `Pdo\Sqlite`, which has the identical reachable bug via its own `setAuthorizer(null)`. SQLite3's `Z_ISUNDEF(retval)` branch now matches `Pdo\Sqlite`'s `ZEND_ASSERT(EG(exception))` shape, so a throwing callback no longer triggers the misleading "An error occurred while invoking the authorizer callback" warning.

`zend_fcc_dup` is not safe here: shallow-copy of `function_handler` would leave a trampoline owned by two FCCs, and dtor of the second would double-free.

Fixes #22122
