### PR TITLE
ext/uri: Fix static build on Windows by defining LEXBOR_STATIC

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,11 @@ PHP                                                                        NEWS
   . Fixed bug GH-22121 (Double free in gdImageSetStyle() after
     overflow-triggered early return). (iliaal)
 
+- URI:
+  . Add LEXBOR_STATIC to CFLAGS_URI on Windows so ext/uri does not see
+    LXB_API as __declspec(dllimport) when linked statically into PHP.
+    (Luther Monson)
+
 - Zlib:
   . Fixed memory leak if deflate initialization fails and there is a dict.
     (ndossche)

--- a/ext/uri/config.w32
+++ b/ext/uri/config.w32
@@ -2,7 +2,7 @@ EXTENSION("uri", "php_uri.c php_uri_common.c uri_parser_rfc3986.c uri_parser_wha
 
 AC_DEFINE("URI_ENABLE_ANSI", 1, "Define to 1 for enabling ANSI support of uriparser.")
 AC_DEFINE("URI_NO_UNICODE", 1, "Define to 1 for disabling unicode support of uriparser.")
-ADD_FLAG("CFLAGS_URI", "/D URI_STATIC_BUILD");
+ADD_FLAG("CFLAGS_URI", "/D URI_STATIC_BUILD /D LEXBOR_STATIC");
 
 ADD_EXTENSION_DEP('uri', 'lexbor');
 ADD_SOURCES("ext/uri/uriparser/src", "UriCommon.c UriCompare.c UriCopy.c UriEscape.c UriFile.c UriIp4.c UriIp4Base.c \


### PR DESCRIPTION
## Summary

`ext/uri` is always built statically and pulls in the bundled lexbor headers via `/I ext/lexbor`. On Windows, lexbor's `LXB_API` macro defaults to `__declspec(dllimport)` when `LEXBOR_STATIC` isn't defined. As a result, when PHP itself is linked statically (no DLL) on Windows, every `lxb_*` symbol referenced from `ext/uri` fails to resolve:

```
libphp.lib(php_uri.obj) : error LNK2019: unresolved external symbol
    __imp_lxb_url_parse referenced in function ...
... (one LNK2019 per lxb_* function reachable from ext/uri) ...
```