### PR TITLE
ext/intl: Preserve int64 precision in IntlNumberRangeFormatter::format()

### DIFF
--- a/ext/intl/rangeformatter/rangeformatter_class.cpp
+++ b/ext/intl/rangeformatter/rangeformatter_class.cpp
@@ -60,6 +60,19 @@ zend_object *IntlNumberRangeFormatter_object_create(zend_class_entry *ce)
     return &intern->zo;
 }
 
+static icu::Formattable rangeformatter_create_formattable(zval *number)
+{
+    icu::Formattable formattable;
+
+    if (Z_TYPE_P(number) == IS_DOUBLE) {
+        formattable.setDouble(Z_DVAL_P(number));
+    } else {
+        formattable.setInt64(static_cast<int64_t>(Z_LVAL_P(number)));
+    }
+
+    return formattable;
+}
+
 U_CFUNC PHP_METHOD(IntlNumberRangeFormatter, __construct)
 {
     ZEND_PARSE_PARAMETERS_NONE();
@@ -154,8 +167,8 @@ U_CFUNC PHP_METHOD(IntlNumberRangeFormatter, format)
 
     UErrorCode error = U_ZERO_ERROR;
 
-    icu::Formattable start_formattable(Z_TYPE_P(start) == IS_DOUBLE ? Z_DVAL_P(start) : Z_LVAL_P(start));
-    icu::Formattable end_formattable(Z_TYPE_P(end) == IS_DOUBLE ? Z_DVAL_P(end) : Z_LVAL_P(end));
+    icu::Formattable start_formattable = rangeformatter_create_formattable(start);
+    icu::Formattable end_formattable = rangeformatter_create_formattable(end);
 
     UnicodeString result = RANGEFORMATTER_OBJECT(obj)->formatFormattableRange(start_formattable, end_formattable, error).toString(error);
 

--- a/ext/intl/tests/rangeformatter/rangeformatter_format_int64.phpt
+++ b/ext/intl/tests/rangeformatter/rangeformatter_format_int64.phpt
@@ -1,0 +1,27 @@
+--TEST--
+IntlNumberRangeFormatter::format() preserves int64 precision
+--EXTENSIONS--
+intl
+--SKIPIF--
+<?php
+if (!class_exists('IntlNumberRangeFormatter')) {
+    die('skip IntlNumberRangeFormatter not available');
+}
+if (PHP_INT_SIZE < 8) {
+    die('skip 64-bit only');
+}
+?>
+--FILE--
+<?php
+$formatter = IntlNumberRangeFormatter::createFromSkeleton(
+    '',
+    'en_US',
+    IntlNumberRangeFormatter::COLLAPSE_AUTO,
+    IntlNumberRangeFormatter::IDENTITY_FALLBACK_SINGLE_VALUE
+);
+
+$formatted = $formatter->format(9007199254740993, 9007199254740993);
+var_dump(preg_replace('/[^0-9]/', '', $formatted));
+?>
+--EXPECT--
+string(16) "9007199254740993"


### PR DESCRIPTION
Now in IntlNumberRangeFormatter::format(), we use 
```c
    icu::Formattable start_formattable(Z_TYPE_P(start) == IS_DOUBLE ? Z_DVAL_P(start) : Z_LVAL_P(start));
    icu::Formattable end_formattable(Z_TYPE_P(end) == IS_DOUBLE ? Z_DVAL_P(end) : Z_LVAL_P(end));
```
to create ICU Formattable values

The ternary expression doesn't work well because it mix double and zend_long operands, and that will lead to precision lost for obvious reasons. That is
```php
<?php
$formatter = IntlNumberRangeFormatter::createFromSkeleton(
    '',
    'en_US',
    IntlNumberRangeFormatter::COLLAPSE_AUTO,
    IntlNumberRangeFormatter::IDENTITY_FALLBACK_SINGLE_VALUE
);

$formatted = $formatter->format(9007199254740993, 9007199254740993);
var_dump(preg_replace('/[^0-9]/', '', $formatted));
?>
```
results in
```                    
string(16) "9007199254740992"
```
while it should be
```
string(16) "9007199254740993"
```

The feature is newly added in php 8.6-dev so we don't need to write NEWS and UPGRADING entries.