### PR TITLE
Fix GH-20921: Avoid signed negation of PHP_INT_MIN in memory stream seek

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,10 @@ PHP                                                                        NEWS
     IntlCalendar::equals(), ::before(), ::after(), and ::isEquivalentTo().
     (Weilin Du)
 
+- Streams:
+  . Fixed bug GH-20921 (UBSan: Negation of PHP_INT_MIN triggers runtime error
+    in streams/memory.c via SplTempFileObject::fseek). (wadakatu)
+
 - Zlib:
   . Fixed memory leak if deflate initialization fails and there is a dict.
     (ndossche)

--- a/ext/standard/tests/streams/gh20921.phpt
+++ b/ext/standard/tests/streams/gh20921.phpt
@@ -1,0 +1,12 @@
+--TEST--
+GH-20921: SplTempFileObject::fseek with PHP_INT_MIN must not trigger UB
+--FILE--
+<?php
+$f = new SplTempFileObject();
+$f->fwrite("abcdef");
+
+var_dump($f->fseek(PHP_INT_MIN, SEEK_END));
+
+?>
+--EXPECT--
+int(-1)

--- a/main/streams/memory.c
+++ b/main/streams/memory.c
@@ -165,7 +165,7 @@ static int php_stream_memory_seek(php_stream *stream, zend_off_t offset, int whe
 				stream->eof = 0;
 				stream->fatal_error = 0;
 				return 0;
-			} else if (ZSTR_LEN(ms->data) < (size_t)(-offset)) {
+			} else if (ZSTR_LEN(ms->data) < -(size_t)offset) {
 				ms->fpos = 0;
 				*newoffs = -1;
 				return -1;


### PR DESCRIPTION
## Summary

Fixes GH-20921.

`php_stream_memory_seek()` evaluated `(size_t)(-offset)` for negative offsets
in the `SEEK_END` branch. When `offset == LONG_MIN`, the unary minus is
performed in signed `zend_off_t` and overflows — undefined behavior under C11
6.5p5 — which UBSan flags:

```
main/streams/memory.c:168:45: runtime error: negation of -9223372036854775808
cannot be represented in type 'zend_off_t' (aka 'long'); cast to an unsigned
type to negate this value to itself
```

The fix casts to `size_t` first so the negation happens in unsigned
arithmetic, which is defined to wrap modulo 2^N and yields the same
absolute value without invoking UB.

### Reproducer

```php
<?php
$f = new SplTempFileObject();
$f->fwrite("abcdef");
var_dump($f->fseek(PHP_INT_MIN, SEEK_END));
```

Run under a UBSan-enabled build (`--enable-undefined-sanitizer`) to observe
the runtime error before the fix.

### Note on the SEEK_CUR branch

A structurally identical `(size_t)(-offset)` exists in the `SEEK_CUR` branch
of the same function (line 131). However, `_php_stream_seek()` rewrites
`SEEK_CUR` to `SEEK_SET` before calling the ops vtable, so that path is
unreachable via the userland `fseek()` API. I left it untouched to keep this
PR focused on the reported, user-reachable case; happy to fold a follow-up
cleanup in if maintainers prefer.

## Test plan

- [x] New regression test `ext/standard/tests/streams/gh20921.phpt`
- [x] `make test TESTS=ext/standard/tests/streams` — 130 pass, 24 skip, 0 fail
- [x] `make test TESTS=ext/spl/tests` — 758 pass, 9 skip, 1 XFAIL, 0 fail
- [ ] CI UBSan job — relies on PR pipeline to verify the UB no longer fires