### PR TITLE
Fix GH-22218: SoapServer::handle() crash on non-array `$_SERVER`.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,10 @@ PHP                                                                        NEWS
     Phar::addEmptyDir() for paths starting with "/.phar", while allowing
     non-magic directory names that merely share the ".phar" prefix. (Weilin Du)
 
+- SOAP:
+  . Fixed bug GH-22218 (SoapServer::handle() crash on $_SERVER not being
+    an array). (David Carlier / Rex-Reynolds)
+
 - Zlib:
   . Fixed memory leak if deflate initialization fails and there is a dict.
     (ndossche)

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -1393,10 +1393,10 @@ PHP_METHOD(SoapServer, handle)
 						return;
 					}
 				}
-			}
 
-			if ((soap_action_z = zend_hash_str_find(Z_ARRVAL_P(server_vars), ZEND_STRL("HTTP_SOAPACTION"))) != NULL && Z_TYPE_P(soap_action_z) == IS_STRING) {
-				soap_action = Z_STRVAL_P(soap_action_z);
+			    if ((soap_action_z = zend_hash_str_find(Z_ARRVAL_P(server_vars), ZEND_STRL("HTTP_SOAPACTION"))) != NULL && Z_TYPE_P(soap_action_z) == IS_STRING) {
+				    soap_action = Z_STRVAL_P(soap_action_z);
+			    }
 			}
 
 			doc_request = soap_xmlParseFile("php://input");

--- a/ext/soap/tests/gh22218.phpt
+++ b/ext/soap/tests/gh22218.phpt
@@ -20,8 +20,6 @@ if (php_sapi_name() == 'cli') echo 'skip needs request body (POST)';
 $_SERVER = 79;
 $server = new SoapServer(null, ['uri' => 'http://test-uri']);
 $server->handle();
-echo "ALIVE\n";
 ?>
 --EXPECTF--
-%A
-ALIVE
+%AFunction 'test' doesn't exist%A

--- a/ext/soap/tests/gh22218.phpt
+++ b/ext/soap/tests/gh22218.phpt
@@ -1,0 +1,27 @@
+--TEST--
+GH-22218 (SoapServer::handle() segfault on non-array/unset $_SERVER)
+--EXTENSIONS--
+soap
+--CREDITS--
+Rex-Reynolds
+--SKIPIF--
+<?php
+if (php_sapi_name() == 'cli') echo 'skip needs request body (POST)';
+?>
+--POST--
+<SOAP-ENV:Envelope
+    xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Body>
+        <test/>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
+--FILE--
+<?php
+$_SERVER = 79;
+$server = new SoapServer(null, ['uri' => 'http://test-uri']);
+$server->handle();
+echo "ALIVE\n";
+?>
+--EXPECTF--
+%A
+ALIVE


### PR DESCRIPTION
add reproducer.

Fix #22218