### PR TITLE
Fix GH-22118: Compare equivalent fake closures in FCCs

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -4096,6 +4096,52 @@ try_again:
 }
 /* }}} */
 
+static bool zend_fcc_function_handler_equals(const zend_function *func1, const zend_function *func2) /* {{{ */
+{
+	if (func1 == func2) {
+		return true;
+	}
+
+	const bool fake_closure1 = (func1->common.fn_flags & ZEND_ACC_FAKE_CLOSURE) != 0;
+	const bool fake_closure2 = (func2->common.fn_flags & ZEND_ACC_FAKE_CLOSURE) != 0;
+
+	if (!fake_closure1 && !fake_closure2) {
+		return false;
+	}
+	if (((func1->common.fn_flags & ZEND_ACC_CLOSURE) && !fake_closure1) ||
+			((func2->common.fn_flags & ZEND_ACC_CLOSURE) && !fake_closure2)) {
+		return false;
+	}
+	if (func1->type != func2->type ||
+			func1->common.scope != func2->common.scope ||
+			!zend_string_equals(func1->common.function_name, func2->common.function_name)) {
+		return false;
+	}
+
+	if (func1->type == ZEND_USER_FUNCTION) {
+		return func1->op_array.opcodes == func2->op_array.opcodes;
+	}
+
+	return func1->internal_function.handler == func2->internal_function.handler;
+}
+/* }}} */
+
+ZEND_API bool zend_fcc_closure_equals_ex(const zend_fcall_info_cache* a, const zend_fcall_info_cache* b) /* {{{ */
+{
+	const zend_function *func1 = a->function_handler;
+	const zend_function *func2 = b->function_handler;
+
+	if (a->closure && a->closure->ce == zend_ce_closure) {
+		func1 = zend_get_closure_method_def(a->closure);
+	}
+	if (b->closure && b->closure->ce == zend_ce_closure) {
+		func2 = zend_get_closure_method_def(b->closure);
+	}
+
+	return zend_fcc_function_handler_equals(func1, func2);
+}
+/* }}} */
+
 ZEND_API zend_string *zend_get_callable_name(const zval *callable) /* {{{ */
 {
 	return zend_get_callable_name_ex(callable, NULL);

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -758,43 +758,7 @@ ZEND_API void zend_fcall_info_argn(zend_fcall_info *fci, uint32_t argc, ...);
 ZEND_API zend_result zend_fcall_info_call(zend_fcall_info *fci, zend_fcall_info_cache *fcc, zval *retval, zval *args);
 
 /* Zend FCC API to store and handle PHP userland functions */
-extern ZEND_API zend_class_entry *zend_ce_closure;
-ZEND_API const zend_function *zend_get_closure_method_def(zend_object *obj);
-
-static zend_always_inline bool zend_fcc_closure_objects_equals(zend_object *closure1, zend_object *closure2)
-{
-	if (closure1 == closure2) {
-		return true;
-	}
-	if (!closure1 || !closure2) {
-		return false;
-	}
-	if (closure1->ce != zend_ce_closure || closure2->ce != zend_ce_closure) {
-		return false;
-	}
-
-	const zend_function *func1 = zend_get_closure_method_def(closure1);
-	const zend_function *func2 = zend_get_closure_method_def(closure2);
-
-	if (!(func1->common.fn_flags & ZEND_ACC_FAKE_CLOSURE) ||
-			!(func2->common.fn_flags & ZEND_ACC_FAKE_CLOSURE)) {
-		return false;
-	}
-	if (func1 == func2) {
-		return true;
-	}
-	if (func1->type != func2->type ||
-			func1->common.scope != func2->common.scope ||
-			!zend_string_equals(func1->common.function_name, func2->common.function_name)) {
-		return false;
-	}
-
-	if (func1->type == ZEND_USER_FUNCTION) {
-		return func1->op_array.opcodes == func2->op_array.opcodes;
-	}
-
-	return func1->internal_function.handler == func2->internal_function.handler;
-}
+ZEND_API bool zend_fcc_closure_equals_ex(const zend_fcall_info_cache* a, const zend_fcall_info_cache* b);
 
 static zend_always_inline bool zend_fcc_equals(const zend_fcall_info_cache* a, const zend_fcall_info_cache* b)
 {
@@ -802,7 +766,7 @@ static zend_always_inline bool zend_fcc_equals(const zend_fcall_info_cache* a, c
 		return a->object == b->object
 			&& a->calling_scope == b->calling_scope
 			&& a->called_scope == b->called_scope
-			&& zend_fcc_closure_objects_equals(a->closure, b->closure)
+			&& (a->closure == b->closure || zend_fcc_closure_equals_ex(a, b))
 		;
 	}
 	if (UNEXPECTED((a->function_handler->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE) &&

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -758,20 +758,63 @@ ZEND_API void zend_fcall_info_argn(zend_fcall_info *fci, uint32_t argc, ...);
 ZEND_API zend_result zend_fcall_info_call(zend_fcall_info *fci, zend_fcall_info_cache *fcc, zval *retval, zval *args);
 
 /* Zend FCC API to store and handle PHP userland functions */
+extern ZEND_API zend_class_entry *zend_ce_closure;
+ZEND_API const zend_function *zend_get_closure_method_def(zend_object *obj);
+
+static zend_always_inline bool zend_fcc_closure_objects_equals(zend_object *closure1, zend_object *closure2)
+{
+	if (closure1 == closure2) {
+		return true;
+	}
+	if (!closure1 || !closure2) {
+		return false;
+	}
+	if (closure1->ce != zend_ce_closure || closure2->ce != zend_ce_closure) {
+		return false;
+	}
+
+	const zend_function *func1 = zend_get_closure_method_def(closure1);
+	const zend_function *func2 = zend_get_closure_method_def(closure2);
+
+	if (!(func1->common.fn_flags & ZEND_ACC_FAKE_CLOSURE) ||
+			!(func2->common.fn_flags & ZEND_ACC_FAKE_CLOSURE)) {
+		return false;
+	}
+	if (func1 == func2) {
+		return true;
+	}
+	if (func1->type != func2->type ||
+			func1->common.scope != func2->common.scope ||
+			!zend_string_equals(func1->common.function_name, func2->common.function_name)) {
+		return false;
+	}
+
+	if (func1->type == ZEND_USER_FUNCTION) {
+		return func1->op_array.opcodes == func2->op_array.opcodes;
+	}
+
+	return func1->internal_function.handler == func2->internal_function.handler;
+}
+
 static zend_always_inline bool zend_fcc_equals(const zend_fcall_info_cache* a, const zend_fcall_info_cache* b)
 {
+	if (a->closure || b->closure) {
+		return a->object == b->object
+			&& a->calling_scope == b->calling_scope
+			&& a->called_scope == b->called_scope
+			&& zend_fcc_closure_objects_equals(a->closure, b->closure)
+		;
+	}
 	if (UNEXPECTED((a->function_handler->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE) &&
 		(b->function_handler->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE))) {
 		return a->object == b->object
 			&& a->calling_scope == b->calling_scope
-			&& a->closure == b->closure
 			&& zend_string_equals(a->function_handler->common.function_name, b->function_handler->common.function_name)
 		;
 	}
 	return a->function_handler == b->function_handler
 		&& a->object == b->object
 		&& a->calling_scope == b->calling_scope
-		&& a->closure == b->closure
 	;
 }
 

--- a/ext/spl/tests/autoloading/gh22118.phpt
+++ b/ext/spl/tests/autoloading/gh22118.phpt
@@ -1,0 +1,33 @@
+--TEST--
+GH-22118: spl_autoload_unregister() unregisters equivalent first-class method callables
+--FILE--
+<?php
+class AutoloadTest
+{
+	public function load(string $class): void
+	{
+		echo "autoload $class\n";
+	}
+
+	public function __call(string $name, array $arguments): void
+	{
+		echo "autoload {$arguments[0]}\n";
+	}
+
+	public function run(): void
+	{
+		spl_autoload_register($this->load(...));
+		var_dump(spl_autoload_unregister($this->load(...)));
+		spl_autoload_call('MissingDirect');
+
+		spl_autoload_register($this->missing(...));
+		var_dump(spl_autoload_unregister($this->missing(...)));
+		spl_autoload_call('MissingTrampoline');
+	}
+}
+
+(new AutoloadTest())->run();
+?>
+--EXPECT--
+bool(true)
+bool(true)

--- a/ext/spl/tests/autoloading/gh22118.phpt
+++ b/ext/spl/tests/autoloading/gh22118.phpt
@@ -2,6 +2,11 @@
 GH-22118: spl_autoload_unregister() unregisters equivalent first-class method callables
 --FILE--
 <?php
+function autoload_string(string $class): void
+{
+	echo "autoload $class\n";
+}
+
 class AutoloadTest
 {
 	public function load(string $class): void
@@ -14,6 +19,11 @@ class AutoloadTest
 		echo "autoload {$arguments[0]}\n";
 	}
 
+	public function __invoke(string $class): void
+	{
+		echo "autoload $class\n";
+	}
+
 	public function run(): void
 	{
 		spl_autoload_register($this->load(...));
@@ -23,11 +33,26 @@ class AutoloadTest
 		spl_autoload_register($this->missing(...));
 		var_dump(spl_autoload_unregister($this->missing(...)));
 		spl_autoload_call('MissingTrampoline');
+
+		spl_autoload_register($this->load(...));
+		var_dump(spl_autoload_unregister([$this, 'load']));
+		spl_autoload_call('MissingArray');
+
+		spl_autoload_register($this(...));
+		var_dump(spl_autoload_unregister($this));
+		spl_autoload_call('MissingInvokable');
 	}
 }
+
+spl_autoload_register(autoload_string(...));
+var_dump(spl_autoload_unregister('autoload_string'));
+spl_autoload_call('MissingString');
 
 (new AutoloadTest())->run();
 ?>
 --EXPECT--
+bool(true)
+bool(true)
+bool(true)
 bool(true)
 bool(true)

--- a/ext/standard/tests/general_functions/gh22118.phpt
+++ b/ext/standard/tests/general_functions/gh22118.phpt
@@ -1,0 +1,40 @@
+--TEST--
+GH-22118: unregister_tick_function() unregisters equivalent first-class method callables
+--FILE--
+<?php
+declare(ticks=1);
+
+class TickTest
+{
+	public int $direct = 0;
+	public int $trampoline = 0;
+
+	public function kick(): void
+	{
+		$this->direct++;
+	}
+
+	public function __call(string $name, array $arguments): void
+	{
+		$this->trampoline++;
+	}
+
+	public function run(): void
+	{
+		register_tick_function($this->kick(...));
+		unregister_tick_function($this->kick(...));
+		echo "direct: {$this->direct}\n";
+
+		register_tick_function($this->missing(...));
+		unregister_tick_function($this->missing(...));
+		echo "trampoline: {$this->trampoline}\n";
+	}
+}
+
+(new TickTest())->run();
+echo "done\n";
+?>
+--EXPECT--
+direct: 1
+trampoline: 1
+done

--- a/ext/standard/tests/general_functions/gh22118.phpt
+++ b/ext/standard/tests/general_functions/gh22118.phpt
@@ -4,14 +4,34 @@ GH-22118: unregister_tick_function() unregisters equivalent first-class method c
 <?php
 declare(ticks=1);
 
+$string = 0;
+
+function tick_string(): void
+{
+	global $string;
+	$string++;
+}
+
 class TickTest
 {
 	public int $direct = 0;
 	public int $trampoline = 0;
+	public int $array = 0;
+	public int $invoke = 0;
 
 	public function kick(): void
 	{
 		$this->direct++;
+	}
+
+	public function arrayCallable(): void
+	{
+		$this->array++;
+	}
+
+	public function __invoke(): void
+	{
+		$this->invoke++;
 	}
 
 	public function __call(string $name, array $arguments): void
@@ -28,13 +48,28 @@ class TickTest
 		register_tick_function($this->missing(...));
 		unregister_tick_function($this->missing(...));
 		echo "trampoline: {$this->trampoline}\n";
+
+		register_tick_function($this->arrayCallable(...));
+		unregister_tick_function([$this, 'arrayCallable']);
+		echo "array: {$this->array}\n";
+
+		register_tick_function($this(...));
+		unregister_tick_function($this);
+		echo "invoke: {$this->invoke}\n";
 	}
 }
+
+register_tick_function(tick_string(...));
+unregister_tick_function('tick_string');
+echo "string: {$string}\n";
 
 (new TickTest())->run();
 echo "done\n";
 ?>
 --EXPECT--
+string: 1
 direct: 1
 trampoline: 1
+array: 1
+invoke: 1
 done


### PR DESCRIPTION
First-class method callable syntax creates a fresh fake Closure object for each expression. Some callback comparisons were still treating Closure-backed callables by Closure object identity, so equivalent fake Closures could fail to unregister.

Update `zend_fcc_equals()` so regular Closure objects still compare by object identity, while fake Closures compare through their Closure method definition instead of generic object comparison. On `master`, SPL autoload already uses `zend_fcc_equals()`, so the same path is covered there too.

Fixes GH-22118.

Tests:
- `PATH="/opt/homebrew/opt/bison/bin:/opt/homebrew/bin:$PATH" ./configure --disable-all --enable-cli`
- `PATH="/opt/homebrew/opt/bison/bin:/opt/homebrew/bin:$PATH" make -j$(sysctl -n hw.ncpu) sapi/cli/php`
- `sapi/cli/php run-tests.php -q -p sapi/cli/php ext/standard/tests/general_functions/gh22118.phpt ext/spl/tests/autoloading/gh22118.phpt ext/spl/tests/autoloading/gh10011.phpt ext/spl/tests/autoloading/spl_autoload_013.phpt ext/spl/tests/autoloading/spl_autoload_014.phpt ext/spl/tests/autoloading/bug75049.phpt ext/spl/tests/autoloading/spl_autoload_unregister_without_registrations.phpt ext/standard/tests/general_functions/bug66094.phpt`
