### PR TITLE
Fixed GH-22216: don't warn in OnUpdateMemoryConsumption on ZTS thread init

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,11 @@ PHP                                                                        NEWS
     Phar::addEmptyDir() for paths starting with "/.phar", while allowing
     non-magic directory names that merely share the ".phar" prefix. (Weilin Du)
 
+- Opcache:
+  . Fixed bug GH-22216 (spurious opcache.memory_consumption warning on each new
+    ZTS thread; the directive is also reported as 0 in worker threads).
+    (Daisuke Komazaki)
+
 - Zlib:
   . Fixed memory leak if deflate initialization fails and there is a dict.
     (ndossche)

--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,9 @@ PHP                                                                        NEWS
     next() call on the inner generator). (iliaal)
 
 - Opcache:
+  . Fixed bug GH-22216 (spurious opcache.memory_consumption warning on each new
+    ZTS thread; the directive is also reported as 0 in worker threads).
+    (Daisuke Komazaki)
   . Fixed opcache.protect_memory race under ZTS. (realFlowControl)
 
 - Readline:

--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -79,7 +79,9 @@ static int validate_api_restriction(void)
 
 static ZEND_INI_MH(OnUpdateMemoryConsumption)
 {
-	if (accel_startup_ok) {
+	/* On ZTS, each new thread runs the on_modify handlers at STAGE_STARTUP to
+	 * populate its own globals; that is thread init, not a post-startup change. */
+	if (accel_startup_ok && stage != ZEND_INI_STAGE_STARTUP) {
 		if (strcmp(sapi_module.name, "fpm-fcgi") == 0) {
 			zend_accel_error(ACCEL_LOG_WARNING, "opcache.memory_consumption cannot be changed when OPcache is already set up. Are you using php_admin_value[opcache.memory_consumption] in an individual pool's configuration?\n");
 		} else {


### PR DESCRIPTION
Fixes GH-22216

## Testing

Put this as `/tmp/ztsrepro/repro_min.c`

```c
#include <sapi/embed/php_embed.h>
#include <pthread.h>

static void *worker(void *arg)
{
    ts_resource(0);
    php_request_startup();
    php_printf("[worker] ");
    zend_eval_string("echo opcache_get_configuration()['directives']['opcache.memory_consumption'], PHP_EOL;", NULL, "w");
    php_request_shutdown(NULL);
    ts_free_thread();
    return NULL;
}

int main(int argc, char **argv)
{
    php_embed_init(argc, argv);
    php_printf("[main]   ");
    zend_eval_string("echo opcache_get_configuration()['directives']['opcache.memory_consumption'], PHP_EOL;", NULL, "m");
    pthread_t t;
    pthread_create(&t, NULL, worker, NULL);
    pthread_join(t, NULL);
    php_embed_shutdown();
    return 0;
}
```

Build php-src with --enable-zts --enable-embed, Run the following from the build root
```
cc /tmp/ztsrepro/repro_min.c -o /tmp/ztsrepro/repro_min -I. -Imain -IZend -ITSRM -Isapi/embed -Iext/date/lib -D_GNU_SOURCE -DZTS -DZEND_SIGNALS -DNDEBUG -pthread -Llibs -lphp -Wl,-rpath,libs
```

### ini

```
echo 'opcache.log_verbosity_level=2' > /tmp/ztsrepro/opcache.ini
```

### before
```
$ PHPRC=/tmp/ztsrepro/opcache.ini /tmp/ztsrepro/repro_min
[main]   134217728
Thu Jun  4 16:35:49 2026 (6129397760): Warning opcache.memory_consumption cannot be changed when OPcache is already set up.

[worker] 0
```
### after
```
$ PHPRC=/tmp/ztsrepro/opcache.ini /tmp/ztsrepro/repro_min
[main]   134217728
[worker] 134217728
```