### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/close-needs-feedback.yml
+++ b/.github/workflows/close-needs-feedback.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Close old issues that need feedback
-        uses: dwieeb/needs-reply@v2
+        uses: dwieeb/needs-reply@71e8d5144caa0d4a1e292348bfafa3866d08c855 # v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           issue-label: "Status: Needs Feedback"

--- a/.github/workflows/close-needs-feedback.yml
+++ b/.github/workflows/close-needs-feedback.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Close old issues that need feedback
-        uses: dwieeb/needs-reply@71e8d5144caa0d4a1e292348bfafa3866d08c855 # v2
+        uses: dwieeb/needs-reply@71e8d5144caa0d4a1e292348bfafa3866d08c855 # v2.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           issue-label: "Status: Needs Feedback"

--- a/.github/workflows/close-stale-feature-requests.yml
+++ b/.github/workflows/close-stale-feature-requests.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@e42e6681d2906409c5dde4a315af6214eaa890ee # v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           days-before-close: 14
           days-before-stale: 90

--- a/.github/workflows/close-stale-feature-requests.yml
+++ b/.github/workflows/close-stale-feature-requests.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@e42e6681d2906409c5dde4a315af6214eaa890ee # v9
         with:
           days-before-close: 14
           days-before-stale: 90

--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@e42e6681d2906409c5dde4a315af6214eaa890ee # v9
         with:
           days-before-close: 7
           days-before-stale: 60

--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@e42e6681d2906409c5dde4a315af6214eaa890ee # v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           days-before-close: 7
           days-before-stale: 60

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.repository == 'php/php-src'
     steps:
       - name: git checkout
-        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Install dependencies
         run: pip install -r docs/requirements.txt
       - name: Check formatting

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,14 +17,14 @@ jobs:
     if: github.repository == 'php/php-src'
     steps:
       - name: git checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
       - name: Install dependencies
         run: pip install -r docs/requirements.txt
       - name: Check formatting
         run: make -C docs check-formatting
       - name: Publish
         if: github.event_name == 'push'
-        uses: sphinx-notes/pages@v3
+        uses: sphinx-notes/pages@71e8d5144caa0d4a1e292348bfafa3866d08c855 # v3
         with:
           checkout: false
           documentation_path: docs/source

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,6 +12,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v6
+      - uses: actions/labeler@18f1af5e3544586314bbe15c0273249c770b2daf # v6
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/real-time-benchmark.yml
+++ b/.github/workflows/real-time-benchmark.yml
@@ -108,21 +108,21 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y terraform=1.5.7-*
       - name: Checkout benchmark suite
-        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: 'kocsismate/php-version-benchmarks'
           ref: 'main'
           fetch-depth: 1
           path: 'php-version-benchmarks'
       - name: Checkout php-src (benchmarked version)
-        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: '${{ env.REPOSITORY }}'
           ref: '${{ env.COMMIT }}'
           fetch-depth: 100
           path: 'php-version-benchmarks/tmp/php_${{ env.ID }}'
       - name: Checkout php-src (baseline version)
-        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: '${{ env.REPOSITORY }}'
           ref: '${{ env.BASELINE_COMMIT }}'
@@ -136,7 +136,7 @@ jobs:
           rm -rf ./php-version-benchmarks/docs/results
       - name: Checkout benchmark data
         if: github.event_name != 'workflow_dispatch'
-        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: php/real-time-benchmark-data
           ssh-key: ${{ secrets.PHP_VERSION_BENCHMARK_RESULTS_DEPLOY_KEY }}

--- a/.github/workflows/real-time-benchmark.yml
+++ b/.github/workflows/real-time-benchmark.yml
@@ -108,21 +108,21 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y terraform=1.5.7-*
       - name: Checkout benchmark suite
-        uses: actions/checkout@v6
+        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
         with:
           repository: 'kocsismate/php-version-benchmarks'
           ref: 'main'
           fetch-depth: 1
           path: 'php-version-benchmarks'
       - name: Checkout php-src (benchmarked version)
-        uses: actions/checkout@v6
+        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
         with:
           repository: '${{ env.REPOSITORY }}'
           ref: '${{ env.COMMIT }}'
           fetch-depth: 100
           path: 'php-version-benchmarks/tmp/php_${{ env.ID }}'
       - name: Checkout php-src (baseline version)
-        uses: actions/checkout@v6
+        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
         with:
           repository: '${{ env.REPOSITORY }}'
           ref: '${{ env.BASELINE_COMMIT }}'
@@ -136,7 +136,7 @@ jobs:
           rm -rf ./php-version-benchmarks/docs/results
       - name: Checkout benchmark data
         if: github.event_name != 'workflow_dispatch'
-        uses: actions/checkout@v6
+        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
         with:
           repository: php/real-time-benchmark-data
           ssh-key: ${{ secrets.PHP_VERSION_BENCHMARK_RESULTS_DEPLOY_KEY }}
@@ -285,7 +285,7 @@ jobs:
           echo "NEWEST_RESULT_DIRECTORY=$(ls -td ${{ github.workspace }}/php-version-benchmarks/docs/results/${{ env.YEAR }}/*/ | head -1)" >> $GITHUB_ENV
       - name: Upload artifacts
         id: upload
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: results
           path: |

--- a/.github/workflows/remove-needs-feedback.yml
+++ b/.github/workflows/remove-needs-feedback.yml
@@ -16,9 +16,9 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions-ecosystem/action-remove-labels@v1
+      - uses: actions-ecosystem/action-remove-labels@f27b608878404679385c85cfa523b85ccb86e213 # v1
         with:
           labels: "Status: Needs Feedback"
-      - uses: actions-ecosystem/action-add-labels@v1
+      - uses: actions-ecosystem/action-add-labels@e79a6962e0d4c0c17b229090214935d2e33f8354 # v1
         with:
           labels: "Status: Needs Triage"

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: [self-hosted, gentoo, ppc64]
     steps:
       - name: git checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
       - name: System info
@@ -59,7 +59,7 @@ jobs:
       image: 'alpine:3.22'
     steps:
       - name: git checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
       - name: apk
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-${{ fromJson(inputs.branch).config.ubuntu_version }}
     steps:
       - name: git checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
       - name: Create MSSQL container
@@ -254,7 +254,7 @@ jobs:
           FIREBIRD_PASSWORD: test
     steps:
       - name: git checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
       - name: apt
@@ -311,7 +311,7 @@ jobs:
     runs-on: macos-${{ matrix.arch == 'X64' && '15-intel' || fromJson(inputs.branch).jobs.MACOS.config.arm64_version }}
     steps:
       - name: git checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
       - name: Update clang
@@ -388,7 +388,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: git checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
       - name: Create MSSQL container
@@ -416,7 +416,7 @@ jobs:
       - name: Generate coverage report
         if: ${{ !cancelled() }}
         run: make gcovr-xml
-      - uses: codecov/codecov-action@v6
+      - uses: codecov/codecov-action@5bef64f19d7facfb25b37b414482c7164d639639 # v6
         if: ${{ !cancelled() }}
         with:
           disable_search: true
@@ -438,7 +438,7 @@ jobs:
       USE_TRACKED_ALLOC: 1
     steps:
       - name: git checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
       - name: apt
@@ -644,7 +644,7 @@ jobs:
     runs-on: ubuntu-${{ fromJson(inputs.branch).config.ubuntu_version }}
     steps:
       - name: git checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
       - name: Create MSSQL container
@@ -707,7 +707,7 @@ jobs:
     runs-on: ubuntu-${{ fromJson(inputs.branch).config.ubuntu_version }}
     steps:
       - name: git checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
       - name: apt
@@ -798,7 +798,7 @@ jobs:
     runs-on: ubuntu-${{ fromJson(inputs.branch).config.ubuntu_version }}
     steps:
       - name: git checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
       - name: apt
@@ -851,7 +851,7 @@ jobs:
       - name: git config
         run: git config --global core.autocrlf false && git config --global core.eol lf
       - name: git checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
       - name: Setup
@@ -870,7 +870,7 @@ jobs:
     timeout-minutes: 50
     steps:
       - name: git checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
       - name: FreeBSD
@@ -886,7 +886,7 @@ jobs:
     timeout-minutes: 50
     steps:
       - name: git checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v5
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
       - name: Solaris
@@ -901,7 +901,7 @@ jobs:
     timeout-minutes: 50
     steps:
       - name: git checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
           fetch-depth: 0
@@ -963,7 +963,7 @@ jobs:
           mysql -uroot -proot -e "CREATE USER 'wordpress'@'localhost' IDENTIFIED BY 'wordpress'; FLUSH PRIVILEGES;"
           mysql -uroot -proot -e "GRANT ALL PRIVILEGES ON *.* TO 'wordpress'@'localhost' WITH GRANT OPTION;"
       - name: git checkout benchmarking-data
-        uses: actions/checkout@v6
+        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
         with:
           repository: php/benchmarking-data
           ssh-key: ${{ secrets.BENCHMARKING_DATA_DEPLOY_KEY }}
@@ -994,7 +994,7 @@ jobs:
             ${{ github.sha }} \
             ${{ github.event.pull_request.base.sha }} \
             > $GITHUB_STEP_SUMMARY
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: profiles
           path: ${{ github.workspace }}/benchmark/profiles

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: [self-hosted, gentoo, ppc64]
     steps:
       - name: git checkout
-        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
       - name: System info
@@ -59,7 +59,7 @@ jobs:
       image: 'alpine:3.22'
     steps:
       - name: git checkout
-        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
       - name: apk
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-${{ fromJson(inputs.branch).config.ubuntu_version }}
     steps:
       - name: git checkout
-        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
       - name: Create MSSQL container
@@ -254,7 +254,7 @@ jobs:
           FIREBIRD_PASSWORD: test
     steps:
       - name: git checkout
-        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
       - name: apt
@@ -311,7 +311,7 @@ jobs:
     runs-on: macos-${{ matrix.arch == 'X64' && '15-intel' || fromJson(inputs.branch).jobs.MACOS.config.arm64_version }}
     steps:
       - name: git checkout
-        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
       - name: Update clang
@@ -388,7 +388,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: git checkout
-        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
       - name: Create MSSQL container
@@ -438,7 +438,7 @@ jobs:
       USE_TRACKED_ALLOC: 1
     steps:
       - name: git checkout
-        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
       - name: apt
@@ -644,7 +644,7 @@ jobs:
     runs-on: ubuntu-${{ fromJson(inputs.branch).config.ubuntu_version }}
     steps:
       - name: git checkout
-        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
       - name: Create MSSQL container
@@ -707,7 +707,7 @@ jobs:
     runs-on: ubuntu-${{ fromJson(inputs.branch).config.ubuntu_version }}
     steps:
       - name: git checkout
-        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
       - name: apt
@@ -798,7 +798,7 @@ jobs:
     runs-on: ubuntu-${{ fromJson(inputs.branch).config.ubuntu_version }}
     steps:
       - name: git checkout
-        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
       - name: apt
@@ -851,7 +851,7 @@ jobs:
       - name: git config
         run: git config --global core.autocrlf false && git config --global core.eol lf
       - name: git checkout
-        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
       - name: Setup
@@ -870,7 +870,7 @@ jobs:
     timeout-minutes: 50
     steps:
       - name: git checkout
-        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
       - name: FreeBSD
@@ -901,7 +901,7 @@ jobs:
     timeout-minutes: 50
     steps:
       - name: git checkout
-        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
           fetch-depth: 0
@@ -963,7 +963,7 @@ jobs:
           mysql -uroot -proot -e "CREATE USER 'wordpress'@'localhost' IDENTIFIED BY 'wordpress'; FLUSH PRIVILEGES;"
           mysql -uroot -proot -e "GRANT ALL PRIVILEGES ON *.* TO 'wordpress'@'localhost' WITH GRANT OPTION;"
       - name: git checkout benchmarking-data
-        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: php/benchmarking-data
           ssh-key: ${{ secrets.BENCHMARKING_DATA_DEPLOY_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       all_variations: ${{ steps.set-matrix.outputs.all_variations }}
       branches: ${{ steps.set-matrix.outputs.branches }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
         with:
           # When running nightly, set fetch-depth to 0 to clone the full
           # repository including all branches. This is required to find the
@@ -48,7 +48,7 @@ jobs:
           fetch-depth: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && '0' || '1' }}
       - name: Grab the commit mapping
         if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-        uses: actions/cache@v5
+        uses: actions/cache@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           path: branch-commit-cache.json
           # The cache key needs to change every time for the

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       all_variations: ${{ steps.set-matrix.outputs.all_variations }}
       branches: ${{ steps.set-matrix.outputs.branches }}
     steps:
-      - uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # When running nightly, set fetch-depth to 0 to clone the full
           # repository including all branches. This is required to find the
@@ -48,7 +48,7 @@ jobs:
           fetch-depth: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && '0' || '1' }}
       - name: Grab the commit mapping
         if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-        uses: actions/cache@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: branch-commit-cache.json
           # The cache key needs to change every time for the

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: git checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
         
       - name: Install dependencies
         run: |
@@ -53,7 +53,7 @@ jobs:
             ccache
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.2
         with:
           key: "unit-tests-${{hashFiles('main/php_version.h')}}"
           append-timestamp: false

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: git checkout
-        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         
       - name: Install dependencies
         run: |
@@ -53,7 +53,7 @@ jobs:
             ccache
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.2
+        uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
         with:
           key: "unit-tests-${{hashFiles('main/php_version.h')}}"
           append-timestamp: false

--- a/.github/workflows/verify-bundled-files.yml
+++ b/.github/workflows/verify-bundled-files.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: git checkout
-        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Detect changed files
         if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' }}
-        uses: dorny/paths-filter@27d5ce7f107fe9357f9df03efb73ab90386fccae # v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: changes
         with:
           filters: |

--- a/.github/workflows/verify-bundled-files.yml
+++ b/.github/workflows/verify-bundled-files.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: git checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v6
 
       - name: Detect changed files
         if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' }}
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@27d5ce7f107fe9357f9df03efb73ab90386fccae # v3
         id: changes
         with:
           filters: |


### PR DESCRIPTION
This PR pins GitHub Actions from mutable version tags (e.g. `@v4`) to full commit SHAs, preventing silent supply chain attacks from compromised action repositories.

Recommended by [GitHub's security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and [OpenSSF Scorecard](https://securityscorecards.dev/).