### PR TITLE
ext/session: fix session GC fork

### DIFF
--- a/ext/session/php_session.h
+++ b/ext/session/php_session.h
@@ -157,8 +157,6 @@ typedef struct _php_ps_globals {
 	zend_string *session_started_filename;
 	uint32_t session_started_lineno;
 	int module_number;
-	/* Unused since the GC probability draw was made stateless; retained only
-	 * to preserve struct layout (ABI) on stable branches. */
 	php_random_status_state_pcgoneseq128xslrr64 random_state;
 	php_random_algo_with_state random;
 	zend_long gc_probability;
@@ -205,6 +203,7 @@ typedef struct _php_ps_globals {
 	bool in_save_handler; /* state if session is in save handler or not */
 	bool set_handler;     /* state if session module i setting handler or not */
 	zend_string *session_vars; /* serialized original session data */
+	bool random_seeded;
 } php_ps_globals;
 
 typedef php_ps_globals zend_ps_globals;

--- a/ext/session/php_session.h
+++ b/ext/session/php_session.h
@@ -157,6 +157,8 @@ typedef struct _php_ps_globals {
 	zend_string *session_started_filename;
 	uint32_t session_started_lineno;
 	int module_number;
+	/* Unused since the GC probability draw was made stateless; retained only
+	 * to preserve struct layout (ABI) on stable branches. */
 	php_random_status_state_pcgoneseq128xslrr64 random_state;
 	php_random_algo_with_state random;
 	zend_long gc_probability;

--- a/ext/session/php_session.h
+++ b/ext/session/php_session.h
@@ -202,8 +202,8 @@ typedef struct _php_ps_globals {
 	bool lazy_write; /* omit session write when it is possible */
 	bool in_save_handler; /* state if session is in save handler or not */
 	bool set_handler;     /* state if session module i setting handler or not */
-	zend_string *session_vars; /* serialized original session data */
 	bool random_seeded;
+	zend_string *session_vars; /* serialized original session data */
 } php_ps_globals;
 
 typedef php_ps_globals zend_ps_globals;

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -394,7 +394,14 @@ static zend_long php_session_gc(bool immediate) /* {{{ */
 	/* GC must be done before reading session data. */
 	if ((PS(mod_data) || PS(mod_user_implemented))) {
 		if (!collect && PS(gc_probability) > 0) {
-			collect = php_random_range(PS(random), 0, PS(gc_divisor) - 1) < PS(gc_probability);
+			/* Draw fresh entropy per request instead of using the per-process
+			 * PS(random) state. The latter is seeded once in GINIT, which runs
+			 * before SAPIs such as PHP-FPM fork their workers, so every worker
+			 * would inherit and replay the same GC-decision sequence. */
+			uint32_t rand_val;
+			if (php_random_bytes_silent(&rand_val, sizeof(rand_val)) == SUCCESS) {
+				collect = (rand_val % (uint32_t) PS(gc_divisor)) < (uint32_t) PS(gc_probability);
+			}
 		}
 
 		if (collect) {
@@ -2979,19 +2986,6 @@ static PHP_GINIT_FUNCTION(ps) /* {{{ */
 	ZVAL_UNDEF(&ps_globals->mod_user_names.ps_validate_sid);
 	ZVAL_UNDEF(&ps_globals->mod_user_names.ps_update_timestamp);
 	ZVAL_UNDEF(&ps_globals->http_session_vars);
-
-	ps_globals->random = (php_random_algo_with_state){
-		.algo = &php_random_algo_pcgoneseq128xslrr64,
-		.state = &ps_globals->random_state,
-	};
-	php_random_uint128_t seed;
-	if (php_random_bytes_silent(&seed, sizeof(seed)) == FAILURE) {
-		seed = php_random_uint128_constant(
-			php_random_generate_fallback_seed(),
-			php_random_generate_fallback_seed()
-		);
-	}
-	php_random_pcgoneseq128xslrr64_seed128(ps_globals->random.state, seed);
 }
 /* }}} */
 

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -394,14 +394,19 @@ static zend_long php_session_gc(bool immediate) /* {{{ */
 	/* GC must be done before reading session data. */
 	if ((PS(mod_data) || PS(mod_user_implemented))) {
 		if (!collect && PS(gc_probability) > 0) {
-			/* Draw fresh entropy per request instead of using the per-process
-			 * PS(random) state. The latter is seeded once in GINIT, which runs
-			 * before SAPIs such as PHP-FPM fork their workers, so every worker
-			 * would inherit and replay the same GC-decision sequence. */
-			uint32_t rand_val;
-			if (php_random_bytes_silent(&rand_val, sizeof(rand_val)) == SUCCESS) {
-				collect = (rand_val % (uint32_t) PS(gc_divisor)) < (uint32_t) PS(gc_probability);
+			/* Seed lazily on first GC draw per process. */
+			if (UNEXPECTED(!PS(random_seeded))) {
+				php_random_uint128_t seed;
+				if (php_random_bytes_silent(&seed, sizeof(seed)) == FAILURE) {
+					seed = php_random_uint128_constant(
+						php_random_generate_fallback_seed(),
+						php_random_generate_fallback_seed()
+					);
+				}
+				php_random_pcgoneseq128xslrr64_seed128(PS(random).state, seed);
+				PS(random_seeded) = true;
 			}
+			collect = php_random_range(PS(random), 0, PS(gc_divisor) - 1) < PS(gc_probability);
 		}
 
 		if (collect) {
@@ -2986,6 +2991,12 @@ static PHP_GINIT_FUNCTION(ps) /* {{{ */
 	ZVAL_UNDEF(&ps_globals->mod_user_names.ps_validate_sid);
 	ZVAL_UNDEF(&ps_globals->mod_user_names.ps_update_timestamp);
 	ZVAL_UNDEF(&ps_globals->http_session_vars);
+
+	ps_globals->random = (php_random_algo_with_state){
+		.algo = &php_random_algo_pcgoneseq128xslrr64,
+		.state = &ps_globals->random_state,
+	};
+	ps_globals->random_seeded = false;
 }
 /* }}} */
 


### PR DESCRIPTION
Fixes https://github.com/php/php-src/issues/21314

If I understand the logic of the bug correctly (retrieved with the help of AI):
1. In NTS builds, `globals_ctor` (GINIT) runs at module registration inside php_module_startup.
2. In PHP-FPM, php_module_startup runs in the master process (fpm_main.c:1757), before `fpm_run()` forks the workers.
3. So the PCG is seeded once in the master. Every worker is a fork() of the master → all inherit the same seed at sequence position 0. Nothing reseeds per request: `PHP_RINIT_FUNCTION(session)` never touches `PS(random)`.
4. The master never serves requests, so its PCG stays frozen at position 0. When workers recycle (`pm.max_requests`) and respawn, each new worker forks from the master and restarts at position 0 of the identical sequence.

Changing the logic back to drawing per request gives back the true randomness.