### PR TITLE
ext/Intl: Return PHP_INT_MIN as int from MessageFormatter::parse() on 64-bit

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -69,6 +69,8 @@ PHP                                                                        NEWS
     argument handling now raises TypeError instead of Error. (Weilin Du)
   . IntlBreakIterator::getLocale() now raises ValueError for invalid locale
     types. (Weilin Du)
+  . Fixed MessageFormatter::parse() and parseMessage() returning PHP_INT_MIN
+    as float rather than int on 64-bit platforms. (Weilin Du)
 
 - JSON:
   . Enriched JSON last error / exception message with error location.

--- a/UPGRADING
+++ b/UPGRADING
@@ -40,6 +40,8 @@ PHP 8.6 UPGRADE NOTES
   . IntlBreakIterator::getLocale() now raises a ValueError when the type is
     neither Locale::ACTUAL_LOCALE nor Locale::VALID_LOCALE instead of
     returning false.
+  . MessageFormatter::parse() and parseMessage() now return PHP_INT_MIN as
+    int, rather than float, on 64-bit platforms when parsing integer values.
 
 - PCNTL:
   . pcntl_alarm() now raises a ValueError if the seconds argument is

--- a/ext/intl/msgformat/msgformat_helpers.cpp
+++ b/ext/intl/msgformat/msgformat_helpers.cpp
@@ -649,7 +649,7 @@ U_CFUNC void umsg_parse_helper(UMessageFormat *fmt, int *count, zval **args, UCh
 
         case Formattable::kInt64:
             aInt64 = fargs[i].getInt64();
-			if(aInt64 > ZEND_LONG_MAX || aInt64 < -ZEND_LONG_MAX) {
+			if(aInt64 > ZEND_LONG_MAX || aInt64 < ZEND_LONG_MIN) {
 				ZVAL_DOUBLE(&(*args)[i], (double)aInt64);
 			} else {
 				ZVAL_LONG(&(*args)[i], (zend_long)aInt64);

--- a/ext/intl/tests/msgfmt_parse_int64_min_64.phpt
+++ b/ext/intl/tests/msgfmt_parse_int64_min_64.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Bug: MessageFormatter::parse() should preserve PHP_INT_MIN as int on 64-bit
+--EXTENSIONS--
+intl
+--SKIPIF--
+<?php if (PHP_INT_SIZE != 8) die("skip 64-bit only"); ?>
+--FILE--
+<?php
+
+$fmt = new MessageFormatter('en_US', '{0,number,integer}');
+$parsed = $fmt->parse('-9,223,372,036,854,775,808');
+var_dump($parsed);
+
+$parsed = MessageFormatter::parseMessage('en_US', '{0,number,integer}', '-9,223,372,036,854,775,808');
+var_dump($parsed);
+
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  int(-9223372036854775808)
+}
+array(1) {
+  [0]=>
+  int(-9223372036854775808)
+}

--- a/ext/intl/tests/msgfmt_parse_int64_min_64.phpt
+++ b/ext/intl/tests/msgfmt_parse_int64_min_64.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug: MessageFormatter::parse() should preserve PHP_INT_MIN as int on 64-bit
+MessageFormatter::parse() with PHP_INT_MIN on 64-bit platform
 --EXTENSIONS--
 intl
 --SKIPIF--


### PR DESCRIPTION
Cleaning up. `-ZEND_LONG_MAX` does not equals to `ZEND_LONG_MIN`, because signed integer ranges are not symmetric
in 64-bit
```
-ZEND_LONG_MAX = -9223372036854775807
ZEND_LONG_MIN = -9223372036854775808
```
This makes -9,223,372,036,854,775,808 in MessageFormatter be degraded into float, but it could be an integer.

```php
<?php

$fmt = new MessageFormatter('en_US', '{0,number,integer}');
$parsed = $fmt->parse('-9,223,372,036,854,775,808');
var_dump($parsed);

$parsed = MessageFormatter::parseMessage('en_US', '{0,number,integer}', '-9,223,372,036,854,775,808');
var_dump($parsed);

?>
```
result in
```php
array(1) {
  [0]=>
  float(-9.223372036854776E+18)
}
array(1) {
  [0]=>
  float(-9.223372036854776E+18)
}
```
But it should be 
```php
array(1) {
  [0]=>
  int(-9223372036854775808)
}
array(1) {
  [0]=>
  int(-9223372036854775808)
}
```
[Reproduce](https://onlinephp.io?s=s7EvyCjg5eLlUknLLVGwVchLLVfwTS0uTkxPdcsvyk0sKUkt0lBPzYsPDVbXUVCvNtDJK81NSi3SycwrSU1PLapV17QGai5ILCpOTQHqBxmjawfmaqjrWuoYGRnrGJsb6RgYm-lYmJromJub6lgYWIB1lSUWxaeU5hZoQLWDxJDNQneHlRVYCiqM31VAUbJst7cDAA%2C%2C&v=8.5.6%2C8.4.21)

This is really a super super edge case. I don't even sure we should treat this as a bug fix or a refactor at this point. It really do come into my mind when I am looking at this code that I don't even think we need any NEWS or UPGRADING entry for this little fix. No similar bugs in the code base.