### PR TITLE
Fix -Werror compile error in `zend_dval_to_lval_cap()`

### DIFF
--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -148,6 +148,7 @@ static zend_always_inline zend_long zend_dval_to_lval_silent(double d)
 /* Used to convert a string float to integer during an (int) cast */
 static zend_always_inline zend_long zend_dval_to_lval_cap(double d, const zend_string *s)
 {
+	ZEND_IGNORE_VALUE(s);
 	if (UNEXPECTED(!zend_finite(d))) {
 		return 0;
 	} else if (!ZEND_DOUBLE_FITS_LONG(d)) {


### PR DESCRIPTION
This made imagick CI fail on PHP 8.5:
```
/usr/include/php/20250925/Zend/zend_operators.h: In function 'zend_dval_to_lval_cap':
/usr/include/php/20250925/Zend/zend_operators.h:149:88: error: unused parameter 's' [-Werror=unused-parameter]
  149 | static zend_always_inline zend_long zend_dval_to_lval_cap(double d, const zend_string *s)
      |                                                                     ~~~~~~~~~~~~~~~~~~~^
cc1: all warnings being treated as errors
```