### PR TITLE
Fix ref unwrap for zend_call_method_if_exists() (zend_test)

### DIFF
--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -543,6 +543,9 @@ static ZEND_FUNCTION(zend_call_method_if_exists)
 		}
 		RETURN_NULL();
 	}
+	if (Z_TYPE_P(return_value) == IS_REFERENCE) {
+		zend_unwrap_reference(return_value);
+	}
 }
 
 static ZEND_FUNCTION(zend_test_call_with_consumed_args)

--- a/ext/zend_test/tests/gh22175.phpt
+++ b/ext/zend_test/tests/gh22175.phpt
@@ -1,0 +1,18 @@
+--TEST--
+GH-22175: zend_call_method_if_exists() must unref return value
+--CREDITS--
+YuanchengJiang
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+class Foo {
+    public function &test() {}
+}
+
+zend_call_method_if_exists(new Foo, 'test');
+
+?>
+--EXPECTF--
+Notice: Only variable references should be returned by reference in %s on line %d


### PR DESCRIPTION
Fixes GH-22175

Isolated to zend_test, so not a true bugfix.