### PR TITLE
Add support for `__exists()`, a magic method for distinguishing "missing" from "set to null"

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -21,6 +21,8 @@ PHP                                                                        NEWS
   . Deprecate specifying a nullable return type for __debugInfo(). (timwolla)
   . Fixed bug GH-22142 (Assertion failure in zendi_try_get_long() on IS_UNDEF).
     (David Carlier)
+  . Fixed GH-12695 (Wrong magic methods sequence with ?? operator).
+    (nicolas-grekas)
 
 - BCMath:
   . Added NUL-byte validation to BCMath functions. (jorgsowa)

--- a/UPGRADING
+++ b/UPGRADING
@@ -19,6 +19,11 @@ PHP 8.6 UPGRADE NOTES
 1. Backward Incompatible Changes
 ========================================
 
+- Core:
+  . ??/empty() on a magic property no longer call __get() when __isset()
+    has materialised the property by writing into the property table.
+    The freshly-written value is returned directly. isset() is unaffected.
+
 - DOM:
   . Properties previously documented as @readonly (e.g. DOMNode::$nodeType,
     DOMDocument::$xmlEncoding, DOMEntity::$actualEncoding, ::$encoding,

--- a/Zend/tests/magic_methods/exists/basic_coalesce.phpt
+++ b/Zend/tests/magic_methods/exists/basic_coalesce.phpt
@@ -1,0 +1,34 @@
+--TEST--
+__exists: `??` calls __exists then __get only if __exists returned true
+--FILE--
+<?php
+
+class C {
+    public function __exists(string $n): bool {
+        echo "  __exists($n)\n";
+        return $n === 'present';
+    }
+    public function __get(string $n): mixed {
+        echo "  __get($n)\n";
+        return "value-of-$n";
+    }
+}
+
+echo "1) `??` when __exists returns true: __exists then __get:\n";
+$c = new C;
+var_dump($c->present ?? 'fallback');
+
+echo "\n2) `??` when __exists returns false: only __exists, fallback used:\n";
+$c = new C;
+var_dump($c->absent ?? 'fallback');
+
+?>
+--EXPECT--
+1) `??` when __exists returns true: __exists then __get:
+  __exists(present)
+  __get(present)
+string(16) "value-of-present"
+
+2) `??` when __exists returns false: only __exists, fallback used:
+  __exists(absent)
+string(8) "fallback"

--- a/Zend/tests/magic_methods/exists/creates_property_in_exists.phpt
+++ b/Zend/tests/magic_methods/exists/creates_property_in_exists.phpt
@@ -1,0 +1,59 @@
+--TEST--
+__exists: when __exists creates the property, __get is not called (fixes GH-12695)
+--FILE--
+<?php
+
+#[AllowDynamicProperties]
+class C {
+    public function __exists(string $n): bool {
+        echo "  __exists($n)\n";
+        $this->$n = 123;
+        return true;
+    }
+    public function __get(string $n): mixed {
+        throw new Exception("__get must not be called when __exists materialized the property");
+    }
+}
+
+echo "1) `??` when __exists creates the property: __get is skipped:\n";
+$c = new C;
+var_dump($c->foo ?? 'fallback');
+
+echo "\n2) Subsequent `??` reads the now-real property without any magic call:\n";
+var_dump($c->foo ?? 'fallback');
+
+echo "\n3) isset() when __exists creates the property: __get is skipped (real prop, value 123 is non-null):\n";
+$c = new C;
+var_dump(isset($c->foo));
+
+echo "\n4) When __exists materialises the property to null, `??` falls back:\n";
+#[AllowDynamicProperties]
+class D {
+    public function __exists(string $n): bool {
+        echo "  __exists($n)\n";
+        $this->$n = null;
+        return true;
+    }
+    public function __get(string $n): mixed {
+        throw new Exception("__get must not be called when __exists materialised the property");
+    }
+}
+$d = new D;
+var_dump($d->foo ?? 'fallback');
+
+?>
+--EXPECT--
+1) `??` when __exists creates the property: __get is skipped:
+  __exists(foo)
+int(123)
+
+2) Subsequent `??` reads the now-real property without any magic call:
+int(123)
+
+3) isset() when __exists creates the property: __get is skipped (real prop, value 123 is non-null):
+  __exists(foo)
+bool(true)
+
+4) When __exists materialises the property to null, `??` falls back:
+  __exists(foo)
+string(8) "fallback"

--- a/Zend/tests/magic_methods/exists/direct_call_null_vs_missing.phpt
+++ b/Zend/tests/magic_methods/exists/direct_call_null_vs_missing.phpt
@@ -1,0 +1,43 @@
+--TEST--
+__exists: directly callable as a method to disambiguate "set to null" from "missing"
+--FILE--
+<?php
+
+/* The __exists method is part of the public API. It can be called directly
+ * to ask "does this property logically exist?", independent of whether its
+ * value is null. This is the gap that __isset cannot fill (since isset()
+ * normalizes null to "not set"). */
+
+class C {
+    private array $store = ['nullProp' => null, 'intProp' => 5];
+    public function __exists(string $n): bool {
+        return array_key_exists($n, $this->store);
+    }
+    public function __get(string $n): mixed {
+        return $this->store[$n] ?? null;
+    }
+}
+
+$c = new C;
+
+echo "1) Direct call: `nullProp` exists (set to null):\n";
+var_dump($c->__exists('nullProp'));
+
+echo "\n2) Direct call: `missing` does not exist:\n";
+var_dump($c->__exists('missing'));
+
+echo "\n3) But isset() collapses both to `false` (legacy isset semantics):\n";
+var_dump(isset($c->nullProp));
+var_dump(isset($c->missing));
+
+?>
+--EXPECT--
+1) Direct call: `nullProp` exists (set to null):
+bool(true)
+
+2) Direct call: `missing` does not exist:
+bool(false)
+
+3) But isset() collapses both to `false` (legacy isset semantics):
+bool(false)
+bool(false)

--- a/Zend/tests/magic_methods/exists/empty_uses_exists.phpt
+++ b/Zend/tests/magic_methods/exists/empty_uses_exists.phpt
@@ -1,0 +1,58 @@
+--TEST--
+__exists: empty() short-circuits on __exists=false; otherwise calls __get for truthiness
+--FILE--
+<?php
+
+class C {
+    public ?string $stored = null;
+    public bool $hasIt;
+    public function __construct(bool $hasIt, ?string $stored = null) {
+        $this->hasIt = $hasIt;
+        $this->stored = $stored;
+    }
+    public function __exists(string $n): bool {
+        echo "  __exists($n)\n";
+        return $this->hasIt;
+    }
+    public function __get(string $n): mixed {
+        echo "  __get($n)\n";
+        return $this->stored;
+    }
+}
+
+echo "1) empty() when __exists=false: only __exists, returns true:\n";
+$c = new C(false);
+var_dump(empty($c->any));
+
+echo "\n2) empty() when __exists=true and __get returns null: returns true:\n";
+$c = new C(true, null);
+var_dump(empty($c->any));
+
+echo "\n3) empty() when __exists=true and __get returns '': returns true:\n";
+$c = new C(true, '');
+var_dump(empty($c->any));
+
+echo "\n4) empty() when __exists=true and __get returns 'x': returns false:\n";
+$c = new C(true, 'x');
+var_dump(empty($c->any));
+
+?>
+--EXPECT--
+1) empty() when __exists=false: only __exists, returns true:
+  __exists(any)
+bool(true)
+
+2) empty() when __exists=true and __get returns null: returns true:
+  __exists(any)
+  __get(any)
+bool(true)
+
+3) empty() when __exists=true and __get returns '': returns true:
+  __exists(any)
+  __get(any)
+bool(true)
+
+4) empty() when __exists=true and __get returns 'x': returns false:
+  __exists(any)
+  __get(any)
+bool(false)

--- a/Zend/tests/magic_methods/exists/enum_disallowed.phpt
+++ b/Zend/tests/magic_methods/exists/enum_disallowed.phpt
@@ -1,0 +1,12 @@
+--TEST--
+__exists: disallowed on enums (mirrors __isset)
+--FILE--
+<?php
+
+enum E {
+    public function __exists(string $n): bool { return true; }
+}
+
+?>
+--EXPECTF--
+Fatal error: Enum E cannot include magic method __exists in %s on line %d

--- a/Zend/tests/magic_methods/exists/exists_supersedes_isset.phpt
+++ b/Zend/tests/magic_methods/exists/exists_supersedes_isset.phpt
@@ -1,0 +1,44 @@
+--TEST--
+__exists: when both __exists and __isset are defined, __exists wins; __isset is never called
+--FILE--
+<?php
+
+class C {
+    public function __exists(string $n): bool {
+        echo "  __exists($n)\n";
+        return true;
+    }
+    public function __isset(string $n): bool {
+        throw new Exception("__isset must not be called when __exists is defined");
+    }
+    public function __get(string $n): mixed {
+        echo "  __get($n)\n";
+        return 'g';
+    }
+}
+
+echo "1) `??`:\n";
+$c = new C; var_dump($c->x ?? 'fb');
+
+echo "\n2) isset():\n";
+$c = new C; var_dump(isset($c->x));
+
+echo "\n3) empty():\n";
+$c = new C; var_dump(empty($c->x));
+
+?>
+--EXPECT--
+1) `??`:
+  __exists(x)
+  __get(x)
+string(1) "g"
+
+2) isset():
+  __exists(x)
+  __get(x)
+bool(true)
+
+3) empty():
+  __exists(x)
+  __get(x)
+bool(false)

--- a/Zend/tests/magic_methods/exists/inheritance.phpt
+++ b/Zend/tests/magic_methods/exists/inheritance.phpt
@@ -1,0 +1,44 @@
+--TEST--
+__exists: inheritance, child __exists overrides parent __isset
+--FILE--
+<?php
+
+class Parent_ {
+    public function __isset(string $n): bool {
+        throw new Exception("Parent::__isset must not be called when child defines __exists");
+    }
+    public function __get(string $n): mixed {
+        echo "  Parent::__get($n)\n";
+        return "g($n)";
+    }
+}
+
+class Child extends Parent_ {
+    public function __exists(string $n): bool {
+        echo "  Child::__exists($n)\n";
+        return $n === 'present';
+    }
+}
+
+echo "1) `??` on child: uses Child::__exists, ignores Parent::__isset:\n";
+$c = new Child;
+var_dump($c->present ?? 'fb');
+var_dump($c->absent ?? 'fb');
+
+echo "\n2) isset() on child: uses Child::__exists + Parent::__get:\n";
+$c = new Child;
+var_dump(isset($c->present));
+
+?>
+--EXPECT--
+1) `??` on child: uses Child::__exists, ignores Parent::__isset:
+  Child::__exists(present)
+  Parent::__get(present)
+string(10) "g(present)"
+  Child::__exists(absent)
+string(2) "fb"
+
+2) isset() on child: uses Child::__exists + Parent::__get:
+  Child::__exists(present)
+  Parent::__get(present)
+bool(true)

--- a/Zend/tests/magic_methods/exists/interface_declaration.phpt
+++ b/Zend/tests/magic_methods/exists/interface_declaration.phpt
@@ -1,0 +1,35 @@
+--TEST--
+__exists: allowed in interfaces, no special engine treatment
+--FILE--
+<?php
+
+/* __exists may be declared on an interface, exactly like __isset and __get.
+ * The engine attaches no special meaning to the interface declaration; it
+ * only consults the implementing class's method. */
+
+interface I {
+    public function __exists(string $n): bool;
+}
+
+class C implements I {
+    public function __exists(string $n): bool {
+        echo "  C::__exists($n)\n";
+        return $n === 'present';
+    }
+    public function __get(string $n): mixed {
+        return "value-of-$n";
+    }
+}
+
+$c = new C;
+var_dump($c->present ?? 'fb');
+var_dump($c->absent  ?? 'fb');
+var_dump($c instanceof I);
+
+?>
+--EXPECT--
+  C::__exists(present)
+string(16) "value-of-present"
+  C::__exists(absent)
+string(2) "fb"
+bool(true)

--- a/Zend/tests/magic_methods/exists/interface_enforcement.phpt
+++ b/Zend/tests/magic_methods/exists/interface_enforcement.phpt
@@ -1,0 +1,20 @@
+--TEST--
+__exists: interface contract is enforced like any other method (missing implementation fatals)
+--FILE--
+<?php
+
+/* When an interface declares __exists, the implementing class must
+ * provide a compatible implementation, exactly like any other method.
+ * Omitting it produces the standard "must implement" compile-time
+ * fatal: the engine attaches no special-case to __exists here. */
+
+interface I {
+    public function __exists(string $n): bool;
+}
+
+class C implements I {
+}
+
+?>
+--EXPECTF--
+Fatal error: Class C contains 1 abstract method and must therefore be declared abstract or implement the remaining method (I::__exists) in %s on line %d

--- a/Zend/tests/magic_methods/exists/isset_equivalence.phpt
+++ b/Zend/tests/magic_methods/exists/isset_equivalence.phpt
@@ -1,0 +1,66 @@
+--TEST--
+__exists: isset() distinguishes "missing" from "set to null" (and is `??`-equivalent)
+--FILE--
+<?php
+
+/* With __exists, isset() must call __get when __exists returns true,
+ * so it can apply the standard isset() semantics ("set and not null").
+ * This restores the documented equivalence:
+ *   isset($x) ? $x : y    is equivalent to    $x ?? y
+ */
+
+class C {
+    private array $store;
+    public function __construct(array $store) { $this->store = $store; }
+    public function __exists(string $n): bool {
+        echo "  __exists($n)\n";
+        return array_key_exists($n, $this->store);
+    }
+    public function __get(string $n): mixed {
+        echo "  __get($n)\n";
+        return $this->store[$n] ?? null;
+    }
+}
+
+echo "1) isset() when __exists=false: only __exists, returns false:\n";
+$c = new C([]);
+var_dump(isset($c->any));
+
+echo "\n2) isset() when __exists=true and __get returns non-null: returns true:\n";
+$c = new C(['x' => 5]);
+var_dump(isset($c->x));
+
+echo "\n3) isset() when __exists=true and __get returns null: returns false (matches normal isset):\n";
+$c = new C(['x' => null]);
+var_dump(isset($c->x));
+
+echo "\n4) `??` agrees with isset() in all three cases:\n";
+$c = new C([]);                var_dump($c->any ?? 'fallback');
+$c = new C(['x' => 5]);        var_dump($c->x ?? 'fallback');
+$c = new C(['x' => null]);     var_dump($c->x ?? 'fallback');
+
+?>
+--EXPECT--
+1) isset() when __exists=false: only __exists, returns false:
+  __exists(any)
+bool(false)
+
+2) isset() when __exists=true and __get returns non-null: returns true:
+  __exists(x)
+  __get(x)
+bool(true)
+
+3) isset() when __exists=true and __get returns null: returns false (matches normal isset):
+  __exists(x)
+  __get(x)
+bool(false)
+
+4) `??` agrees with isset() in all three cases:
+  __exists(any)
+string(8) "fallback"
+  __exists(x)
+  __get(x)
+int(5)
+  __exists(x)
+  __get(x)
+string(8) "fallback"

--- a/Zend/tests/magic_methods/exists/no_get_defined.phpt
+++ b/Zend/tests/magic_methods/exists/no_get_defined.phpt
@@ -1,0 +1,38 @@
+--TEST--
+__exists: without __get, a true return falls through to default property access (warning + null)
+--FILE--
+<?php
+
+class C {
+    public function __exists(string $n): bool {
+        echo "  __exists($n)\n";
+        return true;
+    }
+}
+
+echo "1) `??` with __exists=true and no __get: returns null, so the fallback is used:\n";
+$c = new C;
+var_dump($c->x ?? 'fb');
+
+echo "\n2) __exists=true, no __get, but __exists materialized the property:\n";
+class E {
+    public int $x = 0;
+    public function __exists(string $n): bool {
+        echo "  __exists($n)\n";
+        $this->$n = 7;
+        return true;
+    }
+}
+$e = new E;
+unset($e->x);
+var_dump($e->x ?? 'fb');
+
+?>
+--EXPECTF--
+1) `??` with __exists=true and no __get: returns null, so the fallback is used:
+  __exists(x)
+string(2) "fb"
+
+2) __exists=true, no __get, but __exists materialized the property:
+  __exists(x)
+int(7)

--- a/Zend/tests/magic_methods/exists/not_called_on_plain_read.phpt
+++ b/Zend/tests/magic_methods/exists/not_called_on_plain_read.phpt
@@ -1,0 +1,48 @@
+--TEST--
+__exists: not consulted on a plain read ($obj->prop); only BP_VAR_IS contexts trigger it
+--FILE--
+<?php
+
+/* __exists is scoped to BP_VAR_IS reads (??, isset(), empty(), nullsafe + ??).
+ * A plain read $obj->prop must go straight to __get without consulting
+ * __exists, otherwise classes would pay an extra magic call on every read. */
+
+class C {
+    public function __exists(string $n): bool {
+        echo "  __exists($n)\n";
+        return true;
+    }
+    public function __get(string $n): mixed {
+        echo "  __get($n)\n";
+        return "value-of-$n";
+    }
+}
+
+echo "1) Plain read \$c->prop calls __get only:\n";
+$c = new C;
+$x = $c->foo;
+var_dump($x);
+
+echo "\n2) Plain read in assignment + var_dump: __get only:\n";
+$c = new C;
+$y = $c->bar;
+var_dump($y);
+
+echo "\n3) Same property, BP_VAR_IS context: __exists is consulted (contrast):\n";
+$c = new C;
+var_dump($c->baz ?? 'fb');
+
+?>
+--EXPECT--
+1) Plain read $c->prop calls __get only:
+  __get(foo)
+string(12) "value-of-foo"
+
+2) Plain read in assignment + var_dump: __get only:
+  __get(bar)
+string(12) "value-of-bar"
+
+3) Same property, BP_VAR_IS context: __exists is consulted (contrast):
+  __exists(baz)
+  __get(baz)
+string(12) "value-of-baz"

--- a/Zend/tests/magic_methods/exists/nullsafe_coalesce.phpt
+++ b/Zend/tests/magic_methods/exists/nullsafe_coalesce.phpt
@@ -1,0 +1,41 @@
+--TEST--
+__exists: nullsafe + ?? follows the same sequence as ??
+--FILE--
+<?php
+
+class C {
+    public function __exists(string $n): bool {
+        echo "  __exists($n)\n";
+        return $n === 'present';
+    }
+    public function __get(string $n): mixed {
+        echo "  __get($n)\n";
+        return "value-of-$n";
+    }
+}
+
+echo "1) Nullsafe + ?? when __exists=true: __exists then __get:\n";
+$c = new C;
+var_dump($c?->present ?? 'fallback');
+
+echo "\n2) Nullsafe + ?? when __exists=false: only __exists, fallback used:\n";
+$c = new C;
+var_dump($c?->absent ?? 'fallback');
+
+echo "\n3) Nullsafe + ?? on a null receiver short-circuits before __exists:\n";
+$c = null;
+var_dump($c?->present ?? 'fallback');
+
+?>
+--EXPECT--
+1) Nullsafe + ?? when __exists=true: __exists then __get:
+  __exists(present)
+  __get(present)
+string(16) "value-of-present"
+
+2) Nullsafe + ?? when __exists=false: only __exists, fallback used:
+  __exists(absent)
+string(8) "fallback"
+
+3) Nullsafe + ?? on a null receiver short-circuits before __exists:
+string(8) "fallback"

--- a/Zend/tests/magic_methods/exists/object_released_in_exists.phpt
+++ b/Zend/tests/magic_methods/exists/object_released_in_exists.phpt
@@ -1,0 +1,54 @@
+--TEST--
+__exists: object freed by __exists() during materialization (??, isset, empty)
+--FILE--
+<?php
+
+/* When __exists() materialises the property and the object's last
+ * external reference is dropped during the call, the property table
+ * is freed by the OBJ_RELEASE() after the re-check.
+ *
+ * - For `??` (read_property): the materialised value is copied into the
+ *   caller's `rv` buffer before OBJ_RELEASE, otherwise the returned
+ *   pointer dangles.
+ * - For isset()/empty() (has_property): the property's value is read
+ *   into a local bool before OBJ_RELEASE, so there is no dangling
+ *   pointer to return; this test pins that down. */
+
+class C {
+    public $prop;
+    public function __exists(string $name): bool {
+        global $obj;
+        $obj = null;
+        $this->prop = 'materialised';
+        return true;
+    }
+    public function __get(string $n): mixed {
+        throw new Exception("__get must not be called when __exists materialised the property");
+    }
+}
+
+echo "1) `??`:\n";
+$obj = new C();
+unset($obj->prop);
+var_dump($obj->prop ?? 'fb');
+
+echo "\n2) isset():\n";
+$obj = new C();
+unset($obj->prop);
+var_dump(isset($obj->prop));
+
+echo "\n3) empty():\n";
+$obj = new C();
+unset($obj->prop);
+var_dump(empty($obj->prop));
+
+?>
+--EXPECT--
+1) `??`:
+string(12) "materialised"
+
+2) isset():
+bool(true)
+
+3) empty():
+bool(false)

--- a/Zend/tests/magic_methods/exists/property_exists_unaffected.phpt
+++ b/Zend/tests/magic_methods/exists/property_exists_unaffected.phpt
@@ -1,0 +1,42 @@
+--TEST--
+__exists: property_exists() is not affected by __exists (mirrors __isset behaviour)
+--FILE--
+<?php
+
+/* property_exists() is a reflection-style operator over the declared class
+ * shape plus instance dynamic properties. It must not consult __exists,
+ * exactly as it does not consult __isset today. Users who want
+ * "magic-aware existence" call $obj->__exists($name) directly. */
+
+class C {
+    public int $declared = 1;
+    public function __exists(string $n): bool {
+        echo "  __exists($n) MUST NOT be called\n";
+        return true;
+    }
+    public function __get(string $n): mixed { return null; }
+}
+
+$c = new C;
+
+echo "1) property_exists() on a declared property: true (no magic call):\n";
+var_dump(property_exists($c, 'declared'));
+
+echo "\n2) property_exists() on a non-existent property: false (no magic call):\n";
+var_dump(property_exists($c, 'missing'));
+
+echo "\n3) property_exists(class-string, ...) accepts class shape only:\n";
+var_dump(property_exists('C', 'declared'));
+var_dump(property_exists('C', 'missing'));
+
+?>
+--EXPECT--
+1) property_exists() on a declared property: true (no magic call):
+bool(true)
+
+2) property_exists() on a non-existent property: false (no magic call):
+bool(false)
+
+3) property_exists(class-string, ...) accepts class shape only:
+bool(true)
+bool(false)

--- a/Zend/tests/magic_methods/exists/recursion_guard.phpt
+++ b/Zend/tests/magic_methods/exists/recursion_guard.phpt
@@ -1,0 +1,27 @@
+--TEST--
+__exists: recursion guard prevents infinite recursion when __exists checks the same property
+--FILE--
+<?php
+
+class C {
+    public function __exists(string $n): bool {
+        echo "  __exists($n) entry\n";
+        // Recursive isset on the same property must short-circuit to avoid loop.
+        $r = isset($this->$n);
+        echo "  __exists($n) inner isset = ", ($r ? 'true' : 'false'), "\n";
+        return false;
+    }
+    public function __get(string $n): mixed {
+        echo "  __get($n): should not be called when __exists returns false\n";
+        return null;
+    }
+}
+
+$c = new C;
+var_dump($c->any ?? 'fb');
+
+?>
+--EXPECT--
+  __exists(any) entry
+  __exists(any) inner isset = false
+string(2) "fb"

--- a/Zend/tests/magic_methods/exists/recursion_guard_cross_property.phpt
+++ b/Zend/tests/magic_methods/exists/recursion_guard_cross_property.phpt
@@ -1,0 +1,28 @@
+--TEST--
+__exists: recursion guard is per-property; checking a different property is allowed
+--FILE--
+<?php
+
+/* The recursion guard prevents re-entering __exists() for the same
+ * property while a check for it is in flight. It must NOT short-circuit
+ * checks for a different property: __exists('a') triggering a check on
+ * $this->b should call __exists('b') for real. */
+
+class C {
+    public function __exists(string $n): bool {
+        echo "  __exists($n)\n";
+        if ($n === 'a') {
+            isset($this->b);
+        }
+        return false;
+    }
+}
+
+$c = new C;
+var_dump(isset($c->a));
+
+?>
+--EXPECT--
+  __exists(a)
+  __exists(b)
+bool(false)

--- a/Zend/tests/magic_methods/exists/signature_param_type.phpt
+++ b/Zend/tests/magic_methods/exists/signature_param_type.phpt
@@ -1,0 +1,11 @@
+--TEST--
+__exists: signature validation must take a single string param and return bool
+--FILE--
+<?php
+
+class WrongArgType {
+    public function __exists(int $n): bool { return true; }
+}
+?>
+--EXPECTF--
+Fatal error: WrongArgType::__exists(): Parameter #1 ($n) must be of type string when declared in %s on line %d

--- a/Zend/tests/magic_methods/exists/signature_param_variance.phpt
+++ b/Zend/tests/magic_methods/exists/signature_param_variance.phpt
@@ -1,0 +1,50 @@
+--TEST--
+__exists: parameter follows variance rules (untyped allowed; widened allowed in subclass)
+--FILE--
+<?php
+
+class Untyped {
+    public function __exists($n): bool {
+        echo "  __exists("; var_export($n); echo ")\n";
+        return $n === 'present';
+    }
+    public function __get($n): mixed {
+        return "value-of-$n";
+    }
+}
+
+echo "1) Untyped parameter is allowed (mirrors __isset BC behaviour):\n";
+$o = new Untyped;
+var_dump($o->present ?? 'fb');
+var_dump($o->absent  ?? 'fb');
+
+class Parent_ {
+    public function __exists(string $n): bool { return false; }
+    public function __get(string $n): mixed { return "p-$n"; }
+}
+class Child extends Parent_ {
+    /* Contravariant widening: subclass accepts a wider input set than the parent. */
+    public function __exists(string|int $n): bool {
+        echo "  Child::__exists("; var_export($n); echo ")\n";
+        return $n === 'present';
+    }
+}
+
+echo "\n2) Subclass may widen parameter type (contravariance):\n";
+$c = new Child;
+var_dump($c->present ?? 'fb');
+var_dump($c->absent  ?? 'fb');
+
+?>
+--EXPECT--
+1) Untyped parameter is allowed (mirrors __isset BC behaviour):
+  __exists('present')
+string(16) "value-of-present"
+  __exists('absent')
+string(2) "fb"
+
+2) Subclass may widen parameter type (contravariance):
+  Child::__exists('present')
+string(9) "p-present"
+  Child::__exists('absent')
+string(2) "fb"

--- a/Zend/tests/magic_methods/exists/signature_return_must_be_bool.phpt
+++ b/Zend/tests/magic_methods/exists/signature_return_must_be_bool.phpt
@@ -1,0 +1,11 @@
+--TEST--
+__exists: return type must be bool
+--FILE--
+<?php
+
+class WrongReturnType {
+    public function __exists(string $n): string { return ''; }
+}
+?>
+--EXPECTF--
+Fatal error: WrongReturnType::__exists(): Return type must be bool when declared in %s on line %d

--- a/Zend/tests/magic_methods/exists/signature_return_required.phpt
+++ b/Zend/tests/magic_methods/exists/signature_return_required.phpt
@@ -1,0 +1,11 @@
+--TEST--
+__exists: return type must be declared as bool (no BC carve-out for new method)
+--FILE--
+<?php
+
+class UntypedReturn {
+    public function __exists(string $n) { return true; }
+}
+?>
+--EXPECTF--
+Fatal error: UntypedReturn::__exists(): Return type must be bool in %s on line %d

--- a/Zend/tests/magic_methods/exists/signature_static.phpt
+++ b/Zend/tests/magic_methods/exists/signature_static.phpt
@@ -1,0 +1,11 @@
+--TEST--
+__exists: must not be static
+--FILE--
+<?php
+
+class StaticExists {
+    public static function __exists(string $n): bool { return true; }
+}
+?>
+--EXPECTF--
+Fatal error: Method StaticExists::__exists() cannot be static in %s on line %d

--- a/Zend/tests/magic_methods/exists/typed_property_uninit.phpt
+++ b/Zend/tests/magic_methods/exists/typed_property_uninit.phpt
@@ -1,0 +1,50 @@
+--TEST--
+__exists: skipped for never-initialized typed properties (parity with __isset); unset() is the opt-in
+--FILE--
+<?php
+
+/* For never-initialized typed properties, __exists is skipped, exactly
+ * like __isset. To opt magic methods in for a declared property, call
+ * unset() on it (typically from the constructor). This mirrors the
+ * existing lazy-proxy pattern used with __isset. */
+
+class T {
+    public int $x;
+
+    public function __exists(string $n): bool {
+        echo "  __exists($n)\n";
+        $this->$n = 42;
+        return true;
+    }
+    public function __get(string $n): mixed {
+        throw new Exception("__get must not be called when __exists materialised the property");
+    }
+}
+
+echo "1) Never-initialized typed property: __exists is NOT called (parity with __isset):\n";
+$t = new T;
+var_dump($t->x ?? 'fallback');
+var_dump(isset($t->x));
+
+echo "\n2) After unset(), magic methods kick in and __exists materializes the property:\n";
+$t = new T;
+unset($t->x);
+var_dump($t->x ?? 'fallback');
+var_dump(isset($t->x));
+
+echo "\n3) Subsequent access on the now-materialized property does not call any magic:\n";
+var_dump($t->x);
+
+?>
+--EXPECT--
+1) Never-initialized typed property: __exists is NOT called (parity with __isset):
+string(8) "fallback"
+bool(false)
+
+2) After unset(), magic methods kick in and __exists materializes the property:
+  __exists(x)
+int(42)
+bool(true)
+
+3) Subsequent access on the now-materialized property does not call any magic:
+int(42)

--- a/Zend/tests/magic_methods/gh12695.phpt
+++ b/Zend/tests/magic_methods/gh12695.phpt
@@ -1,0 +1,65 @@
+--TEST--
+GH-12695: __get() is not called under `??` when __isset() materialised the property
+--FILE--
+<?php
+
+#[AllowDynamicProperties]
+class A {
+    public function __get($n) {
+        throw new Exception("__get must not be called when __isset materialised the property");
+    }
+    public function __isset($n) {
+        echo "  __isset($n)\n";
+        $this->$n = 123;
+        return true;
+    }
+}
+
+echo "Dynamic property materialised in __isset, then `??`:\n";
+$a = new A;
+var_dump($a->foo ?? 'fallback');
+
+echo "\nSame on a declared (unset) property:\n";
+class B {
+    public int $x = 99;
+    public function __get($n) {
+        throw new Exception("__get must not be called when __isset materialised the property");
+    }
+    public function __isset($n) {
+        echo "  __isset($n)\n";
+        $this->$n = 7;
+        return true;
+    }
+}
+$b = new B;
+unset($b->x);
+var_dump($b->x ?? 'fallback');
+
+echo "\nWhen __isset() materialises the property to null, `??` falls back:\n";
+#[AllowDynamicProperties]
+class D {
+    public function __get($n) {
+        throw new Exception("__get must not be called when __isset materialised the property");
+    }
+    public function __isset($n) {
+        echo "  __isset($n)\n";
+        $this->$n = null;
+        return true;
+    }
+}
+$d = new D;
+var_dump($d->foo ?? 'fallback');
+
+?>
+--EXPECT--
+Dynamic property materialised in __isset, then `??`:
+  __isset(foo)
+int(123)
+
+Same on a declared (unset) property:
+  __isset(x)
+int(7)
+
+When __isset() materialises the property to null, `??` falls back:
+  __isset(foo)
+string(8) "fallback"

--- a/Zend/tests/magic_methods/gh12695_empty.phpt
+++ b/Zend/tests/magic_methods/gh12695_empty.phpt
@@ -1,0 +1,55 @@
+--TEST--
+GH-12695: empty() also benefits from the post-__isset() materialization re-check
+--FILE--
+<?php
+
+#[AllowDynamicProperties]
+class A {
+    public function __get($n) {
+        throw new Exception("__get must not be called when __isset materialised the property");
+    }
+    public function __isset($n) {
+        echo "  __isset($n)\n";
+        $this->$n = $GLOBALS['next_value'];
+        return true;
+    }
+}
+
+echo "1) empty() when __isset materialised a truthy value: __get is not called, empty=false:\n";
+$GLOBALS['next_value'] = 7;
+$a = new A;
+var_dump(empty($a->foo));
+
+echo "\n2) empty() when __isset materialised a falsy value: __get is not called, empty=true:\n";
+$GLOBALS['next_value'] = 0;
+$a = new A;
+var_dump(empty($a->bar));
+
+echo "\n3) empty() with no materialization: __get is still called (legacy path preserved):\n";
+class B {
+    public function __get($n) {
+        echo "  __get($n)\n";
+        return 'value';
+    }
+    public function __isset($n) {
+        echo "  __isset($n)\n";
+        return true;
+    }
+}
+$b = new B;
+var_dump(empty($b->any));
+
+?>
+--EXPECT--
+1) empty() when __isset materialised a truthy value: __get is not called, empty=false:
+  __isset(foo)
+bool(false)
+
+2) empty() when __isset materialised a falsy value: __get is not called, empty=true:
+  __isset(bar)
+bool(true)
+
+3) empty() with no materialization: __get is still called (legacy path preserved):
+  __isset(any)
+  __get(any)
+bool(false)

--- a/Zend/tests/magic_methods/gh12695_isset_unchanged.phpt
+++ b/Zend/tests/magic_methods/gh12695_isset_unchanged.phpt
@@ -1,0 +1,26 @@
+--TEST--
+GH-12695: isset() itself is unchanged (still does not consult __get)
+--FILE--
+<?php
+
+/* The GH-12695 fix only affects `??` and `empty()` (which currently call
+ * __get after __isset). The isset() construct itself has never consulted
+ * __get and continues not to: it returns whatever __isset returned, cast
+ * to bool. */
+
+class C {
+    public function __get($n) {
+        throw new Exception("__get must not be called from a plain isset()");
+    }
+    public function __isset($n) {
+        echo "  __isset($n)\n";
+        return true;
+    }
+}
+$c = new C;
+var_dump(isset($c->any));
+
+?>
+--EXPECT--
+  __isset(any)
+bool(true)

--- a/Zend/tests/magic_methods/gh12695_no_materialization.phpt
+++ b/Zend/tests/magic_methods/gh12695_no_materialization.phpt
@@ -1,0 +1,65 @@
+--TEST--
+GH-12695: when __isset() does not materialise the property, __get() is still called
+--FILE--
+<?php
+
+/* The re-check after __isset() must not affect the legacy path when
+ * the property is genuinely magic-only: __get() is still called and
+ * its return value drives `??`'s null check. */
+
+echo "1) `??` when __isset=true and __get returns a value: __get is called:\n";
+class C {
+    public function __get($n) {
+        echo "  __get($n)\n";
+        return 'from-get';
+    }
+    public function __isset($n) {
+        echo "  __isset($n)\n";
+        return true;
+    }
+}
+$c = new C;
+var_dump($c->any ?? 'fallback');
+
+echo "\n2) `??` when __isset=true and __get returns null: __get is called and fallback is used:\n";
+class D {
+    public function __get($n) {
+        echo "  __get($n)\n";
+        return null;
+    }
+    public function __isset($n) {
+        echo "  __isset($n)\n";
+        return true;
+    }
+}
+$d = new D;
+var_dump($d->any ?? 'fallback');
+
+echo "\n3) `??` when __isset returns false: __get is not called:\n";
+class E {
+    public function __get($n) {
+        throw new Exception("__get must not be called when __isset returned false");
+    }
+    public function __isset($n) {
+        echo "  __isset($n)\n";
+        return false;
+    }
+}
+$e = new E;
+var_dump($e->any ?? 'fallback');
+
+?>
+--EXPECT--
+1) `??` when __isset=true and __get returns a value: __get is called:
+  __isset(any)
+  __get(any)
+string(8) "from-get"
+
+2) `??` when __isset=true and __get returns null: __get is called and fallback is used:
+  __isset(any)
+  __get(any)
+string(8) "fallback"
+
+3) `??` when __isset returns false: __get is not called:
+  __isset(any)
+string(8) "fallback"

--- a/Zend/tests/magic_methods/gh12695_object_released_in_isset.phpt
+++ b/Zend/tests/magic_methods/gh12695_object_released_in_isset.phpt
@@ -1,0 +1,28 @@
+--TEST--
+GH-12695: object freed by __isset() during materialization
+--FILE--
+<?php
+
+/* The re-check after __isset() copies the materialised value into the
+ * caller's return-value buffer before releasing the object. This is
+ * required because __isset() may drop the last external reference to
+ * the object (here via $obj = null), so the property table is freed
+ * by OBJ_RELEASE() right after the re-check. */
+
+class C {
+    public $prop;
+    public function __isset($name) {
+        global $obj;
+        $obj = null;
+        $this->prop = 'materialised';
+        return true;
+    }
+}
+
+$obj = new C();
+unset($obj->prop);
+var_dump($obj->prop ?? 'fb');
+
+?>
+--EXPECT--
+string(12) "materialised"

--- a/Zend/tests/magic_methods/gh12695_typed_property_characterization.phpt
+++ b/Zend/tests/magic_methods/gh12695_typed_property_characterization.phpt
@@ -1,0 +1,52 @@
+--TEST--
+GH-12695: Characterize current behavior with typed properties
+--FILE--
+<?php
+
+/* For typed declared properties that are uninitialized (never assigned),
+ * the engine deliberately skips __isset (see zend_object_handlers.c
+ * "Skip __isset() for uninitialized typed properties"). This test pins
+ * down that skip and the related behavior on `unset()`'d typed props.
+ */
+
+class T {
+    public int $never;
+    public int $explicitlyUnset = 99;
+    public function __get($n) { echo "  __get($n)\n"; return 42; }
+    public function __isset($n) { echo "  __isset($n)\n"; return true; }
+}
+
+echo "1) `??` on never-initialized typed property: __isset is skipped, fallback used:\n";
+$t = new T;
+var_dump($t->never ?? 'fallback');
+
+echo "\n2) isset() on never-initialized typed property: __isset is skipped, returns false:\n";
+$t = new T;
+var_dump(isset($t->never));
+
+echo "\n3) `??` after explicit unset() on a typed property: __isset and __get are called:\n";
+$t = new T;
+unset($t->explicitlyUnset);
+var_dump($t->explicitlyUnset ?? 'fallback');
+
+echo "\n4) isset() after explicit unset() on a typed property: only __isset is called:\n";
+$t = new T;
+unset($t->explicitlyUnset);
+var_dump(isset($t->explicitlyUnset));
+
+?>
+--EXPECT--
+1) `??` on never-initialized typed property: __isset is skipped, fallback used:
+string(8) "fallback"
+
+2) isset() on never-initialized typed property: __isset is skipped, returns false:
+bool(false)
+
+3) `??` after explicit unset() on a typed property: __isset and __get are called:
+  __isset(explicitlyUnset)
+  __get(explicitlyUnset)
+int(42)
+
+4) isset() after explicit unset() on a typed property: only __isset is called:
+  __isset(explicitlyUnset)
+bool(true)

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -181,6 +181,7 @@ struct _zend_class_entry {
 	zend_function *__set;
 	zend_function *__unset;
 	zend_function *__isset;
+	zend_function *__exists;
 	zend_function *__call;
 	zend_function *__callstatic;
 	zend_function *__tostring;

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2803,6 +2803,20 @@ ZEND_API void zend_check_magic_method_implementation(const zend_class_entry *ce,
 		zend_check_magic_method_public(ce, fptr);
 		zend_check_magic_method_arg_type(0, ce, fptr, error_type, MAY_BE_STRING);
 		zend_check_magic_method_return_type(ce, fptr, error_type, MAY_BE_BOOL);
+	} else if (zend_string_equals_literal(lcname, ZEND_EXISTS_FUNC_NAME)) {
+		zend_check_magic_method_args(1, ce, fptr, error_type);
+		zend_check_magic_method_non_static(ce, fptr, error_type);
+		zend_check_magic_method_public(ce, fptr);
+		zend_check_magic_method_arg_type(0, ce, fptr, error_type, MAY_BE_STRING);
+		/* Unlike __isset, __exists is a new magic method so the return
+		 * type must be declared. Parameter typing follows the regular
+		 * variance rules and may be omitted or widened in subclasses,
+		 * mirroring __isset. */
+		if (!(fptr->common.fn_flags & ZEND_ACC_HAS_RETURN_TYPE)) {
+			zend_error(error_type, "%s::%s(): Return type must be bool",
+				ZSTR_VAL(ce->name), ZSTR_VAL(fptr->common.function_name));
+		}
+		zend_check_magic_method_return_type(ce, fptr, error_type, MAY_BE_BOOL);
 	} else if (zend_string_equals_literal(lcname, ZEND_CALL_FUNC_NAME)) {
 		zend_check_magic_method_args(2, ce, fptr, error_type);
 		zend_check_magic_method_non_static(ce, fptr, error_type);
@@ -2887,6 +2901,9 @@ ZEND_API void zend_add_magic_method(zend_class_entry *ce, zend_function *fptr, c
 		ce->ce_flags |= ZEND_ACC_USE_GUARDS;
 	} else if (zend_string_equals_literal(lcname, ZEND_ISSET_FUNC_NAME)) {
 		ce->__isset = fptr;
+		ce->ce_flags |= ZEND_ACC_USE_GUARDS;
+	} else if (zend_string_equals_literal(lcname, ZEND_EXISTS_FUNC_NAME)) {
+		ce->__exists = fptr;
 		ce->ce_flags |= ZEND_ACC_USE_GUARDS;
 	} else if (zend_string_equals_literal(lcname, ZEND_CALLSTATIC_FUNC_NAME)) {
 		ce->__callstatic = fptr;

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -306,6 +306,7 @@ typedef struct _zend_fcall_info_cache {
 		class_container.__set = NULL;							\
 		class_container.__unset = NULL;							\
 		class_container.__isset = NULL;							\
+		class_container.__exists = NULL;						\
 		class_container.__debugInfo = NULL;						\
 		class_container.__serialize = NULL;						\
 		class_container.__unserialize = NULL;					\

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -2099,6 +2099,7 @@ ZEND_API void zend_initialize_class_data(zend_class_entry *ce, bool nullify_hand
 		ce->__set = NULL;
 		ce->__unset = NULL;
 		ce->__isset = NULL;
+		ce->__exists = NULL;
 		ce->__call = NULL;
 		ce->__callstatic = NULL;
 		ce->__tostring = NULL;

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -1248,6 +1248,7 @@ END_EXTERN_C()
 #define ZEND_SET_FUNC_NAME          "__set"
 #define ZEND_UNSET_FUNC_NAME        "__unset"
 #define ZEND_ISSET_FUNC_NAME        "__isset"
+#define ZEND_EXISTS_FUNC_NAME       "__exists"
 #define ZEND_CALL_FUNC_NAME         "__call"
 #define ZEND_CALLSTATIC_FUNC_NAME   "__callstatic"
 #define ZEND_TOSTRING_FUNC_NAME     "__tostring"

--- a/Zend/zend_enum.c
+++ b/Zend/zend_enum.c
@@ -99,6 +99,7 @@ static void zend_verify_enum_magic_methods(const zend_class_entry *ce)
 	ZEND_ENUM_DISALLOW_MAGIC_METHOD(__set, "__set");
 	ZEND_ENUM_DISALLOW_MAGIC_METHOD(__unset, "__unset");
 	ZEND_ENUM_DISALLOW_MAGIC_METHOD(__isset, "__isset");
+	ZEND_ENUM_DISALLOW_MAGIC_METHOD(__exists, "__exists");
 	ZEND_ENUM_DISALLOW_MAGIC_METHOD(__tostring, "__toString");
 	ZEND_ENUM_DISALLOW_MAGIC_METHOD(__serialize, "__serialize");
 	ZEND_ENUM_DISALLOW_MAGIC_METHOD(__unserialize, "__unserialize");

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -155,6 +155,9 @@ static void do_inherit_parent_constructor(zend_class_entry *ce) /* {{{ */
 	if (EXPECTED(!ce->__isset)) {
 		ce->__isset = parent->__isset;
 	}
+	if (EXPECTED(!ce->__exists)) {
+		ce->__exists = parent->__exists;
+	}
 	if (EXPECTED(!ce->__call)) {
 		ce->__call = parent->__call;
 	}
@@ -3389,6 +3392,7 @@ static zend_class_entry *zend_lazy_class_load(const zend_class_entry *pce)
 			zend_update_inherited_handler(__set);
 			zend_update_inherited_handler(__call);
 			zend_update_inherited_handler(__isset);
+			zend_update_inherited_handler(__exists);
 			zend_update_inherited_handler(__unset);
 			zend_update_inherited_handler(__tostring);
 			zend_update_inherited_handler(__callstatic);

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -270,6 +270,14 @@ static void zend_std_call_issetter(zend_object *zobj, zend_string *prop_name, zv
 }
 /* }}} */
 
+static void zend_std_call_existser(zend_object *zobj, zend_string *prop_name, zval *retval) /* {{{ */
+{
+	zval member;
+	ZVAL_STR(&member, prop_name);
+	zend_call_known_instance_method_with_1_params(zobj->ce->__exists, zobj, retval, &member);
+}
+/* }}} */
+
 
 static zend_always_inline bool is_derived_class(const zend_class_entry *child_class, const zend_class_entry *parent_class) /* {{{ */
 {
@@ -894,14 +902,15 @@ try_again:
 
 	/* For initialized lazy proxies: if the real instance's magic method
 	 * guard is already set for this property, we are inside a recursive
-	 * call from the real instance's __get/__isset. Forward directly to
-	 * the real instance to avoid double invocation. (GH-21478) */
+	 * call from the real instance's __get/__isset/__exists. Forward
+	 * directly to the real instance to avoid double invocation.
+	 * (GH-21478) */
 	if (UNEXPECTED(zend_object_is_lazy_proxy(zobj)
 			&& zend_lazy_object_initialized(zobj))) {
 		zend_object *instance = zend_lazy_object_get_instance(zobj);
 		if (instance->ce->ce_flags & ZEND_ACC_USE_GUARDS) {
 			uint32_t *instance_guard = zend_get_property_guard(instance, name);
-			uint32_t guard_type = ((type == BP_VAR_IS) && zobj->ce->__isset)
+			uint32_t guard_type = ((type == BP_VAR_IS) && (zobj->ce->__exists || zobj->ce->__isset))
 				? IN_ISSET : IN_GET;
 			if ((*instance_guard) & guard_type) {
 				retval = zend_std_read_property(instance, name, type, cache_slot, rv);
@@ -914,8 +923,63 @@ try_again:
 		}
 	}
 
-	/* magic isset */
-	if ((type == BP_VAR_IS) && zobj->ce->__isset) {
+	/* magic exists (when defined, preferred over __isset for `??`) */
+	if ((type == BP_VAR_IS) && zobj->ce->__exists) {
+		zval tmp_result;
+		guard = zend_get_property_guard(zobj, name);
+
+		if (!((*guard) & IN_ISSET)) {
+			GC_ADDREF(zobj);
+
+			*guard |= IN_ISSET;
+			zend_std_call_existser(zobj, name, &tmp_result);
+			*guard &= ~IN_ISSET;
+
+			if (!zend_is_true(&tmp_result)) {
+				retval = &EG(uninitialized_zval);
+				OBJ_RELEASE(zobj);
+				zval_ptr_dtor(&tmp_result);
+				goto exit;
+			}
+
+			zval_ptr_dtor(&tmp_result);
+
+			/* __exists() may have materialised the property by writing
+			 * into the property table. Re-check it before deferring to
+			 * __get(), so the freshly-written value is returned directly
+			 * without a redundant __get() call. The value is copied into
+			 * `rv` because the property table can be freed by the
+			 * OBJ_RELEASE below (e.g. when __exists() drops the last
+			 * external reference to the object). */
+			if (IS_VALID_PROPERTY_OFFSET(property_offset)) {
+				retval = OBJ_PROP(zobj, property_offset);
+				if (Z_TYPE_P(retval) != IS_UNDEF) {
+					ZVAL_COPY(rv, retval);
+					retval = rv;
+					OBJ_RELEASE(zobj);
+					goto exit;
+				}
+			} else if (IS_DYNAMIC_PROPERTY_OFFSET(property_offset)) {
+				if (zobj->properties != NULL) {
+					retval = zend_hash_find(zobj->properties, name);
+					if (retval) {
+						ZVAL_COPY(rv, retval);
+						retval = rv;
+						OBJ_RELEASE(zobj);
+						goto exit;
+					}
+				}
+			}
+			retval = &EG(uninitialized_zval);
+
+			if (zobj->ce->__get && !((*guard) & IN_GET)) {
+				goto call_getter;
+			}
+			OBJ_RELEASE(zobj);
+		} else if (zobj->ce->__get && !((*guard) & IN_GET)) {
+			goto call_getter_addref;
+		}
+	} else if ((type == BP_VAR_IS) && zobj->ce->__isset) {
 		zval tmp_result;
 		guard = zend_get_property_guard(zobj, name);
 
@@ -1021,7 +1085,7 @@ uninit_error:
 			if (UNEXPECTED(guard && (instance->ce->ce_flags & ZEND_ACC_USE_GUARDS))) {
 				/* Find which guard was used on zobj, so we can set the same
 				 * guard on instance. */
-				uint32_t guard_type = (type == BP_VAR_IS) && zobj->ce->__isset
+				uint32_t guard_type = (type == BP_VAR_IS) && (zobj->ce->__exists || zobj->ce->__isset)
 					? IN_ISSET : IN_GET;
 				guard = zend_get_property_guard(instance, name);
 				if (!((*guard) & guard_type)) {
@@ -2484,9 +2548,10 @@ found:
 		goto exit;
 	}
 
-	/* For initialized lazy proxies: if the real instance's __isset guard
-	 * is already set, we are inside a recursive call from the real
-	 * instance's __isset. Forward directly to avoid double invocation. */
+	/* For initialized lazy proxies: if the real instance's __isset/__exists
+	 * guard is already set, we are inside a recursive call from the real
+	 * instance's __isset/__exists. Forward directly to avoid double
+	 * invocation. */
 	if (UNEXPECTED(zend_object_is_lazy_proxy(zobj)
 			&& zend_lazy_object_initialized(zobj))) {
 		zend_object *instance = zend_lazy_object_get_instance(zobj);
@@ -2498,7 +2563,7 @@ found:
 		}
 	}
 
-	if (!zobj->ce->__isset) {
+	if (!zobj->ce->__exists && !zobj->ce->__isset) {
 		goto lazy_init;
 	}
 
@@ -2508,15 +2573,33 @@ found:
 
 		if (!((*guard) & IN_ISSET)) {
 			zval rv;
+			bool use_exists = zobj->ce->__exists != NULL;
 
-			/* have issetter - try with it! */
 			GC_ADDREF(zobj);
-			(*guard) |= IN_ISSET; /* prevent circular getting */
-			zend_std_call_issetter(zobj, name, &rv);
+			(*guard) |= IN_ISSET; /* prevent recursion */
+			if (use_exists) {
+				zend_std_call_existser(zobj, name, &rv);
+			} else {
+				zend_std_call_issetter(zobj, name, &rv);
+			}
 			result = zend_is_true(&rv);
 			zval_ptr_dtor(&rv);
-			if (has_set_exists == ZEND_PROPERTY_NOT_EMPTY && result) {
-				/* GH-12695, see above. */
+
+			/* When the existence check returned true, we may need to
+			 * consult the actual value:
+			 *   - empty(): always (for truthiness).
+			 *   - isset() with __exists: yes, apply non-null check
+			 *     (preserves the documented `isset() <=> ??` equivalence
+			 *     and disambiguates "set to null" from "missing").
+			 *   - isset() with __isset: trust the bool. */
+			bool consult_value = result && !EG(exception)
+				&& (has_set_exists == ZEND_PROPERTY_NOT_EMPTY
+					|| (use_exists && has_set_exists == ZEND_PROPERTY_ISSET));
+
+			if (consult_value) {
+				/* GH-12695: the existence check may have materialised the
+				 * property by writing into the property table. Re-check it
+				 * before deferring to __get(). */
 				zval *prop = NULL;
 				if (IS_VALID_PROPERTY_OFFSET(property_offset)) {
 					prop = OBJ_PROP(zobj, property_offset);
@@ -2528,14 +2611,25 @@ found:
 					prop = zend_hash_find(zobj->properties, name);
 				}
 				if (prop) {
-					result = i_zend_is_true(prop);
-				} else if (EXPECTED(!EG(exception)) && zobj->ce->__get && !((*guard) & IN_GET)) {
+					if (has_set_exists == ZEND_PROPERTY_NOT_EMPTY) {
+						result = i_zend_is_true(prop);
+					} else {
+						ZVAL_DEREF(prop);
+						result = Z_TYPE_P(prop) != IS_NULL;
+					}
+				} else if (zobj->ce->__get && !((*guard) & IN_GET)) {
 					(*guard) |= IN_GET;
 					zend_std_call_getter(zobj, name, &rv);
 					(*guard) &= ~IN_GET;
-					result = i_zend_is_true(&rv);
+					if (has_set_exists == ZEND_PROPERTY_NOT_EMPTY) {
+						result = i_zend_is_true(&rv);
+					} else {
+						result = Z_TYPE(rv) != IS_NULL
+							&& (Z_TYPE(rv) != IS_REFERENCE || Z_TYPE_P(Z_REFVAL(rv)) != IS_NULL);
+					}
 					zval_ptr_dtor(&rv);
 				} else {
+					/* No __get available; treat the value as null. */
 					result = false;
 				}
 			}
@@ -2558,7 +2652,7 @@ lazy_init:
 				goto exit;
 			}
 
-			if (UNEXPECTED(zobj->ce->__isset)) {
+			if (UNEXPECTED(zobj->ce->__exists || zobj->ce->__isset)) {
 				uint32_t *guard = zend_get_property_guard(zobj, name);
 				if (!((*guard) & IN_ISSET)) {
 					(*guard) |= IN_ISSET;

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -934,6 +934,35 @@ try_again:
 			}
 
 			zval_ptr_dtor(&tmp_result);
+
+			/* __isset() may have materialised the property by writing into
+			 * the property table. Re-check it before deferring to __get(),
+			 * so the freshly-written value is returned directly without a
+			 * redundant __get() call (GH-12695). The value is copied into
+			 * `rv` because the property table can be freed by the OBJ_RELEASE
+			 * below (e.g. when __isset() drops the last external reference
+			 * to the object). */
+			if (IS_VALID_PROPERTY_OFFSET(property_offset)) {
+				retval = OBJ_PROP(zobj, property_offset);
+				if (Z_TYPE_P(retval) != IS_UNDEF) {
+					ZVAL_COPY(rv, retval);
+					retval = rv;
+					OBJ_RELEASE(zobj);
+					goto exit;
+				}
+			} else if (IS_DYNAMIC_PROPERTY_OFFSET(property_offset)) {
+				if (zobj->properties != NULL) {
+					retval = zend_hash_find(zobj->properties, name);
+					if (retval) {
+						ZVAL_COPY(rv, retval);
+						retval = rv;
+						OBJ_RELEASE(zobj);
+						goto exit;
+					}
+				}
+			}
+			retval = &EG(uninitialized_zval);
+
 			if (zobj->ce->__get && !((*guard) & IN_GET)) {
 				goto call_getter;
 			}
@@ -2487,7 +2516,20 @@ found:
 			result = zend_is_true(&rv);
 			zval_ptr_dtor(&rv);
 			if (has_set_exists == ZEND_PROPERTY_NOT_EMPTY && result) {
-				if (EXPECTED(!EG(exception)) && zobj->ce->__get && !((*guard) & IN_GET)) {
+				/* GH-12695, see above. */
+				zval *prop = NULL;
+				if (IS_VALID_PROPERTY_OFFSET(property_offset)) {
+					prop = OBJ_PROP(zobj, property_offset);
+					if (Z_TYPE_P(prop) == IS_UNDEF) {
+						prop = NULL;
+					}
+				} else if (IS_DYNAMIC_PROPERTY_OFFSET(property_offset)
+						&& zobj->properties != NULL) {
+					prop = zend_hash_find(zobj->properties, name);
+				}
+				if (prop) {
+					result = i_zend_is_true(prop);
+				} else if (EXPECTED(!EG(exception)) && zobj->ce->__get && !((*guard) & IN_GET)) {
 					(*guard) |= IN_GET;
 					zend_std_call_getter(zobj, name, &rv);
 					(*guard) &= ~IN_GET;

--- a/ext/opcache/zend_file_cache.c
+++ b/ext/opcache/zend_file_cache.c
@@ -938,6 +938,7 @@ static void zend_file_cache_serialize_class(zval                     *zv,
 	SERIALIZE_PTR(ce->__serialize);
 	SERIALIZE_PTR(ce->__unserialize);
 	SERIALIZE_PTR(ce->__isset);
+	SERIALIZE_PTR(ce->__exists);
 	SERIALIZE_PTR(ce->__unset);
 	SERIALIZE_PTR(ce->__tostring);
 	SERIALIZE_PTR(ce->__callstatic);
@@ -1813,6 +1814,7 @@ static void zend_file_cache_unserialize_class(zval                    *zv,
 	UNSERIALIZE_PTR(ce->__serialize);
 	UNSERIALIZE_PTR(ce->__unserialize);
 	UNSERIALIZE_PTR(ce->__isset);
+	UNSERIALIZE_PTR(ce->__exists);
 	UNSERIALIZE_PTR(ce->__unset);
 	UNSERIALIZE_PTR(ce->__tostring);
 	UNSERIALIZE_PTR(ce->__callstatic);

--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -1260,6 +1260,12 @@ void zend_update_parent_ce(zend_class_entry *ce)
 			ce->__isset = tmp;
 		}
 	}
+	if (ce->__exists) {
+		zend_function *tmp = zend_shared_alloc_get_xlat_entry(ce->__exists);
+		if (tmp != NULL) {
+			ce->__exists = tmp;
+		}
+	}
 	if (ce->__unset) {
 		zend_function *tmp = zend_shared_alloc_get_xlat_entry(ce->__unset);
 		if (tmp != NULL) {

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -6723,14 +6723,15 @@ ZEND_METHOD(ReflectionProperty, isReadable)
 		}
 handle_magic_get:
 		if (ce->__get) {
-			if (obj && ce->__isset) {
+			zend_function *check = ce->__exists ? ce->__exists : ce->__isset;
+			if (obj && check) {
 				uint32_t *guard = zend_get_property_guard(obj, ref->unmangled_name);
 				if (!((*guard) & ZEND_GUARD_PROPERTY_ISSET)) {
 					GC_ADDREF(obj);
 					*guard |= ZEND_GUARD_PROPERTY_ISSET;
 					zval member;
 					ZVAL_STR(&member, ref->unmangled_name);
-					zend_call_known_instance_method_with_1_params(ce->__isset, obj, return_value, &member);
+					zend_call_known_instance_method_with_1_params(check, obj, return_value, &member);
 
 					if (Z_TYPE_P(return_value) == IS_REFERENCE) {
 						zend_unwrap_reference(return_value);


### PR DESCRIPTION
See draft RFC at https://wiki.php.net/rfc/exists-magic-method

This PR is based on top of #22181 (a small engine fix for GH-12695, decoupled from this RFC and proposed for merge separately). The first commit in this PR is that fix.