### PR TITLE
bound host copy to its length in php_fopen_do_pasv

### DIFF
--- a/ext/standard/ftp_fopen_wrapper.c
+++ b/ext/standard/ftp_fopen_wrapper.c
@@ -361,8 +361,14 @@ static unsigned short php_fopen_do_pasv(php_stream *stream, char *ip, size_t ip_
 			tpath++;
 		}
 		tpath[-1] = '\0';
-		memcpy(ip, hoststart, ip_size);
-		ip[ip_size-1] = '\0';
+		/* hoststart is now NUL-terminated; copy only its length so a long 227
+		 * message can't drive the fixed-size read past the end of tmp_line */
+		size_t hostlen = (size_t)(tpath - 1 - hoststart);
+		if (hostlen >= ip_size) {
+			hostlen = ip_size - 1;
+		}
+		memcpy(ip, hoststart, hostlen);
+		ip[hostlen] = '\0';
 		hoststart = ip;
 
 		/* pull out the MSB of the port */


### PR DESCRIPTION
php_fopen_do_pasv at ftp_fopen_wrapper.c:364 copies the host with a fixed ip_size from hoststart, which points into the 512-byte tmp_line holding the server's untrusted 227 reply, so a long message before the address tuple drives the read past the end of the buffer. Copy only the NUL-terminated host length instead, capped to ip_size-1.