### PR TITLE
Handle error strerror values in bless

### DIFF
--- a/scripts/dev/bless_tests.php
+++ b/scripts/dev/bless_tests.php
@@ -5,6 +5,20 @@ if ($argc < 2) {
     die("Usage: php bless_tests.php dir/\n");
 }
 
+// Build a list of known errors on this platform, so we can avoid hardcoding
+// platform-specific errors in expect output, as the errno/strerror differs
+// between platforms.
+$strerrors = [];
+if (function_exists("posix_strerror")) {
+	for ($i = -1; $i < 255; $i++) {
+		$str = posix_strerror($i);
+		if (str_contains($str, "Unknown error") && $i > 0) {
+			break;
+		}
+		$strerrors[] = $str;
+	}
+}
+
 $files = getFiles(array_slice($argv, 1));
 foreach ($files as $path) {
     if (!preg_match('/^(.*)\.phpt$/', $path, $matches)) {
@@ -78,6 +92,11 @@ function normalizeOutput(string $out): string {
     // any string. These tend to contain homedirs with usernames, not good.
     $out = preg_replace("/'(\/|[A-Z]:\\\\)\S+\\.\\.\\.'/", "'%s'", $out);
     $out = preg_replace("/'file:(\/|[A-Z]:\\\\)\S+\\.\\.\\.'/", "'%s'", $out);
+    // Replace system error strings for portability.
+    global $strerrors;
+    foreach ($strerrors as $strerror) {
+        $out = str_replace($strerror, "%s", $out);
+    }
     $out = str_replace("\0", '%0', $out);
     return $out;
 }


### PR DESCRIPTION
One annoyance with bless is its tendency to hardcode OS-specific errors in expect output, especially when the test was already making it to begin with, and bless instead hardcodes it again.

Build a list of strerror values, scan the output for them, and replace them with '%s'. Perhaps this may be overzealous, but it does seem to work to keep bless output reasonable with less post-processing.