### PR TITLE
check cp bounds before reading A6 partial short in php_parserr

### DIFF
--- a/ext/standard/dns.c
+++ b/ext/standard/dns.c
@@ -678,6 +678,7 @@ static uint8_t *php_parserr(uint8_t *cp, uint8_t *end, querybuf *answer, int typ
 			}
 			if (n % 16 > 8) {
 				/* Partial short */
+				CHECKCP(1);
 				if (cp[0] != 0) {
 					if (tp > (uint8_t *)name) {
 						in_v6_break = 0;


### PR DESCRIPTION
Noticed the A6 branch in php_parserr reads cp[0] for the partial short without the CHECKCP guard every other field read in this function uses. With a 1-byte A6 rdata whose masklen % 16 is 9..15, cp already sits at end, so that byte is read past the response data and lands in the ipv6 string. Guard it like the surrounding reads.