### PR TITLE
Fix GH-22138: skip libxml/xmlreader tests on non-ASCII paths.

### DIFF
--- a/ext/libxml/tests/bug61367-read_2.phpt
+++ b/ext/libxml/tests/bug61367-read_2.phpt
@@ -5,6 +5,7 @@ dom
 --SKIPIF--
 <?php
 if (LIBXML_VERSION < 20912) die('skip For libxml2 >= 2.9.12 only');
+if (preg_match('/[^\x00-\x7F]/', __DIR__)) die('skip path contains non-ASCII characters that libxml URI parser rejects');
 ?>
 --INI--
 open_basedir=.
@@ -58,6 +59,6 @@ bool(true)
 int(4)
 bool(true)
 
-%s: DOMDocument::loadXML(): %Sfailed to load %s
+%s: DOMDocument::loadXML(): %s
 
 Warning: Attempt to read property "nodeValue" on null in %s on line %d

--- a/ext/libxml/tests/libxml_disable_entity_loader_2.phpt
+++ b/ext/libxml/tests/libxml_disable_entity_loader_2.phpt
@@ -6,6 +6,7 @@ dom
 --SKIPIF--
 <?php
 if (LIBXML_VERSION < 20912) die('skip For libxml2 >= 2.9.12 only');
+if (preg_match('/[^\x00-\x7F]/', __DIR__)) die('skip path contains non-ASCII characters that libxml URI parser rejects');
 ?>
 --FILE--
 <?php
@@ -40,6 +41,6 @@ bool(true)
 Deprecated: Function libxml_disable_entity_loader() is deprecated since 8.0, as external entity loading is disabled by default in %s on line %d
 bool(false)
 
-%s: DOMDocument::loadXML(): %Sfailed to load %s
+%s: DOMDocument::loadXML(): %s
 bool(true)
 Done

--- a/ext/libxml/tests/libxml_entity_loading_disabled_by_default.phpt
+++ b/ext/libxml/tests/libxml_entity_loading_disabled_by_default.phpt
@@ -5,6 +5,10 @@ libxml
 dom
 xml
 simplexml
+--SKIPIF--
+<?php
+if (preg_match('/[^\x00-\x7F]/', __DIR__)) die('skip path contains non-ASCII characters that libxml URI parser rejects');
+?>
 --FILE--
 <?php
 

--- a/ext/xmlreader/tests/012.phpt
+++ b/ext/xmlreader/tests/012.phpt
@@ -2,6 +2,10 @@
 XMLReader: accessing empty and non existing attributes
 --EXTENSIONS--
 xmlreader
+--SKIPIF--
+<?php
+if (preg_match('/[^\x00-\x7F]/', __DIR__)) die('skip path contains non-ASCII characters that libxml URI parser rejects');
+?>
 --FILE--
 <?php
 


### PR DESCRIPTION
libxml2 2.13+ rejects unencoded non-ASCII bytes in SYSTEM URIs via xmlBuildURISafe and emits "Can't resolve URI", which breaks four tests when the source tree lives under a path like "~/下载/". Skip them with a clear reason on such paths, and loosen the EXPECTF for the two tests that previously matched only "failed to load" so both libxml2 message formats are accepted.