### PR TITLE
Fix stream_context_set_option() mutating the default context

### DIFF
--- a/ext/standard/tests/streams/stream_context_set_option_no_default_leak.phpt
+++ b/ext/standard/tests/streams/stream_context_set_option_no_default_leak.phpt
@@ -1,0 +1,29 @@
+--TEST--
+stream_context_set_option() on a context-less stream must not leak into the default context
+--FILE--
+<?php
+$a = fopen('php://memory', 'r+');
+stream_context_set_option($a, 'http', 'filename', 'test.txt');
+
+// The default context must stay untouched.
+var_dump(stream_context_get_options(stream_context_get_default()));
+
+// A later context-less stream must not inherit the option.
+$b = fopen('php://memory', 'r+');
+var_dump(stream_context_get_options($b));
+
+// The stream the option was set on keeps it for itself.
+var_dump(stream_context_get_options($a));
+?>
+--EXPECT--
+array(0) {
+}
+array(0) {
+}
+array(1) {
+  ["http"]=>
+  array(1) {
+    ["filename"]=>
+    string(8) "test.txt"
+  }
+}

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -2248,7 +2248,12 @@ PHPAPI php_stream *_php_stream_open_wrapper_ex(const char *path, const char *mod
 		stream->open_filename = __zend_orig_filename ? __zend_orig_filename : __zend_filename;
 		stream->open_lineno = __zend_orig_lineno ? __zend_orig_lineno : __zend_lineno;
 #endif
-		if (stream->ctx == NULL && context != NULL && !persistent) {
+		/* Attach an explicitly provided context to the stream, but never the
+		 * default context: sharing it by reference would let a later
+		 * stream_context_set_option() on the stream mutate the global default
+		 * context, leaking options into every other stream. Stream errors fall
+		 * back to the default context on their own when the stream has none. */
+		if (stream->ctx == NULL && context != NULL && context != FG(default_context) && !persistent) {
 			php_stream_context_set(stream, context);
 		}
 	}


### PR DESCRIPTION
Since #20524, `_php_stream_open_wrapper_ex()` attaches the implicitly substituted default context to context-less streams. A later `stream_context_set_option()` on such a stream then mutates the global default context, leaking options into every other context-less stream (regression from 8.5):

```php
$a = fopen('php://memory', 'r+');
stream_context_set_option($a, 'http', 'filename', 'test.txt');
var_dump(stream_context_get_options(fopen('php://memory', 'r+')));
// 8.5: [], 8.6: ['http' => ['filename' => 'test.txt']]
```

Fixed by attaching only explicitly provided contexts. Stream errors are unaffected: they already fall back to the default context when the stream has none.
