### PR TITLE
ext/curl: bump minimum libcurl version to 7.61.1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,9 @@ PHP                                                                        NEWS
 - Core:
   . Implemented partial function application RFC. (Arnaud)
 
+- Curl:
+  . Bumped required libcurl version to 7.61.1. (GrahamCampbell)
+
 - GMP:
   . Fixed GMP power and shift operators to reject GMP right operands outside
     the unsigned long range instead of silently truncating them. (Weilin Du)

--- a/UPGRADING
+++ b/UPGRADING
@@ -482,6 +482,9 @@ PHP 8.6 UPGRADE NOTES
 9. Other Changes to Extensions
 ========================================
 
+- Curl:
+  . The Curl extension now requires at least libcurl 7.61.1.
+
 - Hash:
   . The bundled version of xxHash was upgraded to 0.8.2.
 

--- a/ext/curl/config.m4
+++ b/ext/curl/config.m4
@@ -4,7 +4,7 @@ PHP_ARG_WITH([curl],
     [Include cURL support])])
 
 if test "$PHP_CURL" != "no"; then
-  PKG_CHECK_MODULES([CURL], [libcurl >= 7.61.0])
+  PKG_CHECK_MODULES([CURL], [libcurl >= 7.61.1])
   PKG_CHECK_VAR([CURL_FEATURES], [libcurl], [supported_features])
 
   PHP_EVAL_LIBLINE([$CURL_LIBS], [CURL_SHARED_LIBADD])

--- a/ext/curl/sync-constants.php
+++ b/ext/curl/sync-constants.php
@@ -12,7 +12,7 @@ const CURL_DOC_FILE = 'https://curl.se/libcurl/c/symbols-in-versions.html';
 
 const SOURCE_FILE = __DIR__ . '/curl_arginfo.h';
 
-const MIN_SUPPORTED_CURL_VERSION = '7.61.0';
+const MIN_SUPPORTED_CURL_VERSION = '7.61.1';
 
 const IGNORED_CURL_CONSTANTS = [
     'CURLOPT_PROGRESSDATA',


### PR DESCRIPTION
The minimum libcurl was raised to 7.61.0 in #13259 to line up with RHEL 8, the oldest enterprise distribution still in support. The thing is, RHEL 8 and its rebuilds (Rocky, Alma, EL 8) don't actually ship 7.61.0 — they ship 7.61.1, and have done since the original 8.0 GA in May 2019 (`curl-7.61.1-8.el8`). The plain 7.61.0 point release was only the latest stable for about two months in 2018 before 7.61.1 superseded it, and I can't find a supported distribution that carries it. So moving the floor from 7.61.0 to 7.61.1 doesn't drop anything real; it just makes the requirement match the baseline it was already meant to represent.

There's a small concrete upside too. 7.61.1 is where curl/curl@d6cf930 landed, which fixed libcurl reporting success with no response (errno 0) when it needed to rewind an upload to resend it but couldn't. Before that fix the failure was silent; from 7.61.1 it surfaces properly as `CURLE_SEND_FAIL_REWIND`. Requiring 7.61.1 makes that behaviour consistent across every libcurl PHP can be built against. Moreover, in combination with #22230, this would allow a future version of Guzzle to by-pass some janky workaround code on PHP 8.6+ (and eventually remove that code... in like a decade when Guzzle can make PHP 8.6 the minimum version floor).
