### PR TITLE
ext/dba: switch dba_handlers full_info path to zend_string API

### DIFF
--- a/ext/dba/dba.c
+++ b/ext/dba/dba.c
@@ -1282,10 +1282,8 @@ PHP_FUNCTION(dba_handlers)
 
 	for (const dba_handler *hptr = handler; hptr->name; hptr++) {
 		if (full_info) {
-			// TODO: avoid reallocation ???
-			char *str = hptr->info(hptr, NULL);
-			add_assoc_string(return_value, hptr->name, str);
-			efree(str);
+			zend_string *str = hptr->info(hptr, NULL);
+			add_assoc_str(return_value, hptr->name, str);
 		} else {
 			add_next_index_string(return_value, hptr->name);
 		}

--- a/ext/dba/dba_cdb.c
+++ b/ext/dba/dba_cdb.c
@@ -318,11 +318,11 @@ DBA_SYNC_FUNC(cdb)
 DBA_INFO_FUNC(cdb)
 {
 #ifdef DBA_CDB_BUILTIN
-	const char* version_str = NULL;
+	char* version_str = NULL;
 	if (!strcmp(hnd->name, "cdb")) {
-		version_str = cdb_version();
+		version_str = (char*)cdb_version();
 	} else {
-		version_str = cdb_make_version();
+		version_str = (char*)cdb_make_version();
 	}
 	return zend_string_init(cdb_version, strlen(cdb_version), false);
 #else

--- a/ext/dba/dba_cdb.c
+++ b/ext/dba/dba_cdb.c
@@ -318,15 +318,17 @@ DBA_SYNC_FUNC(cdb)
 DBA_INFO_FUNC(cdb)
 {
 #ifdef DBA_CDB_BUILTIN
-	char* version_str = NULL;
+	const char *version_str;
+
 	if (!strcmp(hnd->name, "cdb")) {
-		version_str = (char*)cdb_version();
+		version_str = cdb_version();
 	} else {
-		version_str = (char*)cdb_make_version();
+		version_str = cdb_make_version();
 	}
-	return zend_string_init(cdb_version, strlen(cdb_version), false);
+
+	return zend_string_init(version_str, strlen(version_str), 0);
 #else
-	return zend_string_init("External", strlen("External"), false);
+	return zend_string_init("External", sizeof("External") - 1, 0);
 #endif
 }
 

--- a/ext/dba/dba_cdb.c
+++ b/ext/dba/dba_cdb.c
@@ -318,14 +318,13 @@ DBA_SYNC_FUNC(cdb)
 DBA_INFO_FUNC(cdb)
 {
 #ifdef DBA_CDB_BUILTIN
-	char* version_str = NULL;
+	const char* version_str = NULL;
 	if (!strcmp(hnd->name, "cdb")) {
 		version_str = cdb_version();
-		return zend_string_init(cdb_version, strlen(cdb_version), false);
 	} else {
 		version_str = cdb_make_version();
-		return zend_string_init(cdb_version, strlen(cdb_version), false);
 	}
+	return zend_string_init(cdb_version, strlen(cdb_version), false);
 #else
 	return zend_string_init("External", strlen("External"), false);
 #endif

--- a/ext/dba/dba_cdb.c
+++ b/ext/dba/dba_cdb.c
@@ -318,13 +318,16 @@ DBA_SYNC_FUNC(cdb)
 DBA_INFO_FUNC(cdb)
 {
 #ifdef DBA_CDB_BUILTIN
+	char* version_str = NULL;
 	if (!strcmp(hnd->name, "cdb")) {
-		return estrdup(cdb_version());
+		version_str = cdb_version();
+		return zend_string_init(cdb_version, strlen(cdb_version), false);
 	} else {
-		return estrdup(cdb_make_version());
+		version_str = cdb_make_version();
+		return zend_string_init(cdb_version, strlen(cdb_version), false);
 	}
 #else
-	return estrdup("External");
+	return zend_string_init("External", strlen("External"), false);
 #endif
 }
 

--- a/ext/dba/dba_db1.c
+++ b/ext/dba/dba_db1.c
@@ -177,7 +177,7 @@ DBA_SYNC_FUNC(db1)
 
 DBA_INFO_FUNC(db1)
 {
-	return estrdup(DB1_VERSION);
+	return zend_string_init(DB1_VERSION, strlen(DB1_VERSION), false);
 }
 
 #endif

--- a/ext/dba/dba_db2.c
+++ b/ext/dba/dba_db2.c
@@ -187,7 +187,7 @@ DBA_SYNC_FUNC(db2)
 
 DBA_INFO_FUNC(db2)
 {
-	return estrdup(DB_VERSION_STRING);
+	return zend_string_init(DB_VERSION_STRING, strlen(DB_VERSION_STRING), false);
 }
 
 #endif

--- a/ext/dba/dba_db3.c
+++ b/ext/dba/dba_db3.c
@@ -225,7 +225,7 @@ DBA_SYNC_FUNC(db3)
 
 DBA_INFO_FUNC(db3)
 {
-	return estrdup(DB_VERSION_STRING);
+	return zend_string_init(DB_VERSION_STRING, strlen(DB_VERSION_STRING), false);
 }
 
 #endif

--- a/ext/dba/dba_db4.c
+++ b/ext/dba/dba_db4.c
@@ -282,7 +282,7 @@ DBA_SYNC_FUNC(db4)
 
 DBA_INFO_FUNC(db4)
 {
-	return estrdup(DB_VERSION_STRING);
+	return zend_string_init(DB_VERSION_STRING, strlen(DB_VERSION_STRING), false);
 }
 
 #endif

--- a/ext/dba/dba_dbm.c
+++ b/ext/dba/dba_dbm.c
@@ -188,7 +188,7 @@ DBA_INFO_FUNC(dbm)
 {
 #ifdef DBA_GDBM
 	if (!strcmp(DBM_VERSION, "GDBM"))
-	{
+	{	
 		return dba_info_gdbm(hnd, info);
 	}
 #endif

--- a/ext/dba/dba_dbm.c
+++ b/ext/dba/dba_dbm.c
@@ -192,7 +192,7 @@ DBA_INFO_FUNC(dbm)
 		return dba_info_gdbm(hnd, info);
 	}
 #endif
-	return estrdup(DBM_VERSION);
+	return zend_string_init(DBM_VERSION, strlen(DBM_VERSION), false);
 }
 
 #endif

--- a/ext/dba/dba_flatfile.c
+++ b/ext/dba/dba_flatfile.c
@@ -167,7 +167,7 @@ DBA_SYNC_FUNC(flatfile)
 
 DBA_INFO_FUNC(flatfile)
 {	
-	char* version = flatfile_version();
+	const char* version = flatfile_version();
 	return zend_string_init(version, strlen(version), false);
 }
 

--- a/ext/dba/dba_flatfile.c
+++ b/ext/dba/dba_flatfile.c
@@ -166,8 +166,9 @@ DBA_SYNC_FUNC(flatfile)
 }
 
 DBA_INFO_FUNC(flatfile)
-{
-	return estrdup(flatfile_version());
+{	
+	char* version = flatfile_version();
+	return zend_string_init(version, strlen(version), false);
 }
 
 #endif

--- a/ext/dba/dba_gdbm.c
+++ b/ext/dba/dba_gdbm.c
@@ -189,7 +189,7 @@ DBA_SYNC_FUNC(gdbm)
 
 DBA_INFO_FUNC(gdbm)
 {
-	return estrdup(gdbm_version);
+	return zend_string_init(gdbm_version, strlen(gdbm_version), false);
 }
 
 #endif

--- a/ext/dba/dba_inifile.c
+++ b/ext/dba/dba_inifile.c
@@ -186,7 +186,8 @@ DBA_SYNC_FUNC(inifile)
 
 DBA_INFO_FUNC(inifile)
 {
-	return estrdup(inifile_version());
+	const char* version = inifile_version();
+	return zend_string_init(version, strlen(version), false);
 }
 
 #endif

--- a/ext/dba/dba_lmdb.c
+++ b/ext/dba/dba_lmdb.c
@@ -360,7 +360,7 @@ DBA_SYNC_FUNC(lmdb)
 
 DBA_INFO_FUNC(lmdb)
 {
-	return estrdup(MDB_VERSION_STRING);
+	return zend_string_init(MDB_VERSION_STRING, strlen(MDB_VERSION_STRING), false);
 }
 
 #endif

--- a/ext/dba/dba_ndbm.c
+++ b/ext/dba/dba_ndbm.c
@@ -147,7 +147,7 @@ DBA_SYNC_FUNC(ndbm)
 
 DBA_INFO_FUNC(ndbm)
 {
-	return estrdup("NDBM");
+	return zend_string_init(NDBM, strlen(NDBM), false);
 }
 
 #endif

--- a/ext/dba/dba_qdbm.c
+++ b/ext/dba/dba_qdbm.c
@@ -173,7 +173,7 @@ DBA_SYNC_FUNC(qdbm)
 
 DBA_INFO_FUNC(qdbm)
 {
-	return estrdup(dpversion);
+	return zend_string_init(dpversion, strlen(dpversion), false);
 }
 
 #endif

--- a/ext/dba/dba_tcadb.c
+++ b/ext/dba/dba_tcadb.c
@@ -193,7 +193,7 @@ DBA_SYNC_FUNC(tcadb)
 
 DBA_INFO_FUNC(tcadb)
 {
-	return estrdup(tcversion);
+	return zend_string_init(tcversion, strlen(tcversion), false);;
 }
 
 #endif

--- a/ext/dba/dba_tcadb.c
+++ b/ext/dba/dba_tcadb.c
@@ -193,7 +193,7 @@ DBA_SYNC_FUNC(tcadb)
 
 DBA_INFO_FUNC(tcadb)
 {
-	return zend_string_init(tcversion, strlen(tcversion), false);;
+	return zend_string_init(tcversion, strlen(tcversion), false);
 }
 
 #endif

--- a/ext/dba/php_dba.h
+++ b/ext/dba/php_dba.h
@@ -89,7 +89,7 @@ typedef struct dba_handler {
 	zend_string* (*nextkey)(dba_info *);
 	zend_result (*optimize)(dba_info *);
 	zend_result (*sync)(dba_info *);
-	char* (*info)(const struct dba_handler *hnd, dba_info *);
+	zend_string* (*info)(const struct dba_handler *hnd, dba_info *);
 		/* dba_info==NULL: Handler info, dba_info!=NULL: Database info */
 } dba_handler;
 
@@ -116,7 +116,7 @@ typedef struct dba_handler {
 #define DBA_SYNC_FUNC(x) \
 	zend_result dba_sync_##x(dba_info *info)
 #define DBA_INFO_FUNC(x) \
-	char *dba_info_##x(const dba_handler *hnd, dba_info *info)
+	zend_string *dba_info_##x(const dba_handler *hnd, dba_info *info)
 
 #define DBA_FUNCS(x) \
 	DBA_OPEN_FUNC(x); \


### PR DESCRIPTION
Replace legacy `char*` handling with `zend_string` in `hptr->info()`
removal path to avoid manual `efree()` and improve memory safety.