### PR TITLE
Fix stream_last_errors() rcn hint

### DIFF
--- a/Zend/Optimizer/zend_func_infos.h
+++ b/Zend/Optimizer/zend_func_infos.h
@@ -596,7 +596,7 @@ static const func_info_t func_infos[] = {
 	F1("stream_get_line", MAY_BE_STRING|MAY_BE_FALSE),
 	F1("stream_resolve_include_path", MAY_BE_STRING|MAY_BE_FALSE),
 	F1("stream_get_wrappers", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_LONG|MAY_BE_ARRAY_OF_STRING),
-	F1("stream_last_errors", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_LONG|MAY_BE_ARRAY_OF_OBJECT),
+	FN("stream_last_errors", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_LONG|MAY_BE_ARRAY_OF_OBJECT),
 	F1("stream_get_transports", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_LONG|MAY_BE_ARRAY_OF_STRING),
 #if defined(HAVE_GETTIMEOFDAY)
 	F1("uniqid", MAY_BE_STRING),

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -3564,7 +3564,6 @@ function stream_resolve_include_path(string $filename): string|false {}
 function stream_get_wrappers(): array {}
 
 /**
- * @refcount 1
  * @return array<int, StreamError>
  */
 function stream_last_errors(): array {}
@@ -3577,7 +3576,7 @@ function stream_clear_errors(): void {}
  */
 function stream_get_transports(): array {}
 
-/** 
+/**
  * @param resource|string $stream
  * @param resource|null $context
  */

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit basic_functions.stub.php instead.
- * Stub hash: dcb08d7065d61ed6913f29e5d64e78d1fb4fce77
+ * Stub hash: d997420d0668e5b6ac26c43a8f86cff64891aced
  * Has decl header: yes */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)

--- a/ext/standard/basic_functions_decl.h
+++ b/ext/standard/basic_functions_decl.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit basic_functions.stub.php instead.
- * Stub hash: dcb08d7065d61ed6913f29e5d64e78d1fb4fce77 */
+ * Stub hash: d997420d0668e5b6ac26c43a8f86cff64891aced */
 
-#ifndef ZEND_BASIC_FUNCTIONS_DECL_dcb08d7065d61ed6913f29e5d64e78d1fb4fce77_H
-#define ZEND_BASIC_FUNCTIONS_DECL_dcb08d7065d61ed6913f29e5d64e78d1fb4fce77_H
+#ifndef ZEND_BASIC_FUNCTIONS_DECL_d997420d0668e5b6ac26c43a8f86cff64891aced_H
+#define ZEND_BASIC_FUNCTIONS_DECL_d997420d0668e5b6ac26c43a8f86cff64891aced_H
 
 typedef enum zend_enum_SortDirection {
 	ZEND_ENUM_SortDirection_Ascending = 1,
@@ -20,4 +20,4 @@ typedef enum zend_enum_RoundingMode {
 	ZEND_ENUM_RoundingMode_PositiveInfinity = 8,
 } zend_enum_RoundingMode;
 
-#endif /* ZEND_BASIC_FUNCTIONS_DECL_dcb08d7065d61ed6913f29e5d64e78d1fb4fce77_H */
+#endif /* ZEND_BASIC_FUNCTIONS_DECL_d997420d0668e5b6ac26c43a8f86cff64891aced_H */


### PR DESCRIPTION
This function returns the static empty array, which has rc2 to avoid direct mutation.

See https://github.com/php/php-src/actions/runs/26700348910/job/78692090418.