### PR TITLE
[skip ci] Specify unserialize() in security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,6 +34,8 @@ are not limited to):
 
 - `open_basedir` or `disable_functions` bypasses.
 
+- Malicious `unserialize()` inputs.
+
 # Vulnerability Policy
 
 Our full policy is described at


### PR DESCRIPTION
unserialize() may not receive attacker-controlled inputs according to our documentation.

This is technically already included in the second bullet point, but common enough to be spelled out.