### PR TITLE
Add --enable-embed=static support on Windows

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -145,6 +145,14 @@ PHP                                                                        NEWS
 - Exif:
   . Read correct value for single and double tags. (ndossche)
 
+- Embed:
+  . Added --enable-embed=static support on Windows: php<N>embed.lib is now
+    produced as a self-contained static library (no php<N>.dll dependency)
+    by linking PHP core, statically built extensions, and the embed SAPI
+    into a single .lib, with the corresponding source-side adjustments
+    (PHP/Zend/SAPI/TSRM export defines and TSRMLS cache deduplication).
+    (Luther Monson)
+
 - GD:
   . Fixed bug GH-22121 (Double free in gdImageSetStyle() after
     overflow-triggered early return). (iliaal)

--- a/sapi/embed/config.w32
+++ b/sapi/embed/config.w32
@@ -6,5 +6,15 @@ var PHP_EMBED_PGO = false;
 
 if (PHP_EMBED != "no") {
 	SAPI('embed', 'php_embed.c', 'php' + PHP_VERSION + 'embed.lib', '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');
+	if (PHP_EMBED == "static") {
+		// Static embed mode: php<N>embed.lib is intended to contain PHP
+		// core, extensions and the embed SAPI in a single static library
+		// (no php<N>.dll at runtime). php_embed.c must reach PHP/Zend/
+		// SAPI/TSRM symbols directly rather than through dllimport thunks.
+		ADD_FLAG('CFLAGS_EMBED',
+			'/D PHP_EMBED_STATIC' +
+			' /D PHP_EXPORTS /D LIBZEND_EXPORTS' +
+			' /D SAPI_EXPORTS /D TSRM_EXPORTS');
+	}
 	PHP_INSTALL_HEADERS("sapi/embed", "php_embed.h");
 }

--- a/sapi/embed/php_embed.c
+++ b/sapi/embed/php_embed.c
@@ -30,7 +30,7 @@ static const char HARDCODED_INI[] =
 	"max_execution_time=0\n"
 	"max_input_time=-1\n\0";
 
-#if defined(PHP_WIN32) && defined(ZTS)
+#if defined(PHP_WIN32) && defined(ZTS) && !defined(PHP_EMBED_STATIC)
 ZEND_TSRMLS_CACHE_DEFINE()
 #endif
 

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -1197,6 +1197,14 @@ function SAPI(sapiname, file_list, makefiletarget, cflags, obj_dir, duplicate_so
 	var ld;
 	var manifest;
 
+	// In --enable-embed=static, php<N>embed.lib must contain PHP core, all
+	// statically built extensions, and the embed SAPI itself - no runtime
+	// dependency on php<N>.dll. Substitute the PHP object groups for the
+	// import lib in both the dependency line and the link command.
+	var is_static_embed = (sapiname == "embed" && PHP_EMBED == "static");
+	var dep_phplib_deps  = is_static_embed ? "$(PHP_GLOBAL_OBJS) $(STATIC_EXT_OBJS) $(ASM_OBJS)" : "$(BUILD_DIR)\\$(PHPLIB)";
+	var link_phplib_args = is_static_embed ? "$(PHP_GLOBAL_OBJS_RESP) $(STATIC_EXT_OBJS_RESP) $(ASM_OBJS) $(STATIC_EXT_LIBS)" : "$(BUILD_DIR)\\$(PHPLIB)";
+
 	if (typeof(obj_dir) == "undefined") {
 		sapiname_for_printing = configure_module_dirname;
 	} else {
@@ -1228,7 +1236,7 @@ function SAPI(sapiname, file_list, makefiletarget, cflags, obj_dir, duplicate_so
 	if (MODE_PHPIZE) {
 		MFO.WriteLine("$(BUILD_DIR)\\" + makefiletarget + ": $(DEPS_" + SAPI + ") $(" + SAPI + "_GLOBAL_OBJS) $(PHPLIB) $(BUILD_DIR)\\" + resname + " $(BUILD_DIR)\\" + manifest_name);
 	} else {
-		MFO.WriteLine("$(BUILD_DIR)\\" + makefiletarget + ": $(DEPS_" + SAPI + ") $(" + SAPI + "_GLOBAL_OBJS) $(BUILD_DIR)\\$(PHPLIB) $(BUILD_DIR)\\" + resname  + " $(BUILD_DIR)\\" + manifest_name);
+		MFO.WriteLine("$(BUILD_DIR)\\" + makefiletarget + ": $(DEPS_" + SAPI + ") $(" + SAPI + "_GLOBAL_OBJS) " + dep_phplib_deps + " $(BUILD_DIR)\\" + resname  + " $(BUILD_DIR)\\" + manifest_name);
 	}
 
 	var is_lib = makefiletarget.match(new RegExp("\\.lib$"));
@@ -1276,10 +1284,10 @@ function SAPI(sapiname, file_list, makefiletarget, cflags, obj_dir, duplicate_so
 		}
 	} else {
 		if (ld) {
-			MFO.WriteLine("\t" + ld + " /nologo /out:$(BUILD_DIR)\\" + makefiletarget + " " + ldflags + " $(" + SAPI + "_GLOBAL_OBJS_RESP) $(BUILD_DIR)\\$(PHPLIB) $(ARFLAGS_" + SAPI + ") $(LIBS_" + SAPI + ") $(BUILD_DIR)\\" + resname);
+			MFO.WriteLine("\t" + ld + " /nologo /out:$(BUILD_DIR)\\" + makefiletarget + " " + ldflags + " $(" + SAPI + "_GLOBAL_OBJS_RESP) " + link_phplib_args + " $(ARFLAGS_" + SAPI + ") $(LIBS_" + SAPI + ") $(BUILD_DIR)\\" + resname);
 		} else {
 			ld = CMD_MOD1 + '"$(LINK)"';
-			MFO.WriteLine("\t" + ld + " /nologo " + " $(" + SAPI + "_GLOBAL_OBJS_RESP) $(BUILD_DIR)\\$(PHPLIB) $(LIBS_" + SAPI + ") $(BUILD_DIR)\\" + resname + " /out:$(BUILD_DIR)\\" + makefiletarget + " " + ldflags + " $(LDFLAGS_" + SAPI + ")");
+			MFO.WriteLine("\t" + ld + " /nologo " + " $(" + SAPI + "_GLOBAL_OBJS_RESP) " + link_phplib_args + " $(LIBS_" + SAPI + ") $(BUILD_DIR)\\" + resname + " /out:$(BUILD_DIR)\\" + makefiletarget + " " + ldflags + " $(LDFLAGS_" + SAPI + ")");
 		}
 	}
 


### PR DESCRIPTION
## Summary

Unix already supports `--enable-embed=static` (see `sapi/embed/config.m4`); the Windows `config.w32` ignored the `static` value and `php_embed.c` got compiled as a DLL consumer regardless. Result: linking embed without `php<N>.dll` fails with `LNK2019` on every PHP/Zend symbol referenced from `php_embed.c`, and (under ZTS) `LNK4006` on `_tsrm_ls_cache` due to a duplicate definition between `zend.c` and `php_embed.c`.

When `--enable-embed=static` is passed on Windows:

* `CFLAGS_EMBED` gets `/D PHP_EXPORTS /D LIBZEND_EXPORTS /D SAPI_EXPORTS /D TSRM_EXPORTS` so `php_embed.c` references core symbols directly instead of through `__declspec(dllimport)` thunks.
* `php_embed.c`'s `ZEND_TSRMLS_CACHE_DEFINE()` is skipped (gated on new `PHP_EMBED_STATIC`); `zend.c` provides the canonical definition.

This patches only the source-side adjustments. Producing a fat static lib (composition of `php<N>embed.lib`) is a separate Makefile concern handled by downstream build tools.