### PR TITLE
perf: move EG() and CG() in ZTS builds into __thread storage

### DIFF
--- a/TSRM/TSRM.c
+++ b/TSRM/TSRM.c
@@ -823,7 +823,10 @@ TSRM_API void *tsrm_get_ls_cache(void)
 /* Returns offset of tsrm_ls_cache slot from Thread Control Block address */
 TSRM_API size_t tsrm_get_ls_cache_tcb_offset(void)
 {/*{{{*/
-#if defined(__APPLE__) && defined(__x86_64__)
+#if defined(TSRM_TLS_MODEL_GLOBAL_DYNAMIC)
+	/* No constant TCB offset under global-dynamic, can't use fast path */
+	return 0;
+#elif defined(__APPLE__) && defined(__x86_64__)
     // TODO: Implement support for fast JIT ZTS code ???
 	return 0;
 #elif defined(__x86_64__) && defined(__GNUC__) && !defined(__FreeBSD__) && \

--- a/TSRM/TSRM.c
+++ b/TSRM/TSRM.c
@@ -534,7 +534,7 @@ TSRM_API void *ts_resource_ex(ts_rsrc_id id, THREAD_T *th_id)
 		/* In case that extensions don't use the pointer passed from the dtor, but incorrectly
 		 * use the global pointer, we need to setup the global pointer temporarily here. */
 		set_thread_local_storage_resource_to(thread_resources);
-		/* Dead thread, recycled id: already freed, so just zero it. */
+		/* Free up the old resource from the old thread instance */
 		thread_resources->thread_id = 0;
 		ts_free_resources(thread_resources);
 		free(thread_resources);

--- a/TSRM/TSRM.c
+++ b/TSRM/TSRM.c
@@ -42,6 +42,8 @@ typedef struct {
 	ts_allocate_ctor ctor;
 	ts_allocate_dtor dtor;
 	size_t fast_offset;
+	/* When set, storage comes from __thread memory instead of being allocated by TSRM. */
+	void *(*tls_addr)(void);
 	int done;
 } tsrm_resource_type;
 
@@ -163,14 +165,19 @@ TSRM_API bool tsrm_startup(int expected_threads, int expected_resources, int deb
 
 static void ts_free_resources(tsrm_tls_entry *thread_resources)
 {
+	bool own_thread = thread_resources->thread_id == tsrm_thread_id();
+
 	/* Need to destroy in reverse order to respect dependencies. */
 	for (int i = thread_resources->count - 1; i >= 0; i--) {
 		if (!resource_types_table[i].done) {
+			if (resource_types_table[i].tls_addr && !own_thread) {
+				continue;
+			}
 			if (resource_types_table[i].dtor) {
 				resource_types_table[i].dtor(thread_resources->storage[i]);
 			}
 
-			if (!resource_types_table[i].fast_offset) {
+			if (!resource_types_table[i].fast_offset && !resource_types_table[i].tls_addr) {
 				free(thread_resources->storage[i]);
 			}
 		}
@@ -256,7 +263,10 @@ static void tsrm_update_active_threads(void)
 
 				p->storage = (void *) realloc(p->storage, sizeof(void *)*id_count);
 				for (j=p->count; j<id_count; j++) {
-					if (resource_types_table[j].fast_offset) {
+					if (resource_types_table[j].tls_addr) {
+						TSRM_ASSERT(p->thread_id == tsrm_thread_id());
+						p->storage[j] = resource_types_table[j].tls_addr();
+					} else if (resource_types_table[j].fast_offset) {
 						p->storage[j] = (void *) (((char*)p) + resource_types_table[j].fast_offset);
 					} else {
 						p->storage[j] = (void *) malloc(resource_types_table[j].size);
@@ -301,6 +311,7 @@ TSRM_API ts_rsrc_id ts_allocate_id(ts_rsrc_id *rsrc_id, size_t size, ts_allocate
 	resource_types_table[TSRM_UNSHUFFLE_RSRC_ID(*rsrc_id)].ctor = ctor;
 	resource_types_table[TSRM_UNSHUFFLE_RSRC_ID(*rsrc_id)].dtor = dtor;
 	resource_types_table[TSRM_UNSHUFFLE_RSRC_ID(*rsrc_id)].fast_offset = 0;
+	resource_types_table[TSRM_UNSHUFFLE_RSRC_ID(*rsrc_id)].tls_addr = NULL;
 	resource_types_table[TSRM_UNSHUFFLE_RSRC_ID(*rsrc_id)].done = 0;
 
 	tsrm_update_active_threads();
@@ -359,12 +370,48 @@ TSRM_API ts_rsrc_id ts_allocate_fast_id(ts_rsrc_id *rsrc_id, size_t *offset, siz
 	resource_types_table[TSRM_UNSHUFFLE_RSRC_ID(*rsrc_id)].ctor = ctor;
 	resource_types_table[TSRM_UNSHUFFLE_RSRC_ID(*rsrc_id)].dtor = dtor;
 	resource_types_table[TSRM_UNSHUFFLE_RSRC_ID(*rsrc_id)].fast_offset = *offset;
+	resource_types_table[TSRM_UNSHUFFLE_RSRC_ID(*rsrc_id)].tls_addr = NULL;
 	resource_types_table[TSRM_UNSHUFFLE_RSRC_ID(*rsrc_id)].done = 0;
 
 	tsrm_update_active_threads();
 	tsrm_mutex_unlock(tsmm_mutex);
 
 	TSRM_ERROR((TSRM_ERROR_LEVEL_CORE, "Successfully allocated new resource id %d", *rsrc_id));
+	return *rsrc_id;
+}/*}}}*/
+
+/* allocates a resource id whose per-thread storage is a native __thread block */
+TSRM_API ts_rsrc_id ts_allocate_tls_id(ts_rsrc_id *rsrc_id, void *(*tls_addr)(void), size_t size, ts_allocate_ctor ctor, ts_allocate_dtor dtor)
+{/*{{{*/
+	TSRM_ERROR((TSRM_ERROR_LEVEL_CORE, "Obtaining a new TLS resource id, %d bytes", size));
+
+	tsrm_mutex_lock(tsmm_mutex);
+
+	*rsrc_id = TSRM_SHUFFLE_RSRC_ID(id_count++);
+
+	if (resource_types_table_size < id_count) {
+		tsrm_resource_type *_tmp;
+		_tmp = (tsrm_resource_type *) realloc(resource_types_table, sizeof(tsrm_resource_type)*id_count);
+		if (!_tmp) {
+			TSRM_ERROR((TSRM_ERROR_LEVEL_ERROR, "Unable to allocate storage for resource"));
+			*rsrc_id = 0;
+			tsrm_mutex_unlock(tsmm_mutex);
+			return 0;
+		}
+		resource_types_table = _tmp;
+		resource_types_table_size = id_count;
+	}
+	resource_types_table[TSRM_UNSHUFFLE_RSRC_ID(*rsrc_id)].size = size;
+	resource_types_table[TSRM_UNSHUFFLE_RSRC_ID(*rsrc_id)].ctor = ctor;
+	resource_types_table[TSRM_UNSHUFFLE_RSRC_ID(*rsrc_id)].dtor = dtor;
+	resource_types_table[TSRM_UNSHUFFLE_RSRC_ID(*rsrc_id)].fast_offset = 0;
+	resource_types_table[TSRM_UNSHUFFLE_RSRC_ID(*rsrc_id)].tls_addr = tls_addr;
+	resource_types_table[TSRM_UNSHUFFLE_RSRC_ID(*rsrc_id)].done = 0;
+
+	tsrm_update_active_threads();
+	tsrm_mutex_unlock(tsmm_mutex);
+
+	TSRM_ERROR((TSRM_ERROR_LEVEL_CORE, "Successfully allocated new TLS resource id %d", *rsrc_id));
 	return *rsrc_id;
 }/*}}}*/
 
@@ -397,7 +444,9 @@ static void allocate_new_resource(tsrm_tls_entry **thread_resources_ptr, THREAD_
 		if (resource_types_table[i].done) {
 			(*thread_resources_ptr)->storage[i] = NULL;
 		} else {
-			if (resource_types_table[i].fast_offset) {
+			if (resource_types_table[i].tls_addr) {
+				(*thread_resources_ptr)->storage[i] = resource_types_table[i].tls_addr();
+			} else if (resource_types_table[i].fast_offset) {
 				(*thread_resources_ptr)->storage[i] = (void *) (((char*)(*thread_resources_ptr)) + resource_types_table[i].fast_offset);
 			} else {
 				(*thread_resources_ptr)->storage[i] = (void *) malloc(resource_types_table[i].size);
@@ -485,7 +534,8 @@ TSRM_API void *ts_resource_ex(ts_rsrc_id id, THREAD_T *th_id)
 		/* In case that extensions don't use the pointer passed from the dtor, but incorrectly
 		 * use the global pointer, we need to setup the global pointer temporarily here. */
 		set_thread_local_storage_resource_to(thread_resources);
-		/* Free up the old resource from the old thread instance */
+		/* Dead thread, recycled id: already freed, so just zero it. */
+		thread_resources->thread_id = 0;
 		ts_free_resources(thread_resources);
 		free(thread_resources);
 		/* Allocate a new resource at the same point in the linked list, and relink the next pointer */
@@ -559,7 +609,7 @@ void ts_free_id(ts_rsrc_id id)
 						if (resource_types_table[rsrc_id].dtor) {
 							resource_types_table[rsrc_id].dtor(p->storage[rsrc_id]);
 						}
-						if (!resource_types_table[rsrc_id].fast_offset) {
+						if (!resource_types_table[rsrc_id].fast_offset && !resource_types_table[rsrc_id].tls_addr) {
 							free(p->storage[rsrc_id]);
 						}
 					}

--- a/TSRM/TSRM.h
+++ b/TSRM/TSRM.h
@@ -158,8 +158,13 @@ TSRM_API bool tsrm_is_managed_thread(void);
 # define TSRM_TLS_MODEL_ATTR
 # define TSRM_TLS_MODEL_DEFAULT
 #elif __PIC__ && !defined(__PIE__)
-# define TSRM_TLS_MODEL_ATTR __attribute__((tls_model("initial-exec")))
-# define TSRM_TLS_MODEL_INITIAL_EXEC
+# if defined(TSRM_TLS_MODEL_USE_GLOBAL_DYNAMIC)
+#  define TSRM_TLS_MODEL_ATTR __attribute__((tls_model("global-dynamic")))
+#  define TSRM_TLS_MODEL_GLOBAL_DYNAMIC
+# else
+#  define TSRM_TLS_MODEL_ATTR __attribute__((tls_model("initial-exec")))
+#  define TSRM_TLS_MODEL_INITIAL_EXEC
+# endif
 #else
 # define TSRM_TLS_MODEL_ATTR __attribute__((tls_model("local-exec")))
 # define TSRM_TLS_MODEL_LOCAL_EXEC

--- a/TSRM/TSRM.h
+++ b/TSRM/TSRM.h
@@ -178,15 +178,24 @@ TSRM_API bool tsrm_is_managed_thread(void);
 #define TSRMG_FAST_STATIC(offset, type, element)	(TSRMG_FAST_BULK_STATIC(offset, type)->element)
 #define TSRMG_FAST_BULK_STATIC(offset, type)	((type) (((char*) TSRMLS_CACHE)+(offset)))
 struct _zend_tsrm_ls_cache;
-#ifdef __cplusplus
-#define TSRMLS_MAIN_CACHE_EXTERN() extern "C" { extern TSRM_TLS struct _zend_tsrm_ls_cache _tsrm_ls_cache TSRM_TLS_MODEL_ATTR; }
-#define TSRMLS_CACHE_EXTERN() extern "C" { extern TSRM_TLS struct _zend_tsrm_ls_cache _tsrm_ls_cache; }
+#if defined(ZEND_WIN32) && !defined(LIBZEND_EXPORTS)
+/* Windows can't dllexport the TLS struct, so outside Zend each module
+ * keeps a per-module `void *` pointer and reaches EG/CG via the resource-id indirection. */
+# define ZEND_TSRMLS_CACHE_T void *
+# define TSRMLS_MAIN_CACHE_DEFINE() TSRM_TLS void *_tsrm_ls_cache TSRM_TLS_MODEL_ATTR = NULL;
+# define TSRMLS_CACHE_DEFINE() TSRM_TLS void *_tsrm_ls_cache = NULL;
 #else
-#define TSRMLS_MAIN_CACHE_EXTERN() extern TSRM_TLS struct _zend_tsrm_ls_cache _tsrm_ls_cache TSRM_TLS_MODEL_ATTR;
-#define TSRMLS_CACHE_EXTERN() extern TSRM_TLS struct _zend_tsrm_ls_cache _tsrm_ls_cache;
+# define ZEND_TSRMLS_CACHE_T struct _zend_tsrm_ls_cache
+# define TSRMLS_MAIN_CACHE_DEFINE()
+# define TSRMLS_CACHE_DEFINE()
 #endif
-#define TSRMLS_MAIN_CACHE_DEFINE()
-#define TSRMLS_CACHE_DEFINE()
+#ifdef __cplusplus
+#define TSRMLS_MAIN_CACHE_EXTERN() extern "C" { extern TSRM_TLS ZEND_TSRMLS_CACHE_T _tsrm_ls_cache TSRM_TLS_MODEL_ATTR; }
+#define TSRMLS_CACHE_EXTERN() extern "C" { extern TSRM_TLS ZEND_TSRMLS_CACHE_T _tsrm_ls_cache; }
+#else
+#define TSRMLS_MAIN_CACHE_EXTERN() extern TSRM_TLS ZEND_TSRMLS_CACHE_T _tsrm_ls_cache TSRM_TLS_MODEL_ATTR;
+#define TSRMLS_CACHE_EXTERN() extern TSRM_TLS ZEND_TSRMLS_CACHE_T _tsrm_ls_cache;
+#endif
 #define TSRMLS_CACHE_UPDATE() TSRMLS_CACHE = tsrm_get_ls_cache()
 #define TSRMLS_CACHE (*(void **) &_tsrm_ls_cache)
 

--- a/TSRM/TSRM.h
+++ b/TSRM/TSRM.h
@@ -177,17 +177,18 @@ TSRM_API bool tsrm_is_managed_thread(void);
 #define TSRMG_BULK_STATIC(id, type)	((type) (*((void ***) TSRMLS_CACHE))[TSRM_UNSHUFFLE_RSRC_ID(id)])
 #define TSRMG_FAST_STATIC(offset, type, element)	(TSRMG_FAST_BULK_STATIC(offset, type)->element)
 #define TSRMG_FAST_BULK_STATIC(offset, type)	((type) (((char*) TSRMLS_CACHE)+(offset)))
+struct _zend_tsrm_ls_cache;
 #ifdef __cplusplus
-#define TSRMLS_MAIN_CACHE_EXTERN() extern "C" { extern TSRM_TLS void *TSRMLS_CACHE TSRM_TLS_MODEL_ATTR; }
-#define TSRMLS_CACHE_EXTERN() extern "C" { extern TSRM_TLS void *TSRMLS_CACHE; }
+#define TSRMLS_MAIN_CACHE_EXTERN() extern "C" { extern TSRM_TLS struct _zend_tsrm_ls_cache _tsrm_ls_cache TSRM_TLS_MODEL_ATTR; }
+#define TSRMLS_CACHE_EXTERN() extern "C" { extern TSRM_TLS struct _zend_tsrm_ls_cache _tsrm_ls_cache; }
 #else
-#define TSRMLS_MAIN_CACHE_EXTERN() extern TSRM_TLS void *TSRMLS_CACHE TSRM_TLS_MODEL_ATTR;
-#define TSRMLS_CACHE_EXTERN() extern TSRM_TLS void *TSRMLS_CACHE;
+#define TSRMLS_MAIN_CACHE_EXTERN() extern TSRM_TLS struct _zend_tsrm_ls_cache _tsrm_ls_cache TSRM_TLS_MODEL_ATTR;
+#define TSRMLS_CACHE_EXTERN() extern TSRM_TLS struct _zend_tsrm_ls_cache _tsrm_ls_cache;
 #endif
-#define TSRMLS_MAIN_CACHE_DEFINE() TSRM_TLS void *TSRMLS_CACHE TSRM_TLS_MODEL_ATTR = NULL;
-#define TSRMLS_CACHE_DEFINE() TSRM_TLS void *TSRMLS_CACHE = NULL;
+#define TSRMLS_MAIN_CACHE_DEFINE()
+#define TSRMLS_CACHE_DEFINE()
 #define TSRMLS_CACHE_UPDATE() TSRMLS_CACHE = tsrm_get_ls_cache()
-#define TSRMLS_CACHE _tsrm_ls_cache
+#define TSRMLS_CACHE (*(void **) &_tsrm_ls_cache)
 
 #ifdef __cplusplus
 }

--- a/TSRM/TSRM.h
+++ b/TSRM/TSRM.h
@@ -93,6 +93,8 @@ TSRM_API ts_rsrc_id ts_allocate_id(ts_rsrc_id *rsrc_id, size_t size, ts_allocate
 /* Fast resource in reserved (pre-allocated) space */
 TSRM_API void tsrm_reserve(size_t size);
 TSRM_API ts_rsrc_id ts_allocate_fast_id(ts_rsrc_id *rsrc_id, size_t *offset, size_t size, ts_allocate_ctor ctor, ts_allocate_dtor dtor);
+/* Must be called at startup before any other thread exists. */
+TSRM_API ts_rsrc_id ts_allocate_tls_id(ts_rsrc_id *rsrc_id, void *(*tls_addr)(void), size_t size, ts_allocate_ctor ctor, ts_allocate_dtor dtor);
 
 /* fetches the requested resource for the current thread */
 TSRM_API void *ts_resource_ex(ts_rsrc_id id, THREAD_T *th_id);
@@ -155,7 +157,7 @@ TSRM_API bool tsrm_is_managed_thread(void);
 #if !__has_attribute(tls_model) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__MUSL__) || defined(__HAIKU__)
 # define TSRM_TLS_MODEL_ATTR
 # define TSRM_TLS_MODEL_DEFAULT
-#elif __PIC__
+#elif __PIC__ && !defined(__PIE__)
 # define TSRM_TLS_MODEL_ATTR __attribute__((tls_model("initial-exec")))
 # define TSRM_TLS_MODEL_INITIAL_EXEC
 #else

--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -178,6 +178,23 @@ AC_MSG_RESULT([$ZEND_ZTS])
 AS_VAR_IF([ZEND_ZTS], [yes], [
   AC_DEFINE([ZTS], [1], [Define to 1 if thread safety (ZTS) is enabled.])
   AS_VAR_APPEND([CFLAGS], [" -DZTS"])
+
+  AC_CACHE_CHECK([for __thread support], [php_cv_have_thread_local], [
+    AC_LINK_IFELSE([AC_LANG_PROGRAM(
+      [[static __thread int tls_var;]],
+      [[tls_var = 1; return tls_var;]])],
+      [php_cv_have_thread_local=yes], [php_cv_have_thread_local=no])
+  ])
+  AS_VAR_IF([php_cv_have_thread_local], [yes], [
+    AC_DEFINE([ZEND_EG_TLS], [1],
+      [Define to hold EG()/CG() in a __thread variable under ZTS.])
+    AS_VAR_APPEND([CFLAGS], [" -DZEND_EG_TLS"])
+
+    dnl -mtls-size=12 drops the dead high-bits offset add from TLS access,
+    dnl valid while the thread-local block stays under 4 KiB.
+    AX_CHECK_COMPILE_FLAG([-mtls-size=12],
+      [AS_VAR_APPEND([CFLAGS], [" -mtls-size=12"])])
+  ])
 ])
 
 AC_MSG_CHECKING([whether to enable Zend debugging])

--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -179,22 +179,10 @@ AS_VAR_IF([ZEND_ZTS], [yes], [
   AC_DEFINE([ZTS], [1], [Define to 1 if thread safety (ZTS) is enabled.])
   AS_VAR_APPEND([CFLAGS], [" -DZTS"])
 
-  AC_CACHE_CHECK([for __thread support], [php_cv_have_thread_local], [
-    AC_LINK_IFELSE([AC_LANG_PROGRAM(
-      [[static __thread int tls_var;]],
-      [[tls_var = 1; return tls_var;]])],
-      [php_cv_have_thread_local=yes], [php_cv_have_thread_local=no])
-  ])
-  AS_VAR_IF([php_cv_have_thread_local], [yes], [
-    AC_DEFINE([ZEND_EG_TLS], [1],
-      [Define to hold EG()/CG() in a __thread variable under ZTS.])
-    AS_VAR_APPEND([CFLAGS], [" -DZEND_EG_TLS"])
-
-    dnl -mtls-size=12 drops the dead high-bits offset add from TLS access,
-    dnl valid while the thread-local block stays under 4 KiB.
-    AX_CHECK_COMPILE_FLAG([-mtls-size=12],
-      [AS_VAR_APPEND([CFLAGS], [" -mtls-size=12"])])
-  ])
+  dnl -mtls-size=12 drops the dead high-bits offset add from TLS access,
+  dnl valid while the thread-local block stays under 4 KiB.
+  AX_CHECK_COMPILE_FLAG([-mtls-size=12],
+    [AS_VAR_APPEND([CFLAGS], [" -mtls-size=12"])])
 ])
 
 AC_MSG_CHECKING([whether to enable Zend debugging])

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -54,6 +54,14 @@ ZEND_API int compiler_globals_id;
 ZEND_API int executor_globals_id;
 ZEND_API size_t compiler_globals_offset;
 ZEND_API size_t executor_globals_offset;
+# ifdef ZEND_EG_TLS
+ZEND_API TSRM_TLS TSRM_TLS_MODEL_ATTR zend_executor_globals executor_globals_tls;
+ZEND_API TSRM_TLS TSRM_TLS_MODEL_ATTR zend_compiler_globals compiler_globals_tls;
+/* ts_allocate_tls_id takes a callback so each thread resolves its own block.
+ * A plain &..._tls would capture only the registering thread's address. */
+static void *executor_globals_tls_addr(void) { return &executor_globals_tls; }
+static void *compiler_globals_tls_addr(void) { return &compiler_globals_tls; }
+# endif
 static HashTable *global_function_table = NULL;
 static HashTable *global_class_table = NULL;
 static HashTable *global_constants_table = NULL;
@@ -1019,8 +1027,13 @@ void zend_startup(zend_utility_functions *utility_functions) /* {{{ */
 	zend_init_rsrc_list_dtors();
 
 #ifdef ZTS
+#ifdef ZEND_EG_TLS
+	ts_allocate_tls_id(&compiler_globals_id, compiler_globals_tls_addr, sizeof(zend_compiler_globals), (ts_allocate_ctor) compiler_globals_ctor, (ts_allocate_dtor) compiler_globals_dtor);
+	ts_allocate_tls_id(&executor_globals_id, executor_globals_tls_addr, sizeof(zend_executor_globals), (ts_allocate_ctor) executor_globals_ctor, (ts_allocate_dtor) executor_globals_dtor);
+#else
 	ts_allocate_fast_id(&compiler_globals_id, &compiler_globals_offset, sizeof(zend_compiler_globals), (ts_allocate_ctor) compiler_globals_ctor, (ts_allocate_dtor) compiler_globals_dtor);
 	ts_allocate_fast_id(&executor_globals_id, &executor_globals_offset, sizeof(zend_executor_globals), (ts_allocate_ctor) executor_globals_ctor, (ts_allocate_dtor) executor_globals_dtor);
+#endif
 	ts_allocate_fast_id(&language_scanner_globals_id, &language_scanner_globals_offset, sizeof(zend_php_scanner_globals), (ts_allocate_ctor) php_scanner_globals_ctor, NULL);
 	ts_allocate_fast_id(&ini_scanner_globals_id, &ini_scanner_globals_offset, sizeof(zend_ini_scanner_globals), (ts_allocate_ctor) ini_scanner_globals_ctor, NULL);
 	compiler_globals = ts_resource(compiler_globals_id);

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -52,8 +52,8 @@ static bool startup_done = false;
 #ifdef ZTS
 ZEND_API int compiler_globals_id;
 ZEND_API int executor_globals_id;
-ZEND_API TSRM_TLS TSRM_TLS_MODEL_ATTR zend_executor_globals executor_globals_tls;
-ZEND_API TSRM_TLS TSRM_TLS_MODEL_ATTR zend_compiler_globals compiler_globals_tls;
+ZEND_TLS_API TSRM_TLS TSRM_TLS_MODEL_ATTR zend_executor_globals executor_globals_tls;
+ZEND_TLS_API TSRM_TLS TSRM_TLS_MODEL_ATTR zend_compiler_globals compiler_globals_tls;
 /* ts_allocate_tls_id takes a callback so each thread resolves its own block.
  * A plain &..._tls would capture only the registering thread's address. */
 static void *executor_globals_tls_addr(void) { return &executor_globals_tls; }

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -52,16 +52,12 @@ static bool startup_done = false;
 #ifdef ZTS
 ZEND_API int compiler_globals_id;
 ZEND_API int executor_globals_id;
-ZEND_API size_t compiler_globals_offset;
-ZEND_API size_t executor_globals_offset;
-# ifdef ZEND_EG_TLS
 ZEND_API TSRM_TLS TSRM_TLS_MODEL_ATTR zend_executor_globals executor_globals_tls;
 ZEND_API TSRM_TLS TSRM_TLS_MODEL_ATTR zend_compiler_globals compiler_globals_tls;
 /* ts_allocate_tls_id takes a callback so each thread resolves its own block.
  * A plain &..._tls would capture only the registering thread's address. */
 static void *executor_globals_tls_addr(void) { return &executor_globals_tls; }
 static void *compiler_globals_tls_addr(void) { return &compiler_globals_tls; }
-# endif
 static HashTable *global_function_table = NULL;
 static HashTable *global_class_table = NULL;
 static HashTable *global_constants_table = NULL;
@@ -1027,13 +1023,8 @@ void zend_startup(zend_utility_functions *utility_functions) /* {{{ */
 	zend_init_rsrc_list_dtors();
 
 #ifdef ZTS
-#ifdef ZEND_EG_TLS
 	ts_allocate_tls_id(&compiler_globals_id, compiler_globals_tls_addr, sizeof(zend_compiler_globals), (ts_allocate_ctor) compiler_globals_ctor, (ts_allocate_dtor) compiler_globals_dtor);
 	ts_allocate_tls_id(&executor_globals_id, executor_globals_tls_addr, sizeof(zend_executor_globals), (ts_allocate_ctor) executor_globals_ctor, (ts_allocate_dtor) executor_globals_dtor);
-#else
-	ts_allocate_fast_id(&compiler_globals_id, &compiler_globals_offset, sizeof(zend_compiler_globals), (ts_allocate_ctor) compiler_globals_ctor, (ts_allocate_dtor) compiler_globals_dtor);
-	ts_allocate_fast_id(&executor_globals_id, &executor_globals_offset, sizeof(zend_executor_globals), (ts_allocate_ctor) executor_globals_ctor, (ts_allocate_dtor) executor_globals_dtor);
-#endif
 	ts_allocate_fast_id(&language_scanner_globals_id, &language_scanner_globals_offset, sizeof(zend_php_scanner_globals), (ts_allocate_ctor) php_scanner_globals_ctor, NULL);
 	ts_allocate_fast_id(&ini_scanner_globals_id, &ini_scanner_globals_offset, sizeof(zend_ini_scanner_globals), (ts_allocate_ctor) ini_scanner_globals_ctor, NULL);
 	compiler_globals = ts_resource(compiler_globals_id);

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -53,6 +53,19 @@ static bool startup_done = false;
 ZEND_API int compiler_globals_id;
 ZEND_API int executor_globals_id;
 ZEND_TLS_API TSRM_TLS TSRM_TLS_MODEL_ATTR zend_tsrm_ls_cache _tsrm_ls_cache = {0};
+#if defined(_WIN64) && defined(ZEND_TLS_DIRECT)
+/* Holds &_tsrm_ls_cache in a TEB TLS slot (filled by DllMain) so EG()/CG() reach it
+ * with a single gs:[] load rather than the 3-load __declspec(thread) lookup. */
+ZEND_TLS_API unsigned long zend_win_tsrm_cache_slot = 0;
+ZEND_API void zend_win_tsrm_cache_init(bool alloc)
+{
+	if (alloc) {
+		zend_win_tsrm_cache_slot = TlsAlloc();
+		ZEND_ASSERT(zend_win_tsrm_cache_slot < 64); /* must be a direct TEB TlsSlot */
+	}
+	TlsSetValue(zend_win_tsrm_cache_slot, &_tsrm_ls_cache);
+}
+#endif
 /* ts_allocate_tls_id takes a callback so each thread resolves its own block.
  * A plain &..._tls would capture only the registering thread's address. */
 static void *executor_globals_tls_addr(void) { return &_tsrm_ls_cache.eg; }

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -52,18 +52,16 @@ static bool startup_done = false;
 #ifdef ZTS
 ZEND_API int compiler_globals_id;
 ZEND_API int executor_globals_id;
-ZEND_TLS_API TSRM_TLS TSRM_TLS_MODEL_ATTR zend_executor_globals executor_globals_tls;
-ZEND_TLS_API TSRM_TLS TSRM_TLS_MODEL_ATTR zend_compiler_globals compiler_globals_tls;
+ZEND_TLS_API TSRM_TLS TSRM_TLS_MODEL_ATTR zend_tsrm_ls_cache _tsrm_ls_cache = {0};
 /* ts_allocate_tls_id takes a callback so each thread resolves its own block.
  * A plain &..._tls would capture only the registering thread's address. */
-static void *executor_globals_tls_addr(void) { return &executor_globals_tls; }
-static void *compiler_globals_tls_addr(void) { return &compiler_globals_tls; }
+static void *executor_globals_tls_addr(void) { return &_tsrm_ls_cache.eg; }
+static void *compiler_globals_tls_addr(void) { return &_tsrm_ls_cache.cg; }
 static HashTable *global_function_table = NULL;
 static HashTable *global_class_table = NULL;
 static HashTable *global_constants_table = NULL;
 static HashTable *global_auto_globals_table = NULL;
 static HashTable *global_persistent_list = NULL;
-TSRMLS_MAIN_CACHE_DEFINE()
 # define GLOBAL_FUNCTION_TABLE		global_function_table
 # define GLOBAL_CLASS_TABLE			global_class_table
 # define GLOBAL_CONSTANTS_TABLE		global_constants_table
@@ -805,6 +803,7 @@ static void compiler_globals_dtor(zend_compiler_globals *compiler_globals) /* {{
 
 static void executor_globals_ctor(zend_executor_globals *executor_globals) /* {{{ */
 {
+	_tsrm_ls_cache.self = &_tsrm_ls_cache;
 	zend_startup_constants();
 	zend_copy_constants(executor_globals->zend_constants, GLOBAL_CONSTANTS_TABLE);
 	zend_init_rsrc_plist();

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -327,6 +327,15 @@ struct _zend_executor_globals {
 	void *reserved[ZEND_MAX_RESERVED_RESOURCES];
 };
 
+#ifdef ZTS
+struct _zend_tsrm_ls_cache {
+	void *cache;
+	void *self;
+	zend_executor_globals eg;
+	zend_compiler_globals cg;
+};
+#endif
+
 #define EG_FLAGS_INITIAL				(0)
 #define EG_FLAGS_IN_SHUTDOWN			(1<<0)
 #define EG_FLAGS_OBJECT_STORE_NO_REUSE	(1<<1)

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -51,8 +51,6 @@
 BEGIN_EXTERN_C()
 ZEND_API extern int compiler_globals_id;
 ZEND_API extern int executor_globals_id;
-ZEND_API extern size_t compiler_globals_offset;
-ZEND_API extern size_t executor_globals_offset;
 END_EXTERN_C()
 
 #endif

--- a/Zend/zend_globals_macros.h
+++ b/Zend/zend_globals_macros.h
@@ -26,12 +26,26 @@ typedef struct _zend_executor_globals zend_executor_globals;
 typedef struct _zend_php_scanner_globals zend_php_scanner_globals;
 typedef struct _zend_ini_scanner_globals zend_ini_scanner_globals;
 
+#ifdef ZEND_WIN32
+# define ZEND_TLS_API
+# ifdef LIBZEND_EXPORTS
+#  define ZEND_TLS_DIRECT 1
+# endif
+#else
+# define ZEND_TLS_API ZEND_API
+# define ZEND_TLS_DIRECT 1
+#endif
+
 BEGIN_EXTERN_C()
 
 /* Compiler */
 #ifdef ZTS
-extern ZEND_API TSRM_TLS TSRM_TLS_MODEL_ATTR zend_compiler_globals compiler_globals_tls;
-# define CG(v) (compiler_globals_tls.v)
+# ifdef ZEND_TLS_DIRECT
+extern ZEND_TLS_API TSRM_TLS TSRM_TLS_MODEL_ATTR zend_compiler_globals compiler_globals_tls;
+#  define CG(v) (compiler_globals_tls.v)
+# else
+#  define CG(v) ZEND_TSRMG(compiler_globals_id, zend_compiler_globals *, v)
+# endif
 #else
 # define CG(v) (compiler_globals.v)
 extern ZEND_API struct _zend_compiler_globals compiler_globals;
@@ -41,8 +55,12 @@ ZEND_API int zendparse(void);
 
 /* Executor */
 #ifdef ZTS
-extern ZEND_API TSRM_TLS TSRM_TLS_MODEL_ATTR zend_executor_globals executor_globals_tls;
-# define EG(v) (executor_globals_tls.v)
+# ifdef ZEND_TLS_DIRECT
+extern ZEND_TLS_API TSRM_TLS TSRM_TLS_MODEL_ATTR zend_executor_globals executor_globals_tls;
+#  define EG(v) (executor_globals_tls.v)
+# else
+#  define EG(v) ZEND_TSRMG(executor_globals_id, zend_executor_globals *, v)
+# endif
 #else
 # define EG(v) (executor_globals.v)
 extern ZEND_API zend_executor_globals executor_globals;

--- a/Zend/zend_globals_macros.h
+++ b/Zend/zend_globals_macros.h
@@ -42,13 +42,20 @@ BEGIN_EXTERN_C()
 typedef struct _zend_tsrm_ls_cache zend_tsrm_ls_cache;
 # ifdef ZEND_TLS_DIRECT
 extern ZEND_TLS_API TSRM_TLS TSRM_TLS_MODEL_ATTR zend_tsrm_ls_cache _tsrm_ls_cache;
+/* See zenc.c: zend_win_tsrm_cache_init */
+#  if defined(_WIN64)
+extern ZEND_TLS_API unsigned long zend_win_tsrm_cache_slot;
+#   define ZEND_TSRM_CACHE_PTR ((zend_tsrm_ls_cache*)__readgsqword(0x1480 + zend_win_tsrm_cache_slot * 8))
+#  else
+#   define ZEND_TSRM_CACHE_PTR (&_tsrm_ls_cache)
+#  endif
 # endif
 #endif
 
 /* Compiler */
 #ifdef ZTS
 # ifdef ZEND_TLS_DIRECT
-#  define CG(v) (_tsrm_ls_cache.cg.v)
+#  define CG(v) (ZEND_TSRM_CACHE_PTR->cg.v)
 # else
 #  define CG(v) ZEND_TSRMG(compiler_globals_id, zend_compiler_globals *, v)
 # endif
@@ -62,7 +69,7 @@ ZEND_API int zendparse(void);
 /* Executor */
 #ifdef ZTS
 # ifdef ZEND_TLS_DIRECT
-#  define EG(v) (_tsrm_ls_cache.eg.v)
+#  define EG(v) (ZEND_TSRM_CACHE_PTR->eg.v)
 # else
 #  define EG(v) ZEND_TSRMG(executor_globals_id, zend_executor_globals *, v)
 # endif

--- a/Zend/zend_globals_macros.h
+++ b/Zend/zend_globals_macros.h
@@ -40,7 +40,9 @@ BEGIN_EXTERN_C()
 
 #ifdef ZTS
 typedef struct _zend_tsrm_ls_cache zend_tsrm_ls_cache;
+# ifdef ZEND_TLS_DIRECT
 extern ZEND_TLS_API TSRM_TLS TSRM_TLS_MODEL_ATTR zend_tsrm_ls_cache _tsrm_ls_cache;
+# endif
 #endif
 
 /* Compiler */

--- a/Zend/zend_globals_macros.h
+++ b/Zend/zend_globals_macros.h
@@ -38,11 +38,15 @@ typedef struct _zend_ini_scanner_globals zend_ini_scanner_globals;
 
 BEGIN_EXTERN_C()
 
+#ifdef ZTS
+typedef struct _zend_tsrm_ls_cache zend_tsrm_ls_cache;
+extern ZEND_TLS_API TSRM_TLS TSRM_TLS_MODEL_ATTR zend_tsrm_ls_cache _tsrm_ls_cache;
+#endif
+
 /* Compiler */
 #ifdef ZTS
 # ifdef ZEND_TLS_DIRECT
-extern ZEND_TLS_API TSRM_TLS TSRM_TLS_MODEL_ATTR zend_compiler_globals compiler_globals_tls;
-#  define CG(v) (compiler_globals_tls.v)
+#  define CG(v) (_tsrm_ls_cache.cg.v)
 # else
 #  define CG(v) ZEND_TSRMG(compiler_globals_id, zend_compiler_globals *, v)
 # endif
@@ -56,8 +60,7 @@ ZEND_API int zendparse(void);
 /* Executor */
 #ifdef ZTS
 # ifdef ZEND_TLS_DIRECT
-extern ZEND_TLS_API TSRM_TLS TSRM_TLS_MODEL_ATTR zend_executor_globals executor_globals_tls;
-#  define EG(v) (executor_globals_tls.v)
+#  define EG(v) (_tsrm_ls_cache.eg.v)
 # else
 #  define EG(v) ZEND_TSRMG(executor_globals_id, zend_executor_globals *, v)
 # endif

--- a/Zend/zend_globals_macros.h
+++ b/Zend/zend_globals_macros.h
@@ -30,12 +30,8 @@ BEGIN_EXTERN_C()
 
 /* Compiler */
 #ifdef ZTS
-# ifdef ZEND_EG_TLS
 extern ZEND_API TSRM_TLS TSRM_TLS_MODEL_ATTR zend_compiler_globals compiler_globals_tls;
-#  define CG(v) (compiler_globals_tls.v)
-# else
-#  define CG(v) ZEND_TSRMG_FAST(compiler_globals_offset, zend_compiler_globals *, v)
-# endif
+# define CG(v) (compiler_globals_tls.v)
 #else
 # define CG(v) (compiler_globals.v)
 extern ZEND_API struct _zend_compiler_globals compiler_globals;
@@ -45,12 +41,8 @@ ZEND_API int zendparse(void);
 
 /* Executor */
 #ifdef ZTS
-# ifdef ZEND_EG_TLS
 extern ZEND_API TSRM_TLS TSRM_TLS_MODEL_ATTR zend_executor_globals executor_globals_tls;
-#  define EG(v) (executor_globals_tls.v)
-# else
-#  define EG(v) ZEND_TSRMG_FAST(executor_globals_offset, zend_executor_globals *, v)
-# endif
+# define EG(v) (executor_globals_tls.v)
 #else
 # define EG(v) (executor_globals.v)
 extern ZEND_API zend_executor_globals executor_globals;

--- a/Zend/zend_globals_macros.h
+++ b/Zend/zend_globals_macros.h
@@ -30,7 +30,12 @@ BEGIN_EXTERN_C()
 
 /* Compiler */
 #ifdef ZTS
-# define CG(v) ZEND_TSRMG_FAST(compiler_globals_offset, zend_compiler_globals *, v)
+# ifdef ZEND_EG_TLS
+extern ZEND_API TSRM_TLS TSRM_TLS_MODEL_ATTR zend_compiler_globals compiler_globals_tls;
+#  define CG(v) (compiler_globals_tls.v)
+# else
+#  define CG(v) ZEND_TSRMG_FAST(compiler_globals_offset, zend_compiler_globals *, v)
+# endif
 #else
 # define CG(v) (compiler_globals.v)
 extern ZEND_API struct _zend_compiler_globals compiler_globals;
@@ -40,7 +45,12 @@ ZEND_API int zendparse(void);
 
 /* Executor */
 #ifdef ZTS
-# define EG(v) ZEND_TSRMG_FAST(executor_globals_offset, zend_executor_globals *, v)
+# ifdef ZEND_EG_TLS
+extern ZEND_API TSRM_TLS TSRM_TLS_MODEL_ATTR zend_executor_globals executor_globals_tls;
+#  define EG(v) (executor_globals_tls.v)
+# else
+#  define EG(v) ZEND_TSRMG_FAST(executor_globals_offset, zend_executor_globals *, v)
+# endif
 #else
 # define EG(v) (executor_globals.v)
 extern ZEND_API zend_executor_globals executor_globals;

--- a/ext/opcache/jit/ir/ir_aarch64.dasc
+++ b/ext/opcache/jit/ir/ir_aarch64.dasc
@@ -5868,8 +5868,12 @@ static void ir_emit_tls(ir_ctx *ctx, ir_ref def, ir_insn *insn)
 |		ldr Rx(reg), [Rx(reg), #insn->op3]
 ||	}
 ||# else
+||	/* op2 == 0 with no index requests the bare thread pointer (used to form
+||	 * &EG/&CG with an add); a real TLS var never sits at tprel offset 0. */
+||	if (insn->op2 != 0 || insn->op3 != IR_NULL) {
 ||//???	IR_ASSERT(insn->op2 <= LDR_STR_PIMM64);
-|	ldr Rx(reg), [Rx(reg), #insn->op2]
+|		ldr Rx(reg), [Rx(reg), #insn->op2]
+||	}
 ||# endif
 ||#endif
 	if (IR_REG_SPILLED(ctx->regs[def][0])) {

--- a/ext/opcache/jit/ir/ir_aarch64.dasc
+++ b/ext/opcache/jit/ir/ir_aarch64.dasc
@@ -5868,8 +5868,6 @@ static void ir_emit_tls(ir_ctx *ctx, ir_ref def, ir_insn *insn)
 |		ldr Rx(reg), [Rx(reg), #insn->op3]
 ||	}
 ||# else
-||	/* op2 == 0 with no index requests the bare thread pointer (used to form
-||	 * &EG/&CG with an add); a real TLS var never sits at tprel offset 0. */
 ||	if (insn->op2 != 0 || insn->op3 != IR_NULL) {
 ||//???	IR_ASSERT(insn->op2 <= LDR_STR_PIMM64);
 |		ldr Rx(reg), [Rx(reg), #insn->op2]

--- a/ext/opcache/jit/tls/zend_jit_tls_win.c
+++ b/ext/opcache/jit/tls/zend_jit_tls_win.c
@@ -33,30 +33,21 @@ zend_result zend_jit_resolve_tsrm_ls_cache_offsets(
 	size_t *module_index,
 	size_t *module_offset
 ) {
-	/* To find offset of "_tsrm_ls_cache" in TLS segment we perform a linear scan of local TLS memory */
-	/* Probably, it might be better solution */
+	/* Offset of _tsrm_ls_cache within this module's TLS block. */
 #ifdef _WIN64
 	void ***tls_mem = ((void****)__readgsqword(0x58))[_tls_index];
 #else
 	void ***tls_mem = ((void****)__readfsdword(0x2c))[_tls_index];
 #endif
-	void *val = _tsrm_ls_cache;
-	size_t offset = 0;
 	size_t size = (char*)&_tls_end - (char*)&_tls_start;
-
-	while (offset < size) {
-		if (*tls_mem == val) {
-			*module_index  = _tls_index * sizeof(void*);
-			*module_offset = offset;
-			return SUCCESS;
-		}
-		tls_mem++;
-		offset += sizeof(void*);
-	}
+	size_t offset = (size_t)((char*)&_tsrm_ls_cache - (char*)tls_mem);
 
 	if (offset >= size) {
 		zend_accel_error_noreturn(ACCEL_LOG_FATAL, "Could not enable JIT: offset >= size");
+		return FAILURE;
 	}
 
-	return FAILURE;
+	*module_index  = _tls_index * sizeof(void*);
+	*module_offset = offset;
+	return SUCCESS;
 }

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -201,35 +201,21 @@ static uint32_t default_mflags = 0;
 static bool delayed_call_chain = false; // TODO: remove this var (use jit->delayed_call_level) ???
 
 #ifdef ZTS
-static size_t eg_tls_tcb_offset = 0;
-static size_t cg_tls_tcb_offset = 0;
-/* gottpoff yields the offset from the %fs-based thread pointer that ir_TLS(0)
- * loads. */
-# if defined(__ELF__) && defined(__x86_64__) && defined(__GNUC__) && !defined(TSRM_TLS_MODEL_DEFAULT)
-#  define ZEND_JIT_TLS_TCB_OFFSET(sym) __extension__({ \
-		size_t _off; \
-		__asm__ ("movq " #sym "@gottpoff(%%rip),%0" : "=r" (_off)); \
-		_off; \
-	})
-# elif defined(__ELF__) && defined(__aarch64__) && !defined(__APPLE__) && \
-		(defined(__GNUC__) || defined(__clang__))
-/* The TLS variable sits at a fixed offset from tpidr_el0 (the thread pointer
- * the JIT reads with mrs); compute it once on the main thread. Subtracting the
- * thread pointer is model-independent (works for both local- and initial-exec)
- * and matches tsrm_get_ls_cache_tcb_offset()'s tprel reasoning. */
-#  define ZEND_JIT_TLS_TCB_OFFSET(sym) __extension__({ \
-		char *_tp; \
-		__asm__ ("mrs %0, tpidr_el0" : "=r" (_tp)); \
-		(size_t)((char*)&(sym) - _tp); \
-	})
-# else
-#  define ZEND_JIT_TLS_TCB_OFFSET(sym) ((size_t)0)
-# endif
+static size_t tsrm_ls_cache_tcb_offset = 0;
+static size_t tsrm_tls_index = -1;
+static size_t tsrm_tls_offset = -1;
+
+# define EG_TLS_OFFSET(field) \
+	(tsrm_ls_cache_tcb_offset + offsetof(zend_tsrm_ls_cache, eg) + offsetof(zend_executor_globals, field))
+
+# define CG_TLS_OFFSET(field) \
+	(tsrm_ls_cache_tcb_offset + offsetof(zend_tsrm_ls_cache, cg) + offsetof(zend_compiler_globals, field))
 
 # define jit_EG(_field) \
-	ir_ADD_OFFSET(jit_EG_base(jit), offsetof(zend_executor_globals, _field))
+	ir_ADD_OFFSET(jit_TLS(jit), EG_TLS_OFFSET(_field))
+
 # define jit_CG(_field) \
-	ir_ADD_OFFSET(jit_CG_base(jit), offsetof(zend_compiler_globals, _field))
+	ir_ADD_OFFSET(jit_TLS(jit), CG_TLS_OFFSET(_field))
 
 #else
 
@@ -312,9 +298,7 @@ typedef struct _zend_jit_ctx {
 	uint32_t             delayed_call_level;
 	int                  b;           /* current basic block number or -1 */
 #ifdef ZTS
-	ir_ref               tp;     /* cached thread pointer for &EG/&CG */
-	ir_ref               eg_tls; /* cached base of __thread executor_globals_tls */
-	ir_ref               cg_tls; /* cached base of __thread compiler_globals_tls */
+	ir_ref               tls;
 #endif
 	ir_ref               fp;
 	ir_ref               poly_func_ref; /* restored from parent trace snapshot */
@@ -505,60 +489,41 @@ static const char* zend_reg_name(int8_t reg)
 /* IR helpers */
 
 #ifdef ZTS
-static void * ZEND_FASTCALL zend_jit_get_eg_tls(void)
+static void * ZEND_FASTCALL zend_jit_get_tsrm_ls_cache(void)
 {
-	return &executor_globals_tls;
-}
-static void * ZEND_FASTCALL zend_jit_get_cg_tls(void)
-{
-	return &compiler_globals_tls;
+	return &_tsrm_ls_cache;
 }
 
-/* Walk the control chain back from the current point: reuse the cached ref if we
- * reach it (it still dominates here), but bail at a block start or a call, since
- * the cached value lives in a caller-saved register that a call would clobber. */
-static ir_ref jit_tls_reuse(zend_jit_ctx *jit, ir_ref cached)
-{
-	ir_ref ref = jit->ctx.control;
-
-	while (cached) {
-		if (ref == cached) {
-			return cached;
-		}
-		ir_insn *insn = &jit->ctx.ir_base[ref];
-		if (insn->op >= IR_START || insn->op == IR_CALL) {
-			break;
-		}
-		ref = insn->op1;
-	}
-	return IR_UNUSED;
-}
-
-/* Thread pointer, cached per basic block, used to form &EG/&CG with an add. */
-static ir_ref jit_TP(zend_jit_ctx *jit)
+static ir_ref jit_TLS(zend_jit_ctx *jit)
 {
 	ZEND_ASSERT(jit->ctx.control);
-	if (!jit_tls_reuse(jit, jit->tp)) {
-		jit->tp = ir_TLS(0, IR_NULL);
-	}
-	return jit->tp;
-}
+	if (jit->tls) {
+		/* Emit "TLS" once for basic block */
+		ir_insn *insn;
+		ir_ref ref = jit->ctx.control;
 
-/* Used where the TCB offset is unknown: resolve the base via a cached call. */
-static ir_ref jit_GLOBALS_TLS_call(zend_jit_ctx *jit, ir_ref *cache, const void *fn)
-{
-	ZEND_ASSERT(jit->ctx.control);
-	if (!jit_tls_reuse(jit, *cache)) {
-		*cache = ir_CALL(IR_ADDR, ir_CONST_FC_FUNC(fn));
+		while (1) {
+			if (ref == jit->tls) {
+				return jit->tls;
+			}
+			insn = &jit->ctx.ir_base[ref];
+			if (insn->op >= IR_START || insn->op == IR_CALL) {
+				break;
+			}
+			ref = insn->op1;
+		}
 	}
-	return *cache;
+
+	if (tsrm_ls_cache_tcb_offset == 0 && tsrm_tls_index == -1) {
+		jit->tls = ir_CALL(IR_ADDR, ir_CONST_FC_FUNC(zend_jit_get_tsrm_ls_cache));
+	} else if (tsrm_ls_cache_tcb_offset) {
+		jit->tls = ir_TLS(0, IR_NULL);
+	} else {
+		jit->tls = ir_TLS(tsrm_tls_index, tsrm_tls_offset + offsetof(zend_tsrm_ls_cache, self));
+	}
+
+	return jit->tls;
 }
-# define jit_EG_base(jit) (eg_tls_tcb_offset \
-	? ir_ADD_OFFSET(jit_TP(jit), eg_tls_tcb_offset) \
-	: jit_GLOBALS_TLS_call((jit), &(jit)->eg_tls, zend_jit_get_eg_tls))
-# define jit_CG_base(jit) (cg_tls_tcb_offset \
-	? ir_ADD_OFFSET(jit_TP(jit), cg_tls_tcb_offset) \
-	: jit_GLOBALS_TLS_call((jit), &(jit)->cg_tls, zend_jit_get_cg_tls))
 #endif
 
 static ir_ref jit_CONST_ADDR(zend_jit_ctx *jit, uintptr_t addr)
@@ -2855,9 +2820,7 @@ static void zend_jit_init_ctx(zend_jit_ctx *jit, uint32_t flags)
 	delayed_call_chain = false;
 	jit->b = -1;
 #ifdef ZTS
-	jit->tp = IR_UNUSED;
-	jit->eg_tls = IR_UNUSED;
-	jit->cg_tls = IR_UNUSED;
+	jit->tls = IR_UNUSED;
 #endif
 	jit->fp = IR_UNUSED;
 	jit->poly_func_ref = IR_UNUSED;
@@ -3251,8 +3214,7 @@ static void zend_jit_setup_disasm(void)
 
 	REGISTER_DATA(CG(map_ptr_base));
 #else /* ZTS */
-	REGISTER_HELPER(zend_jit_get_eg_tls);
-	REGISTER_HELPER(zend_jit_get_cg_tls);
+	REGISTER_HELPER(zend_jit_get_tsrm_ls_cache);
 #endif
 #endif
 }
@@ -3463,8 +3425,15 @@ static void zend_jit_setup(bool reattached)
 #endif
 
 #ifdef ZTS
-	eg_tls_tcb_offset = ZEND_JIT_TLS_TCB_OFFSET(executor_globals_tls);
-	cg_tls_tcb_offset = ZEND_JIT_TLS_TCB_OFFSET(compiler_globals_tls);
+	zend_result result = zend_jit_resolve_tsrm_ls_cache_offsets(
+		&tsrm_ls_cache_tcb_offset,
+		&tsrm_tls_index,
+		&tsrm_tls_offset
+	);
+	if (result == FAILURE) {
+		zend_accel_error(ACCEL_LOG_INFO,
+				"Could not get _tsrm_ls_cache offsets, will fallback to runtime resolution");
+	}
 #endif
 
 #if !defined(ZEND_WIN32) && !defined(IR_TARGET_AARCH64)

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -201,56 +201,35 @@ static uint32_t default_mflags = 0;
 static bool delayed_call_chain = false; // TODO: remove this var (use jit->delayed_call_level) ???
 
 #ifdef ZTS
-static size_t tsrm_ls_cache_tcb_offset = 0;
-static size_t tsrm_tls_index = -1;
-static size_t tsrm_tls_offset = -1;
-
-# ifdef ZEND_EG_TLS
-/* When nonzero, &executor_globals_tls/&compiler_globals_tls equal the thread
- * pointer plus this offset, so the JIT forms them without a runtime call. */
 static size_t eg_tls_tcb_offset = 0;
 static size_t cg_tls_tcb_offset = 0;
 /* gottpoff yields the offset from the %fs-based thread pointer that ir_TLS(0)
  * loads. */
-#  if defined(__ELF__) && defined(__x86_64__) && defined(__GNUC__) && !defined(TSRM_TLS_MODEL_DEFAULT)
-#   define ZEND_JIT_TLS_TCB_OFFSET(sym) __extension__({ \
+# if defined(__ELF__) && defined(__x86_64__) && defined(__GNUC__) && !defined(TSRM_TLS_MODEL_DEFAULT)
+#  define ZEND_JIT_TLS_TCB_OFFSET(sym) __extension__({ \
 		size_t _off; \
 		__asm__ ("movq " #sym "@gottpoff(%%rip),%0" : "=r" (_off)); \
 		_off; \
 	})
-#  elif defined(__ELF__) && defined(__aarch64__) && !defined(__APPLE__) && \
+# elif defined(__ELF__) && defined(__aarch64__) && !defined(__APPLE__) && \
 		(defined(__GNUC__) || defined(__clang__))
 /* The TLS variable sits at a fixed offset from tpidr_el0 (the thread pointer
  * the JIT reads with mrs); compute it once on the main thread. Subtracting the
  * thread pointer is model-independent (works for both local- and initial-exec)
  * and matches tsrm_get_ls_cache_tcb_offset()'s tprel reasoning. */
-#   define ZEND_JIT_TLS_TCB_OFFSET(sym) __extension__({ \
+#  define ZEND_JIT_TLS_TCB_OFFSET(sym) __extension__({ \
 		char *_tp; \
 		__asm__ ("mrs %0, tpidr_el0" : "=r" (_tp)); \
 		(size_t)((char*)&(sym) - _tp); \
 	})
-#  else
-#   define ZEND_JIT_TLS_TCB_OFFSET(sym) ((size_t)0)
-#  endif
-# endif
-
-# define EG_TLS_OFFSET(field) \
-	(executor_globals_offset + offsetof(zend_executor_globals, field))
-
-# define CG_TLS_OFFSET(field) \
-	(compiler_globals_offset + offsetof(zend_compiler_globals, field))
-
-# ifdef ZEND_EG_TLS
-#  define jit_EG(_field) \
-	ir_ADD_OFFSET(jit_EG_base(jit), offsetof(zend_executor_globals, _field))
-#  define jit_CG(_field) \
-	ir_ADD_OFFSET(jit_CG_base(jit), offsetof(zend_compiler_globals, _field))
 # else
-#  define jit_EG(_field) \
-	ir_ADD_OFFSET(jit_TLS(jit), EG_TLS_OFFSET(_field))
-#  define jit_CG(_field) \
-	ir_ADD_OFFSET(jit_TLS(jit), CG_TLS_OFFSET(_field))
+#  define ZEND_JIT_TLS_TCB_OFFSET(sym) ((size_t)0)
 # endif
+
+# define jit_EG(_field) \
+	ir_ADD_OFFSET(jit_EG_base(jit), offsetof(zend_executor_globals, _field))
+# define jit_CG(_field) \
+	ir_ADD_OFFSET(jit_CG_base(jit), offsetof(zend_compiler_globals, _field))
 
 #else
 
@@ -333,12 +312,9 @@ typedef struct _zend_jit_ctx {
 	uint32_t             delayed_call_level;
 	int                  b;           /* current basic block number or -1 */
 #ifdef ZTS
-	ir_ref               tls;
-# ifdef ZEND_EG_TLS
 	ir_ref               tp;     /* cached thread pointer for &EG/&CG */
 	ir_ref               eg_tls; /* cached base of __thread executor_globals_tls */
 	ir_ref               cg_tls; /* cached base of __thread compiler_globals_tls */
-# endif
 #endif
 	ir_ref               fp;
 	ir_ref               poly_func_ref; /* restored from parent trace snapshot */
@@ -529,12 +505,6 @@ static const char* zend_reg_name(int8_t reg)
 /* IR helpers */
 
 #ifdef ZTS
-static void * ZEND_FASTCALL zend_jit_get_tsrm_ls_cache(void)
-{
-	return _tsrm_ls_cache;
-}
-
-# ifdef ZEND_EG_TLS
 static void * ZEND_FASTCALL zend_jit_get_eg_tls(void)
 {
 	return &executor_globals_tls;
@@ -583,44 +553,12 @@ static ir_ref jit_GLOBALS_TLS_call(zend_jit_ctx *jit, ir_ref *cache, const void 
 	}
 	return *cache;
 }
-#  define jit_EG_base(jit) (eg_tls_tcb_offset \
+# define jit_EG_base(jit) (eg_tls_tcb_offset \
 	? ir_ADD_OFFSET(jit_TP(jit), eg_tls_tcb_offset) \
 	: jit_GLOBALS_TLS_call((jit), &(jit)->eg_tls, zend_jit_get_eg_tls))
-#  define jit_CG_base(jit) (cg_tls_tcb_offset \
+# define jit_CG_base(jit) (cg_tls_tcb_offset \
 	? ir_ADD_OFFSET(jit_TP(jit), cg_tls_tcb_offset) \
 	: jit_GLOBALS_TLS_call((jit), &(jit)->cg_tls, zend_jit_get_cg_tls))
-# endif
-
-static ZEND_ATTRIBUTE_UNUSED ir_ref jit_TLS(zend_jit_ctx *jit)
-{
-	ZEND_ASSERT(jit->ctx.control);
-	if (jit->tls) {
-		/* Emit "TLS" once for basic block */
-		ir_insn *insn;
-		ir_ref ref = jit->ctx.control;
-
-		while (1) {
-			if (ref == jit->tls) {
-				return jit->tls;
-			}
-			insn = &jit->ctx.ir_base[ref];
-			if (insn->op >= IR_START || insn->op == IR_CALL) {
-				break;
-			}
-			ref = insn->op1;
-		}
-	}
-
-	if (tsrm_ls_cache_tcb_offset == 0 && tsrm_tls_index == -1) {
-		jit->tls = ir_CALL(IR_ADDR, ir_CONST_FC_FUNC(zend_jit_get_tsrm_ls_cache));
-	} else {
-		jit->tls = ir_TLS(
-				tsrm_ls_cache_tcb_offset ? tsrm_ls_cache_tcb_offset : tsrm_tls_index,
-				tsrm_ls_cache_tcb_offset ? IR_NULL : tsrm_tls_offset);
-	}
-
-	return jit->tls;
-}
 #endif
 
 static ir_ref jit_CONST_ADDR(zend_jit_ctx *jit, uintptr_t addr)
@@ -2917,12 +2855,9 @@ static void zend_jit_init_ctx(zend_jit_ctx *jit, uint32_t flags)
 	delayed_call_chain = false;
 	jit->b = -1;
 #ifdef ZTS
-	jit->tls = IR_UNUSED;
-# ifdef ZEND_EG_TLS
 	jit->tp = IR_UNUSED;
 	jit->eg_tls = IR_UNUSED;
 	jit->cg_tls = IR_UNUSED;
-# endif
 #endif
 	jit->fp = IR_UNUSED;
 	jit->poly_func_ref = IR_UNUSED;
@@ -3316,11 +3251,8 @@ static void zend_jit_setup_disasm(void)
 
 	REGISTER_DATA(CG(map_ptr_base));
 #else /* ZTS */
-	REGISTER_HELPER(zend_jit_get_tsrm_ls_cache);
-# ifdef ZEND_EG_TLS
 	REGISTER_HELPER(zend_jit_get_eg_tls);
 	REGISTER_HELPER(zend_jit_get_cg_tls);
-# endif
 #endif
 #endif
 }
@@ -3531,19 +3463,8 @@ static void zend_jit_setup(bool reattached)
 #endif
 
 #ifdef ZTS
-	zend_result result = zend_jit_resolve_tsrm_ls_cache_offsets(
-		&tsrm_ls_cache_tcb_offset,
-		&tsrm_tls_index,
-		&tsrm_tls_offset
-	);
-	if (result == FAILURE) {
-		zend_accel_error(ACCEL_LOG_INFO,
-				"Could not get _tsrm_ls_cache offsets, will fallback to runtime resolution");
-	}
-# ifdef ZEND_EG_TLS
 	eg_tls_tcb_offset = ZEND_JIT_TLS_TCB_OFFSET(executor_globals_tls);
 	cg_tls_tcb_offset = ZEND_JIT_TLS_TCB_OFFSET(compiler_globals_tls);
-# endif
 #endif
 
 #if !defined(ZEND_WIN32) && !defined(IR_TARGET_AARCH64)

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -205,17 +205,52 @@ static size_t tsrm_ls_cache_tcb_offset = 0;
 static size_t tsrm_tls_index = -1;
 static size_t tsrm_tls_offset = -1;
 
+# ifdef ZEND_EG_TLS
+/* When nonzero, &executor_globals_tls/&compiler_globals_tls equal the thread
+ * pointer plus this offset, so the JIT forms them without a runtime call. */
+static size_t eg_tls_tcb_offset = 0;
+static size_t cg_tls_tcb_offset = 0;
+/* gottpoff yields the offset from the %fs-based thread pointer that ir_TLS(0)
+ * loads. */
+#  if defined(__ELF__) && defined(__x86_64__) && defined(__GNUC__) && !defined(TSRM_TLS_MODEL_DEFAULT)
+#   define ZEND_JIT_TLS_TCB_OFFSET(sym) __extension__({ \
+		size_t _off; \
+		__asm__ ("movq " #sym "@gottpoff(%%rip),%0" : "=r" (_off)); \
+		_off; \
+	})
+#  elif defined(__ELF__) && defined(__aarch64__) && !defined(__APPLE__) && \
+		(defined(__GNUC__) || defined(__clang__))
+/* The TLS variable sits at a fixed offset from tpidr_el0 (the thread pointer
+ * the JIT reads with mrs); compute it once on the main thread. Subtracting the
+ * thread pointer is model-independent (works for both local- and initial-exec)
+ * and matches tsrm_get_ls_cache_tcb_offset()'s tprel reasoning. */
+#   define ZEND_JIT_TLS_TCB_OFFSET(sym) __extension__({ \
+		char *_tp; \
+		__asm__ ("mrs %0, tpidr_el0" : "=r" (_tp)); \
+		(size_t)((char*)&(sym) - _tp); \
+	})
+#  else
+#   define ZEND_JIT_TLS_TCB_OFFSET(sym) ((size_t)0)
+#  endif
+# endif
+
 # define EG_TLS_OFFSET(field) \
 	(executor_globals_offset + offsetof(zend_executor_globals, field))
 
 # define CG_TLS_OFFSET(field) \
 	(compiler_globals_offset + offsetof(zend_compiler_globals, field))
 
-# define jit_EG(_field) \
+# ifdef ZEND_EG_TLS
+#  define jit_EG(_field) \
+	ir_ADD_OFFSET(jit_EG_base(jit), offsetof(zend_executor_globals, _field))
+#  define jit_CG(_field) \
+	ir_ADD_OFFSET(jit_CG_base(jit), offsetof(zend_compiler_globals, _field))
+# else
+#  define jit_EG(_field) \
 	ir_ADD_OFFSET(jit_TLS(jit), EG_TLS_OFFSET(_field))
-
-# define jit_CG(_field) \
+#  define jit_CG(_field) \
 	ir_ADD_OFFSET(jit_TLS(jit), CG_TLS_OFFSET(_field))
+# endif
 
 #else
 
@@ -299,6 +334,11 @@ typedef struct _zend_jit_ctx {
 	int                  b;           /* current basic block number or -1 */
 #ifdef ZTS
 	ir_ref               tls;
+# ifdef ZEND_EG_TLS
+	ir_ref               tp;     /* cached thread pointer for &EG/&CG */
+	ir_ref               eg_tls; /* cached base of __thread executor_globals_tls */
+	ir_ref               cg_tls; /* cached base of __thread compiler_globals_tls */
+# endif
 #endif
 	ir_ref               fp;
 	ir_ref               poly_func_ref; /* restored from parent trace snapshot */
@@ -494,7 +534,64 @@ static void * ZEND_FASTCALL zend_jit_get_tsrm_ls_cache(void)
 	return _tsrm_ls_cache;
 }
 
-static ir_ref jit_TLS(zend_jit_ctx *jit)
+# ifdef ZEND_EG_TLS
+static void * ZEND_FASTCALL zend_jit_get_eg_tls(void)
+{
+	return &executor_globals_tls;
+}
+static void * ZEND_FASTCALL zend_jit_get_cg_tls(void)
+{
+	return &compiler_globals_tls;
+}
+
+/* Walk the control chain back from the current point: reuse the cached ref if we
+ * reach it (it still dominates here), but bail at a block start or a call, since
+ * the cached value lives in a caller-saved register that a call would clobber. */
+static ir_ref jit_tls_reuse(zend_jit_ctx *jit, ir_ref cached)
+{
+	ir_ref ref = jit->ctx.control;
+
+	while (cached) {
+		if (ref == cached) {
+			return cached;
+		}
+		ir_insn *insn = &jit->ctx.ir_base[ref];
+		if (insn->op >= IR_START || insn->op == IR_CALL) {
+			break;
+		}
+		ref = insn->op1;
+	}
+	return IR_UNUSED;
+}
+
+/* Thread pointer, cached per basic block, used to form &EG/&CG with an add. */
+static ir_ref jit_TP(zend_jit_ctx *jit)
+{
+	ZEND_ASSERT(jit->ctx.control);
+	if (!jit_tls_reuse(jit, jit->tp)) {
+		jit->tp = ir_TLS(0, IR_NULL);
+	}
+	return jit->tp;
+}
+
+/* Used where the TCB offset is unknown: resolve the base via a cached call. */
+static ir_ref jit_GLOBALS_TLS_call(zend_jit_ctx *jit, ir_ref *cache, const void *fn)
+{
+	ZEND_ASSERT(jit->ctx.control);
+	if (!jit_tls_reuse(jit, *cache)) {
+		*cache = ir_CALL(IR_ADDR, ir_CONST_FC_FUNC(fn));
+	}
+	return *cache;
+}
+#  define jit_EG_base(jit) (eg_tls_tcb_offset \
+	? ir_ADD_OFFSET(jit_TP(jit), eg_tls_tcb_offset) \
+	: jit_GLOBALS_TLS_call((jit), &(jit)->eg_tls, zend_jit_get_eg_tls))
+#  define jit_CG_base(jit) (cg_tls_tcb_offset \
+	? ir_ADD_OFFSET(jit_TP(jit), cg_tls_tcb_offset) \
+	: jit_GLOBALS_TLS_call((jit), &(jit)->cg_tls, zend_jit_get_cg_tls))
+# endif
+
+static ZEND_ATTRIBUTE_UNUSED ir_ref jit_TLS(zend_jit_ctx *jit)
 {
 	ZEND_ASSERT(jit->ctx.control);
 	if (jit->tls) {
@@ -2821,6 +2918,11 @@ static void zend_jit_init_ctx(zend_jit_ctx *jit, uint32_t flags)
 	jit->b = -1;
 #ifdef ZTS
 	jit->tls = IR_UNUSED;
+# ifdef ZEND_EG_TLS
+	jit->tp = IR_UNUSED;
+	jit->eg_tls = IR_UNUSED;
+	jit->cg_tls = IR_UNUSED;
+# endif
 #endif
 	jit->fp = IR_UNUSED;
 	jit->poly_func_ref = IR_UNUSED;
@@ -3215,6 +3317,10 @@ static void zend_jit_setup_disasm(void)
 	REGISTER_DATA(CG(map_ptr_base));
 #else /* ZTS */
 	REGISTER_HELPER(zend_jit_get_tsrm_ls_cache);
+# ifdef ZEND_EG_TLS
+	REGISTER_HELPER(zend_jit_get_eg_tls);
+	REGISTER_HELPER(zend_jit_get_cg_tls);
+# endif
 #endif
 #endif
 }
@@ -3434,6 +3540,10 @@ static void zend_jit_setup(bool reattached)
 		zend_accel_error(ACCEL_LOG_INFO,
 				"Could not get _tsrm_ls_cache offsets, will fallback to runtime resolution");
 	}
+# ifdef ZEND_EG_TLS
+	eg_tls_tcb_offset = ZEND_JIT_TLS_TCB_OFFSET(executor_globals_tls);
+	cg_tls_tcb_offset = ZEND_JIT_TLS_TCB_OFFSET(compiler_globals_tls);
+# endif
 #endif
 
 #if !defined(ZEND_WIN32) && !defined(IR_TARGET_AARCH64)

--- a/sapi/apache2handler/config.m4
+++ b/sapi/apache2handler/config.m4
@@ -85,6 +85,10 @@ if test "$PHP_APXS2" != "no"; then
   LIBPHP_CFLAGS="-shared"
   PHP_SUBST([LIBPHP_CFLAGS])
 
+  dnl httpd dlopen's libphp.so without linking against it, so _tsrm_ls_cache can't
+  dnl use initial-exec (overflows the static TLS surplus)
+  AS_VAR_APPEND([CFLAGS], [" -DTSRM_TLS_MODEL_USE_GLOBAL_DYNAMIC"])
+
   php_sapi_apache2handler_type=shared
   AS_CASE([$host_alias],
     [*aix*], [

--- a/win32/dllmain.c
+++ b/win32/dllmain.c
@@ -27,9 +27,21 @@
 	eq. initializing something before the DLL even is
 	available to be called. */
 
+#if defined(_WIN64) && defined(ZTS)
+ZEND_API void zend_win_tsrm_cache_init(bool alloc);
+#endif
+
 BOOL WINAPI DllMain(HINSTANCE inst, DWORD reason, LPVOID dummy)
 {
 	BOOL ret = TRUE;
+
+#if defined(_WIN64) && defined(ZTS)
+	if (reason == DLL_PROCESS_ATTACH) {
+		zend_win_tsrm_cache_init(true);
+	} else if (reason == DLL_THREAD_ATTACH) {
+		zend_win_tsrm_cache_init(false);
+	}
+#endif
 
 #ifdef HAVE_LIBXML
 	/* This imply that only LIBXML_STATIC_FOR_DLL is supported ATM.


### PR DESCRIPTION
So, I was chasing what caused [the much higher instruction count on aarch64 for clang vs gcc](https://github.com/shivammathur/homebrew-php/issues/5161#issuecomment-4608440602) and while figuring that out, got side tracked to figuring out that ZTS builds also have a ton of extra instructions compared to NTS builds. Turned out it was mostly just from constantly accessing executor and compiler globals when running phpstan. Each access became pseudo assembly:

```asm
mrs _tsrm_ls_cache
add cache offset low bits
add cache offset high bits
load relative base address
load accessed global
```

Here we're slashing one extra load and one add by moving EG and CG onto actual thread storage. Benchmarks are using phpstan on full laravel codebase (full symfony codebase showed the same, but I added the LE optimization after and don't want to rerun 6 hours of benchmarks) and phoronix-test-suite phpbench.

aarch64:
- ~80% fewer extra instructions
- Ampere A1 cloud machine, ~0.15% variance in wall clock between runs
<table><thead><tr><th>build</th><th>PHPStan cyc</th><th>instr</th><th>wall</th><th>phpbench</th><th>phpbench
  JIT</th></tr></thead><tbody><tr><td>gcc-nts</td><td>90.67B</td><td>108.22B</td><td>32.0s</td><td>715719</td><td>1164671</td></tr><tr><td>gcc-zts</td><td>94.44B</td><td>116.28B</td><td>33.2s</td><td>662475</td><td>1111162</td></tr><tr><td>gcc-zts-patch</td><td>91.61B</td><td>109.66B</td><td>32.3s</td><td>704490</td><td>1146721</td></tr><tr><td>clang-nts
  </td><td>95.20B</td><td>113.29B</td><td>33.4s</td><td>709077</td><td>1118672</td></tr><tr><td>clang-zts</td><td>97.92B
  </td><td>120.82B</td><td>34.4s</td><td>665074</td><td>1069905</td></tr><tr><td>clang-zts-patch</td><td>93.40B</td><td>
  114.72B</td><td>33.1s</td><td>696929</td><td>1101997</td></tr></tbody></table>

x86_64:
- ~35% fewer extra instructions
- no cycle count on x86_64 because lack of hardware counter support in WSL
- i7 12650h with locked cpu frequency, take the wall times with a grain of salt:
<table><thead><tr><th>build</th><th>PHPStan cyc</th><th>instr</th><th>wall</th><th>phpbench</th><th>phpbench JIT</th></tr></thead><tbody><tr><td>gcc-nts</td><td>n/a</td><td>11.01B</td><td>113.91s</td><td>1065687</td><td>1793058</td></tr><tr><td>gcc-zts</td><td>n/a</td><td>11.23B</td><td>115.47s</td><td>1033552</td><td>1767360</td></tr><tr><td>gcc-zts-patch</td><td>n/a</td><td>11.15B</td><td>116.34s</td><td>1005077</td><td>1713823</td></tr><tr><td>clang-nts</td><td>n/a</td><td>11.38B</td><td>112.92s</td><td>1125988</td><td>1795096</td></tr><tr><td>clang-zts</td><td>n/a</td><td>11.64B</td><td>114.67s</td><td>1087697</td><td>1757513</td></tr><tr><td>clang-zts-patch</td><td>n/a</td><td>11.53B</td><td>112.22s</td><td>1145744</td><td>1793294</td></tr></tbody></table>

Windows:

<table><tr><th>build</th><th>PHPStan cyc</th><th>instr</th><th>wall</th><th>phpbench</th><th>phpbench
  JIT</th></tr><tr><td>MSVC NTS</td><td>292.5 B</td><td>9.264 B</td><td>142.4
  s</td><td>1,031,726</td><td>2,356,862</td></tr><tr><td>MSVC ZTS</td><td>304.3 B</td><td>9.618 B</td><td>147.8
  s</td><td>993,438</td><td>2,088,220</td></tr><tr><td>MSVC ZTS patch</td><td>298.0 B</td><td>9.386 B</td><td>144.1
  s</td><td>1,017,994</td><td>2,172,147</td></tr><tr><td>clang NTS</td><td>245.0 B</td><td>7.661 B</td><td>119.4
  s</td><td>1,714,131</td><td>2,665,852</td></tr><tr><td>clang ZTS</td><td>281.4 B</td><td>8.804 B</td><td>137.5
  s</td><td>1,368,453</td><td>2,213,663</td></tr><tr><td>clang ZTS patch</td><td>258.1 B</td><td>8.067 B</td><td>127.7
  s</td><td>1,556,141</td><td>2,198,706</td></tr></table>

### LLM disclosure
claude
- ~adjusted the JIT~
- transformed the raw bash results into these (hopefully beautiful) html tables
- edit: it failed at the tables, or I failed copy-pasting