### PR TITLE
Fix GH-22115: Tracing JIT drops loop-PHI CV register from SNAPSHOT

### DIFF
--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -3215,10 +3215,16 @@ static zend_jit_reg_var* zend_jit_trace_allocate_registers(zend_jit_trace_rec *t
 		zend_ssa_phi *phi = ssa->blocks[1].phis;
 
 		while (phi) {
-			i = phi->sources[1];
-			if (RA_HAS_IVAL(i) && !ssa->vars[phi->ssa_var].no_val) {
-				RA_IVAL_END(i, idx);
-				RA_IVAL_FLAGS(i) &= ~ZREG_LAST_USE;
+			if (RA_HAS_IVAL(phi->sources[1]) && !ssa->vars[phi->ssa_var].no_val) {
+				int cv = ssa->vars[phi->ssa_var].var;
+				int k;
+
+				/* All SSA versions of a loop-carried CV share the same register */
+				for (k = 0; k < ssa->vars_count; k++) {
+					if (ssa->vars[k].var == cv && RA_HAS_IVAL(k)) {
+						RA_IVAL_FLAGS(k) &= ~ZREG_LAST_USE;
+					}
+				}
 			}
 			phi = phi->next;
 		}

--- a/ext/opcache/tests/jit/gh22115.phpt
+++ b/ext/opcache/tests/jit/gh22115.phpt
@@ -1,0 +1,35 @@
+--TEST--
+GH-22115: Tracing JIT drops loop-PHI CV register from SNAPSHOT after intermediate op1_def
+--EXTENSIONS--
+opcache
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.file_update_protection=0
+opcache.jit_buffer_size=32M
+opcache.jit=tracing
+--FILE--
+<?php
+function f(array $meta, int $n): int {
+    $s = 0;
+    $i = 0;
+    $sink = 0;
+    while ($i < $n) {
+        $copy = $s;
+        $sink += $copy;
+        $m = (int) $meta[$s];
+        if (($m & 0xFF) === 1) {
+            $i++;
+            $s = ($m >> 16) & 0xFFFF;
+            continue;
+        }
+        return $s;
+    }
+    return $s;
+}
+$meta = [0 => 1 | (1 << 16), 1 => 2 | (2 << 16)];
+for ($w = 0; $w < 2000; $w++) f($meta, 3);
+var_dump(f($meta, 3));
+?>
+--EXPECT--
+int(1)


### PR DESCRIPTION
Fixes GH-22115.

Extends the existing loop-PHI pre-pass to clear ZREG_LAST_USE on every SSA version of any loop-carried CV, not just phi->sources[1]. Intermediate versions from opcodes with op1_def under RC inference (SEND_VAR, QM_ASSIGN, CAST, etc.) were keeping the flag and tripping cleanup_stack mid-loop.

Hmm why so many no-op macros lurking here? Looks like leftovers from the new 8.4 IR stuff that was added. Not touching that.

Is a quick fix, NOT AN EXPERT. Needs expertise