### PR TITLE
Make the behavior of `request_parse_body()` and ini settings congruent in option `max_input_vars`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -226,6 +226,9 @@ PHP                                                                        NEWS
     contains null bytes. (Weilin Du)
   . parse_str() now raises a ValueError when the $string argument contains
     null bytes. (Weilin Du)
+  . request_parse_body() now emits a warning and falls back to the
+    max_input_vars ini setting for negative max_input_vars option values.
+    (Xu Chen)
   . proc_open() now raises a ValueError when the $cwd argument contains
     null bytes. (Weilin Du)
   . ini_get_all() now includes the built-in default value in the details.

--- a/UPGRADING
+++ b/UPGRADING
@@ -142,6 +142,9 @@ PHP 8.6 UPGRADE NOTES
     contains null bytes.
   . parse_str() now raises a ValueError when the $string argument contains
     null bytes.
+  . request_parse_body() now emits a warning and falls back to the
+    max_input_vars ini setting when the $options argument contains a negative
+    max_input_vars value.
   . linkinfo() now raises a ValueError when the $path argument is empty.
   . pathinfo() now raises a ValueError when an invalid $flag
     argument value is passed.

--- a/ext/standard/http.c
+++ b/ext/standard/http.c
@@ -247,7 +247,7 @@ PHP_FUNCTION(http_build_query)
 }
 /* }}} */
 
-static zend_result cache_request_parse_body_option(HashTable *options, zval *option, int cache_offset)
+static zend_result cache_request_parse_body_option(zval *option, int cache_offset, const char *non_negative_option_name)
 {
 	if (option) {
 		zend_long result;
@@ -264,6 +264,11 @@ static zend_result cache_request_parse_body_option(HashTable *options, zval *opt
 		} else {
 			zend_value_error("Invalid %s value in $options argument", zend_zval_value_name(option));
 			return FAILURE;
+		}
+		if (non_negative_option_name && result < 0) {
+			zend_error(E_WARNING, "\"%s\" option in $options argument must be greater than or equal to 0", non_negative_option_name);
+			SG(request_parse_body_context).options_cache[cache_offset].set = false;
+			return SUCCESS;
 		}
 		SG(request_parse_body_context).options_cache[cache_offset].set = true;
 		SG(request_parse_body_context).options_cache[cache_offset].value = result;
@@ -290,7 +295,15 @@ static zend_result cache_request_parse_body_options(HashTable *options)
 
 #define CHECK_OPTION(name) \
 	if (zend_string_equals_literal_ci(key, #name)) { \
-		if (cache_request_parse_body_option(options, value, REQUEST_PARSE_BODY_OPTION_ ## name) == FAILURE) { \
+		if (cache_request_parse_body_option(value, REQUEST_PARSE_BODY_OPTION_ ## name, NULL) == FAILURE) { \
+			return FAILURE; \
+		} \
+		continue; \
+	}
+
+#define CHECK_NON_NEGATIVE_OPTION(name) \
+	if (zend_string_equals_literal_ci(key, #name)) { \
+		if (cache_request_parse_body_option(value, REQUEST_PARSE_BODY_OPTION_ ## name, #name) == FAILURE) { \
 			return FAILURE; \
 		} \
 		continue; \
@@ -300,7 +313,7 @@ static zend_result cache_request_parse_body_options(HashTable *options)
 			case 'm':
 			case 'M':
 				CHECK_OPTION(max_file_uploads);
-				CHECK_OPTION(max_input_vars);
+				CHECK_NON_NEGATIVE_OPTION(max_input_vars);
 				CHECK_OPTION(max_multipart_body_parts);
 				break;
 			case 'p':
@@ -317,7 +330,8 @@ static zend_result cache_request_parse_body_options(HashTable *options)
 		return FAILURE;
 	} ZEND_HASH_FOREACH_END();
 
-#undef CACHE_OPTION
+#undef CHECK_OPTION
+#undef CHECK_NON_NEGATIVE_OPTION
 
 	return SUCCESS;
 }

--- a/ext/standard/tests/http/request_parse_body/multipart_options_negative_max_input_vars.phpt
+++ b/ext/standard/tests/http/request_parse_body/multipart_options_negative_max_input_vars.phpt
@@ -1,0 +1,38 @@
+--TEST--
+request_parse_body() negative max_input_vars option falls back to ini setting
+--INI--
+max_input_vars=1
+--ENV--
+REQUEST_METHOD=PUT
+--POST_RAW--
+Content-Type: multipart/form-data; boundary=---------------------------84000087610663814162942123332
+-----------------------------84000087610663814162942123332
+Content-Disposition: form-data; name="field1"
+
+post field data
+-----------------------------84000087610663814162942123332
+Content-Disposition: form-data; name="field2"
+
+post field data
+-----------------------------84000087610663814162942123332--
+--FILE--
+<?php
+
+try {
+    [$_POST, $_FILES] = request_parse_body([
+        'max_input_vars' => -1,
+    ]);
+} catch (Throwable $e) {
+    echo get_class($e), ': ', $e->getMessage(), "\n";
+}
+
+var_dump($_POST, $_FILES);
+
+?>
+--EXPECTF--
+Warning: "max_input_vars" option in $options argument must be greater than or equal to 0 in %s on line %d
+RequestParseBodyException: Input variables exceeded 1. To increase the limit change max_input_vars in php.ini.
+array(0) {
+}
+array(0) {
+}


### PR DESCRIPTION
`request_parse_body()` currently accepts out-of-range values for limit-related options.

This can weaken or bypass request body limits. In particular, for `application/x-www-form-urlencoded` bodies, negative `max_input_vars` values are read into an unsigned `uint64_t`, so passing `max_input_vars => -1` effectively turns the limit into a very large value.

`post_max_size => -1` and `post_max_size => 0` also disable the size check, because the check only runs when the configured value is greater than zero. `upload_max_filesize` follows the same positive-size-limit pattern.

This patch rejects invalid option ranges for:

```text
max_file_uploads       must be >= 0
max_input_vars         must be >= 0
post_max_size          must be > 0
upload_max_filesize    must be > 0
```

`max_multipart_body_parts` is left unchanged because negative values currently have a special meaning there: derive the multipart body part limit from `max_input_vars + max_file_uploads`.

This is a hardening / validation fix, not a security report. The options are supplied by application code, but accepting invalid ranges makes it easy to accidentally disable request body limits.

### Local verification

Using php-src master `be41c36b68f`, tested with the built-in web server:

```text
request_parse_body(['max_input_vars' => -1])
```

accepted all urlencoded fields, while:

```text
request_parse_body(['max_input_vars' => 1])
```

triggered the expected max-input-vars warning path.

Also verified:

```text
request_parse_body(['post_max_size' => -1])
```

accepted a body that was rejected when `post_max_size => 1`.

### Tests

```bash
sapi/cli/php run-tests.php ext/standard/tests/http/request_parse_body/options_negative_values.phpt
sapi/cli/php run-tests.php ext/standard/tests/http/request_parse_body
```