### PR TITLE
ext/zip: memory leak when zip cancel callback bails out.

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -2999,7 +2999,7 @@ static void php_zip_progress_callback(zip_t *arch, double state, void *ptr)
 {
 	ze_zip_object *obj = ptr;
 
-	if (!EG(active) || obj->bailout_callback) {
+	if (UNEXPECTED(!EG(active) || obj->bailout_callback)) {
 		return;
 	}
 
@@ -3054,7 +3054,7 @@ static int php_zip_cancel_callback(zip_t *arch, void *ptr)
 	zval cb_retval;
 	ze_zip_object *obj = ptr;
 
-	if (!EG(active) || obj->bailout_callback) {
+	if (UNEXPECTED(!EG(active) || obj->bailout_callback)) {
 		return 0;
 	}
 

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -628,6 +628,12 @@ static bool php_zipobj_close(ze_zip_object *obj, zend_string **out_str) /* {{{ *
 
 	obj->za = NULL;
 	obj->from_string = false;
+
+	if (obj->bailout_callback) {
+		obj->bailout_callback = false;
+		zend_bailout();
+	}
+
 	return success;
 }
 /* }}} */
@@ -1073,10 +1079,16 @@ static void php_zip_object_dtor(zend_object *object)
 
 	if (intern->za) {
 		if (zip_close(intern->za) != 0) {
-			php_error_docref(NULL, E_WARNING, "Cannot destroy the zip context: %s", zip_strerror(intern->za));
+			if (!intern->bailout_callback) {
+				php_error_docref(NULL, E_WARNING, "Cannot destroy the zip context: %s", zip_strerror(intern->za));
+			}
 			zip_discard(intern->za);
 		}
 		intern->za = NULL;
+		if (intern->bailout_callback) {
+			intern->bailout_callback = false;
+			zend_bailout();
+		}
 	}
 }
 
@@ -2985,17 +2997,20 @@ PHP_METHOD(ZipArchive, getStream)
 #ifdef HAVE_PROGRESS_CALLBACK
 static void php_zip_progress_callback(zip_t *arch, double state, void *ptr)
 {
-	if (!EG(active)) {
+	ze_zip_object *obj = ptr;
+
+	if (!EG(active) || obj->bailout_callback) {
 		return;
 	}
 
 	zval cb_args[1];
-	ze_zip_object *obj = ptr;
 
 	ZVAL_DOUBLE(&cb_args[0], state);
 
 	zend_try {
 		zend_call_known_fcc(&obj->progress_callback, NULL, 1, cb_args, NULL);
+	} zend_catch {
+		obj->bailout_callback = true;
 	} zend_end_try();
 }
 
@@ -3039,13 +3054,14 @@ static int php_zip_cancel_callback(zip_t *arch, void *ptr)
 	zval cb_retval;
 	ze_zip_object *obj = ptr;
 
-	if (!EG(active)) {
+	if (!EG(active) || obj->bailout_callback) {
 		return 0;
 	}
 
 	zend_try {
 		zend_call_known_fcc(&obj->cancel_callback, &cb_retval, 0, NULL, NULL);
 	} zend_catch {
+		obj->bailout_callback = true;
 		/* Cancel if a bailout occurs to allow cleanup to happen */
 		return -1;
 	} zend_end_try();

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -2993,7 +2993,10 @@ static void php_zip_progress_callback(zip_t *arch, double state, void *ptr)
 	ze_zip_object *obj = ptr;
 
 	ZVAL_DOUBLE(&cb_args[0], state);
-	zend_call_known_fcc(&obj->progress_callback, NULL, 1, cb_args, NULL);
+
+	zend_try {
+		zend_call_known_fcc(&obj->progress_callback, NULL, 1, cb_args, NULL);
+	} zend_end_try();
 }
 
 /* {{{ register a progression callback: void callback(double state); */
@@ -3040,7 +3043,13 @@ static int php_zip_cancel_callback(zip_t *arch, void *ptr)
 		return 0;
 	}
 
-	zend_call_known_fcc(&obj->cancel_callback, &cb_retval, 0, NULL, NULL);
+	zend_try {
+		zend_call_known_fcc(&obj->cancel_callback, &cb_retval, 0, NULL, NULL);
+	} zend_catch {
+		/* Cancel if a bailout occurs to allow cleanup to happen */
+		return -1;
+	} zend_end_try();
+
 	if (Z_ISUNDEF(cb_retval)) {
 		/* Cancel if an exception has been thrown */
 		return -1;

--- a/ext/zip/php_zip.h
+++ b/ext/zip/php_zip.h
@@ -74,6 +74,7 @@ typedef struct _ze_zip_object {
 	zip_int64_t last_id;
 	int err_zip;
 	int err_sys;
+	bool bailout_callback;
 #ifdef HAVE_PROGRESS_CALLBACK
 	zend_fcall_info_cache progress_callback;
 #endif

--- a/ext/zip/tests/gh22176.phpt
+++ b/ext/zip/tests/gh22176.phpt
@@ -1,59 +1,33 @@
 --TEST--
-GH-22176 (Memory leak when a ZipArchive cancel/progress callback bails out in the shutdown destructor)
+GH-22176 (Memory leak when a ZipArchive cancel callback bails out in the shutdown destructor)
 --EXTENSIONS--
 zip
 --SKIPIF--
 <?php
 if (!method_exists('ZipArchive', 'registerCancelCallback')) die('skip libzip too old');
-if (!method_exists('ZipArchive', 'registerProgressCallback')) die('skip libzip too old');
 ?>
 --FILE--
 <?php
-$dir = __DIR__ . '/';
-
-$cancel = new ZipArchive;
-$cancel->open($dir . 'gh22176_cancel.zip', ZipArchive::CREATE);
-$cancel->registerCancelCallback(function () {
+$zip = new ZipArchive;
+$zip->open(__DIR__ . '/gh22176_cancel.zip', ZipArchive::CREATE);
+$zip->registerCancelCallback(function () {
     throw new \Exception('cancel boom');
 });
-$cancel->addFromString('test', 'test');
-
-$progress = new ZipArchive;
-$progress->open($dir . 'gh22176_progress.zip', ZipArchive::CREATE);
-$progress->registerProgressCallback(0.5, function ($r) {
-    throw new \Exception('progress boom');
-});
-$progress->addFromString('test', 'test');
-
+$zip->addFromString('test', 'test');
 echo "done\n";
-// Both archives are flushed and the objects destroyed during request
-// shutdown; the thrown exceptions bail out through libzip's zip_close()
-// without leaking its internal state.
+// The archive is flushed and the object destroyed during request shutdown;
+// the thrown exception bails out through libzip's zip_close() without leaking
+// its internal state, and the bailout resumes once libzip has unwound.
 ?>
 --CLEAN--
 <?php
 @unlink(__DIR__ . '/gh22176_cancel.zip');
-@unlink(__DIR__ . '/gh22176_progress.zip');
 ?>
 --EXPECTF--
 done
-
-Fatal error: Uncaught Exception: progress boom in %s:%d
-Stack trace:
-#0 [internal function]: {closure:%s:%d}(0.0)
-#1 {main}
-  thrown in %s on line %d
-
-Fatal error: Uncaught Exception: progress boom in %s:%d
-Stack trace:
-#0 [internal function]: {closure:%s:%d}(1.0)
-#1 {main}
-  thrown in %s on line %d
 
 Fatal error: Uncaught Exception: cancel boom in %s:%d
 Stack trace:
 #0 [internal function]: {closure:%s:%d}()
 #1 {main}
   thrown in %s on line %d
-
-Warning: PHP Request Shutdown: Cannot destroy the zip context: %s in Unknown on line 0

--- a/ext/zip/tests/gh22176.phpt
+++ b/ext/zip/tests/gh22176.phpt
@@ -1,0 +1,59 @@
+--TEST--
+GH-22176 (Memory leak when a ZipArchive cancel/progress callback bails out in the shutdown destructor)
+--EXTENSIONS--
+zip
+--SKIPIF--
+<?php
+if (!method_exists('ZipArchive', 'registerCancelCallback')) die('skip libzip too old');
+if (!method_exists('ZipArchive', 'registerProgressCallback')) die('skip libzip too old');
+?>
+--FILE--
+<?php
+$dir = __DIR__ . '/';
+
+$cancel = new ZipArchive;
+$cancel->open($dir . 'gh22176_cancel.zip', ZipArchive::CREATE);
+$cancel->registerCancelCallback(function () {
+    throw new \Exception('cancel boom');
+});
+$cancel->addFromString('test', 'test');
+
+$progress = new ZipArchive;
+$progress->open($dir . 'gh22176_progress.zip', ZipArchive::CREATE);
+$progress->registerProgressCallback(0.5, function ($r) {
+    throw new \Exception('progress boom');
+});
+$progress->addFromString('test', 'test');
+
+echo "done\n";
+// Both archives are flushed and the objects destroyed during request
+// shutdown; the thrown exceptions bail out through libzip's zip_close()
+// without leaking its internal state.
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/gh22176_cancel.zip');
+@unlink(__DIR__ . '/gh22176_progress.zip');
+?>
+--EXPECTF--
+done
+
+Fatal error: Uncaught Exception: progress boom in %s:%d
+Stack trace:
+#0 [internal function]: {closure:%s:%d}(0.0)
+#1 {main}
+  thrown in %s on line %d
+
+Fatal error: Uncaught Exception: progress boom in %s:%d
+Stack trace:
+#0 [internal function]: {closure:%s:%d}(1.0)
+#1 {main}
+  thrown in %s on line %d
+
+Fatal error: Uncaught Exception: cancel boom in %s:%d
+Stack trace:
+#0 [internal function]: {closure:%s:%d}()
+#1 {main}
+  thrown in %s on line %d
+
+Warning: PHP Request Shutdown: Cannot destroy the zip context: %s in Unknown on line 0

--- a/ext/zip/tests/gh22176_progress.phpt
+++ b/ext/zip/tests/gh22176_progress.phpt
@@ -1,0 +1,33 @@
+--TEST--
+GH-22176 (Memory leak when a ZipArchive progress callback bails out in the shutdown destructor)
+--EXTENSIONS--
+zip
+--SKIPIF--
+<?php
+if (!method_exists('ZipArchive', 'registerProgressCallback')) die('skip libzip too old');
+?>
+--FILE--
+<?php
+$zip = new ZipArchive;
+$zip->open(__DIR__ . '/gh22176_progress.zip', ZipArchive::CREATE);
+$zip->registerProgressCallback(0.5, function ($r) {
+    throw new \Exception('progress boom');
+});
+$zip->addFromString('test', 'test');
+echo "done\n";
+// The archive is flushed and the object destroyed during request shutdown;
+// the thrown exception bails out through libzip's zip_close() without leaking
+// its internal state, and the bailout resumes once libzip has unwound.
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/gh22176_progress.zip');
+?>
+--EXPECTF--
+done
+
+Fatal error: Uncaught Exception: progress boom in %s:%d
+Stack trace:
+#0 [internal function]: {closure:%s:%d}(0.0)
+#1 {main}
+  thrown in %s on line %d


### PR DESCRIPTION
Fix #22176

A cancel callback that throws during the implicit zip_close() in the shutdown destructor triggers a zend_bailout that longjmps through libzip, skipping its free(filelist). Wrap the call in zend_try/zend_catch and cancel on bailout so libzip can unwind and clean up.

While at it, apply the same guard to the progress callback, which is invoked from libzip the same way and is prone to the identical leak.