### PR TITLE
Fix GH-22060 and GH-22122: pin $this in zend_call_function

### DIFF
--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1006,6 +1006,11 @@ cleanup_args:
 		fci_cache->function_handler = NULL;
 	}
 
+	zend_object *pinned_this = (call_info & ZEND_CALL_HAS_THIS) ? fci_cache->object : NULL;
+	if (pinned_this) {
+		GC_ADDREF(pinned_this);
+	}
+
 	const zend_class_entry *orig_fake_scope = EG(fake_scope);
 	EG(fake_scope) = NULL;
 	if (func->type == ZEND_USER_FUNCTION) {
@@ -1072,6 +1077,10 @@ cleanup_args:
 		}
 	}
 	EG(fake_scope) = orig_fake_scope;
+
+	if (pinned_this) {
+		OBJ_RELEASE(pinned_this);
+	}
 
 	zend_vm_stack_free_call_frame(call);
 

--- a/ext/pdo_sqlite/tests/gh22122.phpt
+++ b/ext/pdo_sqlite/tests/gh22122.phpt
@@ -1,0 +1,40 @@
+--TEST--
+GH-22122 (Use-after-free in Pdo\Sqlite authorizer when callback releases the authorizer)
+--EXTENSIONS--
+pdo_sqlite
+--FILE--
+<?php
+$db = Pdo\Sqlite::connect('sqlite::memory:');
+
+class Auth {
+    public string $state = "alive";
+
+    public function authorize(int $action, ...$args): int {
+        global $db;
+        $db->setAuthorizer(null);
+        echo "method: ", $this->state, "\n";
+        return Pdo\Sqlite::OK;
+    }
+}
+$auth = new Auth();
+$db->setAuthorizer([$auth, 'authorize']);
+unset($auth);
+$db->exec('SELECT 1');
+
+$capture = "closure-alive";
+$closure = function (int $action, ...$args) use (&$capture, $db): int {
+    $db->setAuthorizer(null);
+    echo "closure: ", $capture, "\n";
+    return Pdo\Sqlite::OK;
+};
+$db->setAuthorizer($closure);
+unset($closure);
+$db->exec('SELECT 2');
+
+$db->exec('SELECT 3');
+echo "post-disable query ok\n";
+?>
+--EXPECT--
+method: alive
+closure: closure-alive
+post-disable query ok

--- a/ext/spl/tests/autoloading/gh22060.phpt
+++ b/ext/spl/tests/autoloading/gh22060.phpt
@@ -1,0 +1,27 @@
+--TEST--
+GH-22060 (Class autoloader $this freed via spl_autoload_unregister during dispatch)
+--FILE--
+<?php
+
+class Loader {
+    public string $data = "loader-data";
+
+    public function load(string $class): void {
+        spl_autoload_unregister([$this, 'load']);
+        echo $this->data, "\n";
+    }
+}
+
+$obj = new Loader();
+spl_autoload_register([$obj, 'load']);
+unset($obj);
+
+try {
+    new NonExistentClass42();
+} catch (\Throwable $e) {
+    echo $e::class, ": ", $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+loader-data
+Error: Class "NonExistentClass42" not found

--- a/ext/sqlite3/tests/gh22122.phpt
+++ b/ext/sqlite3/tests/gh22122.phpt
@@ -1,0 +1,40 @@
+--TEST--
+GH-22122 (Use-after-free in SQLite3 authorizer when callback releases the authorizer)
+--EXTENSIONS--
+sqlite3
+--FILE--
+<?php
+$db = new SQLite3(':memory:');
+
+class Auth {
+    public string $state = "alive";
+
+    public function authorize(int $action, ...$args): int {
+        global $db;
+        $db->setAuthorizer(null);
+        echo "method: ", $this->state, "\n";
+        return SQLite3::OK;
+    }
+}
+$auth = new Auth();
+$db->setAuthorizer([$auth, 'authorize']);
+unset($auth);
+$db->exec('SELECT 1');
+
+$capture = "closure-alive";
+$closure = function (int $action, ...$args) use (&$capture, $db): int {
+    $db->setAuthorizer(null);
+    echo "closure: ", $capture, "\n";
+    return SQLite3::OK;
+};
+$db->setAuthorizer($closure);
+unset($closure);
+$db->exec('SELECT 2');
+
+$db->exec('SELECT 3');
+echo "post-disable query ok\n";
+?>
+--EXPECT--
+method: alive
+closure: closure-alive
+post-disable query ok

--- a/tests/output/gh20352.phpt
+++ b/tests/output/gh20352.phpt
@@ -21,7 +21,4 @@ ob_start(new Test, 1);
 echo "trigger bug";
 ?>
 --EXPECTF--
-%r(Notice: ob_start\(\): Failed to create buffer in [^\r\n]+ on line \d+\r?\n(\r?\n)?)+%r
-Notice: ob_start(): Failed to create buffer in %s on line %d
-
 Fatal error: ob_start(): Cannot use output buffering in output buffering display handlers in %s on line %d


### PR DESCRIPTION
Both reports are the same use-after-free: the callback ran with `fci_cache->object` as `$this` without holding a reference, so a callback that released the last reference to its own receiver (autoloader self-unregistering, SQLite3 authorizer calling setAuthorizer(null)) freed it mid-call. Pinning the receiver across the call in `zend_call_function()` covers both reports and every other site that dispatches through it. gh20352's expected output shifts with it: the output handler's destructor now fires after `__invoke()` returns rather than mid-deactivation.
