### PR TITLE
Zend: add object_init_instantiable_class() API and use it

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -1785,26 +1785,34 @@ ZEND_API void object_properties_load(zend_object *object, const HashTable *prope
 }
 /* }}} */
 
+static ZEND_COLD zend_never_inline void zend_cannot_instantiate_class(zend_class_entry *class_type) {
+	if (class_type->ce_flags & ZEND_ACC_INTERFACE) {
+		zend_throw_error(NULL, "Cannot instantiate interface %s", ZSTR_VAL(class_type->name));
+	} else if (class_type->ce_flags & ZEND_ACC_TRAIT) {
+		zend_throw_error(NULL, "Cannot instantiate trait %s", ZSTR_VAL(class_type->name));
+	} else if (class_type->ce_flags & ZEND_ACC_ENUM) {
+		zend_throw_error(NULL, "Cannot instantiate enum %s", ZSTR_VAL(class_type->name));
+	} else {
+		ZEND_ASSERT(class_type->ce_flags & (ZEND_ACC_IMPLICIT_ABSTRACT_CLASS|ZEND_ACC_EXPLICIT_ABSTRACT_CLASS));
+		zend_throw_error(NULL, "Cannot instantiate abstract class %s", ZSTR_VAL(class_type->name));
+	}
+}
+
 /* This function requires 'properties' to contain all props declared in the
  * class and all props being public. If only a subset is given or the class
  * has protected members then you need to merge the properties separately by
  * calling zend_merge_properties(). */
-static zend_always_inline zend_result _object_and_properties_init(zval *arg, zend_class_entry *class_type, HashTable *properties) /* {{{ */
+static zend_always_inline zend_result _object_and_properties_init(zval *arg, zend_class_entry *class_type, HashTable *properties, bool known_instantiable) /* {{{ */
 {
-	if (UNEXPECTED(class_type->ce_flags & ZEND_ACC_UNINSTANTIABLE)) {
-		if (class_type->ce_flags & ZEND_ACC_INTERFACE) {
-			zend_throw_error(NULL, "Cannot instantiate interface %s", ZSTR_VAL(class_type->name));
-		} else if (class_type->ce_flags & ZEND_ACC_TRAIT) {
-			zend_throw_error(NULL, "Cannot instantiate trait %s", ZSTR_VAL(class_type->name));
-		} else if (class_type->ce_flags & ZEND_ACC_ENUM) {
-			zend_throw_error(NULL, "Cannot instantiate enum %s", ZSTR_VAL(class_type->name));
-		} else {
-			ZEND_ASSERT(class_type->ce_flags & (ZEND_ACC_IMPLICIT_ABSTRACT_CLASS|ZEND_ACC_EXPLICIT_ABSTRACT_CLASS));
-			zend_throw_error(NULL, "Cannot instantiate abstract class %s", ZSTR_VAL(class_type->name));
+	if (!known_instantiable) {
+		if (UNEXPECTED(class_type->ce_flags & ZEND_ACC_UNINSTANTIABLE)) {
+			zend_cannot_instantiate_class(class_type);
+			ZVAL_NULL(arg);
+			Z_OBJ_P(arg) = NULL;
+			return FAILURE;
 		}
-		ZVAL_NULL(arg);
-		Z_OBJ_P(arg) = NULL;
-		return FAILURE;
+	} else {
+		ZEND_ASSERT((class_type->ce_flags & ZEND_ACC_UNINSTANTIABLE) == 0);
 	}
 
 	if (UNEXPECTED(!(class_type->ce_flags & ZEND_ACC_CONSTANTS_UPDATED))) {
@@ -1833,19 +1841,24 @@ static zend_always_inline zend_result _object_and_properties_init(zval *arg, zen
 
 ZEND_API zend_result object_and_properties_init(zval *arg, zend_class_entry *class_type, HashTable *properties) /* {{{ */
 {
-	return _object_and_properties_init(arg, class_type, properties);
+	return _object_and_properties_init(arg, class_type, properties, false);
 }
 /* }}} */
 
 ZEND_API zend_result object_init_ex(zval *arg, zend_class_entry *class_type) /* {{{ */
 {
-	return _object_and_properties_init(arg, class_type, NULL);
+	return _object_and_properties_init(arg, class_type, NULL, false);
 }
 /* }}} */
 
+ZEND_API zend_result object_init_instantiable_class(zval *arg, zend_class_entry *class_type) /* {{{ */
+{
+	return _object_and_properties_init(arg, class_type, NULL, true);
+}
+
 ZEND_API zend_result object_init_with_constructor(zval *arg, zend_class_entry *class_type, uint32_t param_count, zval *params, HashTable *named_params) /* {{{ */
 {
-	zend_result status = _object_and_properties_init(arg, class_type, NULL);
+	zend_result status = _object_and_properties_init(arg, class_type, NULL, false);
 	if (UNEXPECTED(status == FAILURE)) {
 		ZVAL_UNDEF(arg);
 		return FAILURE;

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -544,6 +544,7 @@ static zend_always_inline void array_init(zval *arg)
 
 ZEND_API void object_init(zval *arg);
 ZEND_API zend_result object_init_ex(zval *arg, zend_class_entry *ce);
+ZEND_API zend_result object_init_instantiable_class(zval *arg, zend_class_entry *class_type);
 ZEND_API zend_result object_init_with_constructor(zval *arg, zend_class_entry *class_type, uint32_t param_count, zval *params, HashTable *named_params);
 ZEND_API zend_result object_and_properties_init(zval *arg, zend_class_entry *ce, HashTable *properties);
 ZEND_API void object_properties_init(zend_object *object, zend_class_entry *class_type);

--- a/Zend/zend_closures.c
+++ b/Zend/zend_closures.c
@@ -762,7 +762,7 @@ static void zend_create_closure_ex(zval *res, zend_function *func, zend_class_en
 	zend_closure *closure;
 	void *ptr;
 
-	object_init_ex(res, zend_ce_closure);
+	object_init_instantiable_class(res, zend_ce_closure);
 
 	closure = (zend_closure *)Z_OBJ_P(res);
 

--- a/Zend/zend_gc.c
+++ b/Zend/zend_gc.c
@@ -1915,7 +1915,7 @@ static zend_fiber *gc_create_destructor_fiber(void)
 
 	GC_TRACE("starting destructor fiber");
 
-	if (UNEXPECTED(object_init_ex(&zobj, zend_ce_fiber) == FAILURE)) {
+	if (UNEXPECTED(object_init_instantiable_class(&zobj, zend_ce_fiber) == FAILURE)) {
 		gc_create_destructor_fiber_error();
 	}
 

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -4697,7 +4697,7 @@ ZEND_VM_HANDLER(139, ZEND_GENERATOR_CREATE, ANY, ANY)
 		uint32_t num_args, used_stack, call_info;
 
 		SAVE_OPLINE();
-		object_init_ex(return_value, zend_ce_generator);
+		object_init_instantiable_class(return_value, zend_ce_generator);
 
 		/*
 		 * Normally the execute_data is allocated on the VM stack (because it does

--- a/Zend/zend_weakrefs.c
+++ b/Zend/zend_weakrefs.c
@@ -263,7 +263,7 @@ found_weakref:
 static zend_always_inline void zend_weakref_create(zend_object *referent, zval *return_value) {
 	zend_weakref *wr;
 
-	object_init_ex(return_value, zend_ce_weakref);
+	object_init_instantiable_class(return_value, zend_ce_weakref);
 
 	wr = zend_weakref_fetch(return_value);
 	wr->referent = referent;

--- a/ext/curl/curl_file.c
+++ b/ext/curl/curl_file.c
@@ -58,7 +58,7 @@ ZEND_METHOD(CURLFile, __construct)
 /* {{{ Create the CURLFile object */
 PHP_FUNCTION(curl_file_create)
 {
-	object_init_ex( return_value, curl_CURLFile_class );
+	object_init_instantiable_class( return_value, curl_CURLFile_class );
 	curlfile_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
 /* }}} */

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -1024,7 +1024,7 @@ php_curl *init_curl_handle_into_zval(zval *curl)
 {
 	php_curl *ch;
 
-	object_init_ex(curl, curl_ce);
+	object_init_instantiable_class(curl, curl_ce);
 	ch = Z_CURL_P(curl);
 
 	init_curl_handle(ch);

--- a/ext/curl/multi.c
+++ b/ext/curl/multi.c
@@ -64,7 +64,7 @@ PHP_FUNCTION(curl_multi_init)
 		zend_throw_error(NULL, "%s(): Could not initialize a new cURL multi handle", get_active_function_name());
 		RETURN_THROWS();
 	}
-	object_init_ex(return_value, curl_multi_ce);
+	object_init_instantiable_class(return_value, curl_multi_ce);
 	mh = Z_CURL_MULTI_P(return_value);
 	mh->multi = multi;
 

--- a/ext/curl/share.c
+++ b/ext/curl/share.c
@@ -34,7 +34,7 @@ PHP_FUNCTION(curl_share_init)
 
 	ZEND_PARSE_PARAMETERS_NONE();
 
-	object_init_ex(return_value, curl_share_ce);
+	object_init_instantiable_class(return_value, curl_share_ce);
 	sh = Z_CURL_SHARE_P(return_value);
 
 	sh->share = curl_share_init();
@@ -194,7 +194,7 @@ PHP_FUNCTION(curl_share_init_persistent)
 	} ZEND_HASH_FOREACH_END();
 
 	// We're now decently confident that we'll be returning a CurlSharePersistentHandle object, so we construct it here.
-	object_init_ex(return_value, curl_share_persistent_ce);
+	object_init_instantiable_class(return_value, curl_share_persistent_ce);
 
 	// Next we initialize a property field for the CurlSharePersistentHandle object with the enabled share options.
 	array_init(&share_opts_prop);

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -1487,7 +1487,7 @@ static void create_date_period_datetime(timelib_time *datetime, zend_class_entry
 	if (datetime) {
 		php_date_obj *date_obj;
 
-		zend_result result = object_init_ex(zv, ce);
+		zend_result result = object_init_instantiable_class(zv, ce);
 		ZEND_ASSERT(result == SUCCESS && "should succeed as it reuses an existing object's ce");
 		date_obj = Z_PHPDATE_P(zv);
 		date_obj->time = timelib_time_clone(datetime);
@@ -1501,7 +1501,7 @@ static void create_date_period_interval(timelib_rel_time *interval, zval *zv)
 	if (interval) {
 		php_interval_obj *interval_obj;
 
-		object_init_ex(zv, date_ce_interval);
+		object_init_instantiable_class(zv, date_ce_interval);
 		interval_obj = Z_PHPINTERVAL_P(zv);
 		interval_obj->diff = timelib_rel_time_clone(interval);
 		interval_obj->initialized = true;
@@ -5838,7 +5838,7 @@ PHP_METHOD(DatePeriod, __set_state)
 		Z_PARAM_ARRAY_HT(myht)
 	ZEND_PARSE_PARAMETERS_END();
 
-	object_init_ex(return_value, date_ce_period);
+	object_init_instantiable_class(return_value, date_ce_period);
 	period_obj = Z_PHPPERIOD_P(return_value);
 	if (!php_date_period_initialize_from_hash(period_obj, myht)) {
 		zend_throw_error(NULL, "Invalid serialization data for DatePeriod object");

--- a/ext/dba/dba.c
+++ b/ext/dba/dba.c
@@ -589,7 +589,7 @@ static void php_dba_open(INTERNAL_FUNCTION_PARAMETERS, bool persistent)
 				RETURN_FALSE;
 			}
 
-			object_init_ex(return_value, dba_connection_ce);
+			object_init_instantiable_class(return_value, dba_connection_ce);
 			dba_connection *connection = Z_DBA_CONNECTION_P(return_value);
 			connection->info = (dba_info *)le->ptr;
 			connection->hash = zend_string_dup(resource_key, /* persistent */ true);
@@ -783,7 +783,7 @@ static void php_dba_open(INTERNAL_FUNCTION_PARAMETERS, bool persistent)
 	zval *connection_zval;
 	dba_connection *connection;
 	if ((connection_zval = zend_hash_find(&DBA_G(connections), resource_key)) == NULL) {
-		object_init_ex(return_value, dba_connection_ce);
+		object_init_instantiable_class(return_value, dba_connection_ce);
 		connection = Z_DBA_CONNECTION_P(return_value);
 
 		connection->info = pecalloc(1, sizeof(dba_info), persistent);

--- a/ext/dom/documenttype.c
+++ b/ext/dom/documenttype.c
@@ -51,7 +51,7 @@ zend_result dom_documenttype_entities_read(dom_object *obj, zval *retval)
 {
 	DOM_PROP_NODE(xmlDtdPtr, dtdptr, obj);
 
-	object_init_ex(retval, dom_get_dtd_namednodemap_ce(instanceof_function(obj->std.ce, dom_modern_documenttype_class_entry)));
+	object_init_instantiable_class(retval, dom_get_dtd_namednodemap_ce(instanceof_function(obj->std.ce, dom_modern_documenttype_class_entry)));
 
 	xmlHashTable *entityht = (xmlHashTable *) dtdptr->entities;
 
@@ -72,7 +72,7 @@ zend_result dom_documenttype_notations_read(dom_object *obj, zval *retval)
 {
 	DOM_PROP_NODE(xmlDtdPtr, dtdptr, obj);
 
-	object_init_ex(retval, dom_get_dtd_namednodemap_ce(instanceof_function(obj->std.ce, dom_modern_documenttype_class_entry)));
+	object_init_instantiable_class(retval, dom_get_dtd_namednodemap_ce(instanceof_function(obj->std.ce, dom_modern_documenttype_class_entry)));
 
 	xmlHashTable *notationht = (xmlHashTable *) dtdptr->notations;
 

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -199,7 +199,7 @@ zend_result dom_element_class_list_read(dom_object *obj, zval *retval)
 {
 	zval *cached_token_list = dom_element_class_list_zval(obj);
 	if (Z_ISUNDEF_P(cached_token_list)) {
-		object_init_ex(cached_token_list, dom_token_list_class_entry);
+		object_init_instantiable_class(cached_token_list, dom_token_list_class_entry);
 		dom_token_list_object *intern = php_dom_token_list_from_obj(Z_OBJ_P(cached_token_list));
 		dom_token_list_ctor(intern, obj);
 	}
@@ -824,7 +824,7 @@ static void dom_element_get_elements_by_tag_name(INTERNAL_FUNCTION_PARAMETERS, z
 
 	DOM_GET_THIS_INTERN(intern);
 
-	object_init_ex(return_value, iter_ce);
+	object_init_instantiable_class(return_value, iter_ce);
 	namednode = Z_DOMOBJ_P(return_value);
 	php_dom_create_obj_map(intern, namednode, NULL, name, NULL, &php_dom_obj_map_by_tag_name);
 }
@@ -856,7 +856,7 @@ PHP_METHOD(Dom_Element, getElementsByClassName)
 
 	DOM_GET_THIS_INTERN(intern);
 
-	object_init_ex(return_value, dom_html_collection_class_entry);
+	object_init_instantiable_class(return_value, dom_html_collection_class_entry);
 	namednode = Z_DOMOBJ_P(return_value);
 
 	HashTable *token_set;
@@ -1287,7 +1287,7 @@ static void dom_element_get_elements_by_tag_name_ns(INTERNAL_FUNCTION_PARAMETERS
 
 	DOM_GET_THIS_INTERN(intern);
 
-	object_init_ex(return_value, iter_ce);
+	object_init_instantiable_class(return_value, iter_ce);
 	namednode = Z_DOMOBJ_P(return_value);
 	php_dom_create_obj_map(intern, namednode, NULL, name, uri, &php_dom_obj_map_by_tag_name);
 }
@@ -2080,7 +2080,7 @@ static void dom_element_get_in_scope_namespace_info(php_dom_libxml_ns_mapper *ns
 		}
 
 		zval zv;
-		object_init_ex(&zv, dom_namespace_info_class_entry);
+		object_init_instantiable_class(&zv, dom_namespace_info_class_entry);
 		zend_object *obj = Z_OBJ(zv);
 
 		if (ZSTR_LEN(prefix) != 0) {

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -292,7 +292,7 @@ zend_result dom_node_child_nodes_read(dom_object *obj, zval *retval)
 {
 	DOM_PROP_NODE(xmlNodePtr, nodep, obj);
 
-	object_init_ex(retval, dom_get_nodelist_ce(false));
+	object_init_instantiable_class(retval, dom_get_nodelist_ce(false));
 	dom_object *intern = Z_DOMOBJ_P(retval);
 	php_dom_create_obj_map(obj, intern, NULL, NULL, NULL, &php_dom_obj_map_child_nodes);
 
@@ -303,7 +303,7 @@ zend_result dom_modern_node_child_nodes_read(dom_object *obj, zval *retval)
 {
 	DOM_PROP_NODE(xmlNodePtr, nodep, obj);
 
-	object_init_ex(retval, dom_get_nodelist_ce(true));
+	object_init_instantiable_class(retval, dom_get_nodelist_ce(true));
 	dom_object *intern = Z_DOMOBJ_P(retval);
 	php_dom_create_obj_map(obj, intern, NULL, NULL, NULL, &php_dom_obj_map_child_nodes);
 
@@ -437,7 +437,7 @@ zend_result dom_node_attributes_read(dom_object *obj, zval *retval)
 	DOM_PROP_NODE(xmlNodePtr, nodep, obj);
 
 	if (nodep->type == XML_ELEMENT_NODE) {
-		object_init_ex(retval, dom_get_namednodemap_ce(php_dom_follow_spec_intern(obj)));
+		object_init_instantiable_class(retval, dom_get_namednodemap_ce(php_dom_follow_spec_intern(obj)));
 		dom_object *intern = Z_DOMOBJ_P(retval);
 		php_dom_create_obj_map(obj, intern, NULL, NULL, NULL, &php_dom_obj_map_attributes);
 	} else {

--- a/ext/dom/parentnode/css_selectors.c
+++ b/ext/dom/parentnode/css_selectors.c
@@ -244,7 +244,7 @@ void dom_parent_node_query_selector_all(xmlNodePtr thisp, dom_object *intern, zv
 		zend_array_destroy(list);
 		RETURN_THROWS();
 	} else {
-		object_init_ex(return_value, dom_modern_nodelist_class_entry);
+		object_init_instantiable_class(return_value, dom_modern_nodelist_class_entry);
 		dom_object *ret_obj = Z_DOMOBJ_P(return_value);
 		dom_nnodemap_object *mapptr = (dom_nnodemap_object *) ret_obj->ptr;
 		mapptr->array = list;

--- a/ext/dom/parentnode/tree.c
+++ b/ext/dom/parentnode/tree.c
@@ -33,7 +33,7 @@ zend_result dom_parent_node_children_read(dom_object *obj, zval *retval)
 {
 	zval *cached_children = dom_parent_node_children(obj);
 	if (Z_ISUNDEF_P(cached_children)) {
-		object_init_ex(cached_children, dom_html_collection_class_entry);
+		object_init_instantiable_class(cached_children, dom_html_collection_class_entry);
 		php_dom_create_obj_map(obj, Z_DOMOBJ_P(cached_children), NULL, NULL, NULL, &php_dom_obj_map_child_elements);
 
 		/* Handle cycles for potential TMPVARs (could also be CV but we can't differentiate).

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -1761,7 +1761,7 @@ dom_object *php_dom_instantiate_object_helper(zval *return_value, zend_class_ent
 }
 
 void php_dom_create_implementation(zval *retval, bool modern) {
-	object_init_ex(retval, dom_get_domimplementation_ce(modern));
+	object_init_instantiable_class(retval, dom_get_domimplementation_ce(modern));
 }
 
 /* {{{ int dom_hierarchy(xmlNodePtr parent, xmlNodePtr child) */

--- a/ext/dom/xpath.c
+++ b/ext/dom/xpath.c
@@ -380,7 +380,7 @@ static void php_xpath_eval(INTERNAL_FUNCTION_PARAMETERS, int type, bool modern) 
 				ZVAL_EMPTY_ARRAY(&retval);
 			}
 
-			object_init_ex(return_value, dom_get_nodelist_ce(modern));
+			object_init_instantiable_class(return_value, dom_get_nodelist_ce(modern));
 			nodeobj = Z_DOMOBJ_P(return_value);
 			dom_nnodemap_object *mapptr = nodeobj->ptr;
 

--- a/ext/enchant/enchant.c
+++ b/ext/enchant/enchant.c
@@ -262,7 +262,7 @@ PHP_FUNCTION(enchant_broker_init)
 
 	pbroker = enchant_broker_init();
 	if (pbroker) {
-		object_init_ex(return_value, enchant_broker_ce);
+		object_init_instantiable_class(return_value, enchant_broker_ce);
 		broker = Z_ENCHANT_BROKER_P(return_value);
 		broker->pbroker = pbroker;
 		broker->nb_dict = 0;
@@ -434,7 +434,7 @@ PHP_FUNCTION(enchant_broker_request_dict)
 	if (pdict) {
 		pbroker->nb_dict++;
 
-		object_init_ex(return_value, enchant_dict_ce);
+		object_init_instantiable_class(return_value, enchant_dict_ce);
 		dict = Z_ENCHANT_DICT_P(return_value);
 		dict->pdict = pdict;
 		ZVAL_COPY(&dict->zbroker, broker);
@@ -468,7 +468,7 @@ PHP_FUNCTION(enchant_broker_request_pwl_dict)
 	if (pdict) {
 		pbroker->nb_dict++;
 
-		object_init_ex(return_value, enchant_dict_ce);
+		object_init_instantiable_class(return_value, enchant_dict_ce);
 		dict = Z_ENCHANT_DICT_P(return_value);
 		dict->pdict = pdict;
 		ZVAL_COPY(&dict->zbroker, broker);

--- a/ext/ftp/php_ftp.c
+++ b/ext/ftp/php_ftp.c
@@ -168,7 +168,7 @@ PHP_FUNCTION(ftp_connect)
 	ftp->use_ssl = false;
 #endif
 
-	object_init_ex(return_value, php_ftp_ce);
+	object_init_instantiable_class(return_value, php_ftp_ce);
 	ftp_object_from_zend_object(Z_OBJ_P(return_value))->ftp = ftp;
 }
 /* }}} */
@@ -203,7 +203,7 @@ PHP_FUNCTION(ftp_ssl_connect)
 	/* enable ssl */
 	ftp->use_ssl = true;
 
-	object_init_ex(return_value, php_ftp_ce);
+	object_init_instantiable_class(return_value, php_ftp_ce);
 	ftp_object_from_zend_object(Z_OBJ_P(return_value))->ftp = ftp;
 }
 /* }}} */

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -183,7 +183,7 @@ static void php_gd_image_object_free(zend_object *intern)
  */
 void php_gd_assign_libgdimageptr_as_extgdimage(zval *val, gdImagePtr image)
 {
-	object_init_ex(val, gd_image_ce);
+	object_init_instantiable_class(val, gd_image_ce);
 	php_gd_exgdimage_from_zobj_p(Z_OBJ_P(val))->image = image;
 }
 
@@ -600,7 +600,7 @@ PHP_FUNCTION(imageloadfont)
 	}
 	php_stream_close(stream);
 
-	object_init_ex(return_value, gd_font_ce);
+	object_init_instantiable_class(return_value, gd_font_ce);
 	php_gd_font_object_from_zend_object(Z_OBJ_P(return_value))->font = font;
 }
 /* }}} */

--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -634,7 +634,7 @@ PHP_FUNCTION(hash_init)
 		}
 	}
 
-	object_init_ex(return_value, php_hashcontext_ce);
+	object_init_instantiable_class(return_value, php_hashcontext_ce);
 	hash = php_hashcontext_from_object(Z_OBJ_P(return_value));
 
 	context = php_hash_alloc_context(ops);

--- a/ext/intl/breakiterator/breakiterator_class.cpp
+++ b/ext/intl/breakiterator/breakiterator_class.cpp
@@ -58,7 +58,7 @@ U_CFUNC	void breakiterator_object_create(zval *object,
 	}
 
 	if (brand_new) {
-		object_init_ex(object, ce);
+		object_init_instantiable_class(object, ce);
 	}
 	breakiterator_object_construct(object, biter);
 }

--- a/ext/intl/breakiterator/breakiterator_iterators.cpp
+++ b/ext/intl/breakiterator/breakiterator_iterators.cpp
@@ -231,7 +231,7 @@ void IntlIterator_from_BreakIterator_parts(zval *break_iter_zv,
 {
 	IntlIterator_object *ii;
 
-	object_init_ex(object, IntlPartsIterator_ce_ptr);
+	object_init_instantiable_class(object, IntlPartsIterator_ce_ptr);
 	ii = Z_INTL_ITERATOR_P(object);
 
 	ii->iterator = (zend_object_iterator*)emalloc(sizeof(zoi_break_iter_parts));

--- a/ext/intl/calendar/calendar_class.cpp
+++ b/ext/intl/calendar/calendar_class.cpp
@@ -53,7 +53,7 @@ U_CFUNC	void calendar_object_create(zval *object,
 		ce = Calendar_ce_ptr;
 	}
 
-	object_init_ex(object, ce);
+	object_init_instantiable_class(object, ce);
 	calendar_object_construct(object, calendar);
 }
 

--- a/ext/intl/calendar/calendar_methods.cpp
+++ b/ext/intl/calendar/calendar_methods.cpp
@@ -1038,7 +1038,7 @@ U_CFUNC PHP_FUNCTION(intlcal_from_date_time)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (date_str) {
-		object_init_ex(&zv_tmp, php_date_get_date_ce());
+		object_init_instantiable_class(&zv_tmp, php_date_get_date_ce());
 		ZVAL_STR(&zv_arg, date_str);
 		zend_call_known_instance_method_with_1_params(Z_OBJCE(zv_tmp)->constructor, Z_OBJ(zv_tmp), NULL, &zv_arg);
 		date_obj = Z_OBJ(zv_tmp);
@@ -1148,7 +1148,7 @@ U_CFUNC PHP_FUNCTION(intlcal_to_date_time)
 	/* resources allocated from now on */
 
 	/* Finally, instantiate object and call constructor */
-	object_init_ex(return_value, php_date_get_date_ce());
+	object_init_instantiable_class(return_value, php_date_get_date_ce());
 	zend_call_known_instance_method_with_2_params(
 		Z_OBJCE_P(return_value)->constructor, Z_OBJ_P(return_value), NULL, &ts_zval, timezone_zval);
 	if (EG(exception)) {

--- a/ext/intl/calendar/gregoriancalendar_methods.cpp
+++ b/ext/intl/calendar/gregoriancalendar_methods.cpp
@@ -209,7 +209,7 @@ static void _php_intlgregcal_constructor_body(INTERNAL_FUNCTION_PARAMETERS, bool
 
 U_CFUNC PHP_FUNCTION(intlgregcal_create_instance)
 {
-	object_init_ex(return_value, GregorianCalendar_ce_ptr);
+	object_init_instantiable_class(return_value, GregorianCalendar_ce_ptr);
 	_php_intlgregcal_constructor_body(INTERNAL_FUNCTION_PARAM_PASSTHRU, /* is_constructor */ false);
 }
 
@@ -254,7 +254,7 @@ U_CFUNC PHP_METHOD(IntlGregorianCalendar, createFromDate)
 		goto cleanup;
 	}
 
-	object_init_ex(return_value, GregorianCalendar_ce_ptr);
+	object_init_instantiable_class(return_value, GregorianCalendar_ce_ptr);
 	co = Z_INTL_CALENDAR_P(return_value);
 	co->ucal = gcal.release();
 
@@ -303,7 +303,7 @@ U_CFUNC PHP_METHOD(IntlGregorianCalendar, createFromDateTime)
 		goto cleanup;
 	}
 
-	object_init_ex(return_value, GregorianCalendar_ce_ptr);
+	object_init_instantiable_class(return_value, GregorianCalendar_ce_ptr);
 	co = Z_INTL_CALENDAR_P(return_value);
 	// TODO: trying to get passed the ownership change step
 	co->ucal = gcal.release();

--- a/ext/intl/collator/collator_create.cpp
+++ b/ext/intl/collator/collator_create.cpp
@@ -59,7 +59,7 @@ static int collator_ctor(INTERNAL_FUNCTION_PARAMETERS)
 /* {{{ Create collator. */
 U_CFUNC PHP_FUNCTION( collator_create )
 {
-	object_init_ex( return_value, Collator_ce_ptr );
+	object_init_instantiable_class( return_value, Collator_ce_ptr );
 	if (collator_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU) == FAILURE) {
 		zval_ptr_dtor(return_value);
 		RETURN_NULL();

--- a/ext/intl/common/common_enum.cpp
+++ b/ext/intl/common/common_enum.cpp
@@ -133,7 +133,7 @@ static const zend_object_iterator_funcs string_enum_object_iterator_funcs = {
 U_CFUNC void IntlIterator_from_StringEnumeration(StringEnumeration *se, zval *object)
 {
 	IntlIterator_object *ii;
-	object_init_ex(object, IntlIterator_ce_ptr);
+	object_init_instantiable_class(object, IntlIterator_ce_ptr);
 	ii = Z_INTL_ITERATOR_P(object);
 	ii->iterator = (zend_object_iterator*)emalloc(sizeof(zoi_with_current));
 	zend_iterator_init(ii->iterator);

--- a/ext/intl/dateformat/dateformat_create.cpp
+++ b/ext/intl/dateformat/dateformat_create.cpp
@@ -206,7 +206,7 @@ error:
 /* {{{ Create formatter. */
 U_CFUNC PHP_FUNCTION( datefmt_create )
 {
-    object_init_ex( return_value, IntlDateFormatter_ce_ptr );
+    object_init_instantiable_class( return_value, IntlDateFormatter_ce_ptr );
     if (datefmt_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU) == FAILURE) {
 		zval_ptr_dtor(return_value);
 		RETURN_NULL();

--- a/ext/intl/dateformat/datepatterngenerator_methods.cpp
+++ b/ext/intl/dateformat/datepatterngenerator_methods.cpp
@@ -72,7 +72,7 @@ static zend_result dtpg_ctor(INTERNAL_FUNCTION_PARAMETERS)
 
 U_CFUNC PHP_METHOD( IntlDatePatternGenerator, create )
 {
-    object_init_ex( return_value, IntlDatePatternGenerator_ce_ptr );
+    object_init_instantiable_class( return_value, IntlDatePatternGenerator_ce_ptr );
     if (dtpg_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU) == FAILURE) {
 		zval_ptr_dtor(return_value);
 		RETURN_NULL();

--- a/ext/intl/formatter/formatter_main.cpp
+++ b/ext/intl/formatter/formatter_main.cpp
@@ -133,7 +133,7 @@ static int numfmt_ctor(INTERNAL_FUNCTION_PARAMETERS)
 /* {{{ Create number formatter. */
 U_CFUNC PHP_FUNCTION( numfmt_create )
 {
-	object_init_ex( return_value, NumberFormatter_ce_ptr );
+	object_init_instantiable_class( return_value, NumberFormatter_ce_ptr );
 	if (numfmt_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU) == FAILURE) {
 		zval_ptr_dtor(return_value);
 		RETURN_NULL();

--- a/ext/intl/msgformat/msgformat.cpp
+++ b/ext/intl/msgformat/msgformat.cpp
@@ -103,7 +103,7 @@ static int msgfmt_ctor(INTERNAL_FUNCTION_PARAMETERS)
 /* {{{ Create formatter. */
 U_CFUNC PHP_FUNCTION( msgfmt_create )
 {
-	object_init_ex( return_value, MessageFormatter_ce_ptr );
+	object_init_instantiable_class( return_value, MessageFormatter_ce_ptr );
 	if (msgfmt_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU) == FAILURE) {
 		zval_ptr_dtor(return_value);
 		RETURN_NULL();

--- a/ext/intl/resourcebundle/resourcebundle.cpp
+++ b/ext/intl/resourcebundle/resourcebundle.cpp
@@ -68,7 +68,7 @@ U_CFUNC void resourcebundle_extract_value( zval *return_value, ResourceBundle_ob
 
 		case URES_ARRAY:
 		case URES_TABLE:
-			object_init_ex( return_value, ResourceBundle_ce_ptr );
+			object_init_instantiable_class( return_value, ResourceBundle_ce_ptr );
 			newrb = Z_INTL_RESOURCEBUNDLE_P(return_value);
 			newrb->me = source->child;
 			source->child = NULL;

--- a/ext/intl/resourcebundle/resourcebundle_class.cpp
+++ b/ext/intl/resourcebundle/resourcebundle_class.cpp
@@ -159,7 +159,7 @@ PHP_METHOD( ResourceBundle, __construct )
 /* {{{ */
 U_CFUNC PHP_FUNCTION( resourcebundle_create )
 {
-	object_init_ex( return_value, ResourceBundle_ce_ptr );
+	object_init_instantiable_class( return_value, ResourceBundle_ce_ptr );
 	if (resourcebundle_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU) == FAILURE) {
 		zval_ptr_dtor(return_value);
 		RETURN_NULL();

--- a/ext/intl/timezone/timezone_class.cpp
+++ b/ext/intl/timezone/timezone_class.cpp
@@ -51,7 +51,7 @@ U_CFUNC void timezone_object_construct(const TimeZone *zone, zval *object, int o
 {
 	TimeZone_object	*to;
 
-	object_init_ex(object, TimeZone_ce_ptr);
+	object_init_instantiable_class(object, TimeZone_ce_ptr);
 	TIMEZONE_METHOD_FETCH_OBJECT_NO_CHECK; /* fetch zend object from zval "object" into "to" */
 	to->utimezone = zone;
 	to->should_delete = owned;
@@ -76,7 +76,7 @@ U_CFUNC zval *timezone_convert_to_datetimezone(const TimeZone *timeZone,
 	if (id.compare(0, 3, UnicodeString("GMT", sizeof("GMT")-1, US_INV)) == 0) {
 		/* The DateTimeZone constructor doesn't support offset time zones,
 		* so we must mess with DateTimeZone structure ourselves */
-		object_init_ex(ret, php_date_get_timezone_ce());
+		object_init_instantiable_class(ret, php_date_get_timezone_ce());
 		php_timezone_obj *tzobj = Z_PHPTIMEZONE_P(ret);
 
 		tzobj->initialized	  = true;

--- a/ext/intl/transliterator/transliterator_methods.cpp
+++ b/ext/intl/transliterator/transliterator_methods.cpp
@@ -47,7 +47,7 @@ static int create_transliterator( char *str_id, size_t str_id_len, zend_long dir
 		return FAILURE;
 	}
 
-	object_init_ex( object, Transliterator_ce_ptr );
+	object_init_instantiable_class( object, Transliterator_ce_ptr );
 	TRANSLITERATOR_METHOD_FETCH_OBJECT_NO_CHECK; /* fetch zend object from zval "object" into "to" */
 
 	/* Convert transliterator id to UTF-16 */
@@ -152,7 +152,7 @@ U_CFUNC PHP_FUNCTION( transliterator_create_from_rules )
 	}
 
 	object = return_value;
-	object_init_ex( object, Transliterator_ce_ptr );
+	object_init_instantiable_class( object, Transliterator_ce_ptr );
 	TRANSLITERATOR_METHOD_FETCH_OBJECT_NO_CHECK;
 
 	intl_convert_utf8_to_utf16( &ustr_rules, &ustr_rules_len,
@@ -208,7 +208,7 @@ U_CFUNC PHP_FUNCTION( transliterator_create_inverse )
 	to_orig = to;
 
 	object = return_value;
-	object_init_ex( object, Transliterator_ce_ptr );
+	object_init_instantiable_class( object, Transliterator_ce_ptr );
 	TRANSLITERATOR_METHOD_FETCH_OBJECT_NO_CHECK; /* change "to" into new object (from "object" ) */
 
 	utrans = utrans_openInverse( to_orig->utrans, TRANSLITERATOR_ERROR_CODE_P( to ) );

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -1029,7 +1029,7 @@ PHP_FUNCTION(ldap_connect)
 			LDAPG(tls_newctx) = false;
 		}
 #endif
-		object_init_ex(return_value, ldap_link_ce);
+		object_init_instantiable_class(return_value, ldap_link_ce);
 		ld = Z_LDAP_LINK_P(return_value);
 
 #ifdef LDAP_API_FEATURE_X_OPENLDAP
@@ -1107,7 +1107,7 @@ PHP_FUNCTION(ldap_connect_wallet) {
 		RETURN_FALSE;
 	}
 
-	object_init_ex(return_value, ldap_link_ce);
+	object_init_instantiable_class(return_value, ldap_link_ce);
 	ld = Z_LDAP_LINK_P(return_value);
 
 	{
@@ -1255,7 +1255,7 @@ PHP_FUNCTION(ldap_bind_ext)
 		}
 
 		/* return a PHP control object */
-		object_init_ex(return_value, ldap_result_ce);
+		object_init_instantiable_class(return_value, ldap_result_ce);
 		ldap_resultdata *result = Z_LDAP_RESULT_P(return_value);
 		result->result = ldap_res;
 	}
@@ -1691,7 +1691,7 @@ process:
 			}
 			if (rcs[i] != -1) {
 				zval object;
-				object_init_ex(&object, ldap_result_ce);
+				object_init_instantiable_class(&object, ldap_result_ce);
 				result = Z_LDAP_RESULT_P(&object);
 				result->result = ldap_res;
 				add_next_index_zval(return_value, &object);
@@ -1761,7 +1761,7 @@ cleanup_parallel:
 				php_error_docref(NULL, E_WARNING, "Partial search results returned: Adminlimit exceeded");
 			}
 #endif
-			object_init_ex(return_value, ldap_result_ce);
+			object_init_instantiable_class(return_value, ldap_result_ce);
 			result = Z_LDAP_RESULT_P(return_value);
 			result->result = ldap_res;
 		}
@@ -1868,7 +1868,7 @@ PHP_FUNCTION(ldap_first_entry)
 	if ((entry = ldap_first_entry(ld->link, ldap_result->result)) == NULL) {
 		RETVAL_FALSE;
 	} else {
-		object_init_ex(return_value, ldap_result_entry_ce);
+		object_init_instantiable_class(return_value, ldap_result_entry_ce);
 		ldap_result_entry *resultentry = Z_LDAP_RESULT_ENTRY_P(return_value);
 		ZVAL_COPY(&resultentry->res, result);
 		resultentry->data = entry;
@@ -1897,7 +1897,7 @@ PHP_FUNCTION(ldap_next_entry)
 	if ((entry_next = ldap_next_entry(ld->link, resultentry->data)) == NULL) {
 		RETVAL_FALSE;
 	} else {
-		object_init_ex(return_value, ldap_result_entry_ce);
+		object_init_instantiable_class(return_value, ldap_result_entry_ce);
 		ldap_result_entry *resultentry_next = Z_LDAP_RESULT_ENTRY_P(return_value);
 		ZVAL_COPY(&resultentry_next->res, &resultentry->res);
 		resultentry_next->data = entry_next;
@@ -2401,7 +2401,7 @@ static void php_ldap_do_modify(INTERNAL_FUNCTION_PARAMETERS, int oper, bool ext)
 			}
 
 			/* return a PHP control object */
-			object_init_ex(return_value, ldap_result_ce);
+			object_init_instantiable_class(return_value, ldap_result_ce);
 			result = Z_LDAP_RESULT_P(return_value);
 			result->result = ldap_res;
 		} else RETVAL_TRUE;
@@ -2423,7 +2423,7 @@ static void php_ldap_do_modify(INTERNAL_FUNCTION_PARAMETERS, int oper, bool ext)
 			}
 
 			/* return a PHP control object */
-			object_init_ex(return_value, ldap_result_ce);
+			object_init_instantiable_class(return_value, ldap_result_ce);
 			result = Z_LDAP_RESULT_P(return_value);
 			result->result = ldap_res;
 		} else {
@@ -2558,7 +2558,7 @@ static void php_ldap_do_delete(INTERNAL_FUNCTION_PARAMETERS, bool ext)
 		}
 
 		/* return a PHP control object */
-		object_init_ex(return_value, ldap_result_ce);
+		object_init_instantiable_class(return_value, ldap_result_ce);
 		ldap_resultdata *result = Z_LDAP_RESULT_P(return_value);
 		result->result = ldap_res;
 	} else {
@@ -3529,7 +3529,7 @@ PHP_FUNCTION(ldap_first_reference)
 	if ((entry = ldap_first_reference(ld->link, ldap_result->result)) == NULL) {
 		RETVAL_FALSE;
 	} else {
-		object_init_ex(return_value, ldap_result_entry_ce);
+		object_init_instantiable_class(return_value, ldap_result_entry_ce);
 		ldap_result_entry *resultentry = Z_LDAP_RESULT_ENTRY_P(return_value);
 		ZVAL_COPY(&resultentry->res, result);
 		resultentry->data = entry;
@@ -3558,7 +3558,7 @@ PHP_FUNCTION(ldap_next_reference)
 	if ((entry_next = ldap_next_reference(ld->link, resultentry->data)) == NULL) {
 		RETVAL_FALSE;
 	} else {
-		object_init_ex(return_value, ldap_result_entry_ce);
+		object_init_instantiable_class(return_value, ldap_result_entry_ce);
 		ldap_result_entry *resultentry_next = Z_LDAP_RESULT_ENTRY_P(return_value);
 		ZVAL_COPY(&resultentry_next->res, &resultentry->res);
 		resultentry_next->data = entry_next;
@@ -3673,7 +3673,7 @@ static void php_ldap_do_rename(INTERNAL_FUNCTION_PARAMETERS, bool ext)
 		}
 
 		/* return a PHP control object */
-		object_init_ex(return_value, ldap_result_ce);
+		object_init_instantiable_class(return_value, ldap_result_ce);
 		ldap_resultdata *result = Z_LDAP_RESULT_P(return_value);
 		result->result = ldap_res;
 	} else {
@@ -4125,7 +4125,7 @@ static void php_ldap_exop(INTERNAL_FUNCTION_PARAMETERS, bool force_sync) {
 	}
 
 	/* return a PHP control object */
-	object_init_ex(return_value, ldap_result_ce);
+	object_init_instantiable_class(return_value, ldap_result_ce);
 	result = Z_LDAP_RESULT_P(return_value);
 	result->result = ldap_res;
 

--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -1150,7 +1150,7 @@ PHP_FUNCTION(libxml_use_internal_errors)
 
 static void php_libxml_create_error_object(zval *return_value, const xmlError *error)
 {
-	object_init_ex(return_value, libxmlerror_class_entry);
+	object_init_instantiable_class(return_value, libxmlerror_class_entry);
 	add_property_long(return_value, "level", error->level);
 	add_property_long(return_value, "code", error->code);
 	add_property_long(return_value, "column", error->int2);

--- a/ext/mysqli/mysqli_exception.c
+++ b/ext/mysqli/mysqli_exception.c
@@ -39,7 +39,7 @@ void php_mysqli_throw_sql_exception(char *sqlstate, int errorno, char *format, .
 		return;
 	}
 
-	object_init_ex(&sql_ex, mysqli_exception_class_entry);
+	object_init_instantiable_class(&sql_ex, mysqli_exception_class_entry);
 
 	if (message) {
 		zend_update_property_string(

--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -861,7 +861,7 @@ PHP_FUNCTION(odbc_prepare)
 	odbc_connection *conn = Z_ODBC_CONNECTION_P(pv_conn);
 	CHECK_ODBC_CONNECTION(conn);
 
-	object_init_ex(return_value, odbc_result_ce);
+	object_init_instantiable_class(return_value, odbc_result_ce);
 	result = Z_ODBC_RESULT_P(return_value);
 
 	result->numparams = 0;
@@ -1240,7 +1240,7 @@ PHP_FUNCTION(odbc_exec)
 	odbc_connection *conn = Z_ODBC_CONNECTION_P(pv_conn);
 	CHECK_ODBC_CONNECTION(conn);
 
-	object_init_ex(return_value, odbc_result_ce);
+	object_init_instantiable_class(return_value, odbc_result_ce);
 	result = Z_ODBC_RESULT_P(return_value);
 
 	rc = SQLAllocHandle(SQL_HANDLE_STMT, conn->hdbc, &(result->stmt));
@@ -1884,7 +1884,7 @@ bool odbc_sqlconnect(zval *zv, char *db, char *uid, char *pwd, int cur_opt, bool
 	SQLRETURN ret;
 	odbc_link *link;
 
-	object_init_ex(zv, odbc_connection_ce);
+	object_init_instantiable_class(zv, odbc_connection_ce);
 	link = Z_ODBC_LINK_P(zv);
 	link->connection = pecalloc(1, sizeof(odbc_connection), persistent);
 	zend_hash_init(&link->connection->results, 0, NULL, ZVAL_PTR_DTOR, true);
@@ -2127,7 +2127,7 @@ try_and_get_another_connection:
 
 			zval *link_zval;
 			if ((link_zval = zend_hash_str_find(&ODBCG(connections), hashed_details, hashed_details_len)) == NULL) {
-				object_init_ex(return_value, odbc_connection_ce);
+				object_init_instantiable_class(return_value, odbc_connection_ce);
 				odbc_link *link = Z_ODBC_LINK_P(return_value);
 				link->connection = db_conn;
 				link->hash = zend_string_init(hashed_details, hashed_details_len, persistent);
@@ -2564,7 +2564,7 @@ PHP_FUNCTION(odbc_tables)
 	odbc_connection *conn = Z_ODBC_CONNECTION_P(pv_conn);
 	CHECK_ODBC_CONNECTION(conn);
 
-	object_init_ex(return_value, odbc_result_ce);
+	object_init_instantiable_class(return_value, odbc_result_ce);
 	result = Z_ODBC_RESULT_P(return_value);
 
 	rc = SQLAllocHandle(SQL_HANDLE_STMT, conn->hdbc, &(result->stmt));
@@ -2629,7 +2629,7 @@ PHP_FUNCTION(odbc_columns)
 	odbc_connection *conn = Z_ODBC_CONNECTION_P(pv_conn);
 	CHECK_ODBC_CONNECTION(conn);
 
-	object_init_ex(return_value, odbc_result_ce);
+	object_init_instantiable_class(return_value, odbc_result_ce);
 	result = Z_ODBC_RESULT_P(return_value);
 
 	rc = SQLAllocHandle(SQL_HANDLE_STMT, conn->hdbc, &(result->stmt));
@@ -2696,7 +2696,7 @@ PHP_FUNCTION(odbc_columnprivileges)
 	odbc_connection *conn = Z_ODBC_CONNECTION_P(pv_conn);
 	CHECK_ODBC_CONNECTION(conn);
 
-	object_init_ex(return_value, odbc_result_ce);
+	object_init_instantiable_class(return_value, odbc_result_ce);
 	result = Z_ODBC_RESULT_P(return_value);
 
 	rc = SQLAllocHandle(SQL_HANDLE_STMT, conn->hdbc, &(result->stmt));
@@ -2768,7 +2768,7 @@ PHP_FUNCTION(odbc_foreignkeys)
 	odbc_connection *conn = Z_ODBC_CONNECTION_P(pv_conn);
 	CHECK_ODBC_CONNECTION(conn);
 
-	object_init_ex(return_value, odbc_result_ce);
+	object_init_instantiable_class(return_value, odbc_result_ce);
 	result = Z_ODBC_RESULT_P(return_value);
 
 	rc = SQLAllocHandle(SQL_HANDLE_STMT, conn->hdbc, &(result->stmt));
@@ -2831,7 +2831,7 @@ PHP_FUNCTION(odbc_gettypeinfo)
 	odbc_connection *conn = Z_ODBC_CONNECTION_P(pv_conn);
 	CHECK_ODBC_CONNECTION(conn);
 
-	object_init_ex(return_value, odbc_result_ce);
+	object_init_instantiable_class(return_value, odbc_result_ce);
 	result = Z_ODBC_RESULT_P(return_value);
 
 	rc = SQLAllocHandle(SQL_HANDLE_STMT, conn->hdbc, &(result->stmt));
@@ -2886,7 +2886,7 @@ PHP_FUNCTION(odbc_primarykeys)
 	odbc_connection *conn = Z_ODBC_CONNECTION_P(pv_conn);
 	CHECK_ODBC_CONNECTION(conn);
 
-	object_init_ex(return_value, odbc_result_ce);
+	object_init_instantiable_class(return_value, odbc_result_ce);
 	result = Z_ODBC_RESULT_P(return_value);
 
 	rc = SQLAllocHandle(SQL_HANDLE_STMT, conn->hdbc, &(result->stmt));
@@ -2945,7 +2945,7 @@ PHP_FUNCTION(odbc_procedurecolumns)
 	odbc_connection *conn = Z_ODBC_CONNECTION_P(pv_conn);
 	CHECK_ODBC_CONNECTION(conn);
 
-	object_init_ex(return_value, odbc_result_ce);
+	object_init_instantiable_class(return_value, odbc_result_ce);
 	result = Z_ODBC_RESULT_P(return_value);
 
 	rc = SQLAllocHandle(SQL_HANDLE_STMT, conn->hdbc, &(result->stmt));
@@ -3004,7 +3004,7 @@ PHP_FUNCTION(odbc_procedures)
 	odbc_connection *conn = Z_ODBC_CONNECTION_P(pv_conn);
 	CHECK_ODBC_CONNECTION(conn);
 
-	object_init_ex(return_value, odbc_result_ce);
+	object_init_instantiable_class(return_value, odbc_result_ce);
 	result = Z_ODBC_RESULT_P(return_value);
 
 	rc = SQLAllocHandle(SQL_HANDLE_STMT, conn->hdbc, &(result->stmt));
@@ -3069,7 +3069,7 @@ PHP_FUNCTION(odbc_specialcolumns)
 	odbc_connection *conn = Z_ODBC_CONNECTION_P(pv_conn);
 	CHECK_ODBC_CONNECTION(conn);
 
-	object_init_ex(return_value, odbc_result_ce);
+	object_init_instantiable_class(return_value, odbc_result_ce);
 	result = Z_ODBC_RESULT_P(return_value);
 
 	rc = SQLAllocHandle(SQL_HANDLE_STMT, conn->hdbc, &(result->stmt));
@@ -3135,7 +3135,7 @@ PHP_FUNCTION(odbc_statistics)
 	odbc_connection *conn = Z_ODBC_CONNECTION_P(pv_conn);
 	CHECK_ODBC_CONNECTION(conn);
 
-	object_init_ex(return_value, odbc_result_ce);
+	object_init_instantiable_class(return_value, odbc_result_ce);
 	result = Z_ODBC_RESULT_P(return_value);
 
 	rc = SQLAllocHandle(SQL_HANDLE_STMT, conn->hdbc, &(result->stmt));
@@ -3195,7 +3195,7 @@ PHP_FUNCTION(odbc_tableprivileges)
 	odbc_connection *conn = Z_ODBC_CONNECTION_P(pv_conn);
 	CHECK_ODBC_CONNECTION(conn);
 
-	object_init_ex(return_value, odbc_result_ce);
+	object_init_instantiable_class(return_value, odbc_result_ce);
 	result = Z_ODBC_RESULT_P(return_value);
 
 	rc = SQLAllocHandle(SQL_HANDLE_STMT, conn->hdbc, &(result->stmt));

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -139,7 +139,7 @@ bool php_openssl_is_pkey_ce(zval *val)
 
 void php_openssl_pkey_object_init(zval *zv, EVP_PKEY *pkey, bool is_private)
 {
-	object_init_ex(zv, php_openssl_pkey_ce);
+	object_init_instantiable_class(zv, php_openssl_pkey_ce);
 	php_openssl_pkey_object *obj = Z_OPENSSL_PKEY_P(zv);
 	obj->pkey = pkey;
 	obj->is_private = is_private;
@@ -259,7 +259,7 @@ SSL_SESSION *php_openssl_session_from_zval(zval *zv)
 
 void php_openssl_session_object_init(zval *zv, SSL_SESSION *session)
 {
-	object_init_ex(zv, php_openssl_session_ce);
+	object_init_instantiable_class(zv, php_openssl_session_ce);
 	php_openssl_session_object *obj = Z_OPENSSL_SESSION_P(zv);
 	obj->session = session;
 
@@ -1646,7 +1646,7 @@ PHP_FUNCTION(openssl_x509_read)
 		RETURN_FALSE;
 	}
 
-	object_init_ex(return_value, php_openssl_certificate_ce);
+	object_init_instantiable_class(return_value, php_openssl_certificate_ce);
 	x509_cert_obj = Z_OPENSSL_CERTIFICATE_P(return_value);
 	x509_cert_obj->x509 = cert_obj ? X509_dup(cert) : cert;
 }
@@ -2247,7 +2247,7 @@ PHP_FUNCTION(openssl_csr_sign)
 		goto cleanup;
 	}
 
-	object_init_ex(return_value, php_openssl_certificate_ce);
+	object_init_instantiable_class(return_value, php_openssl_certificate_ce);
 	cert_object = Z_OPENSSL_CERTIFICATE_P(return_value);
 	cert_object->x509 = new_cert;
 	new_cert_used = true;
@@ -2320,7 +2320,7 @@ PHP_FUNCTION(openssl_csr_new)
 						RETVAL_TRUE;
 
 						if (X509_REQ_sign(csr, req.priv_key, req.digest)) {
-							object_init_ex(return_value, php_openssl_request_ce);
+							object_init_instantiable_class(return_value, php_openssl_request_ce);
 							x509_request_obj = Z_OPENSSL_REQUEST_P(return_value);
 							x509_request_obj->csr = csr;
 							csr = NULL;

--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -2623,7 +2623,7 @@ static int php_openssl_capture_peer_certs(php_stream *stream,
 			"ssl", "capture_peer_cert")) &&
 		zend_is_true(val)
 	) {
-		object_init_ex(&zcert, php_openssl_certificate_ce);
+		object_init_instantiable_class(&zcert, php_openssl_certificate_ce);
 		cert_object = Z_OPENSSL_CERTIFICATE_P(&zcert);
 		cert_object->x509 = peer_cert;
 
@@ -2648,7 +2648,7 @@ static int php_openssl_capture_peer_certs(php_stream *stream,
 			for (i = 0; i < sk_X509_num(chain); i++) {
 				X509 *mycert = X509_dup(sk_X509_value(chain, i));
 
-				object_init_ex(&zcert, php_openssl_certificate_ce);
+				object_init_instantiable_class(&zcert, php_openssl_certificate_ce);
 				cert_object = Z_OPENSSL_CERTIFICATE_P(&zcert);
 				cert_object->x509 = mycert;
 				add_next_index_zval(&arr, &zcert);

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -39,7 +39,7 @@ void pdo_throw_exception(unsigned int driver_errcode, char *driver_errmsg, pdo_e
 {
 		zval error_info,pdo_exception;
 
-		object_init_ex(&pdo_exception, php_pdo_get_exception());
+		object_init_instantiable_class(&pdo_exception, php_pdo_get_exception());
 		array_init(&error_info);
 
 		add_next_index_string(&error_info, *pdo_error);
@@ -107,7 +107,7 @@ void pdo_raise_impl_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, pdo_error_type sqlst
 		zval ex, info;
 		zend_class_entry *pdo_ex = php_pdo_get_exception();
 
-		object_init_ex(&ex, pdo_ex);
+		object_init_instantiable_class(&ex, pdo_ex);
 
 		zend_update_property_str(zend_ce_exception, Z_OBJ(ex), "message", sizeof("message")-1, message);
 		zend_update_property_string(zend_ce_exception, Z_OBJ(ex), "code", sizeof("code")-1, *pdo_err);
@@ -182,7 +182,7 @@ PDO_API void pdo_handle_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt) /* {{{ */
 		zval ex;
 		zend_class_entry *pdo_ex = php_pdo_get_exception();
 
-		object_init_ex(&ex, pdo_ex);
+		object_init_instantiable_class(&ex, pdo_ex);
 
 		zend_update_property_str(zend_ce_exception, Z_OBJ(ex), "message", sizeof("message") - 1, message);
 		zend_update_property_string(zend_ce_exception, Z_OBJ(ex), "code", sizeof("code") - 1, *pdo_err);

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -754,7 +754,7 @@ static void php_pgsql_do_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent)
 			}
 		}
 
-		object_init_ex(return_value, pgsql_link_ce);
+		object_init_instantiable_class(return_value, pgsql_link_ce);
 		link = Z_PGSQL_LINK_P(return_value);
 		link->conn = pgsql;
 		link->hash = zend_string_copy(str.s);
@@ -805,7 +805,7 @@ static void php_pgsql_do_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent)
 			}
 		}
 
-		object_init_ex(return_value, pgsql_link_ce);
+		object_init_instantiable_class(return_value, pgsql_link_ce);
 		link = Z_PGSQL_LINK_P(return_value);
 		link->conn = pgsql;
 		link->hash = zend_string_copy(str.s);
@@ -1207,7 +1207,7 @@ PHP_FUNCTION(pg_query)
 		case PGRES_COMMAND_OK: /* successful command that did not return rows */
 		default:
 			if (pgsql_result) {
-				object_init_ex(return_value, pgsql_result_ce);
+				object_init_instantiable_class(return_value, pgsql_result_ce);
 				pgsql_result_handle *pg_result = Z_PGSQL_RESULT_P(return_value);
 				pg_result->conn = pgsql;
 				pg_result->result = pgsql_result;
@@ -1345,7 +1345,7 @@ PHP_FUNCTION(pg_query_params)
 		case PGRES_COMMAND_OK: /* successful command that did not return rows */
 		default:
 			if (pgsql_result) {
-				object_init_ex(return_value, pgsql_result_ce);
+				object_init_instantiable_class(return_value, pgsql_result_ce);
 				pg_result = Z_PGSQL_RESULT_P(return_value);
 				pg_result->conn = pgsql;
 				pg_result->result = pgsql_result;
@@ -1430,7 +1430,7 @@ PHP_FUNCTION(pg_prepare)
 		case PGRES_COMMAND_OK: /* successful command that did not return rows */
 		default:
 			if (pgsql_result) {
-				object_init_ex(return_value, pgsql_result_ce);
+				object_init_instantiable_class(return_value, pgsql_result_ce);
 				pg_result = Z_PGSQL_RESULT_P(return_value);
 				pg_result->conn = pgsql;
 				pg_result->result = pgsql_result;
@@ -1528,7 +1528,7 @@ PHP_FUNCTION(pg_execute)
 		case PGRES_COMMAND_OK: /* successful command that did not return rows */
 		default:
 			if (pgsql_result) {
-				object_init_ex(return_value, pgsql_result_ce);
+				object_init_instantiable_class(return_value, pgsql_result_ce);
 				pg_result = Z_PGSQL_RESULT_P(return_value);
 				pg_result->conn = pgsql;
 				pg_result->result = pgsql_result;
@@ -2755,7 +2755,7 @@ PHP_FUNCTION(pg_lo_open)
 		}
 	}
 
-	object_init_ex(return_value, pgsql_lob_ce);
+	object_init_instantiable_class(return_value, pgsql_lob_ce);
 	pgsql_lofp = Z_PGSQL_LOB_P(return_value);
 	pgsql_lofp->conn = pgsql;
 	pgsql_lofp->lofd = pgsql_lofd;
@@ -4289,7 +4289,7 @@ PHP_FUNCTION(pg_get_result)
 		RETURN_FALSE;
 	}
 
-	object_init_ex(return_value, pgsql_result_ce);
+	object_init_instantiable_class(return_value, pgsql_result_ce);
 	pg_result = Z_PGSQL_RESULT_P(return_value);
 	pg_result->conn = pgsql;
 	pg_result->result = pgsql_result;
@@ -5792,7 +5792,7 @@ PHP_FUNCTION(pg_insert)
 			case PGRES_COMMAND_OK: /* successful command that did not return rows */
 			default:
 				if (pg_result) {
-					object_init_ex(return_value, pgsql_result_ce);
+					object_init_instantiable_class(return_value, pgsql_result_ce);
 					pgsql_result_handle *pg_res = Z_PGSQL_RESULT_P(return_value);
 					pg_res->conn = pg_link;
 					pg_res->result = pg_result;
@@ -6419,7 +6419,7 @@ PHP_FUNCTION(pg_close_stmt)
 		RETURN_FALSE;
 	} else {
 		pgsql_result_handle *pg_handle;
-		object_init_ex(return_value, pgsql_result_ce);
+		object_init_instantiable_class(return_value, pgsql_result_ce);
 		pg_handle = Z_PGSQL_RESULT_P(return_value);
 		pg_handle->conn = link->conn;
 		pg_handle->result = pgsql_result;

--- a/ext/random/randomizer.c
+++ b/ext/random/randomizer.c
@@ -66,7 +66,7 @@ PHP_METHOD(Random_Randomizer, __construct)
 		ZVAL_COPY(&engine, param_engine);
 	} else {
 		/* Create default RNG instance */
-		object_init_ex(&engine, random_ce_Random_Engine_Secure);
+		object_init_instantiable_class(&engine, random_ce_Random_Engine_Secure);
 	}
 
 	zend_update_property(random_ce_Random_Randomizer, Z_OBJ_P(ZEND_THIS), "engine", strlen("engine"), &engine);

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -1244,7 +1244,7 @@ static void reflection_attribute_factory(zval *object, HashTable *attributes, ze
 	reflection_object *intern;
 	attribute_reference *reference;
 
-	object_init_ex(object, reflection_attribute_ptr);
+	object_init_instantiable_class(object, reflection_attribute_ptr);
 	intern  = Z_REFLECTION_P(object);
 	reference = (attribute_reference*) emalloc(sizeof(attribute_reference));
 	reference->attributes = attributes;
@@ -1392,7 +1392,7 @@ PHPAPI void zend_reflection_class_factory(zend_class_entry *ce, zval *object)
 
 	zend_class_entry *reflection_ce =
 		ce->ce_flags & ZEND_ACC_ENUM ? reflection_enum_ptr : reflection_class_ptr;
-	object_init_ex(object, reflection_ce);
+	object_init_instantiable_class(object, reflection_ce);
 	intern = Z_REFLECTION_P(object);
 	intern->ptr = ce;
 	intern->ref_type = REF_TYPE_OTHER;
@@ -1404,7 +1404,7 @@ PHPAPI void zend_reflection_class_factory(zend_class_entry *ce, zval *object)
 /* {{{ reflection_extension_factory_ex */
 static void reflection_extension_factory_ex(zval *object, zend_module_entry *module)
 {
-	object_init_ex(object, reflection_extension_ptr);
+	object_init_instantiable_class(object, reflection_extension_ptr);
 	reflection_object *intern = Z_REFLECTION_P(object);
 	intern->ptr = module;
 	intern->ref_type = REF_TYPE_OTHER;
@@ -1433,7 +1433,7 @@ static void reflection_parameter_factory(zend_function *fptr, zval *closure_obje
 	parameter_reference *reference;
 	zval *prop_name;
 
-	object_init_ex(object, reflection_parameter_ptr);
+	object_init_instantiable_class(object, reflection_parameter_ptr);
 	intern = Z_REFLECTION_P(object);
 	reference = (parameter_reference*) emalloc(sizeof(parameter_reference));
 	reference->arg_info = arg_info;
@@ -1504,13 +1504,13 @@ static void reflection_type_factory(zend_type type, zval *object, bool legacy_be
 
 	switch (type_kind) {
 		case INTERSECTION_TYPE:
-			object_init_ex(object, reflection_intersection_type_ptr);
+			object_init_instantiable_class(object, reflection_intersection_type_ptr);
 			break;
 		case UNION_TYPE:
-			object_init_ex(object, reflection_union_type_ptr);
+			object_init_instantiable_class(object, reflection_union_type_ptr);
 			break;
 		case NAMED_TYPE:
-			object_init_ex(object, reflection_named_type_ptr);
+			object_init_instantiable_class(object, reflection_named_type_ptr);
 			break;
 		default: ZEND_UNREACHABLE();
 	}
@@ -1537,7 +1537,7 @@ static void reflection_type_factory(zend_type type, zval *object, bool legacy_be
 static void reflection_function_factory(zend_function *function, zval *closure_object, zval *object)
 {
 	reflection_object *intern;
-	object_init_ex(object, reflection_function_ptr);
+	object_init_instantiable_class(object, reflection_function_ptr);
 	intern = Z_REFLECTION_P(object);
 	intern->ptr = function;
 	intern->ref_type = REF_TYPE_FUNCTION;
@@ -1554,7 +1554,7 @@ static void reflection_method_factory(zend_class_entry *ce, zend_function *metho
 {
 	reflection_object *intern;
 
-	object_init_ex(object, reflection_method_ptr);
+	object_init_instantiable_class(object, reflection_method_ptr);
 	intern = Z_REFLECTION_P(object);
 	intern->ptr = method;
 	intern->ref_type = REF_TYPE_FUNCTION;
@@ -1574,7 +1574,7 @@ static void reflection_property_factory(zend_class_entry *ce, zend_string *name,
 	reflection_object *intern;
 	property_reference *reference;
 
-	object_init_ex(object, reflection_property_ptr);
+	object_init_instantiable_class(object, reflection_property_ptr);
 	intern = Z_REFLECTION_P(object);
 	reference = (property_reference*) emalloc(sizeof(property_reference));
 	reference->prop = prop;
@@ -1600,7 +1600,7 @@ static void reflection_class_constant_factory(zend_string *name_str, zend_class_
 {
 	reflection_object *intern;
 
-	object_init_ex(object, reflection_class_constant_ptr);
+	object_init_instantiable_class(object, reflection_class_constant_ptr);
 	intern = Z_REFLECTION_P(object);
 	intern->ptr = constant;
 	intern->ref_type = REF_TYPE_CLASS_CONSTANT;
@@ -1618,7 +1618,7 @@ static void reflection_enum_case_factory(zend_class_entry *ce, zend_string *name
 	zend_class_entry *case_reflection_class = ce->enum_backing_type == IS_UNDEF
 		? reflection_enum_unit_case_ptr
 		: reflection_enum_backed_case_ptr;
-	object_init_ex(object, case_reflection_class);
+	object_init_instantiable_class(object, case_reflection_class);
 	intern = Z_REFLECTION_P(object);
 	intern->ptr = constant;
 	intern->ref_type = REF_TYPE_CLASS_CONSTANT;
@@ -4558,7 +4558,7 @@ ZEND_METHOD(ReflectionClass, getMethods)
 		zval obj_tmp;
 		zend_object *obj;
 		if (!has_obj) {
-			object_init_ex(&obj_tmp, ce);
+			object_init_instantiable_class(&obj_tmp, ce);
 			obj = Z_OBJ(obj_tmp);
 		} else {
 			obj = Z_OBJ(intern->obj);
@@ -7364,7 +7364,7 @@ ZEND_METHOD(ReflectionReference, fromArrayElement)
 		RETURN_NULL();
 	}
 
-	object_init_ex(return_value, reflection_reference_ptr);
+	object_init_instantiable_class(return_value, reflection_reference_ptr);
 	intern = Z_REFLECTION_P(return_value);
 	ZVAL_COPY(&intern->obj, item);
 	intern->ref_type = REF_TYPE_OTHER;

--- a/ext/shmop/shmop.c
+++ b/ext/shmop/shmop.c
@@ -144,7 +144,7 @@ PHP_FUNCTION(shmop_open)
 		RETURN_THROWS();
 	}
 
-	object_init_ex(return_value, shmop_ce);
+	object_init_instantiable_class(return_value, shmop_ce);
 	shmop = Z_SHMOP_P(return_value);
 	shmop->key = key;
 	shmop->shmflg |= mode;

--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -2907,7 +2907,7 @@ static zval *guess_zval_convert(zval *ret, encodeTypePtr type, xmlNodePtr data)
 		char *ns;
 		xmlNsPtr nsptr;
 
-		object_init_ex(&soapvar, soap_var_class_entry);
+		object_init_instantiable_class(&soapvar, soap_var_class_entry);
 		ZVAL_LONG(Z_VAR_ENC_TYPE_P(&soapvar), enc->details.type);
 		ZVAL_COPY_VALUE(Z_VAR_ENC_VALUE_P(&soapvar), ret);
 		parse_namespace(type_name, &cptype, &ns);

--- a/ext/soap/php_http.c
+++ b/ext/soap/php_http.c
@@ -557,7 +557,7 @@ try_again:
 			zval_ptr_dtor(url_zval);
 		}
 
-		object_init_ex(url_zval, soap_url_class_entry);
+		object_init_instantiable_class(url_zval, soap_url_class_entry);
 		soap_url_object *url_obj = Z_SOAP_URL_P(url_zval);
 		url_obj->uri = uri;
 

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -1511,7 +1511,7 @@ PHP_METHOD(SoapServer, handle)
 
 		/* If new session or something weird happned */
 		if (soap_obj == NULL) {
-			object_init_ex(&tmp_soap, service->soap_class.ce);
+			object_init_instantiable_class(&tmp_soap, service->soap_class.ce);
 
 			/* Call constructor */
 			if (service->soap_class.ce->constructor) {
@@ -2241,7 +2241,7 @@ PHP_METHOD(SoapClient, __construct)
 			zval_ptr_dtor(sdl_zval);
 		}
 
-		object_init_ex(sdl_zval, soap_sdl_class_entry);
+		object_init_instantiable_class(sdl_zval, soap_sdl_class_entry);
 		soap_sdl_object *sdl_object = Z_SOAP_SDL_P(sdl_zval);
 		sdl_object->sdl = sdl;
 
@@ -2990,7 +2990,7 @@ static void add_soap_fault_en(zval *obj, char *fault_code, char *fault_string, c
 static void set_soap_fault(zval *obj, const char *fault_code_ns, const char *fault_code, const char *fault_string, const char *fault_actor, zval *fault_detail, zend_string *name, zend_string *lang) /* {{{ */
 {
 	if (Z_TYPE_P(obj) != IS_OBJECT) {
-		object_init_ex(obj, soap_fault_class_entry);
+		object_init_instantiable_class(obj, soap_fault_class_entry);
 	}
 
 	ZVAL_STRING(Z_FAULT_STRING_P(obj), fault_string ? fault_string : "");

--- a/ext/sockets/conversions.c
+++ b/ext/sockets/conversions.c
@@ -1467,7 +1467,7 @@ void to_zval_read_fd_array(const char *data, zval *zv, res_context *ctx)
 			return;
 		}
 		if (S_ISSOCK(statbuf.st_mode)) {
-			object_init_ex(&elem, socket_ce);
+			object_init_instantiable_class(&elem, socket_ce);
 			php_socket *sock = Z_SOCKET_P(&elem);
 
 			if (!socket_import_file_descriptor(fd, sock)) {

--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -710,7 +710,7 @@ PHP_FUNCTION(socket_create_listen)
 		RETURN_THROWS();
 	}
 
-	object_init_ex(return_value, socket_ce);
+	object_init_instantiable_class(return_value, socket_ce);
 	php_sock = Z_SOCKET_P(return_value);
 
 	if (!php_open_listen_sock(php_sock, (unsigned short)port, backlog)) {
@@ -738,7 +738,7 @@ PHP_FUNCTION(socket_accept)
 	php_sock = Z_SOCKET_P(arg1);
 	ENSURE_SOCKET_VALID(php_sock);
 
-	object_init_ex(return_value, socket_ce);
+	object_init_instantiable_class(return_value, socket_ce);
 	new_sock = Z_SOCKET_P(return_value);
 
 	if (!php_accept_connect(php_sock, new_sock, (struct sockaddr*)&sa, &php_sa_len)) {
@@ -1180,7 +1180,7 @@ PHP_FUNCTION(socket_create)
 
 	PHP_ETH_PROTO_CHECK(protocol, domain);
 
-	object_init_ex(return_value, socket_ce);
+	object_init_instantiable_class(return_value, socket_ce);
 	php_sock = Z_SOCKET_P(return_value);
 
 	php_sock->bsd_socket = socket(domain, type, protocol);
@@ -2419,10 +2419,10 @@ PHP_FUNCTION(socket_create_pair)
 		RETURN_THROWS();
 	}
 
-	object_init_ex(&retval[0], socket_ce);
+	object_init_instantiable_class(&retval[0], socket_ce);
 	php_sock[0] = Z_SOCKET_P(&retval[0]);
 
-	object_init_ex(&retval[1], socket_ce);
+	object_init_instantiable_class(&retval[1], socket_ce);
 	php_sock[1] = Z_SOCKET_P(&retval[1]);
 
 	php_sock[0]->bsd_socket = fds_array[0];
@@ -2605,7 +2605,7 @@ PHP_FUNCTION(socket_import_stream)
 		RETURN_FALSE;
 	}
 
-	object_init_ex(return_value, socket_ce);
+	object_init_instantiable_class(return_value, socket_ce);
 	retsock = Z_SOCKET_P(return_value);
 
 	if (!socket_import_file_descriptor(socket, retsock)) {
@@ -2850,7 +2850,7 @@ PHP_FUNCTION(socket_addrinfo_lookup)
 				) {
 			zval zaddr;
 
-			object_init_ex(&zaddr, address_info_ce);
+			object_init_instantiable_class(&zaddr, address_info_ce);
 			res = Z_ADDRESS_INFO_P(&zaddr);
 
 			memcpy(&res->addrinfo, rp, sizeof(struct addrinfo));
@@ -2887,7 +2887,7 @@ PHP_FUNCTION(socket_addrinfo_bind)
 
 	PHP_ETH_PROTO_CHECK(ai->addrinfo.ai_protocol, ai->addrinfo.ai_family);
 
-	object_init_ex(return_value, socket_ce);
+	object_init_instantiable_class(return_value, socket_ce);
 	php_sock = Z_SOCKET_P(return_value);
 
 	php_sock->bsd_socket = socket(ai->addrinfo.ai_family, ai->addrinfo.ai_socktype, ai->addrinfo.ai_protocol);
@@ -2929,7 +2929,7 @@ PHP_FUNCTION(socket_addrinfo_connect)
 
 	PHP_ETH_PROTO_CHECK(ai->addrinfo.ai_protocol, ai->addrinfo.ai_family);
 
-	object_init_ex(return_value, socket_ce);
+	object_init_instantiable_class(return_value, socket_ce);
 	php_sock = Z_SOCKET_P(return_value);
 
 	php_sock->bsd_socket = socket(ai->addrinfo.ai_family, ai->addrinfo.ai_socktype, ai->addrinfo.ai_protocol);
@@ -3112,7 +3112,7 @@ PHP_FUNCTION(socket_wsaprotocol_info_import)
 		RETURN_FALSE;
 	}
 
-	object_init_ex(return_value, socket_ce);
+	object_init_instantiable_class(return_value, socket_ce);
 	php_sock = Z_SOCKET_P(return_value);
 
 	php_sock->bsd_socket = sock;

--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -750,7 +750,7 @@ PHP_METHOD(SplFixedArray, fromArray)
 		spl_fixedarray_init(&array, 0);
 	}
 
-	object_init_ex(return_value, spl_ce_SplFixedArray);
+	object_init_instantiable_class(return_value, spl_ce_SplFixedArray);
 
 	intern = Z_SPLFIXEDARRAY_P(return_value);
 	intern->array = array;

--- a/ext/spl/spl_iterators.c
+++ b/ext/spl/spl_iterators.c
@@ -2809,7 +2809,7 @@ PHP_METHOD(AppendIterator, __construct)
 	}
 
 	intern->dit_type = DIT_AppendIterator;
-	object_init_ex(&intern->u.append.zarrayit, spl_ce_ArrayIterator);
+	object_init_instantiable_class(&intern->u.append.zarrayit, spl_ce_ArrayIterator);
 	zend_call_method_with_0_params(Z_OBJ(intern->u.append.zarrayit), spl_ce_ArrayIterator, &spl_ce_ArrayIterator->constructor, "__construct", NULL);
 	intern->u.append.iterator = spl_ce_ArrayIterator->get_iterator(spl_ce_ArrayIterator, &intern->u.append.zarrayit, 0);
 

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -509,7 +509,7 @@ PHP_METHOD(SQLite3, prepare)
 		RETURN_FALSE;
 	}
 
-	object_init_ex(return_value, php_sqlite3_stmt_entry);
+	object_init_instantiable_class(return_value, php_sqlite3_stmt_entry);
 	stmt_obj = Z_SQLITE3_STMT_P(return_value);
 	stmt_obj->db_obj = db_obj;
 	Z_ADDREF_P(object);
@@ -561,7 +561,7 @@ PHP_METHOD(SQLite3, query)
 		RETURN_FALSE;
 	}
 
-	object_init_ex(&stmt, php_sqlite3_stmt_entry);
+	object_init_instantiable_class(&stmt, php_sqlite3_stmt_entry);
 	stmt_obj = Z_SQLITE3_STMT_P(&stmt);
 	stmt_obj->db_obj = db_obj;
 	Z_ADDREF_P(object);
@@ -575,7 +575,7 @@ PHP_METHOD(SQLite3, query)
 
 	stmt_obj->initialised = true;
 
-	object_init_ex(return_value, php_sqlite3_result_entry);
+	object_init_instantiable_class(return_value, php_sqlite3_result_entry);
 	result = Z_SQLITE3_RESULT_P(return_value);
 	result->db_obj = db_obj;
 	result->stmt_obj = stmt_obj;
@@ -1837,7 +1837,7 @@ PHP_METHOD(SQLite3Stmt, execute)
 		case SQLITE_DONE: /* Valid but no results */
 		{
 			sqlite3_reset(stmt_obj->stmt);
-			object_init_ex(return_value, php_sqlite3_result_entry);
+			object_init_instantiable_class(return_value, php_sqlite3_result_entry);
 			result = Z_SQLITE3_RESULT_P(return_value);
 
 			result->is_prepared_statement = true;

--- a/ext/standard/dir.c
+++ b/ext/standard/dir.c
@@ -130,7 +130,7 @@ static void _php_do_opendir(INTERNAL_FUNCTION_PARAMETERS, int createobject)
 	php_set_default_dir(dirp->res);
 
 	if (createobject) {
-		object_init_ex(return_value, dir_class_entry_ptr);
+		object_init_instantiable_class(return_value, dir_class_entry_ptr);
 		ZVAL_STRINGL(Z_DIRECTORY_PATH_P(return_value), dirname, dir_len);
 		ZVAL_RES(Z_DIRECTORY_HANDLE_P(return_value), dirp->res);
 		php_stream_auto_cleanup(dirp); /* so we don't get warnings under debug */

--- a/ext/sysvmsg/sysvmsg.c
+++ b/ext/sysvmsg/sysvmsg.c
@@ -213,7 +213,7 @@ PHP_FUNCTION(msg_get_queue)
 		RETURN_THROWS();
 	}
 
-	object_init_ex(return_value, sysvmsg_queue_ce);
+	object_init_instantiable_class(return_value, sysvmsg_queue_ce);
 	mq = Z_SYSVMSG_QUEUE_P(return_value);
 
 	mq->key = key;

--- a/ext/sysvsem/sysvsem.c
+++ b/ext/sysvsem/sysvsem.c
@@ -251,7 +251,7 @@ PHP_FUNCTION(sem_get)
 		}
 	}
 
-	object_init_ex(return_value, sysvsem_ce);
+	object_init_instantiable_class(return_value, sysvsem_ce);
 
 	sem_ptr = Z_SYSVSEM_P(return_value);
 	sem_ptr->key   = key;

--- a/ext/sysvshm/sysvshm.c
+++ b/ext/sysvshm/sysvshm.c
@@ -169,7 +169,7 @@ PHP_FUNCTION(shm_attach)
 		chunk_ptr->free = shm_size-chunk_ptr->end;
 	}
 
-	object_init_ex(return_value, sysvshm_ce);
+	object_init_instantiable_class(return_value, sysvshm_ce);
 
 	shm_list_ptr = Z_SYSVSHM_P(return_value);
 

--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -213,7 +213,7 @@ static zend_result php_tidy_apply_config(TidyDoc doc, const zend_string *str_str
 
 static void tidy_create_node_object(zval *zv, PHPTidyDoc *ptdoc, TidyNode node)
 {
-	object_init_ex(zv, tidy_ce_node);
+	object_init_instantiable_class(zv, tidy_ce_node);
 	PHPTidyObj *newobj = Z_TIDY_P(zv);
 	newobj->node = node;
 	newobj->type = is_node;
@@ -1016,7 +1016,7 @@ PHP_FUNCTION(tidy_parse_string)
 		RETURN_THROWS();
 	}
 
-	object_init_ex(return_value, tidy_ce_doc);
+	object_init_instantiable_class(return_value, tidy_ce_doc);
 	obj = Z_TIDY_P(return_value);
 
 	if (php_tidy_apply_config(obj->ptdoc->doc, options_str, options_ht, 2) != SUCCESS
@@ -1084,7 +1084,7 @@ PHP_FUNCTION(tidy_parse_file)
 		RETURN_THROWS();
 	}
 
-	object_init_ex(return_value, tidy_ce_doc);
+	object_init_instantiable_class(return_value, tidy_ce_doc);
 	obj = Z_TIDY_P(return_value);
 
 	if (php_tidy_apply_config(obj->ptdoc->doc, options_str, options_ht, 2) != SUCCESS

--- a/ext/uri/php_uri.c
+++ b/ext/uri/php_uri.c
@@ -330,9 +330,9 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 2) PHPAPI void php_uri_instantiate_uri(
 		}
 	} else {
 		if (EX(func)->common.fn_flags & ZEND_ACC_STATIC) {
-			object_init_ex(return_value, Z_CE_P(ZEND_THIS));
+			object_init_instantiable_class(return_value, Z_CE_P(ZEND_THIS));
 		} else {
-			object_init_ex(return_value, Z_OBJCE_P(ZEND_THIS));
+			object_init_instantiable_class(return_value, Z_OBJCE_P(ZEND_THIS));
 		}
 		uri_object = Z_URI_OBJECT_P(return_value);
 	}

--- a/ext/uri/uri_parser_whatwg.c
+++ b/ext/uri/uri_parser_whatwg.c
@@ -72,7 +72,7 @@ static const char *fill_errors(zval *errors)
 	lexbor_plog_entry_t *lxb_error;
 	while ((lxb_error = lexbor_array_obj_pop(&lexbor_parser.log->list)) != NULL) {
 		zval error;
-		object_init_ex(&error, php_uri_ce_whatwg_url_validation_error);
+		object_init_instantiable_class(&error, php_uri_ce_whatwg_url_validation_error);
 		zend_update_property_string(php_uri_ce_whatwg_url_validation_error, Z_OBJ(error), ZEND_STRL("context"), (const char *) lxb_error->data);
 
 		const char *error_str;

--- a/ext/xml/xml.c
+++ b/ext/xml/xml.c
@@ -1096,7 +1096,7 @@ static void php_xml_parser_create_impl(INTERNAL_FUNCTION_PARAMETERS, int ns_supp
 		ns_param = ":";
 	}
 
-	object_init_ex(return_value, xml_parser_ce);
+	object_init_instantiable_class(return_value, xml_parser_ce);
 	parser = Z_XMLPARSER_P(return_value);
 	parser->parser = XML_ParserCreate_MM((auto_detect ? NULL : encoding),
 	                                     &php_xml_mem_hdlrs, (XML_Char*)ns_param);

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -909,7 +909,7 @@ PHP_FUNCTION(inflate_init)
 		RETURN_THROWS();
 	}
 
-	object_init_ex(return_value, inflate_context_ce);
+	object_init_instantiable_class(return_value, inflate_context_ce);
 	ctx = Z_INFLATE_CONTEXT_P(return_value);
 
 	ctx->Z.zalloc = php_zlib_alloc;
@@ -1158,7 +1158,7 @@ PHP_FUNCTION(deflate_init)
 		RETURN_THROWS();
 	}
 
-	object_init_ex(return_value, deflate_context_ce);
+	object_init_instantiable_class(return_value, deflate_context_ce);
 	ctx = Z_DEFLATE_CONTEXT_P(return_value);
 
 	ctx->Z.zalloc = php_zlib_alloc;

--- a/main/streams/stream_errors.c
+++ b/main/streams/stream_errors.c
@@ -37,7 +37,7 @@ static void php_stream_error_entry_free(php_stream_error_entry *entry);
 /* Helper to create a single StreamError object from an entry */
 static void php_stream_error_create_object(zval *zv, php_stream_error_entry *entry)
 {
-	object_init_ex(zv, php_ce_stream_error);
+	object_init_instantiable_class(zv, php_ce_stream_error);
 
 	const char *case_name = NULL;
 	if (entry->code > 0 && entry->code <= ZEND_ENUM_StreamErrorCode_CASE_COUNT) {
@@ -375,7 +375,7 @@ static void php_stream_throw_exception_with_errors(php_stream_error_operation *o
 	}
 
 	zval ex;
-	object_init_ex(&ex, php_ce_stream_exception);
+	object_init_instantiable_class(&ex, php_ce_stream_exception);
 
 	/* Set message from first error */
 	zend_update_property_string(php_ce_stream_exception, Z_OBJ(ex), ZEND_STRL("message"),

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -1069,7 +1069,7 @@ do_repeat:
 					zend_call_known_function(
 						create_from_method, NULL, pce, &ref, 1, &arg, NULL);
 				} else {
-					object_init_ex(&ref, pce);
+					object_init_instantiable_class(&ref, pce);
 					zend_call_known_instance_method_with_1_params(
 						pce->constructor, Z_OBJ(ref), NULL, &arg);
 				}


### PR DESCRIPTION
This is an idea that kinda came up while working on #19797 

In most cases when an extension calls `object_init_ex()` it's instantiating one of its own classes, and thus it knows it is instantiable. Therefore, I propose to introduce a new API which skips the (albeit cheap) check.

The secondary motivation is that I'm not fully certain I agree that it should be the task of `object_init_ex()` to check if an object is instantiable. This is especially relevant for #19797 as I would like to have a single API to that checks that the CE is a concrete class, but also that the constructor is actually callable (i.e. public or within scope) *prior* to attempting to create the object.

It is probably possible to convert more `object_init_ex()` (especially those in ext/date) but those are not immediately obvious.