### PR TITLE
ext/*: Make `X_from_obj(zend_object *obj)` functions macros

### DIFF
--- a/ext/curl/curl_private.h
+++ b/ext/curl/curl_private.h
@@ -151,15 +151,11 @@ void _php_setup_easy_copy_handlers(php_curl *ch, php_curl *source);
 /* Consumes `zv` */
 zend_long php_curl_get_long(zval *zv);
 
-static inline php_curl *curl_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, php_curl, std);
-}
+#define curl_from_obj(obj) ZEND_CONTAINER_OF(obj, php_curl, std)
 
 #define Z_CURL_P(zv) curl_from_obj(Z_OBJ_P(zv))
 
-static inline php_curlsh *curl_share_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, php_curlsh, std);
-}
+#define curl_share_from_obj(obj) ZEND_CONTAINER_OF(obj, php_curlsh, std)
 
 #define Z_CURL_SHARE_P(zv) curl_share_from_obj(Z_OBJ_P(zv))
 

--- a/ext/curl/multi.c
+++ b/ext/curl/multi.c
@@ -48,9 +48,7 @@
 
 zend_class_entry *curl_multi_ce;
 
-static inline php_curlm *curl_multi_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, php_curlm, std);
-}
+#define curl_multi_from_obj(obj) ZEND_CONTAINER_OF(obj, php_curlm, std)
 
 #define Z_CURL_MULTI_P(zv) curl_multi_from_obj(Z_OBJ_P(zv))
 

--- a/ext/date/php_date.h
+++ b/ext/date/php_date.h
@@ -58,9 +58,7 @@ struct _php_date_obj {
 	zend_object   std;
 };
 
-static inline php_date_obj *php_date_obj_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, php_date_obj, std);
-}
+#define php_date_obj_from_obj(obj) ZEND_CONTAINER_OF(obj, php_date_obj, std)
 
 #define Z_PHPDATE_P(zv)  php_date_obj_from_obj(Z_OBJ_P((zv)))
 
@@ -75,9 +73,7 @@ struct _php_timezone_obj {
 	zend_object std;
 };
 
-static inline php_timezone_obj *php_timezone_obj_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, php_timezone_obj, std);
-}
+#define php_timezone_obj_from_obj(obj) ZEND_CONTAINER_OF(obj, php_timezone_obj, std)
 
 #define Z_PHPTIMEZONE_P(zv)  php_timezone_obj_from_obj(Z_OBJ_P((zv)))
 
@@ -93,9 +89,7 @@ struct _php_interval_obj {
 	zend_object       std;
 };
 
-static inline php_interval_obj *php_interval_obj_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, php_interval_obj, std);
-}
+#define php_interval_obj_from_obj(obj) ZEND_CONTAINER_OF(obj, php_interval_obj, std)
 
 #define Z_PHPINTERVAL_P(zv)  php_interval_obj_from_obj(Z_OBJ_P((zv)))
 
@@ -112,9 +106,7 @@ struct _php_period_obj {
 	zend_object       std;
 };
 
-static inline php_period_obj *php_period_obj_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, php_period_obj, std);
-}
+#define php_period_obj_from_obj(obj) ZEND_CONTAINER_OF(obj, php_period_obj, std)
 
 #define Z_PHPPERIOD_P(zv)  php_period_obj_from_obj(Z_OBJ_P((zv)))
 

--- a/ext/dba/dba.c
+++ b/ext/dba/dba.c
@@ -335,10 +335,7 @@ static zend_result dba_connection_cast_object(zend_object *obj, zval *result, in
 	return zend_std_cast_object_tostring(obj, result, type);
 }
 
-static inline dba_connection *dba_connection_from_obj(zend_object *obj)
-{
-	return ZEND_CONTAINER_OF(obj, dba_connection, std);
-}
+#define dba_connection_from_obj(obj) ZEND_CONTAINER_OF(obj, dba_connection, std)
 
 #define Z_DBA_CONNECTION_P(zv) dba_connection_from_obj(Z_OBJ_P(zv))
 #define Z_DBA_INFO_P(zv) Z_DBA_CONNECTION_P(zv)->info

--- a/ext/dom/xml_common.h
+++ b/ext/dom/xml_common.h
@@ -27,9 +27,7 @@ typedef struct _dom_object {
 	zend_object std;
 } dom_object;
 
-static inline dom_object *php_dom_obj_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, dom_object, std);
-}
+#define php_dom_obj_from_obj(obj) ZEND_CONTAINER_OF(obj, dom_object, std)
 
 #define Z_DOMOBJ_P(zv)  php_dom_obj_from_obj(Z_OBJ_P((zv)))
 

--- a/ext/enchant/enchant.c
+++ b/ext/enchant/enchant.c
@@ -48,9 +48,7 @@ typedef struct _dict_struct {
 zend_class_entry *enchant_broker_ce;
 static zend_object_handlers enchant_broker_handlers;
 
-static inline enchant_broker *enchant_broker_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, enchant_broker, std);
-}
+#define enchant_broker_from_obj(obj) ZEND_CONTAINER_OF(obj, enchant_broker, std)
 
 #define Z_ENCHANT_BROKER_P(zv) enchant_broker_from_obj(Z_OBJ_P(zv))
 
@@ -66,9 +64,7 @@ static zend_object *enchant_broker_create_object(zend_class_entry *class_type) {
 zend_class_entry *enchant_dict_ce;
 static zend_object_handlers enchant_dict_handlers;
 
-static inline enchant_dict *enchant_dict_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, enchant_dict, std);
-}
+#define enchant_dict_from_obj(obj) ZEND_CONTAINER_OF(obj, enchant_dict, std)
 
 #define Z_ENCHANT_DICT_P(zv) enchant_dict_from_obj(Z_OBJ_P(zv))
 

--- a/ext/fileinfo/fileinfo.c
+++ b/ext/fileinfo/fileinfo.c
@@ -43,9 +43,7 @@ typedef struct _finfo_object {
 	zend_object zo;
 } finfo_object;
 
-static inline finfo_object *php_finfo_fetch_object(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, finfo_object, zo);
-}
+#define php_finfo_fetch_object(obj) ZEND_CONTAINER_OF(obj, finfo_object, zo)
 
 #define Z_FINFO_P(zv) php_finfo_fetch_object(Z_OBJ_P((zv)))
 

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -144,14 +144,7 @@ static zend_function *php_gd_image_object_get_constructor(zend_object *object)
 	return NULL;
 }
 
-/**
- * Returns the underlying php_gd_image_object from a zend_object
- */
-
-static zend_always_inline php_gd_image_object* php_gd_exgdimage_from_zobj_p(zend_object* obj)
-{
-	return ZEND_CONTAINER_OF(obj, php_gd_image_object, std);
-}
+#define php_gd_exgdimage_from_zobj_p(obj) ZEND_CONTAINER_OF(obj, php_gd_image_object, std)
 
 /**
  * Converts an extension GdImage instance contained within a zval into the gdImagePtr

--- a/ext/gmp/php_gmp_int.h
+++ b/ext/gmp/php_gmp_int.h
@@ -35,9 +35,7 @@ typedef struct _gmp_object {
 	zend_object std;
 } gmp_object;
 
-static inline gmp_object *php_gmp_object_from_zend_object(zend_object *zobj) {
-	return ZEND_CONTAINER_OF(zobj, gmp_object, std);
-}
+#define php_gmp_object_from_zend_object(zobj) ZEND_CONTAINER_OF(zobj, gmp_object, std)
 
 PHP_GMP_API zend_class_entry *php_gmp_class_entry(void);
 

--- a/ext/intl/breakiterator/breakiterator_class.h
+++ b/ext/intl/breakiterator/breakiterator_class.h
@@ -41,9 +41,7 @@ typedef struct {
 	zend_object	zo;
 } BreakIterator_object;
 
-static inline BreakIterator_object *php_intl_breakiterator_fetch_object(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, BreakIterator_object, zo);
-}
+#define php_intl_breakiterator_fetch_object(obj) ZEND_CONTAINER_OF(obj, BreakIterator_object, zo)
 #define Z_INTL_BREAKITERATOR_P(zv) php_intl_breakiterator_fetch_object(Z_OBJ_P(zv))
 
 #define BREAKITER_ERROR(bio)		(bio)->err

--- a/ext/intl/calendar/calendar_class.h
+++ b/ext/intl/calendar/calendar_class.h
@@ -38,9 +38,7 @@ typedef struct {
 	zend_object	zo;
 } Calendar_object;
 
-static inline Calendar_object *php_intl_calendar_fetch_object(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, Calendar_object, zo);
-}
+#define php_intl_calendar_fetch_object(obj) ZEND_CONTAINER_OF(obj, Calendar_object, zo)
 #define Z_INTL_CALENDAR_P(zv) php_intl_calendar_fetch_object(Z_OBJ_P(zv))
 
 #define CALENDAR_ERROR(co)		(co)->err

--- a/ext/intl/collator/collator_class.h
+++ b/ext/intl/collator/collator_class.h
@@ -47,9 +47,7 @@ typedef struct {
 #define COLLATOR_ERROR_CODE(co)   INTL_ERROR_CODE(COLLATOR_ERROR(co))
 #define COLLATOR_ERROR_CODE_P(co) &(INTL_ERROR_CODE(COLLATOR_ERROR(co)))
 
-static inline Collator_object *php_intl_collator_fetch_object(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, Collator_object, zo);
-}
+#define php_intl_collator_fetch_object(obj) ZEND_CONTAINER_OF(obj, Collator_object, zo)
 #define Z_INTL_COLLATOR_P(zv) php_intl_collator_fetch_object(Z_OBJ_P(zv))
 
 #ifdef __cplusplus

--- a/ext/intl/common/common_enum.h
+++ b/ext/intl/common/common_enum.h
@@ -51,10 +51,7 @@ typedef struct {
 	zend_object				zo;
 } IntlIterator_object;
 
-
-static inline IntlIterator_object *php_intl_iterator_fetch_object(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, IntlIterator_object, zo);
-}
+#define php_intl_iterator_fetch_object(obj) ZEND_CONTAINER_OF(obj, IntlIterator_object, zo)
 #define Z_INTL_ITERATOR_P(zv) php_intl_iterator_fetch_object(Z_OBJ_P(zv))
 
 typedef struct {

--- a/ext/intl/dateformat/dateformat_class.h
+++ b/ext/intl/dateformat/dateformat_class.h
@@ -36,9 +36,7 @@ typedef struct {
 	zend_object		zo;
 } IntlDateFormatter_object;
 
-static inline IntlDateFormatter_object *php_intl_dateformatter_fetch_object(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, IntlDateFormatter_object, zo);
-}
+#define php_intl_dateformatter_fetch_object(obj) ZEND_CONTAINER_OF(obj, IntlDateFormatter_object, zo)
 #define Z_INTL_DATEFORMATTER_P(zv) php_intl_dateformatter_fetch_object(Z_OBJ_P(zv))
 
 #ifdef __cplusplus

--- a/ext/intl/dateformat/datepatterngenerator_class.h
+++ b/ext/intl/dateformat/datepatterngenerator_class.h
@@ -36,9 +36,7 @@ typedef struct {
 	zend_object	zo;
 } IntlDatePatternGenerator_object;
 
-static inline IntlDatePatternGenerator_object *php_intl_datepatterngenerator_fetch_object(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, IntlDatePatternGenerator_object, zo);
-}
+#define php_intl_datepatterngenerator_fetch_object(obj) ZEND_CONTAINER_OF(obj, IntlDatePatternGenerator_object, zo)
 #define Z_INTL_DATEPATTERNGENERATOR_P(zv) php_intl_datepatterngenerator_fetch_object(Z_OBJ_P(zv))
 
 #define DTPATTERNGEN_ERROR(dtpgo)		(dtpgo)->err

--- a/ext/intl/formatter/formatter_class.h
+++ b/ext/intl/formatter/formatter_class.h
@@ -32,9 +32,7 @@ typedef struct {
 	zend_object     zo;
 } NumberFormatter_object;
 
-static inline NumberFormatter_object *php_intl_number_format_fetch_object(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, NumberFormatter_object, zo);
-}
+#define php_intl_number_format_fetch_object(obj) ZEND_CONTAINER_OF(obj, NumberFormatter_object, zo)
 #define Z_INTL_NUMBERFORMATTER_P(zv) php_intl_number_format_fetch_object(Z_OBJ_P(zv))
 
 #ifdef __cplusplus

--- a/ext/intl/listformatter/listformatter_class.h
+++ b/ext/intl/listformatter/listformatter_class.h
@@ -42,9 +42,7 @@ typedef struct {
     zend_object     zo;
 } ListFormatter_object;
 
-static inline ListFormatter_object *php_intl_listformatter_fetch_object(zend_object *obj) {
-    return ZEND_CONTAINER_OF(obj, ListFormatter_object, zo);
-}
+#define php_intl_listformatter_fetch_object(obj) ZEND_CONTAINER_OF(obj, ListFormatter_object, zo)
 #define Z_INTL_LISTFORMATTER_P(zv) php_intl_listformatter_fetch_object(Z_OBJ_P(zv))
 
 #define LISTFORMATTER_ERROR(lfo) (lfo)->lf_data.error

--- a/ext/intl/msgformat/msgformat_class.h
+++ b/ext/intl/msgformat/msgformat_class.h
@@ -30,10 +30,7 @@ typedef struct {
 	zend_object     zo;
 } MessageFormatter_object;
 
-
-static inline MessageFormatter_object *php_intl_messageformatter_fetch_object(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, MessageFormatter_object, zo);
-}
+#define php_intl_messageformatter_fetch_object(obj) ZEND_CONTAINER_OF(obj, MessageFormatter_object, zo)
 #define Z_INTL_MESSAGEFORMATTER_P(zv) php_intl_messageformatter_fetch_object(Z_OBJ_P(zv))
 
 void msgformat_register_class( void );

--- a/ext/intl/rangeformatter/rangeformatter_class.h
+++ b/ext/intl/rangeformatter/rangeformatter_class.h
@@ -36,9 +36,7 @@ typedef struct {
     zend_object     zo;
 } IntlNumberRangeFormatter_object;
 
-static inline IntlNumberRangeFormatter_object *php_intl_numberrangeformatter_fetch_object(zend_object *obj) {
-    return ZEND_CONTAINER_OF(obj, IntlNumberRangeFormatter_object, zo);
-}
+#define php_intl_numberrangeformatter_fetch_object(obj) ZEND_CONTAINER_OF(obj, IntlNumberRangeFormatter_object, zo)
 
 #define Z_INTL_RANGEFORMATTER_P(zv) php_intl_numberrangeformatter_fetch_object(Z_OBJ_P(zv))
 

--- a/ext/intl/spoofchecker/spoofchecker_class.h
+++ b/ext/intl/spoofchecker/spoofchecker_class.h
@@ -42,9 +42,7 @@ typedef struct {
 	zend_object     zo;
 } Spoofchecker_object;
 
-static inline Spoofchecker_object *php_intl_spoofchecker_fetch_object(zend_object *obj) {
-	    return ZEND_CONTAINER_OF(obj, Spoofchecker_object, zo);
-}
+#define php_intl_spoofchecker_fetch_object(obj) ZEND_CONTAINER_OF(obj, Spoofchecker_object, zo)
 #define Z_INTL_SPOOFCHECKER_P(zv) php_intl_spoofchecker_fetch_object((Z_OBJ_P(zv)))
 
 #define SPOOFCHECKER_ERROR(co) (co)->err

--- a/ext/intl/timezone/timezone_class.h
+++ b/ext/intl/timezone/timezone_class.h
@@ -46,9 +46,7 @@ typedef struct {
 	zend_object		zo;
 } TimeZone_object;
 
-static inline TimeZone_object *php_intl_timezone_fetch_object(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, TimeZone_object, zo);
-}
+#define php_intl_timezone_fetch_object(obj) ZEND_CONTAINER_OF(obj, TimeZone_object, zo)
 #define Z_INTL_TIMEZONE_P(zv) php_intl_timezone_fetch_object(Z_OBJ_P(zv))
 
 #define TIMEZONE_ERROR(to)						(to)->err

--- a/ext/intl/transliterator/transliterator_class.h
+++ b/ext/intl/transliterator/transliterator_class.h
@@ -38,9 +38,7 @@ typedef struct {
 	zend_object     zo;
 } Transliterator_object;
 
-static inline Transliterator_object *php_intl_transliterator_fetch_object(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, Transliterator_object, zo);
-}
+#define php_intl_transliterator_fetch_object(obj) ZEND_CONTAINER_OF(obj, Transliterator_object, zo)
 #define Z_INTL_TRANSLITERATOR_P(zv) php_intl_transliterator_fetch_object(Z_OBJ_P(zv))
 
 #define TRANSLITERATOR_FORWARD UTRANS_FORWARD

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -100,9 +100,7 @@ ZEND_TSRMLS_CACHE_DEFINE()
 ZEND_GET_MODULE(ldap)
 #endif
 
-static inline ldap_linkdata *ldap_link_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, ldap_linkdata, std);
-}
+#define ldap_link_from_obj(obj) ZEND_CONTAINER_OF(obj, ldap_linkdata, std)
 
 #define Z_LDAP_LINK_P(zv) ldap_link_from_obj(Z_OBJ_P(zv))
 
@@ -147,9 +145,7 @@ static void ldap_link_free_obj(zend_object *obj)
 	zend_object_std_dtor(&ld->std);
 }
 
-static inline ldap_resultdata *ldap_result_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, ldap_resultdata, std);
-}
+#define ldap_result_from_obj(obj) ZEND_CONTAINER_OF(obj, ldap_resultdata, std)
 
 #define Z_LDAP_RESULT_P(zv) ldap_result_from_obj(Z_OBJ_P(zv))
 
@@ -184,9 +180,7 @@ static void ldap_result_free_obj(zend_object *obj)
 	zend_object_std_dtor(&result->std);
 }
 
-static inline ldap_result_entry *ldap_result_entry_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, ldap_result_entry, std);
-}
+#define ldap_result_entry_from_obj(obj) ZEND_CONTAINER_OF(obj, ldap_result_entry, std)
 
 #define Z_LDAP_RESULT_ENTRY_P(zv) ldap_result_entry_from_obj(Z_OBJ_P(zv))
 

--- a/ext/mysqli/php_mysqli_structs.h
+++ b/ext/mysqli/php_mysqli_structs.h
@@ -61,9 +61,7 @@ typedef struct _mysqli_object {
 	zend_object 		zo;
 } mysqli_object; /* extends zend_object */
 
-static inline mysqli_object *php_mysqli_fetch_object(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, mysqli_object, zo);
-}
+#define php_mysqli_fetch_object(obj) ZEND_CONTAINER_OF(obj, mysqli_object, zo)
 
 #define Z_MYSQLI_P(zv) php_mysqli_fetch_object(Z_OBJ_P((zv)))
 

--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -60,7 +60,6 @@
 void odbc_do_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent);
 static void safe_odbc_disconnect(void *handle);
 static void close_results_with_connection(odbc_connection *conn);
-static inline odbc_result *odbc_result_from_obj(zend_object *obj);
 
 static int le_pconn;
 
@@ -85,10 +84,7 @@ static void odbc_insert_new_result(odbc_connection *connection, zval *result)
 	Z_ADDREF_P(result);
 }
 
-static inline odbc_link *odbc_link_from_obj(zend_object *obj)
-{
-	return ZEND_CONTAINER_OF(obj, odbc_link, std);
-}
+#define odbc_link_from_obj(obj) ZEND_CONTAINER_OF(obj, odbc_link, std)
 
 static int _close_pconn_with_res(zval *zv, void *p)
 {
@@ -202,10 +198,7 @@ static void odbc_connection_free_obj(zend_object *obj)
 	zend_object_std_dtor(&link->std);
 }
 
-static inline odbc_result *odbc_result_from_obj(zend_object *obj)
-{
-	return ZEND_CONTAINER_OF(obj, odbc_result, std);
-}
+#define odbc_result_from_obj(obj) ZEND_CONTAINER_OF(obj, odbc_result, std)
 
 static zend_object *odbc_result_create_object(zend_class_entry *class_type)
 {

--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -68,6 +68,7 @@ static zend_object_handlers odbc_connection_object_handlers, odbc_result_object_
 
 #define Z_ODBC_LINK_P(zv) odbc_link_from_obj(Z_OBJ_P(zv))
 #define Z_ODBC_CONNECTION_P(zv) Z_ODBC_LINK_P(zv)->connection
+#define odbc_result_from_obj(obj) ZEND_CONTAINER_OF(obj, odbc_result, std)
 #define Z_ODBC_RESULT_P(zv) odbc_result_from_obj(Z_OBJ_P(zv))
 
 static void odbc_insert_new_result(odbc_connection *connection, zval *result)
@@ -197,8 +198,6 @@ static void odbc_connection_free_obj(zend_object *obj)
 
 	zend_object_std_dtor(&link->std);
 }
-
-#define odbc_result_from_obj(obj) ZEND_CONTAINER_OF(obj, odbc_result, std)
 
 static zend_object *odbc_result_create_object(zend_class_entry *class_type)
 {

--- a/ext/openssl/php_openssl.h
+++ b/ext/openssl/php_openssl.h
@@ -163,9 +163,7 @@ typedef struct _php_openssl_certificate_object {
 
 extern zend_class_entry *php_openssl_certificate_ce;
 
-static inline php_openssl_certificate_object *php_openssl_certificate_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, php_openssl_certificate_object, std);
-}
+#define php_openssl_certificate_from_obj(obj) ZEND_CONTAINER_OF(obj, php_openssl_certificate_object, std)
 
 #define Z_OPENSSL_CERTIFICATE_P(zv) php_openssl_certificate_from_obj(Z_OBJ_P(zv))
 
@@ -178,9 +176,7 @@ typedef struct _php_openssl_x509_request_object {
 	zend_object std;
 } php_openssl_request_object;
 
-static inline php_openssl_request_object *php_openssl_request_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, php_openssl_request_object, std);
-}
+#define php_openssl_request_from_obj(obj) ZEND_CONTAINER_OF(obj, php_openssl_request_object, std)
 
 #define Z_OPENSSL_REQUEST_P(zv) php_openssl_request_from_obj(Z_OBJ_P(zv))
 
@@ -194,9 +190,7 @@ typedef struct _php_openssl_pkey_object {
 	zend_object std;
 } php_openssl_pkey_object;
 
-static inline php_openssl_pkey_object *php_openssl_pkey_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, php_openssl_pkey_object, std);
-}
+#define php_openssl_pkey_from_obj(obj) ZEND_CONTAINER_OF(obj, php_openssl_pkey_object, std)
 
 #define Z_OPENSSL_PKEY_P(zv) php_openssl_pkey_from_obj(Z_OBJ_P(zv))
 

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -521,9 +521,7 @@ static inline pdo_dbh_t *php_pdo_dbh_fetch_inner(zend_object *obj) {
 	return (pdo_dbh_t *)((ZEND_CONTAINER_OF(obj, pdo_dbh_object_t, std))->inner);
 }
 
-static inline pdo_dbh_object_t *php_pdo_dbh_fetch_object(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, pdo_dbh_object_t, std);
-}
+#define php_pdo_dbh_fetch_object(obj) ZEND_CONTAINER_OF(obj, pdo_dbh_object_t, std)
 
 #define Z_PDO_DBH_P(zv) php_pdo_dbh_fetch_inner(Z_OBJ_P((zv)))
 #define Z_PDO_OBJECT_P(zv) php_pdo_dbh_fetch_object(Z_OBJ_P((zv)))
@@ -637,11 +635,7 @@ struct _pdo_stmt_t {
 	zend_object std;
 };
 
-
-
-static inline pdo_stmt_t *php_pdo_stmt_fetch_object(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, pdo_stmt_t, std);
-}
+#define php_pdo_stmt_fetch_object(obj) ZEND_CONTAINER_OF(obj, pdo_stmt_t, std)
 
 #define Z_PDO_STMT_P(zv) php_pdo_stmt_fetch_object(Z_OBJ_P((zv)))
 
@@ -650,9 +644,7 @@ struct _pdo_row_t {
 	zend_object std;
 };
 
-static inline pdo_row_t *php_pdo_row_fetch_object(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, pdo_row_t, std);
-}
+#define php_pdo_row_fetch_object(obj) ZEND_CONTAINER_OF(obj, pdo_row_t, std)
 
 struct _pdo_scanner_t {
 	const char *ptr, *cur, *tok, *end;

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -151,9 +151,7 @@ static int le_plink;
 static zend_class_entry *pgsql_link_ce, *pgsql_result_ce, *pgsql_lob_ce;
 static zend_object_handlers pgsql_link_object_handlers, pgsql_result_object_handlers, pgsql_lob_object_handlers;
 
-static inline pgsql_link_handle *pgsql_link_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, pgsql_link_handle, std);
-}
+#define pgsql_link_from_obj(obj) ZEND_CONTAINER_OF(obj, pgsql_link_handle, std)
 
 #define Z_PGSQL_LINK_P(zv) pgsql_link_from_obj(Z_OBJ_P(zv))
 
@@ -207,9 +205,7 @@ static void pgsql_link_free_obj(zend_object *obj)
 	zend_object_std_dtor(&link->std);
 }
 
-static inline pgsql_result_handle *pgsql_result_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, pgsql_result_handle, std);
-}
+#define pgsql_result_from_obj(obj) ZEND_CONTAINER_OF(obj, pgsql_result_handle, std)
 
 #define Z_PGSQL_RESULT_P(zv) pgsql_result_from_obj(Z_OBJ_P(zv))
 
@@ -244,9 +240,7 @@ static void pgsql_result_free_obj(zend_object *obj)
 	zend_object_std_dtor(&pg_result->std);
 }
 
-static inline pgLofp *pgsql_lob_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, pgLofp, std);
-}
+#define pgsql_lob_from_obj(obj) ZEND_CONTAINER_OF(obj, pgLofp, std)
 
 #define Z_PGSQL_LOB_P(zv) pgsql_lob_from_obj(Z_OBJ_P(zv))
 

--- a/ext/random/php_random.h
+++ b/ext/random/php_random.h
@@ -125,13 +125,8 @@ extern PHPAPI zend_class_entry *random_ce_Random_Randomizer;
 
 extern PHPAPI zend_class_entry *random_ce_Random_IntervalBoundary;
 
-static inline php_random_engine *php_random_engine_from_obj(zend_object *object) {
-	return ZEND_CONTAINER_OF(object, php_random_engine, std);
-}
-
-static inline php_random_randomizer *php_random_randomizer_from_obj(zend_object *object) {
-	return ZEND_CONTAINER_OF(object, php_random_randomizer, std);
-}
+#define php_random_engine_from_obj(object) ZEND_CONTAINER_OF(object, php_random_engine, std)
+#define php_random_randomizer_from_obj(object) ZEND_CONTAINER_OF(object, php_random_randomizer, std)
 
 # define Z_RANDOM_ENGINE_P(zval) php_random_engine_from_obj(Z_OBJ_P(zval))
 

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -174,9 +174,7 @@ typedef struct {
 	zend_object zo;
 } reflection_object;
 
-static inline reflection_object *reflection_object_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, reflection_object, zo);
-}
+#define reflection_object_from_obj(obj) ZEND_CONTAINER_OF(obj, reflection_object, zo)
 
 #define Z_REFLECTION_P(zv)  reflection_object_from_obj(Z_OBJ_P((zv)))
 /* }}} */

--- a/ext/shmop/shmop.c
+++ b/ext/shmop/shmop.c
@@ -68,10 +68,7 @@ typedef struct php_shmop
 zend_class_entry *shmop_ce;
 static zend_object_handlers shmop_object_handlers;
 
-static inline php_shmop *shmop_from_obj(zend_object *obj)
-{
-	return ZEND_CONTAINER_OF(obj, php_shmop, std);
-}
+#define shmop_from_obj(obj) ZEND_CONTAINER_OF(obj, php_shmop, std)
 
 #define Z_SHMOP_P(zv) shmop_from_obj(Z_OBJ_P(zv))
 

--- a/ext/simplexml/php_simplexml_exports.h
+++ b/ext/simplexml/php_simplexml_exports.h
@@ -35,10 +35,7 @@
 
 PHP_SXE_API zend_object *sxe_object_new(zend_class_entry *ce);
 
-static inline php_sxe_object *php_sxe_fetch_object(zend_object *obj) /* {{{ */ {
-	return ZEND_CONTAINER_OF(obj, php_sxe_object, zo);
-}
-/* }}} */
+#define php_sxe_fetch_object(obj) ZEND_CONTAINER_OF(obj, php_sxe_object, zo)
 
 #define Z_SXEOBJ_P(zv) php_sxe_fetch_object(Z_OBJ_P((zv)))
 

--- a/ext/snmp/php_snmp.h
+++ b/ext/snmp/php_snmp.h
@@ -56,9 +56,7 @@ typedef struct _php_snmp_object {
 	zend_object zo;
 } php_snmp_object;
 
-static inline php_snmp_object *php_snmp_fetch_object(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, php_snmp_object, zo);
-}
+#define php_snmp_fetch_object(obj) ZEND_CONTAINER_OF(obj, php_snmp_object, zo)
 
 #define Z_SNMP_P(zv) php_snmp_fetch_object(Z_OBJ_P((zv)))
 

--- a/ext/soap/php_soap.h
+++ b/ext/soap/php_soap.h
@@ -258,10 +258,7 @@ typedef struct soap_url_object {
 	zend_object std;
 } soap_url_object;
 
-static inline soap_url_object *soap_url_object_fetch(zend_object *obj)
-{
-	return ZEND_CONTAINER_OF(obj, soap_url_object, std);
-}
+#define soap_url_object_fetch(obj) ZEND_CONTAINER_OF(obj, soap_url_object, std)
 
 #define Z_SOAP_URL_P(zv) soap_url_object_fetch(Z_OBJ_P(zv))
 

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -205,13 +205,8 @@ typedef struct {
 	zend_object std;
 } soap_client_object;
 
-static inline soap_client_object *soap_client_object_fetch(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, soap_client_object, std);
-}
-
-static inline soap_server_object *soap_server_object_fetch(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, soap_server_object, std);
-}
+#define soap_client_object_fetch(obj) ZEND_CONTAINER_OF(obj, soap_client_object, std)
+#define soap_server_object_fetch(obj) ZEND_CONTAINER_OF(obj, soap_server_object, std)
 
 static zend_object *soap_client_object_create(zend_class_entry *ce)
 {
@@ -286,10 +281,7 @@ static zend_result soap_url_cast_object(zend_object *obj, zval *result, int type
 	return zend_std_cast_object_tostring(obj, result, type);
 }
 
-static inline soap_sdl_object *soap_sdl_object_fetch(zend_object *obj)
-{
-	return ZEND_CONTAINER_OF(obj, soap_sdl_object, std);
-}
+#define soap_sdl_object_fetch(obj) ZEND_CONTAINER_OF(obj, soap_sdl_object, std)
 
 #define Z_SOAP_SDL_P(zv) soap_sdl_object_fetch(Z_OBJ_P(zv))
 

--- a/ext/sockets/php_sockets.h
+++ b/ext/sockets/php_sockets.h
@@ -75,9 +75,7 @@ typedef struct {
 
 extern PHP_SOCKETS_API zend_class_entry *socket_ce;
 
-static inline php_socket *socket_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, php_socket, std);
-}
+#define socket_from_obj(obj) ZEND_CONTAINER_OF(obj, php_socket, std)
 
 #define Z_SOCKET_P(zv) socket_from_obj(Z_OBJ_P(zv))
 

--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -180,9 +180,7 @@ typedef struct {
 zend_class_entry *address_info_ce;
 static zend_object_handlers address_info_object_handlers;
 
-static inline php_addrinfo *address_info_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, php_addrinfo, std);
-}
+#define address_info_from_obj(obj) ZEND_CONTAINER_OF(obj, php_addrinfo, std)
 
 #define Z_ADDRESS_INFO_P(zv) address_info_from_obj(Z_OBJ_P(zv))
 

--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -850,18 +850,17 @@ PHP_FUNCTION(socket_listen)
 PHP_FUNCTION(socket_close)
 {
 	zval *arg1;
-	php_socket *php_socket;
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
 		Z_PARAM_OBJECT_OF_CLASS(arg1, socket_ce)
 	ZEND_PARSE_PARAMETERS_END();
 
-	php_socket = Z_SOCKET_P(arg1);
-	ENSURE_SOCKET_VALID(php_socket);
+	php_socket *socket = Z_SOCKET_P(arg1);
+	ENSURE_SOCKET_VALID(socket);
 
-	if (!Z_ISUNDEF(php_socket->zstream)) {
+	if (!Z_ISUNDEF(socket->zstream)) {
 		php_stream *stream = NULL;
-		php_stream_from_zval_no_verify(stream, &php_socket->zstream);
+		php_stream_from_zval_no_verify(stream, &socket->zstream);
 		if (stream != NULL) {
 			/* close & destroy stream, incl. removing it from the rsrc list;
 			 * resource stored in php_sock->zstream will become invalid */
@@ -870,13 +869,13 @@ PHP_FUNCTION(socket_close)
 					(stream->is_persistent?PHP_STREAM_FREE_CLOSE_PERSISTENT:0));
 		}
 	} else {
-		if (!IS_INVALID_SOCKET(php_socket)) {
-			close(php_socket->bsd_socket);
+		if (!IS_INVALID_SOCKET(socket)) {
+			close(socket->bsd_socket);
 		}
 	}
 
-	ZVAL_UNDEF(&php_socket->zstream);
-	php_socket->bsd_socket = -1;
+	ZVAL_UNDEF(&socket->zstream);
+	socket->bsd_socket = -1;
 }
 /* }}} */
 

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -51,10 +51,7 @@ typedef struct _spl_array_object {
 	zend_object       std;
 } spl_array_object;
 
-static inline spl_array_object *spl_array_from_obj(zend_object *obj) /* {{{ */ {
-	return ZEND_CONTAINER_OF(obj, spl_array_object, std);
-}
-/* }}} */
+#define spl_array_from_obj(obj) ZEND_CONTAINER_OF(obj, spl_array_object, std)
 
 #define Z_SPLARRAY_P(zv)  spl_array_from_obj(Z_OBJ_P((zv)))
 

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -48,11 +48,7 @@ PHPAPI zend_class_entry *spl_ce_GlobIterator;
 PHPAPI zend_class_entry *spl_ce_SplFileObject;
 PHPAPI zend_class_entry *spl_ce_SplTempFileObject;
 
-/* Object helper */
-static inline spl_filesystem_object *spl_filesystem_from_obj(zend_object *obj) /* {{{ */ {
-	return ZEND_CONTAINER_OF(obj, spl_filesystem_object, std);
-}
-/* }}} */
+#define spl_filesystem_from_obj(obj) ZEND_CONTAINER_OF(obj, spl_filesystem_object, std)
 
 /* define an overloaded iterator structure */
 typedef struct {

--- a/ext/spl/spl_dllist.c
+++ b/ext/spl/spl_dllist.c
@@ -85,10 +85,7 @@ struct _spl_dllist_it {
 	int                    flags;
 };
 
-static inline spl_dllist_object *spl_dllist_from_obj(zend_object *obj) /* {{{ */ {
-	return ZEND_CONTAINER_OF(obj, spl_dllist_object, std);
-}
-/* }}} */
+#define spl_dllist_from_obj(obj) ZEND_CONTAINER_OF(obj, spl_dllist_object, std)
 
 #define Z_SPLDLLIST_P(zv)  spl_dllist_from_obj(Z_OBJ_P((zv)))
 

--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -53,10 +53,7 @@ typedef struct _spl_fixedarray_it {
 	zend_long            current;
 } spl_fixedarray_it;
 
-static spl_fixedarray_object *spl_fixed_array_from_obj(zend_object *obj)
-{
-	return ZEND_CONTAINER_OF(obj, spl_fixedarray_object, std);
-}
+#define spl_fixed_array_from_obj(obj) ZEND_CONTAINER_OF(obj, spl_fixedarray_object, std)
 
 #define Z_SPLFIXEDARRAY_P(zv)  spl_fixed_array_from_obj(Z_OBJ_P((zv)))
 

--- a/ext/spl/spl_heap.c
+++ b/ext/spl/spl_heap.c
@@ -70,10 +70,7 @@ typedef struct _spl_pqueue_elem {
 	zval priority;
 } spl_pqueue_elem;
 
-static inline spl_heap_object *spl_heap_from_obj(zend_object *obj) /* {{{ */ {
-	return ZEND_CONTAINER_OF(obj, spl_heap_object, std);
-}
-/* }}} */
+#define spl_heap_from_obj(obj) ZEND_CONTAINER_OF(obj, spl_heap_object, std)
 
 #define Z_SPLHEAP_P(zv)  spl_heap_from_obj(Z_OBJ_P((zv)))
 

--- a/ext/spl/spl_iterators.c
+++ b/ext/spl/spl_iterators.c
@@ -136,16 +136,11 @@ typedef struct _spl_dual_it_object {
 static zend_object_handlers spl_handlers_rec_it_it;
 static zend_object_handlers spl_handlers_dual_it;
 
-static inline spl_recursive_it_object *spl_recursive_it_from_obj(zend_object *obj) /* {{{ */ {
-	return ZEND_CONTAINER_OF(obj, spl_recursive_it_object, std);
-}
-/* }}} */
+#define spl_recursive_it_from_obj(obj) ZEND_CONTAINER_OF(obj, spl_recursive_it_object, std)
 
 #define Z_SPLRECURSIVE_IT_P(zv)  spl_recursive_it_from_obj(Z_OBJ_P((zv)))
 
-static inline spl_dual_it_object *spl_dual_it_from_obj(zend_object *obj) /* {{{ */ {
-	return ZEND_CONTAINER_OF(obj, spl_dual_it_object, std);
-} /* }}} */
+#define spl_dual_it_from_obj(obj) ZEND_CONTAINER_OF(obj, spl_dual_it_object, std)
 
 #define Z_SPLDUAL_IT_P(zv)  spl_dual_it_from_obj(Z_OBJ_P((zv)))
 

--- a/ext/spl/spl_observer.c
+++ b/ext/spl/spl_observer.c
@@ -64,10 +64,7 @@ typedef struct _spl_SplObjectStorageElement {
 	zval inf;
 } spl_SplObjectStorageElement; /* }}} */
 
-static inline spl_SplObjectStorage *spl_object_storage_from_obj(zend_object *obj) /* {{{ */ {
-	return ZEND_CONTAINER_OF(obj, spl_SplObjectStorage, std);
-}
-/* }}} */
+#define spl_object_storage_from_obj(obj) ZEND_CONTAINER_OF(obj, spl_SplObjectStorage, std)
 
 #define Z_SPLOBJSTORAGE_P(zv)  spl_object_storage_from_obj(Z_OBJ_P((zv)))
 

--- a/ext/sqlite3/php_sqlite3_structs.h
+++ b/ext/sqlite3/php_sqlite3_structs.h
@@ -72,9 +72,7 @@ typedef struct _php_sqlite3_db_object  {
 	zend_object zo;
 } php_sqlite3_db_object;
 
-static inline php_sqlite3_db_object *php_sqlite3_db_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, php_sqlite3_db_object, zo);
-}
+#define php_sqlite3_db_from_obj(obj) ZEND_CONTAINER_OF(obj, php_sqlite3_db_object, zo)
 
 #define Z_SQLITE3_DB_P(zv)  php_sqlite3_db_from_obj(Z_OBJ_P((zv)))
 
@@ -101,9 +99,7 @@ struct _php_sqlite3_result_object  {
 	zend_object zo;
 };
 
-static inline php_sqlite3_result *php_sqlite3_result_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, php_sqlite3_result, zo);
-}
+#define php_sqlite3_result_from_obj(obj) ZEND_CONTAINER_OF(obj, php_sqlite3_result, zo)
 
 #define Z_SQLITE3_RESULT_P(zv)  php_sqlite3_result_from_obj(Z_OBJ_P((zv)))
 
@@ -119,9 +115,7 @@ struct _php_sqlite3_stmt_object  {
 	zend_object zo;
 };
 
-static inline php_sqlite3_stmt *php_sqlite3_stmt_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, php_sqlite3_stmt, zo);
-}
+#define php_sqlite3_stmt_from_obj(obj) ZEND_CONTAINER_OF(obj, php_sqlite3_stmt, zo)
 
 #define Z_SQLITE3_STMT_P(zv)  php_sqlite3_stmt_from_obj(Z_OBJ_P((zv)))
 

--- a/ext/sysvmsg/sysvmsg.c
+++ b/ext/sysvmsg/sysvmsg.c
@@ -65,9 +65,7 @@ ZEND_GET_MODULE(sysvmsg)
 zend_class_entry *sysvmsg_queue_ce;
 static zend_object_handlers sysvmsg_queue_object_handlers;
 
-static inline sysvmsg_queue_t *sysvmsg_queue_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, sysvmsg_queue_t, std);
-}
+#define sysvmsg_queue_from_obj(obj) ZEND_CONTAINER_OF(obj, sysvmsg_queue_t, std)
 
 #define Z_SYSVMSG_QUEUE_P(zv) sysvmsg_queue_from_obj(Z_OBJ_P(zv))
 

--- a/ext/sysvsem/sysvsem.c
+++ b/ext/sysvsem/sysvsem.c
@@ -82,9 +82,7 @@ ZEND_GET_MODULE(sysvsem)
 zend_class_entry *sysvsem_ce;
 static zend_object_handlers sysvsem_object_handlers;
 
-static inline sysvsem_sem *sysvsem_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, sysvsem_sem, std);
-}
+#define sysvsem_from_obj(obj) ZEND_CONTAINER_OF(obj, sysvsem_sem, std)
 
 #define Z_SYSVSEM_P(zv) sysvsem_from_obj(Z_OBJ_P(zv))
 

--- a/ext/sysvshm/sysvshm.c
+++ b/ext/sysvshm/sysvshm.c
@@ -33,9 +33,7 @@
 zend_class_entry *sysvshm_ce;
 static zend_object_handlers sysvshm_object_handlers;
 
-static inline sysvshm_shm *sysvshm_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, sysvshm_shm, std);
-}
+#define sysvshm_from_obj(obj) ZEND_CONTAINER_OF(obj, sysvshm_shm, std)
 
 #define Z_SYSVSHM_P(zv) sysvshm_from_obj(Z_OBJ_P(zv))
 

--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -104,9 +104,7 @@ struct _PHPTidyObj {
 	zend_object		std;
 };
 
-static inline PHPTidyObj *php_tidy_fetch_object(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, PHPTidyObj, std);
-}
+#define php_tidy_fetch_object(obj) ZEND_CONTAINER_OF(obj, PHPTidyObj, std)
 
 #define Z_TIDY_P(zv) php_tidy_fetch_object(Z_OBJ_P((zv)))
 /* }}} */

--- a/ext/uri/php_uri_common.h
+++ b/ext/uri/php_uri_common.h
@@ -149,9 +149,7 @@ typedef struct php_uri_object {
 	zend_object std;
 } php_uri_object;
 
-static inline php_uri_object *php_uri_object_from_obj(zend_object *object) {
-	return ZEND_CONTAINER_OF(object, php_uri_object, std);
-}
+#define php_uri_object_from_obj(object) ZEND_CONTAINER_OF(object, php_uri_object, std)
 
 #define Z_URI_OBJECT_P(zv) php_uri_object_from_obj(Z_OBJ_P((zv)))
 

--- a/ext/xml/xml.c
+++ b/ext/xml/xml.c
@@ -295,9 +295,7 @@ static void xml_xmlchar_zval(const XML_Char *s, int len, const XML_Char *encodin
 }
 /* }}} */
 
-static inline xml_parser *xml_parser_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, xml_parser, std);
-}
+#define xml_parser_from_obj(obj) ZEND_CONTAINER_OF(obj, xml_parser, std)
 
 #define Z_XMLPARSER_P(zv) xml_parser_from_obj(Z_OBJ_P(zv))
 

--- a/ext/xmlreader/php_xmlreader.h
+++ b/ext/xmlreader/php_xmlreader.h
@@ -44,9 +44,7 @@ typedef struct _xmlreader_object {
 	zend_object  std;
 } xmlreader_object;
 
-static inline xmlreader_object *php_xmlreader_fetch_object(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, xmlreader_object, std);
-}
+#define php_xmlreader_fetch_object(obj) ZEND_CONTAINER_OF(obj, xmlreader_object, std)
 
 #define Z_XMLREADER_P(zv) php_xmlreader_fetch_object(Z_OBJ_P((zv)))
 

--- a/ext/xmlwriter/php_xmlwriter.h
+++ b/ext/xmlwriter/php_xmlwriter.h
@@ -37,9 +37,7 @@ typedef struct _ze_xmlwriter_object {
 	zend_object std;
 } ze_xmlwriter_object;
 
-static inline ze_xmlwriter_object *php_xmlwriter_fetch_object(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, ze_xmlwriter_object, std);
-}
+#define php_xmlwriter_fetch_object(obj) ZEND_CONTAINER_OF(obj, ze_xmlwriter_object, std)
 
 #define Z_XMLWRITER_P(zv) php_xmlwriter_fetch_object(Z_OBJ_P((zv)))
 

--- a/ext/xsl/php_xsl.h
+++ b/ext/xsl/php_xsl.h
@@ -60,9 +60,7 @@ typedef struct xsl_object {
 	zend_object std;
 } xsl_object;
 
-static inline xsl_object *php_xsl_fetch_object(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, xsl_object, std);
-}
+#define php_xsl_fetch_object(obj) ZEND_CONTAINER_OF(obj, xsl_object, std)
 
 #define Z_XSL_P(zv) php_xsl_fetch_object(Z_OBJ_P((zv)))
 

--- a/ext/zip/php_zip.h
+++ b/ext/zip/php_zip.h
@@ -81,9 +81,7 @@ typedef struct _ze_zip_object {
 	zend_object zo;
 } ze_zip_object;
 
-static inline ze_zip_object *php_zip_fetch_object(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, ze_zip_object, zo);
-}
+#define php_zip_fetch_object(obj) ZEND_CONTAINER_OF(obj, ze_zip_object, zo)
 
 #define Z_ZIP_P(zv) php_zip_fetch_object(Z_OBJ_P((zv)))
 

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -47,9 +47,7 @@ ZEND_DECLARE_MODULE_GLOBALS(zlib)
 zend_class_entry *inflate_context_ce;
 static zend_object_handlers inflate_context_object_handlers;
 
-static inline php_zlib_context *inflate_context_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, php_zlib_context, std);
-}
+#define inflate_context_from_obj(obj) ZEND_CONTAINER_OF(obj, php_zlib_context, std)
 
 #define Z_INFLATE_CONTEXT_P(zv) inflate_context_from_obj(Z_OBJ_P(zv))
 
@@ -85,9 +83,7 @@ static void inflate_context_free_obj(zend_object *object)
 zend_class_entry *deflate_context_ce;
 static zend_object_handlers deflate_context_object_handlers;
 
-static inline php_zlib_context *deflate_context_from_obj(zend_object *obj) {
-	return ZEND_CONTAINER_OF(obj, php_zlib_context, std);
-}
+#define deflate_context_from_obj(obj) ZEND_CONTAINER_OF(obj, php_zlib_context, std)
 
 #define Z_DEFLATE_CONTEXT_P(zv) deflate_context_from_obj(Z_OBJ_P(zv))
 


### PR DESCRIPTION
With the introduction of the `ZEND_CONTAINER_OF()` macro we can now preserve whether or not the `zend_object *` is `const` when extracting the class-specific struct. This change will allow to use `const zend_object *` in more locations.

Changes performed with Coccinelle followed by some manual cleanup for comment and whitespace formatting:

    @a@
    attribute name zend_always_inline;
    type T;
    identifier obj;
    identifier f;
    typedef zend_object;
    @@

     T* f(zend_object *obj) { return ZEND_CONTAINER_OF(obj, T, std); }
    + #define f(obj) ZEND_CONTAINER_OF(obj, T, std)

    @@
    identifier a.f;
    @@

    - f(...) { ... }

    @b@
    attribute name zend_always_inline;
    type T;
    identifier obj;
    identifier f;
    typedef zend_object;
    @@

     T* f(zend_object *obj) { return ZEND_CONTAINER_OF(obj, T, zo); }
    + #define f(obj) ZEND_CONTAINER_OF(obj, T, zo)

    @@
    identifier b.f;
    @@

    - f(...) { ... }