### PR TITLE
Fix GH-22168: Make phpdbg ignore unloaded catch classes

### DIFF
--- a/sapi/phpdbg/phpdbg_utils.c
+++ b/sapi/phpdbg/phpdbg_utils.c
@@ -633,7 +633,7 @@ PHPDBG_API bool phpdbg_check_caught_ex(zend_execute_data *execute_data, zend_obj
 				zend_class_entry *ce;
 
 				if (!(ce = CACHED_PTR(cur->extended_value & ~ZEND_LAST_CATCH))) {
-					ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(cur, cur->op1)), Z_STR_P(RT_CONSTANT(cur, cur->op1) + 1), ZEND_FETCH_CLASS_NO_AUTOLOAD);
+					ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(cur, cur->op1)), Z_STR_P(RT_CONSTANT(cur, cur->op1) + 1), ZEND_FETCH_CLASS_NO_AUTOLOAD | ZEND_FETCH_CLASS_SILENT);
 					CACHE_PTR(cur->extended_value & ~ZEND_LAST_CATCH, ce);
 				}
 

--- a/sapi/phpdbg/tests/exceptions_004.phpt
+++ b/sapi/phpdbg/tests/exceptions_004.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-22168 (Exception caught by a later catch is not misreported as uncaught when an earlier catch references a non-existent class)
+--PHPDBG--
+r
+q
+--EXPECTF--
+[Successful compilation of %s]
+prompt> Caught it. 'handled' it
+[Script ended normally]
+prompt>
+--FILE--
+<?php declare(strict_types=1);
+
+try {
+    throw new RuntimeException();
+} catch (LibrarySpecificException) {
+    // A library specific exception. Not autoloaded since it did not happen.
+} catch (RuntimeException) {
+    echo "Caught it. 'handled' it\n";
+}


### PR DESCRIPTION
Fixes GH-22168

## Problem

When running under interactive phpdbg, phpdbg reports a bogus fatal error for
an exception that is actually caught if an earlier `catch` block references a
class that does not exist and is not autoloaded:

```php
<?php declare(strict_types=1);

try {
    throw new RuntimeException();
} catch (LibrarySpecificException) {
    // Not autoloaded since it did not happen.
} catch (RuntimeException) {
    echo "Caught it. 'handled' it\n";
}
```

`php` and `phpdbg -qrr` print the expected output:

```text
Caught it. 'handled' it
```

but interactive phpdbg reports:

```text
PHP Fatal error: During class fetch: Uncaught RuntimeException ...
```

## Cause

`phpdbg_check_caught_ex()` resolves catch block classes via
`zend_fetch_class_by_name()` with `ZEND_FETCH_CLASS_NO_AUTOLOAD`, but without
`ZEND_FETCH_CLASS_SILENT`.

This differs from the actual `ZEND_CATCH` opcode handler, which resolves catch
types with `ZEND_FETCH_CLASS_SILENT`.

If the earlier catch type does not exist, the non-silent class fetch reports an
error while the original exception is already active. This makes phpdbg report
the caught exception as uncaught.

## Fix

Add `ZEND_FETCH_CLASS_SILENT` to the phpdbg catch check, matching the behavior
of the `ZEND_CATCH` opcode handler.

A regression test was added in:

```text
sapi/phpdbg/tests/exceptions_004.phpt
```

## Tested

- Confirmed the issue with an A/B build
- Confirmed the fix makes interactive phpdbg print the expected output
- phpdbg test suite: 64 passed, 0 failed
