### PR TITLE
ext/intl: Fix ResourceBundle fallback-disabled error message

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -61,6 +61,8 @@ PHP                                                                        NEWS
   . Upgrade xxHash to 0.8.2. (timwolla)
 
 - Intl:
+  . Fixed malformed ResourceBundle::get() error message when fallback is
+    disabled. (Weilin Du)
   . Added IntlNumberRangeFormatter class to format an interval of two numbers
     with a given skeleton, locale, collapse type and identity fallback.
     (BogdanUngureanu)

--- a/UPGRADING
+++ b/UPGRADING
@@ -47,6 +47,9 @@ PHP 8.6 UPGRADE NOTES
   . UConverter::transcode() now rejects from_subst and to_subst option values
     longer than 127 bytes instead of silently truncating the length before
     passing it to ICU.
+  . ResourceBundle::get() and resourcebundle_get() now report fallback-disabled
+    resource lookups with "without fallback to <locale>" instead of the
+    malformed "without fallback from to <locale>".
 
 - PCNTL:
   . pcntl_alarm() now raises a ValueError if the seconds argument is

--- a/ext/intl/resourcebundle/resourcebundle_class.cpp
+++ b/ext/intl/resourcebundle/resourcebundle_class.cpp
@@ -220,12 +220,12 @@ static zval *resource_bundle_array_fetch(
 	}
 
 	if (!fallback && (INTL_DATA_ERROR_CODE(rb) == U_USING_FALLBACK_WARNING || INTL_DATA_ERROR_CODE(rb) == U_USING_DEFAULT_WARNING)) {
-		UErrorCode icuerror;
+		UErrorCode icuerror = U_ZERO_ERROR;
 		const char * locale = ures_getLocaleByType( rb->me, ULOC_ACTUAL_LOCALE, &icuerror );
 		if (is_numeric) {
-			spprintf(&pbuf, 0, "Cannot load element %d without fallback from to %s", index, locale);
+			spprintf(&pbuf, 0, "Cannot load element %d without fallback to %s", index, locale);
 		} else {
-			spprintf(&pbuf, 0, "Cannot load element '%s' without fallback from to %s", key, locale);
+			spprintf(&pbuf, 0, "Cannot load element '%s' without fallback to %s", key, locale);
 		}
 		intl_errors_set_custom_msg( INTL_DATA_ERROR_P(rb), pbuf);
 		efree(pbuf);

--- a/ext/intl/tests/resourcebundle_get_without_fallback.phpt
+++ b/ext/intl/tests/resourcebundle_get_without_fallback.phpt
@@ -4,23 +4,45 @@ ResourceBundle::get() rejects fallback results when fallback is disabled with co
 intl
 --FILE--
 <?php
-function debug($res) {
-    if (is_null($res)) {
-        $ret = "NULL\n";
-    } else {
-        $ret = print_r($res, true) . "\n";
-    }
-    return $ret . sprintf("%5d: %s\n", intl_get_error_code(), intl_get_error_message());
+require_once "resourcebundle.inc";
+
+$fixture = __DIR__ . '/resourcebundle_get_without_fallback_tmp';
+if (!is_dir($fixture)) {
+    mkdir($fixture);
 }
+copy(BUNDLE . '/root.res', $fixture . '/root.res');
 
-$bundle = new ResourceBundle('de_DE', 'ICUDATA');
-echo debug($bundle->get('Version', false));
+$resIndex = file_get_contents(BUNDLE . '/res_index.res');
+$resIndex = str_replace("\0es\0root", "\0en\0root", $resIndex, $replacementCount);
+if ($replacementCount !== 1) {
+    die("Failed to prepare resource bundle index\n");
+}
+file_put_contents($fixture . '/res_index.res', $resIndex);
 
-$bundle = resourcebundle_create('de_DE', 'ICUDATA');
-echo debug(resourcebundle_get($bundle, 'Version', false));
+// Keep the binary layout intact while making this key fall back to root.res.
+$enBundle = file_get_contents(BUNDLE . '/es.res');
+$enBundle = str_replace('teststring', 'teststrinh', $enBundle, $replacementCount);
+if ($replacementCount !== 1) {
+    die("Failed to prepare resource bundle fixture\n");
+}
+file_put_contents($fixture . '/en.res', $enBundle);
+
+$bundle = new ResourceBundle('en', $fixture);
+echo debug($bundle->get('teststring', false));
+
+$bundle = resourcebundle_create('en', $fixture);
+echo debug(resourcebundle_get($bundle, 'teststring', false));
 ?>
 --EXPECTF--
 NULL
- %i: ResourceBundle::get(): Cannot load element 'Version' without fallback to %s: U_USING_%s_WARNING
+ %i: ResourceBundle::get(): Cannot load element 'teststring' without fallback to %s: U_USING_%s_WARNING
 NULL
- %i: resourcebundle_get(): Cannot load element 'Version' without fallback to %s: U_USING_%s_WARNING
+ %i: resourcebundle_get(): Cannot load element 'teststring' without fallback to %s: U_USING_%s_WARNING
+--CLEAN--
+<?php
+$fixture = __DIR__ . '/resourcebundle_get_without_fallback_tmp';
+@unlink($fixture . '/en.res');
+@unlink($fixture . '/root.res');
+@unlink($fixture . '/res_index.res');
+@rmdir($fixture);
+?>

--- a/ext/intl/tests/resourcebundle_get_without_fallback.phpt
+++ b/ext/intl/tests/resourcebundle_get_without_fallback.phpt
@@ -1,0 +1,26 @@
+--TEST--
+ResourceBundle::get() rejects fallback results when fallback is disabled with correct error message
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+function debug($res) {
+    if (is_null($res)) {
+        $ret = "NULL\n";
+    } else {
+        $ret = print_r($res, true) . "\n";
+    }
+    return $ret . sprintf("%5d: %s\n", intl_get_error_code(), intl_get_error_message());
+}
+
+$bundle = new ResourceBundle('de_DE', 'ICUDATA');
+echo debug($bundle->get('Version', false));
+
+$bundle = resourcebundle_create('de_DE', 'ICUDATA');
+echo debug(resourcebundle_get($bundle, 'Version', false));
+?>
+--EXPECTF--
+NULL
+ %i: ResourceBundle::get(): Cannot load element 'Version' without fallback to %s: U_USING_%s_WARNING
+NULL
+ %i: resourcebundle_get(): Cannot load element 'Version' without fallback to %s: U_USING_%s_WARNING


### PR DESCRIPTION
When ResourceBundle::get() rejects fallback results when fallback is disabled
Original error message:
```
Cannot load element %d without fallback from to %s
```
It should be
```
Cannot load element %d without fallback to %s
```
I also change the declaration line of `icuerror` to make it initialized. Not sure if this worth NEWS and UPGRADING entries but I am targeting master as this is actually a typo fix.
