### PR TITLE
Deprecate A and H ZPP specs

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -925,6 +925,8 @@ static const char *zend_parse_arg_impl(zval *arg, va_list *va, const char **spec
 			break;
 
 		case 'A':
+			zend_error(E_DEPRECATED, "ZPP spec A is deprecated");
+			ZEND_FALLTHROUGH;
 		case 'a':
 			{
 				zval **p = va_arg(*va, zval **);
@@ -936,6 +938,8 @@ static const char *zend_parse_arg_impl(zval *arg, va_list *va, const char **spec
 			break;
 
 		case 'H':
+			zend_error(E_DEPRECATED, "ZPP spec H is deprecated");
+			ZEND_FALLTHROUGH;
 		case 'h':
 			{
 				HashTable **p = va_arg(*va, HashTable **);

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -996,9 +996,12 @@ PHP_METHOD(ArrayObject, __construct)
 		return; /* nothing to do */
 	}
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|AlC", &array, &ar_flags, &ce_get_iterator) == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(0, 3)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_ARRAY_OR_OBJECT(array)
+		Z_PARAM_LONG(ar_flags)
+		Z_PARAM_CLASS(ce_get_iterator)
+	ZEND_PARSE_PARAMETERS_END();
 
 	intern = Z_SPLARRAY_P(object);
 
@@ -1073,9 +1076,9 @@ PHP_METHOD(ArrayObject, exchangeArray)
 	zval *object = ZEND_THIS, *array;
 	spl_array_object *intern = Z_SPLARRAY_P(object);
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "A", &array) == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY_OR_OBJECT(array)
+	ZEND_PARSE_PARAMETERS_END();
 
 	if (intern->nApplyCount > 0) {
 		zend_throw_error(NULL, "Modification of ArrayObject during sorting is prohibited");
@@ -1654,9 +1657,11 @@ PHP_METHOD(ArrayIterator, __construct)
 		return; /* nothing to do */
 	}
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|Al", &array, &ar_flags) == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(0, 2)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_ARRAY_OR_OBJECT(array)
+		Z_PARAM_LONG(ar_flags)
+	ZEND_PARSE_PARAMETERS_END();
 
 	intern = Z_SPLARRAY_P(object);
 


### PR DESCRIPTION
As they allow using an object as an array which has special requirements due to Enum and readonly props