### PR TITLE
Fix compilation errors up until Clang 21.0

### DIFF
--- a/Zend/zend_cpuinfo.h
+++ b/Zend/zend_cpuinfo.h
@@ -272,7 +272,10 @@ static zend_always_inline int zend_cpu_supports_avx512_vbmi(void) {
 #endif
 
 /* __builtin_cpu_supports has pclmul from gcc9 and clang 19 */
-#if defined(PHP_HAVE_BUILTIN_CPU_SUPPORTS) && (!defined(__GNUC__) || (defined(__clang__) && __clang_major__ >= 19) || (ZEND_GCC_VERSION >= 9000))
+#if defined(PHP_HAVE_BUILTIN_CPU_SUPPORTS) && defined(__x86_64__) && \
+	( \
+		(!defined(__GNUC__) || (defined(__clang__) && __clang_major__ >= 19) || (ZEND_GCC_VERSION >= 9000)) \
+	)
 ZEND_NO_SANITIZE_ADDRESS
 static inline int zend_cpu_supports_pclmul(void) {
 #ifdef PHP_HAVE_BUILTIN_CPU_INIT
@@ -287,7 +290,11 @@ static inline int zend_cpu_supports_pclmul(void) {
 #endif
 
 /* __builtin_cpu_supports has cldemote from gcc11 and clang 19 */
-#if defined(PHP_HAVE_BUILTIN_CPU_SUPPORTS) && ((defined(__clang__) && (__clang_major__ >= 19)) || (!defined(__clang__) && defined(__GNUC__) && (ZEND_GCC_VERSION >= 11000)))
+#if defined(PHP_HAVE_BUILTIN_CPU_SUPPORTS) && defined(__x86_64__) && \
+	( \
+		(defined(__clang__) && (__clang_major__ >= 19)) || \
+		(!defined(__clang__) && defined(__GNUC__) && (ZEND_GCC_VERSION >= 11000)) \
+	)
 #define HAVE_ZEND_CPU_SUPPORTS_CLDEMOTE 1
 ZEND_NO_SANITIZE_ADDRESS
 static inline int zend_cpu_supports_cldemote(void) {

--- a/Zend/zend_cpuinfo.h
+++ b/Zend/zend_cpuinfo.h
@@ -272,7 +272,7 @@ static zend_always_inline int zend_cpu_supports_avx512_vbmi(void) {
 #endif
 
 /* __builtin_cpu_supports has pclmul from gcc9 and clang 19 */
-#if defined(PHP_HAVE_BUILTIN_CPU_SUPPORTS) && defined(__x86_64__) && \
+#if defined(PHP_HAVE_BUILTIN_CPU_SUPPORTS) && (defined(__x86_64__) || defined(__i386__)) && \
 	( \
 		(!defined(__GNUC__) || (defined(__clang__) && __clang_major__ >= 19) || (ZEND_GCC_VERSION >= 9000)) \
 	)
@@ -290,7 +290,7 @@ static inline int zend_cpu_supports_pclmul(void) {
 #endif
 
 /* __builtin_cpu_supports has cldemote from gcc11 and clang 19 */
-#if defined(PHP_HAVE_BUILTIN_CPU_SUPPORTS) && defined(__x86_64__) && \
+#if defined(PHP_HAVE_BUILTIN_CPU_SUPPORTS) && (defined(__x86_64__) || defined(__i386__)) && \
 	( \
 		(defined(__clang__) && (__clang_major__ >= 19)) || \
 		(!defined(__clang__) && defined(__GNUC__) && (ZEND_GCC_VERSION >= 11000)) \

--- a/ext/lexbor/config.m4
+++ b/ext/lexbor/config.m4
@@ -1,4 +1,4 @@
-PHP_LEXBOR_CFLAGS="-I@ext_srcdir@/"
+PHP_LEXBOR_CFLAGS="-Wno-unterminated-string-initialization -I@ext_srcdir@/"
 LEXBOR_DIR="lexbor"
 
 AC_DEFINE([HAVE_LEXBOR], [1], [Define to 1 if the PHP extension 'lexbor' is available.])

--- a/ext/lexbor/config.m4
+++ b/ext/lexbor/config.m4
@@ -1,4 +1,4 @@
-PHP_LEXBOR_CFLAGS="-Wno-unterminated-string-initialization -I@ext_srcdir@/"
+PHP_LEXBOR_CFLAGS="-Wno-unknown-warning-option -Wno-unterminated-string-initialization -I@ext_srcdir@/"
 LEXBOR_DIR="lexbor"
 
 AC_DEFINE([HAVE_LEXBOR], [1], [Define to 1 if the PHP extension 'lexbor' is available.])


### PR DESCRIPTION
- The "pclmul" and "cldemote" CPU features are both only available on x86, and the __builtin_cpu_supports() checks in question fail on Clang, so they shouldn't even be tried to be run (similar fixes before: https://github.com/php/php-src/pull/18629).
- The res.h file in Lexbor contains some unterminated strings (e.g. https://github.com/php/php-src/blob/d58d3d2fd6c1cfa7e3489a9859eda63086af762f/ext/lexbor/lexbor/html/tokenizer/res.h#L203), and a new compiler warning fails by default because of them. This needs to be suppressed.