### PR TITLE
Implement function autoloading

### DIFF
--- a/UPGRADING.FUNCTION-AUTOLOADING
+++ b/UPGRADING.FUNCTION-AUTOLOADING
@@ -1,0 +1,53 @@
+UPGRADE NOTES: FUNCTION AUTOLOADING
+
+1. New Features
+2. Changed Functions
+3. New Functions
+4. Internal API Changes
+
+========================================
+1. New Features
+========================================
+
+- Core:
+  . Added function autoloading support. Register callbacks via
+    spl_autoload_register_function_loader() that are invoked when an
+    undefined function is called.
+    Function autoloading is triggered by direct calls to undefined
+    functions, dynamic calls through a string variable ("$func()"), and
+    function_exists($name, true). It is not triggered when a function
+    name is used as a callable (callable parameters, is_callable(),
+    Closure::fromCallable()) or by the Reflection API;
+    spl_autoload_call_function_loader() can be used to trigger it
+    manually in those situations.
+
+========================================
+2. Changed Functions
+========================================
+
+- Core:
+  . function_exists() now accepts an optional bool $autoload parameter.
+    When true, triggers function autoloading before returning false.
+    Unlike class_exists(), it defaults to false so that existing
+    function_exists() guards around conditional function definitions
+    (polyfills) do not start triggering autoloaders.
+
+========================================
+3. New Functions
+========================================
+
+- SPL:
+  . spl_autoload_register_function_loader() registers a function autoloader.
+  . spl_autoload_unregister_function_loader() unregisters a function autoloader.
+  . spl_autoload_function_loaders() returns registered function autoloaders.
+  . spl_autoload_call_function_loader() manually triggers function autoloading.
+
+========================================
+4. Internal API Changes
+========================================
+
+- Zend:
+  . zend_autoload_fcc_map_to_callable_zval_map() has been renamed to
+    zend_autoload_class_fcc_map_to_callable_zval_map(), since there is
+    now a function loader counterpart,
+    zend_autoload_function_fcc_map_to_callable_zval_map().

--- a/Zend/tests/autoload/function_autoload_backslash_prefix.phpt
+++ b/Zend/tests/autoload/function_autoload_backslash_prefix.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Function autoloading strips leading backslash from name passed to autoloader
+--FILE--
+<?php
+$log = [];
+
+spl_autoload_register_function_loader(function (string $name) use (&$log) {
+    $log[] = $name;
+    if ($name === 'Ns\prefixed_func') {
+        eval('namespace Ns; function prefixed_func() { return "ok"; }');
+    }
+});
+
+var_dump(function_exists('\\Ns\\prefixed_func', true));
+var_dump(\Ns\prefixed_func());
+var_dump($log);
+?>
+--EXPECT--
+bool(true)
+string(2) "ok"
+array(1) {
+  [0]=>
+  string(16) "Ns\prefixed_func"
+}

--- a/Zend/tests/autoload/function_autoload_basic.phpt
+++ b/Zend/tests/autoload/function_autoload_basic.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Basic function autoloading
+--FILE--
+<?php
+spl_autoload_register_function_loader(function (string $name) {
+    echo "autoloading -- ";
+    if ($name === 'test_func') {
+        eval('function test_func() { return "autoloaded"; }');
+    }
+});
+
+var_dump(test_func());
+var_dump(test_func());
+?>
+--EXPECT--
+autoloading -- string(10) "autoloaded"
+string(10) "autoloaded"

--- a/Zend/tests/autoload/function_autoload_call.phpt
+++ b/Zend/tests/autoload/function_autoload_call.phpt
@@ -1,0 +1,32 @@
+--TEST--
+spl_autoload_call_function_loader() manual trigger
+--FILE--
+<?php
+$log = [];
+
+spl_autoload_register_function_loader(function (string $name) use (&$log) {
+    $log[] = $name;
+    if ($name === 'manual_func' && !function_exists('manual_func')) {
+        eval('function manual_func() { return "manual"; }');
+    }
+});
+
+var_dump(function_exists('manual_func'));
+spl_autoload_call_function_loader('manual_func');
+var_dump(function_exists('manual_func'));
+var_dump(manual_func());
+
+// runs the loaders again even though manual_func() exists now
+spl_autoload_call_function_loader('manual_func');
+var_dump($log);
+?>
+--EXPECT--
+bool(false)
+bool(true)
+string(6) "manual"
+array(2) {
+  [0]=>
+  string(11) "manual_func"
+  [1]=>
+  string(11) "manual_func"
+}

--- a/Zend/tests/autoload/function_autoload_call_missing.phpt
+++ b/Zend/tests/autoload/function_autoload_call_missing.phpt
@@ -1,0 +1,22 @@
+--TEST--
+spl_autoload_call_function_loader() with non-existent function
+--FILE--
+<?php
+$log = [];
+
+spl_autoload_register_function_loader(function (string $name) use (&$log) {
+    $log[] = $name;
+});
+
+spl_autoload_call_function_loader('nonexistent_func');
+echo "No exception\n";
+var_dump(function_exists('nonexistent_func'));
+var_dump($log);
+?>
+--EXPECT--
+No exception
+bool(false)
+array(1) {
+  [0]=>
+  string(16) "nonexistent_func"
+}

--- a/Zend/tests/autoload/function_autoload_case_insensitive.phpt
+++ b/Zend/tests/autoload/function_autoload_case_insensitive.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Function autoloading is case-insensitive
+--FILE--
+<?php
+$log = [];
+
+spl_autoload_register_function_loader(function (string $name) use (&$log) {
+    $log[] = $name;
+    if (strtolower($name) === 'my_func') {
+        eval('function my_func() { return "loaded"; }');
+    }
+});
+
+var_dump(My_Func());
+
+var_dump(MY_FUNC()); // different case, no second autoload
+
+var_dump($log);
+?>
+--EXPECT--
+string(6) "loaded"
+string(6) "loaded"
+array(1) {
+  [0]=>
+  string(7) "My_Func"
+}

--- a/Zend/tests/autoload/function_autoload_class_independent.phpt
+++ b/Zend/tests/autoload/function_autoload_class_independent.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Class and function autoloaders are independent
+--FILE--
+<?php
+$class_log = [];
+$func_log = [];
+
+spl_autoload_register(function (string $name) use (&$class_log) {
+    $class_log[] = $name;
+});
+
+spl_autoload_register_function_loader(function (string $name) use (&$func_log) {
+    $func_log[] = $name;
+});
+
+class_exists('SomeClass');
+function_exists('some_func', true);
+
+echo "Class autoloader received:\n";
+var_dump($class_log);
+echo "Function autoloader received:\n";
+var_dump($func_log);
+?>
+--EXPECT--
+Class autoloader received:
+array(1) {
+  [0]=>
+  string(9) "SomeClass"
+}
+Function autoloader received:
+array(1) {
+  [0]=>
+  string(9) "some_func"
+}

--- a/Zend/tests/autoload/function_autoload_duplicate.phpt
+++ b/Zend/tests/autoload/function_autoload_duplicate.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Duplicate function autoloader registration is ignored
+--FILE--
+<?php
+$loader = function (string $name) {};
+
+spl_autoload_register_function_loader($loader);
+spl_autoload_register_function_loader($loader);
+
+var_dump(count(spl_autoload_function_loaders()));
+?>
+--EXPECT--
+int(1)

--- a/Zend/tests/autoload/function_autoload_dynamic_call.phpt
+++ b/Zend/tests/autoload/function_autoload_dynamic_call.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Function autoloading via dynamic call
+--FILE--
+<?php
+spl_autoload_register_function_loader(function (string $name) {
+    if ($name === 'dynamic_func') {
+        eval('function dynamic_func() { return "dynamic"; }');
+    }
+});
+
+$f = 'dynamic_func';
+var_dump($f());
+?>
+--EXPECT--
+string(7) "dynamic"

--- a/Zend/tests/autoload/function_autoload_exception.phpt
+++ b/Zend/tests/autoload/function_autoload_exception.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Exception during function autoloading
+--FILE--
+<?php
+spl_autoload_register_function_loader(function (string $name) {
+    throw new RuntimeException("Autoload failed for: $name");
+});
+
+try {
+    missing_func();
+} catch (RuntimeException $e) {
+    echo $e->getMessage(), "\n";
+}
+
+// failed autoloads are not cached, so the loader runs again
+try {
+    missing_func();
+} catch (RuntimeException $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Autoload failed for: missing_func
+Autoload failed for: missing_func

--- a/Zend/tests/autoload/function_autoload_exception_dynamic.phpt
+++ b/Zend/tests/autoload/function_autoload_exception_dynamic.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Exception during function autoloading via dynamic call
+--FILE--
+<?php
+spl_autoload_register_function_loader(function (string $name) {
+    throw new RuntimeException("Autoload failed for: $name");
+});
+
+$f = 'missing_func';
+try {
+    $f();
+} catch (RuntimeException $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Autoload failed for: missing_func

--- a/Zend/tests/autoload/function_autoload_exception_ns.phpt
+++ b/Zend/tests/autoload/function_autoload_exception_ns.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Exception during function autoloading via namespace fallback
+--FILE--
+<?php
+namespace App;
+
+\spl_autoload_register_function_loader(function (string $name) {
+    throw new \RuntimeException("Autoload failed for: $name");
+});
+
+try {
+    some_func();
+} catch (\RuntimeException $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Autoload failed for: App\some_func

--- a/Zend/tests/autoload/function_autoload_function_exists.phpt
+++ b/Zend/tests/autoload/function_autoload_function_exists.phpt
@@ -1,0 +1,18 @@
+--TEST--
+function_exists() with autoload parameter
+--FILE--
+<?php
+spl_autoload_register_function_loader(function (string $name) {
+    if ($name === 'lazy_func') {
+        eval('function lazy_func() { return "lazy"; }');
+    }
+});
+
+var_dump(function_exists('lazy_func'));
+var_dump(function_exists('lazy_func', true));
+var_dump(function_exists('lazy_func'));
+?>
+--EXPECT--
+bool(false)
+bool(true)
+bool(true)

--- a/Zend/tests/autoload/function_autoload_invalid_name.phpt
+++ b/Zend/tests/autoload/function_autoload_invalid_name.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Function autoloaders are not invoked for invalid or empty function names
+--FILE--
+<?php
+spl_autoload_register_function_loader(function (string $name) {
+    echo "autoload($name)\n";
+    if ($name === 'valid_fn') {
+        function valid_fn() {
+            echo "valid_fn called\n";
+        }
+    }
+});
+
+$f = 'foo bar';
+try {
+    $f();
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+var_dump(function_exists('', true));
+var_dump(function_exists('foo bar', true));
+
+$g = 'valid_fn';
+$g();
+?>
+--EXPECT--
+Call to undefined function foo bar()
+bool(false)
+bool(false)
+autoload(valid_fn)
+valid_fn called

--- a/Zend/tests/autoload/function_autoload_list.phpt
+++ b/Zend/tests/autoload/function_autoload_list.phpt
@@ -1,0 +1,23 @@
+--TEST--
+spl_autoload_function_loaders() lists registered loaders
+--FILE--
+<?php
+var_dump(spl_autoload_function_loaders());
+
+$a = function (string $name) {};
+$b = function (string $name) {};
+
+spl_autoload_register_function_loader($a);
+spl_autoload_register_function_loader($b);
+
+$loaders = spl_autoload_function_loaders();
+var_dump(count($loaders));
+var_dump($loaders[0] === $a);
+var_dump($loaders[1] === $b);
+?>
+--EXPECT--
+array(0) {
+}
+int(2)
+bool(true)
+bool(true)

--- a/Zend/tests/autoload/function_autoload_method.phpt
+++ b/Zend/tests/autoload/function_autoload_method.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Function autoloading with static method and instance method as autoloader
+--FILE--
+<?php
+class StaticLoader {
+    public static function load(string $name): void {
+        if ($name === 'static_loaded') {
+            eval('function static_loaded() { return "from_static"; }');
+        }
+    }
+}
+
+class InstanceLoader {
+    public function load(string $name): void {
+        if ($name === 'instance_loaded') {
+            eval('function instance_loaded() { return "from_instance"; }');
+        }
+    }
+}
+
+spl_autoload_register_function_loader([StaticLoader::class, 'load']);
+var_dump(static_loaded());
+
+$obj = new InstanceLoader();
+spl_autoload_register_function_loader([$obj, 'load']);
+var_dump(instance_loaded());
+
+var_dump(count(spl_autoload_function_loaders()));
+?>
+--EXPECT--
+string(11) "from_static"
+string(13) "from_instance"
+int(2)

--- a/Zend/tests/autoload/function_autoload_multiple.phpt
+++ b/Zend/tests/autoload/function_autoload_multiple.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Multiple function autoloaders
+--FILE--
+<?php
+$log = [];
+
+spl_autoload_register_function_loader(function (string $name) use (&$log) {
+    $log[] = "loader1: $name";
+});
+
+spl_autoload_register_function_loader(function (string $name) use (&$log) {
+    $log[] = "loader2: $name";
+    if ($name === 'test_func') {
+        eval('function test_func() { return "from_loader2"; }');
+    }
+});
+
+// never called, loader2 already defined test_func
+spl_autoload_register_function_loader(function (string $name) use (&$log) {
+    $log[] = "loader3: $name";
+});
+
+var_dump(test_func());
+var_dump($log);
+?>
+--EXPECT--
+string(12) "from_loader2"
+array(2) {
+  [0]=>
+  string(18) "loader1: test_func"
+  [1]=>
+  string(18) "loader2: test_func"
+}

--- a/Zend/tests/autoload/function_autoload_mutation.phpt
+++ b/Zend/tests/autoload/function_autoload_mutation.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Function autoloader modifying autoloader list during autoloading
+--FILE--
+<?php
+$log = [];
+
+$first = function (string $name) use (&$log, &$second) {
+    $log[] = "first: $name";
+    spl_autoload_register_function_loader($second);
+};
+
+$second = function (string $name) use (&$log) {
+    $log[] = "second: $name";
+    if ($name === 'test_func') {
+        eval('function test_func() { return "ok"; }');
+    }
+};
+
+spl_autoload_register_function_loader($first);
+
+var_dump(test_func());
+var_dump($log);
+?>
+--EXPECT--
+string(2) "ok"
+array(2) {
+  [0]=>
+  string(16) "first: test_func"
+  [1]=>
+  string(17) "second: test_func"
+}

--- a/Zend/tests/autoload/function_autoload_mutation_unregister.phpt
+++ b/Zend/tests/autoload/function_autoload_mutation_unregister.phpt
@@ -1,0 +1,46 @@
+--TEST--
+Function autoloader unregistering itself during autoloading skips the next loader
+--FILE--
+<?php
+$log = [];
+
+$first = function (string $name) use (&$log, &$first) {
+    $log[] = "first: $name";
+    spl_autoload_unregister_function_loader($first);
+};
+
+$second = function (string $name) use (&$log) {
+    $log[] = "second: $name";
+    if ($name === 'test_func') {
+        eval('function test_func() { return "ok"; }');
+    }
+};
+
+spl_autoload_register_function_loader($first);
+spl_autoload_register_function_loader($second);
+
+try {
+    test_func();
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+var_dump(count(spl_autoload_function_loaders()));
+var_dump($log);
+
+var_dump(test_func());
+var_dump($log);
+?>
+--EXPECT--
+Call to undefined function test_func()
+int(1)
+array(1) {
+  [0]=>
+  string(16) "first: test_func"
+}
+string(2) "ok"
+array(2) {
+  [0]=>
+  string(16) "first: test_func"
+  [1]=>
+  string(17) "second: test_func"
+}

--- a/Zend/tests/autoload/function_autoload_namespace.phpt
+++ b/Zend/tests/autoload/function_autoload_namespace.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Namespaced function autoloading
+--FILE--
+<?php
+spl_autoload_register_function_loader(function (string $name) {
+    echo "Autoloading: $name\n";
+    if ($name === 'App\Util\helper') {
+        eval('namespace App\Util; function helper() { return "ns_helper"; }');
+    }
+});
+
+var_dump(\App\Util\helper());
+?>
+--EXPECT--
+Autoloading: App\Util\helper
+string(9) "ns_helper"

--- a/Zend/tests/autoload/function_autoload_namespace_fallback.phpt
+++ b/Zend/tests/autoload/function_autoload_namespace_fallback.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Namespace fallback function autoloading
+--FILE--
+<?php
+namespace App;
+
+\spl_autoload_register_function_loader(function (string $name) {
+    echo "Autoloading: $name\n";
+    if ($name === 'App\local_func') {
+        eval('namespace App; function local_func() { return "local"; }');
+    } elseif ($name === 'App\global_func') {
+        eval('function global_func() { return "global"; }');
+    }
+});
+
+var_dump(local_func());
+var_dump(local_func());
+
+try {
+    global_func();
+} catch (\Error $e) {
+    echo $e->getMessage(), "\n";
+}
+var_dump(global_func());
+?>
+--EXPECT--
+Autoloading: App\local_func
+string(5) "local"
+string(5) "local"
+Autoloading: App\global_func
+Call to undefined function App\global_func()
+string(6) "global"

--- a/Zend/tests/autoload/function_autoload_prepend.phpt
+++ b/Zend/tests/autoload/function_autoload_prepend.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Function autoloader prepend
+--FILE--
+<?php
+$log = [];
+
+spl_autoload_register_function_loader(function (string $name) use (&$log) {
+    $log[] = "first";
+});
+
+spl_autoload_register_function_loader(function (string $name) use (&$log) {
+    $log[] = "prepended";
+    if ($name === 'test_func') {
+        eval('function test_func() { return "ok"; }');
+    }
+}, prepend: true);
+
+var_dump(test_func());
+var_dump($log);
+?>
+--EXPECT--
+string(2) "ok"
+array(1) {
+  [0]=>
+  string(9) "prepended"
+}

--- a/Zend/tests/autoload/function_autoload_recursion.phpt
+++ b/Zend/tests/autoload/function_autoload_recursion.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Function autoloading recursion prevention
+--FILE--
+<?php
+spl_autoload_register_function_loader(function (string $name) {
+    echo "Autoloading: $name\n";
+    if ($name === 'recursive_func') {
+        try {
+            recursive_func();
+        } catch (Error $e) {
+            echo "Caught: " . $e->getMessage() . "\n";
+        }
+    }
+});
+
+try {
+    recursive_func();
+} catch (Error $e) {
+    echo "Final: " . $e->getMessage() . "\n";
+}
+?>
+--EXPECT--
+Autoloading: recursive_func
+Caught: Call to undefined function recursive_func()
+Final: Call to undefined function recursive_func()

--- a/Zend/tests/autoload/function_autoload_trampoline.phpt
+++ b/Zend/tests/autoload/function_autoload_trampoline.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Trampoline as function autoloader
+--FILE--
+<?php
+class TrampolineTest {
+    public function __call(string $name, array $arguments) {
+        echo "Trampoline for $name: $arguments[0]\n";
+    }
+}
+$o = new TrampolineTest();
+$callback1 = [$o, 'trampoline1'];
+$callback2 = [$o, 'trampoline2'];
+
+spl_autoload_register_function_loader($callback1);
+spl_autoload_register_function_loader($callback2);
+spl_autoload_register_function_loader($callback1);
+
+var_dump(count(spl_autoload_function_loaders()));
+var_dump(function_exists('tramp_func', true));
+
+var_dump(spl_autoload_unregister_function_loader($callback1));
+var_dump(spl_autoload_unregister_function_loader($callback1));
+var_dump(spl_autoload_unregister_function_loader($callback2));
+
+var_dump(spl_autoload_function_loaders());
+var_dump(function_exists('tramp_func', true));
+?>
+--EXPECT--
+int(2)
+Trampoline for trampoline1: tramp_func
+Trampoline for trampoline2: tramp_func
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+array(0) {
+}
+bool(false)

--- a/Zend/tests/autoload/function_autoload_unregister.phpt
+++ b/Zend/tests/autoload/function_autoload_unregister.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Function autoloader unregister
+--FILE--
+<?php
+$loader = function (string $name) {
+    eval("function $name() { return 'ok'; }");
+};
+
+spl_autoload_register_function_loader($loader);
+var_dump(count(spl_autoload_function_loaders()));
+
+spl_autoload_unregister_function_loader($loader);
+var_dump(count(spl_autoload_function_loaders()));
+
+try {
+    missing_func();
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+int(1)
+int(0)
+Call to undefined function missing_func()

--- a/Zend/tests/autoload/function_autoload_unregister_false.phpt
+++ b/Zend/tests/autoload/function_autoload_unregister_false.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Unregistering a function autoloader that was never registered returns false
+--FILE--
+<?php
+$loader = function (string $name) {};
+
+var_dump(spl_autoload_unregister_function_loader($loader));
+
+spl_autoload_register_function_loader($loader);
+var_dump(spl_autoload_unregister_function_loader($loader));
+var_dump(spl_autoload_unregister_function_loader($loader));
+?>
+--EXPECT--
+bool(false)
+bool(true)
+bool(false)

--- a/Zend/zend_autoload.c
+++ b/Zend/zend_autoload.c
@@ -24,6 +24,7 @@
 #include "zend_string.h"
 
 ZEND_TLS HashTable *zend_class_autoload_functions;
+ZEND_TLS HashTable *zend_function_autoload_functions;
 
 static void zend_autoload_callback_zval_destroy(zval *element)
 {
@@ -131,12 +132,109 @@ ZEND_API bool zend_autoload_unregister_class_loader(const zend_fcall_info_cache 
 
 /* We do not return a HashTable* because zend_empty_array is not collectable,
  * therefore the zval holding this value must do so. Something that ZVAL_EMPTY_ARRAY(); does. */
-ZEND_API void zend_autoload_fcc_map_to_callable_zval_map(zval *return_value) {
+ZEND_API void zend_autoload_class_fcc_map_to_callable_zval_map(zval *return_value) {
 	if (zend_class_autoload_functions) {
 		zend_fcall_info_cache *fcc;
 
 		zend_array *map = zend_new_array(zend_hash_num_elements(zend_class_autoload_functions));
 		ZEND_HASH_MAP_FOREACH_PTR(zend_class_autoload_functions, fcc) {
+			zval tmp;
+			zend_get_callable_zval_from_fcc(fcc, &tmp);
+			zend_hash_next_index_insert(map, &tmp);
+		} ZEND_HASH_FOREACH_END();
+		RETURN_ARR(map);
+	}
+	RETURN_EMPTY_ARRAY();
+}
+
+ZEND_API zend_function *zend_perform_function_autoload(zend_string *function_name, zend_string *lc_name)
+{
+	if (!zend_function_autoload_functions) {
+		return NULL;
+	}
+
+	zval zname;
+	ZVAL_STR(&zname, function_name);
+
+	const HashTable *function_autoload_functions = zend_function_autoload_functions;
+
+	/* Cannot use ZEND_HASH_MAP_FOREACH_PTR here as autoloaders may be
+	 * added/removed during autoloading. */
+	HashPosition pos;
+	zend_hash_internal_pointer_reset_ex(function_autoload_functions, &pos);
+	while (true) {
+		zend_fcall_info_cache *func_info = zend_hash_get_current_data_ptr_ex(function_autoload_functions, &pos);
+		if (!func_info) {
+			break;
+		}
+		zend_call_known_fcc(func_info, /* retval */ NULL, /* param_count */ 1, /* params */ &zname, /* named_params */ NULL);
+
+		if (EG(exception)) {
+			return NULL;
+		}
+
+		zend_function *fbc = zend_hash_find_ptr(EG(function_table), lc_name);
+		if (fbc) {
+			return fbc;
+		}
+
+		zend_hash_move_forward_ex(function_autoload_functions, &pos);
+	}
+	return NULL;
+}
+
+ZEND_API void zend_autoload_register_function_loader(zend_fcall_info_cache *fcc, bool prepend)
+{
+	ZEND_ASSERT(ZEND_FCC_INITIALIZED(*fcc));
+
+	if (!zend_function_autoload_functions) {
+		ALLOC_HASHTABLE(zend_function_autoload_functions);
+		zend_hash_init(zend_function_autoload_functions, 1, NULL, zend_autoload_callback_zval_destroy, false);
+		/* Initialize as non-packed hash table for prepend functionality. */
+		zend_hash_real_init_mixed(zend_function_autoload_functions);
+	}
+
+	ZEND_ASSERT(
+		fcc->function_handler->type != ZEND_INTERNAL_FUNCTION
+		|| !zend_string_equals_literal(fcc->function_handler->common.function_name, "spl_autoload_call_function_loader")
+	);
+
+	/* If function is already registered, don't do anything */
+	if (autoload_find_registered_function(zend_function_autoload_functions, fcc)) {
+		/* Release potential call trampoline */
+		zend_release_fcall_info_cache(fcc);
+		return;
+	}
+
+	zend_fcc_addref(fcc);
+	zend_hash_next_index_insert_mem(zend_function_autoload_functions, fcc, sizeof(zend_fcall_info_cache));
+	if (prepend && zend_hash_num_elements(zend_function_autoload_functions) > 1) {
+		/* Move the newly created element to the head of the hashtable */
+		ZEND_ASSERT(!HT_IS_PACKED(zend_function_autoload_functions));
+		Bucket tmp = zend_function_autoload_functions->arData[zend_function_autoload_functions->nNumUsed-1];
+		memmove(zend_function_autoload_functions->arData + 1, zend_function_autoload_functions->arData, sizeof(Bucket) * (zend_function_autoload_functions->nNumUsed - 1));
+		zend_function_autoload_functions->arData[0] = tmp;
+		zend_hash_rehash(zend_function_autoload_functions);
+	}
+}
+
+ZEND_API bool zend_autoload_unregister_function_loader(const zend_fcall_info_cache *fcc) {
+	if (zend_function_autoload_functions) {
+		Bucket *p = autoload_find_registered_function(zend_function_autoload_functions, fcc);
+		if (p) {
+			zend_hash_del_bucket(zend_function_autoload_functions, p);
+			return true;
+		}
+	}
+	return false;
+}
+
+ZEND_API void zend_autoload_function_fcc_map_to_callable_zval_map(zval *return_value) {
+	if (zend_function_autoload_functions) {
+		zend_fcall_info_cache *fcc;
+
+		zend_array *map = zend_new_array(zend_hash_num_elements(zend_function_autoload_functions));
+		ZEND_HASH_MAP_FOREACH_PTR(zend_function_autoload_functions, fcc) {
 			zval tmp;
 			zend_get_callable_zval_from_fcc(fcc, &tmp);
 			zend_hash_next_index_insert(map, &tmp);
@@ -161,5 +259,10 @@ void zend_autoload_shutdown(void)
 		zend_hash_destroy(zend_class_autoload_functions);
 		FREE_HASHTABLE(zend_class_autoload_functions);
 		zend_class_autoload_functions = NULL;
+	}
+	if (zend_function_autoload_functions) {
+		zend_hash_destroy(zend_function_autoload_functions);
+		FREE_HASHTABLE(zend_function_autoload_functions);
+		zend_function_autoload_functions = NULL;
 	}
 }

--- a/Zend/zend_autoload.h
+++ b/Zend/zend_autoload.h
@@ -26,9 +26,15 @@
 ZEND_API zend_class_entry *zend_perform_class_autoload(zend_string *class_name, zend_string *lc_name);
 ZEND_API void zend_autoload_register_class_loader(zend_fcall_info_cache *fcc, bool prepend);
 ZEND_API bool zend_autoload_unregister_class_loader(const zend_fcall_info_cache *fcc);
-ZEND_API void zend_autoload_fcc_map_to_callable_zval_map(zval *return_value);
+ZEND_API void zend_autoload_class_fcc_map_to_callable_zval_map(zval *return_value);
 /* Only for deprecated strange behaviour of spl_autoload_unregister() */
 ZEND_API void zend_autoload_clean_class_loaders(void);
+
+ZEND_API zend_function *zend_perform_function_autoload(zend_string *function_name, zend_string *lc_name);
+ZEND_API void zend_autoload_register_function_loader(zend_fcall_info_cache *fcc, bool prepend);
+ZEND_API bool zend_autoload_unregister_function_loader(const zend_fcall_info_cache *fcc);
+ZEND_API void zend_autoload_function_fcc_map_to_callable_zval_map(zval *return_value);
+
 void zend_autoload_shutdown(void);
 
 #endif

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -37,6 +37,7 @@
 
 ZEND_MINIT_FUNCTION(core) { /* {{{ */
 	zend_autoload = zend_perform_class_autoload;
+	zend_function_autoload = zend_perform_function_autoload;
 	zend_register_default_classes();
 
 	zend_standard_class_def = register_class_stdClass();
@@ -1174,11 +1175,14 @@ ZEND_FUNCTION(enum_exists)
 ZEND_FUNCTION(function_exists)
 {
 	zend_string *name;
+	bool autoload = false;
 	bool exists;
 	zend_string *lcname;
 
-	ZEND_PARSE_PARAMETERS_START(1, 1)
+	ZEND_PARSE_PARAMETERS_START(1, 2)
 		Z_PARAM_STR(name)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_BOOL(autoload)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_VAL(name)[0] == '\\') {
@@ -1190,6 +1194,12 @@ ZEND_FUNCTION(function_exists)
 	}
 
 	exists = zend_hash_exists(EG(function_table), lcname);
+
+	if (!exists && autoload) {
+		zend_function *fbc = zend_lookup_function(name, lcname);
+		exists = (fbc != NULL);
+	}
+
 	zend_string_release_ex(lcname, 0);
 
 	RETURN_BOOL(exists);

--- a/Zend/zend_builtin_functions.stub.php
+++ b/Zend/zend_builtin_functions.stub.php
@@ -99,7 +99,7 @@ function trait_exists(string $trait, bool $autoload = true): bool {}
 
 function enum_exists(string $enum, bool $autoload = true): bool {}
 
-function function_exists(string $function): bool {}
+function function_exists(string $function, bool $autoload = false): bool {}
 
 function class_alias(string $class, string $alias, bool $autoload = true): bool {}
 

--- a/Zend/zend_builtin_functions_arginfo.h
+++ b/Zend/zend_builtin_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit zend_builtin_functions.stub.php instead.
- * Stub hash: 64c61862de86d9968930893bf21b516119724064 */
+ * Stub hash: 480dfa84aa0025f383decf05898c9a7754e564eb */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_clone, 0, 1, IS_OBJECT, 0)
 	ZEND_ARG_TYPE_INFO(0, object, IS_OBJECT, 0)
@@ -126,6 +126,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_function_exists, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, function, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, autoload, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_alias, 0, 2, _IS_BOOL, 0)

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -5147,15 +5147,21 @@ static zend_never_inline zend_execute_data *zend_init_dynamic_call_string(zend_s
 			lcname = zend_string_tolower(function);
 		}
 		if (UNEXPECTED((func = zend_hash_find(EG(function_table), lcname)) == NULL)) {
-			zend_throw_error(NULL, "Call to undefined function %s()", ZSTR_VAL(function));
+			fbc = zend_lookup_function(function, lcname);
+			if (UNEXPECTED(fbc == NULL)) {
+				if (!EG(exception)) {
+					zend_throw_error(NULL, "Call to undefined function %s()", ZSTR_VAL(function));
+				}
+				zend_string_release_ex(lcname, 0);
+				return NULL;
+			}
 			zend_string_release_ex(lcname, 0);
-			return NULL;
-		}
-		zend_string_release_ex(lcname, 0);
-
-		fbc = Z_FUNC_P(func);
-		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!RUN_TIME_CACHE(&fbc->op_array))) {
-			init_func_run_time_cache(&fbc->op_array);
+		} else {
+			zend_string_release_ex(lcname, 0);
+			fbc = Z_FUNC_P(func);
+			if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!RUN_TIME_CACHE(&fbc->op_array))) {
+				init_func_run_time_cache(&fbc->op_array);
+			}
 		}
 		called_scope = NULL;
 	}

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -36,6 +36,9 @@ ZEND_API extern void (*zend_execute_internal)(zend_execute_data *execute_data, z
 /* The lc_name may be stack allocated! */
 ZEND_API extern zend_class_entry *(*zend_autoload)(zend_string *name, zend_string *lc_name);
 
+/* The lc_name may be stack allocated! */
+ZEND_API extern zend_function *(*zend_function_autoload)(zend_string *name, zend_string *lc_name);
+
 void init_executor(void);
 void shutdown_executor(void);
 void shutdown_destructors(void);
@@ -48,8 +51,16 @@ ZEND_API void zend_execute(zend_op_array *op_array, zval *return_value);
 ZEND_API void execute_ex(zend_execute_data *execute_data);
 ZEND_API void execute_internal(zend_execute_data *execute_data, zval *return_value);
 ZEND_API bool zend_is_valid_class_name(const zend_string *name);
+
+/* Function names use the same character set as class names. */
+static zend_always_inline bool zend_is_valid_function_name(const zend_string *name)
+{
+	return zend_is_valid_class_name(name);
+}
+
 ZEND_API zend_class_entry *zend_lookup_class(zend_string *name);
 ZEND_API zend_class_entry *zend_lookup_class_ex(zend_string *name, zend_string *lcname, uint32_t flags);
+ZEND_API zend_function *zend_lookup_function(zend_string *name, zend_string *lc_name);
 ZEND_API zend_class_entry *zend_get_called_scope(const zend_execute_data *ex);
 ZEND_API zend_object *zend_get_this_object(const zend_execute_data *ex);
 ZEND_API zend_result zend_eval_string(const char *str, zval *retval_ptr, const char *string_name);

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -51,6 +51,7 @@
 ZEND_API void (*zend_execute_ex)(zend_execute_data *execute_data);
 ZEND_API void (*zend_execute_internal)(zend_execute_data *execute_data, zval *return_value);
 ZEND_API zend_class_entry *(*zend_autoload)(zend_string *name, zend_string *lc_name);
+ZEND_API zend_function *(*zend_function_autoload)(zend_string *name, zend_string *lc_name);
 
 #ifdef ZEND_WIN32
 ZEND_TLS HANDLE tq_timer = NULL;
@@ -155,6 +156,7 @@ void init_executor(void) /* {{{ */
 
 	zend_hash_init(&EG(included_files), 8, NULL, NULL, 0);
 	zend_hash_init(&EG(autoload_current_classnames), 8, NULL, NULL, 0);
+	zend_hash_init(&EG(autoload_current_functionnames), 8, NULL, NULL, 0);
 
 	EG(ticks_count) = 0;
 
@@ -502,6 +504,7 @@ void shutdown_executor(void) /* {{{ */
 
 		zend_hash_destroy(&EG(included_files));
 		zend_hash_destroy(&EG(autoload_current_classnames));
+		zend_hash_destroy(&EG(autoload_current_functionnames));
 
 		zend_stack_destroy(&EG(user_error_handlers_error_reporting));
 		zend_stack_destroy(&EG(user_error_handlers));
@@ -1296,6 +1299,60 @@ ZEND_API zend_class_entry *zend_lookup_class_ex(zend_string *name, zend_string *
 ZEND_API zend_class_entry *zend_lookup_class(zend_string *name) /* {{{ */
 {
 	return zend_lookup_class_ex(name, NULL, 0);
+}
+/* }}} */
+
+ZEND_API zend_function *zend_lookup_function(zend_string *name, zend_string *lc_name) /* {{{ */
+{
+	zval *func = zend_hash_find(EG(function_table), lc_name);
+	if (func) {
+		zend_function *fbc = Z_FUNC_P(func);
+		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!RUN_TIME_CACHE(&fbc->op_array))) {
+			zend_init_func_run_time_cache(&fbc->op_array);
+		}
+		return fbc;
+	}
+
+	/* The compiler is not-reentrant. Make sure we autoload only during run-time. */
+	if (zend_is_compiling()) {
+		return NULL;
+	}
+
+	if (!zend_function_autoload) {
+		return NULL;
+	}
+
+	/* Verify function name before passing it to the autoloader. */
+	if (!ZSTR_LEN(name) || !zend_is_valid_function_name(name)) {
+		return NULL;
+	}
+
+	if (zend_hash_add_empty_element(&EG(autoload_current_functionnames), lc_name) == NULL) {
+		return NULL;
+	}
+
+	zend_string *autoload_name;
+	if (ZSTR_VAL(name)[0] == '\\') {
+		autoload_name = zend_string_init(ZSTR_VAL(name) + 1, ZSTR_LEN(name) - 1, 0);
+	} else {
+		autoload_name = zend_string_copy(name);
+	}
+
+	zend_string *previous_filename = EG(filename_override);
+	zend_long previous_lineno = EG(lineno_override);
+	EG(filename_override) = NULL;
+	EG(lineno_override) = -1;
+	zend_function *fbc = zend_function_autoload(autoload_name, lc_name);
+	EG(filename_override) = previous_filename;
+	EG(lineno_override) = previous_lineno;
+
+	zend_string_release_ex(autoload_name, 0);
+	zend_hash_del(&EG(autoload_current_functionnames), lc_name);
+
+	if (fbc && EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!RUN_TIME_CACHE(&fbc->op_array))) {
+		zend_init_func_run_time_cache(&fbc->op_array);
+	}
+	return fbc;
 }
 /* }}} */
 

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -227,6 +227,7 @@ struct _zend_executor_globals {
 	zend_atomic_bool timed_out;
 
 	HashTable autoload_current_classnames;
+	HashTable autoload_current_functionnames;
 
 	zend_long hard_timeout;
 	void *stack_base;

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -3903,11 +3903,19 @@ ZEND_VM_HOT_HANDLER(59, ZEND_INIT_FCALL_BY_NAME, ANY, CONST, NUM|CACHE_SLOT)
 		function_name = (zval*)RT_CONSTANT(opline, opline->op2);
 		func = zend_hash_find_known_hash(EG(function_table), Z_STR_P(function_name+1));
 		if (UNEXPECTED(func == NULL)) {
-			ZEND_VM_DISPATCH_TO_HELPER(zend_undefined_function_helper);
-		}
-		fbc = Z_FUNC_P(func);
-		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!RUN_TIME_CACHE(&fbc->op_array))) {
-			init_func_run_time_cache(&fbc->op_array);
+			SAVE_OPLINE();
+			fbc = zend_lookup_function(Z_STR_P(function_name), Z_STR_P(function_name+1));
+			if (UNEXPECTED(fbc == NULL)) {
+				if (EG(exception)) {
+					HANDLE_EXCEPTION();
+				}
+				ZEND_VM_DISPATCH_TO_HELPER(zend_undefined_function_helper);
+			}
+		} else {
+			fbc = Z_FUNC_P(func);
+			if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!RUN_TIME_CACHE(&fbc->op_array))) {
+				init_func_run_time_cache(&fbc->op_array);
+			}
 		}
 		CACHE_PTR(opline->result.num, fbc);
 	}
@@ -4059,7 +4067,17 @@ ZEND_VM_HOT_HANDLER(69, ZEND_INIT_NS_FCALL_BY_NAME, ANY, CONST, NUM|CACHE_SLOT)
 		if (func == NULL) {
 			func = zend_hash_find_known_hash(EG(function_table), Z_STR_P(func_name + 2));
 			if (UNEXPECTED(func == NULL)) {
-				ZEND_VM_DISPATCH_TO_HELPER(zend_undefined_function_helper);
+				/* Autoload with the fully qualified name */
+				SAVE_OPLINE();
+				fbc = zend_lookup_function(Z_STR_P(func_name), Z_STR_P(func_name + 1));
+				if (UNEXPECTED(fbc == NULL)) {
+					if (EG(exception)) {
+						HANDLE_EXCEPTION();
+					}
+					ZEND_VM_DISPATCH_TO_HELPER(zend_undefined_function_helper);
+				}
+				CACHE_PTR(opline->result.num, fbc);
+				ZEND_VM_C_GOTO(ns_fcall_init);
 			}
 		}
 		fbc = Z_FUNC_P(func);
@@ -4069,6 +4087,7 @@ ZEND_VM_HOT_HANDLER(69, ZEND_INIT_NS_FCALL_BY_NAME, ANY, CONST, NUM|CACHE_SLOT)
 		CACHE_PTR(opline->result.num, fbc);
 	}
 
+ZEND_VM_C_LABEL(ns_fcall_init):
 	call = _zend_vm_stack_push_call_frame(ZEND_CALL_NESTED_FUNCTION,
 		fbc, opline->extended_value, NULL);
 	call->prev_execute_data = EX(call);

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -4072,11 +4072,19 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_I
 		function_name = (zval*)RT_CONSTANT(opline, opline->op2);
 		func = zend_hash_find_known_hash(EG(function_table), Z_STR_P(function_name+1));
 		if (UNEXPECTED(func == NULL)) {
-			ZEND_VM_TAIL_CALL(zend_undefined_function_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
-		}
-		fbc = Z_FUNC_P(func);
-		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!RUN_TIME_CACHE(&fbc->op_array))) {
-			init_func_run_time_cache(&fbc->op_array);
+			SAVE_OPLINE();
+			fbc = zend_lookup_function(Z_STR_P(function_name), Z_STR_P(function_name+1));
+			if (UNEXPECTED(fbc == NULL)) {
+				if (EG(exception)) {
+					HANDLE_EXCEPTION();
+				}
+				ZEND_VM_TAIL_CALL(zend_undefined_function_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
+			}
+		} else {
+			fbc = Z_FUNC_P(func);
+			if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!RUN_TIME_CACHE(&fbc->op_array))) {
+				init_func_run_time_cache(&fbc->op_array);
+			}
 		}
 		CACHE_PTR(opline->result.num, fbc);
 	}
@@ -4157,7 +4165,17 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_I
 		if (func == NULL) {
 			func = zend_hash_find_known_hash(EG(function_table), Z_STR_P(func_name + 2));
 			if (UNEXPECTED(func == NULL)) {
-				ZEND_VM_TAIL_CALL(zend_undefined_function_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
+				/* Autoload with the fully qualified name */
+				SAVE_OPLINE();
+				fbc = zend_lookup_function(Z_STR_P(func_name), Z_STR_P(func_name + 1));
+				if (UNEXPECTED(fbc == NULL)) {
+					if (EG(exception)) {
+						HANDLE_EXCEPTION();
+					}
+					ZEND_VM_TAIL_CALL(zend_undefined_function_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
+				}
+				CACHE_PTR(opline->result.num, fbc);
+				goto ns_fcall_init;
 			}
 		}
 		fbc = Z_FUNC_P(func);
@@ -4167,6 +4185,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_I
 		CACHE_PTR(opline->result.num, fbc);
 	}
 
+ns_fcall_init:
 	call = _zend_vm_stack_push_call_frame(ZEND_CALL_NESTED_FUNCTION,
 		fbc, opline->extended_value, NULL);
 	call->prev_execute_data = EX(call);
@@ -56746,11 +56765,19 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_F
 		function_name = (zval*)RT_CONSTANT(opline, opline->op2);
 		func = zend_hash_find_known_hash(EG(function_table), Z_STR_P(function_name+1));
 		if (UNEXPECTED(func == NULL)) {
-			ZEND_VM_TAIL_CALL(zend_undefined_function_helper_SPEC_TAILCALL(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
-		}
-		fbc = Z_FUNC_P(func);
-		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!RUN_TIME_CACHE(&fbc->op_array))) {
-			init_func_run_time_cache(&fbc->op_array);
+			SAVE_OPLINE();
+			fbc = zend_lookup_function(Z_STR_P(function_name), Z_STR_P(function_name+1));
+			if (UNEXPECTED(fbc == NULL)) {
+				if (EG(exception)) {
+					HANDLE_EXCEPTION();
+				}
+				ZEND_VM_TAIL_CALL(zend_undefined_function_helper_SPEC_TAILCALL(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
+			}
+		} else {
+			fbc = Z_FUNC_P(func);
+			if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!RUN_TIME_CACHE(&fbc->op_array))) {
+				init_func_run_time_cache(&fbc->op_array);
+			}
 		}
 		CACHE_PTR(opline->result.num, fbc);
 	}
@@ -56831,7 +56858,17 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_N
 		if (func == NULL) {
 			func = zend_hash_find_known_hash(EG(function_table), Z_STR_P(func_name + 2));
 			if (UNEXPECTED(func == NULL)) {
-				ZEND_VM_TAIL_CALL(zend_undefined_function_helper_SPEC_TAILCALL(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
+				/* Autoload with the fully qualified name */
+				SAVE_OPLINE();
+				fbc = zend_lookup_function(Z_STR_P(func_name), Z_STR_P(func_name + 1));
+				if (UNEXPECTED(fbc == NULL)) {
+					if (EG(exception)) {
+						HANDLE_EXCEPTION();
+					}
+					ZEND_VM_TAIL_CALL(zend_undefined_function_helper_SPEC_TAILCALL(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
+				}
+				CACHE_PTR(opline->result.num, fbc);
+				goto ns_fcall_init;
 			}
 		}
 		fbc = Z_FUNC_P(func);
@@ -56841,6 +56878,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_N
 		CACHE_PTR(opline->result.num, fbc);
 	}
 
+ns_fcall_init:
 	call = _zend_vm_stack_push_call_frame(ZEND_CALL_NESTED_FUNCTION,
 		fbc, opline->extended_value, NULL);
 	call->prev_execute_data = EX(call);

--- a/ext/opcache/jit/zend_jit_helpers.c
+++ b/ext/opcache/jit/zend_jit_helpers.c
@@ -51,9 +51,30 @@ static zend_never_inline zend_op_array* ZEND_FASTCALL zend_jit_init_func_run_tim
 }
 /* }}} */
 
-static zend_function* ZEND_FASTCALL zend_jit_find_func_helper(zend_string *name, void **cache_slot)
+static zend_function* ZEND_FASTCALL zend_jit_find_func_helper(zend_string *name, zend_string *lc_name, void **cache_slot)
 {
-	zval *func = zend_hash_find_known_hash(EG(function_table), name);
+	zval *func = zend_hash_find_known_hash(EG(function_table), lc_name);
+	zend_function *fbc;
+
+	if (UNEXPECTED(func == NULL)) {
+		fbc = zend_lookup_function(name, lc_name);
+		if (fbc == NULL) {
+			return NULL;
+		}
+	} else {
+		fbc = Z_FUNC_P(func);
+		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!RUN_TIME_CACHE(&fbc->op_array))) {
+			fbc = _zend_jit_init_func_run_time_cache(&fbc->op_array);
+		}
+	}
+	*cache_slot = fbc;
+	return fbc;
+}
+
+/* ZEND_INIT_FCALL: the function existed at compile time, so don't autoload on a runtime miss. */
+static zend_function* ZEND_FASTCALL zend_jit_find_known_func_helper(zend_string *lc_name, void **cache_slot)
+{
+	zval *func = zend_hash_find_known_hash(EG(function_table), lc_name);
 	zend_function *fbc;
 
 	if (UNEXPECTED(func == NULL)) {
@@ -83,7 +104,13 @@ static zend_function* ZEND_FASTCALL zend_jit_find_ns_func_helper(zval *func_name
 	if (func == NULL) {
 		func = zend_hash_find_known_hash(EG(function_table), Z_STR_P(func_name + 2));
 		if (UNEXPECTED(func == NULL)) {
-			return NULL;
+			/* Autoload with the fully qualified name */
+			fbc = zend_lookup_function(Z_STR_P(func_name), Z_STR_P(func_name + 1));
+			if (fbc == NULL) {
+				return NULL;
+			}
+			*cache_slot = fbc;
+			return fbc;
 		}
 	}
 	fbc = Z_FUNC_P(func);

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -2164,6 +2164,13 @@ static int zend_jit_invalid_this_stub(zend_jit_ctx *jit)
 
 static int zend_jit_undefined_function_stub(zend_jit_ctx *jit)
 {
+	// JIT: if (EG(exception)) goto exception_handler;
+	ir_ref exception_ref = ir_LOAD_A(jit_EG_exception(jit));
+	ir_ref if_exception = ir_IF(exception_ref);
+	ir_IF_TRUE(if_exception);
+	ir_IJMP(jit_STUB_ADDR(jit, jit_stub_exception_handler));
+	ir_IF_FALSE(if_exception);
+
 	// JIT: load EX(opline)
 	ir_ref ref = ir_LOAD_A(jit_FP(jit));
 	ir_ref arg3 = ir_LOAD_U32(ir_ADD_OFFSET(ref, offsetof(zend_op, op2.constant)));
@@ -3108,6 +3115,7 @@ static void zend_jit_setup_disasm(void)
 	REGISTER_HELPER(zend_jit_extend_stack_helper);
 	REGISTER_HELPER(zend_jit_init_func_run_time_cache_helper);
 	REGISTER_HELPER(zend_jit_find_func_helper);
+	REGISTER_HELPER(zend_jit_find_known_func_helper);
 	REGISTER_HELPER(zend_jit_find_ns_func_helper);
 	REGISTER_HELPER(zend_jit_jmp_frameless_helper);
 	REGISTER_HELPER(zend_jit_unref_helper);
@@ -8887,12 +8895,16 @@ static int zend_jit_init_fcall(zend_jit_ctx *jit, const zend_op *opline, uint32_
 		} else {
 			zval *zv = RT_CONSTANT(opline, opline->op2);
 
+			/* The helpers may invoke a function autoloader, which runs user code. */
+			jit_SET_EX_OPLINE(jit, opline);
+
 			if (opline->opcode == ZEND_INIT_FCALL) {
-				ref = ir_CALL_2(IR_ADDR, ir_CONST_FC_FUNC(zend_jit_find_func_helper),
+				ref = ir_CALL_2(IR_ADDR, ir_CONST_FC_FUNC(zend_jit_find_known_func_helper),
 					ir_CONST_ADDR(Z_STR_P(zv)),
 					cache_slot_ref);
 			} else if (opline->opcode == ZEND_INIT_FCALL_BY_NAME) {
-				ref = ir_CALL_2(IR_ADDR, ir_CONST_FC_FUNC(zend_jit_find_func_helper),
+				ref = ir_CALL_3(IR_ADDR, ir_CONST_FC_FUNC(zend_jit_find_func_helper),
+					ir_CONST_ADDR(Z_STR_P(zv)),
 					ir_CONST_ADDR(Z_STR_P(zv + 1)),
 					cache_slot_ref);
 			} else if (opline->opcode == ZEND_INIT_NS_FCALL_BY_NAME) {
@@ -8916,7 +8928,6 @@ static int zend_jit_init_fcall(zend_jit_ctx *jit, const zend_op *opline, uint32_
 					return 0;
 				}
 			} else {
-jit_SET_EX_OPLINE(jit, opline);
 				ir_GUARD(ref, jit_STUB_ADDR(jit, jit_stub_undefined_function));
 			}
 		}

--- a/ext/opcache/tests/jit/function_autoload_001.phpt
+++ b/ext/opcache/tests/jit/function_autoload_001.phpt
@@ -1,0 +1,29 @@
+--TEST--
+JIT INIT_FCALL_BY_NAME: function autoloading preserves the original case
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.file_update_protection=0
+opcache.jit=function
+opcache.jit_buffer_size=16M
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+spl_autoload_register_function_loader(function (string $name) {
+    echo "Autoloading: $name\n";
+    if (strtolower($name) === 'jit_func') {
+        eval('function jit_func() { return "jit_ok"; }');
+    }
+});
+
+function test() {
+    return Jit_Func();
+}
+var_dump(test());
+var_dump(test());
+?>
+--EXPECT--
+Autoloading: Jit_Func
+string(6) "jit_ok"
+string(6) "jit_ok"

--- a/ext/opcache/tests/jit/function_autoload_002.phpt
+++ b/ext/opcache/tests/jit/function_autoload_002.phpt
@@ -1,0 +1,36 @@
+--TEST--
+JIT INIT_FCALL_BY_NAME: exception thrown by the function autoloader
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.file_update_protection=0
+opcache.jit=function
+opcache.jit_buffer_size=16M
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+spl_autoload_register_function_loader(function (string $name) {
+    throw new RuntimeException("Autoload failed for: $name");
+});
+
+function test() {
+    missing_func();
+}
+
+try {
+    test();
+} catch (RuntimeException $e) {
+    echo $e->getMessage(), "\n";
+    var_dump($e->getTrace()[0]['line']);
+}
+try {
+    test();
+} catch (RuntimeException $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Autoload failed for: missing_func
+int(7)
+Autoload failed for: missing_func

--- a/ext/opcache/tests/jit/function_autoload_003.phpt
+++ b/ext/opcache/tests/jit/function_autoload_003.phpt
@@ -1,0 +1,31 @@
+--TEST--
+JIT INIT_NS_FCALL_BY_NAME: function autoloading with namespace fallback
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.file_update_protection=0
+opcache.jit=function
+opcache.jit_buffer_size=16M
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+namespace App;
+
+\spl_autoload_register_function_loader(function (string $name) {
+    echo "Autoloading: $name\n";
+    if ($name === 'App\ns_func') {
+        eval('namespace App; function ns_func() { return "ns_ok"; }');
+    }
+});
+
+function test() {
+    return ns_func();
+}
+var_dump(test());
+var_dump(test());
+?>
+--EXPECT--
+Autoloading: App\ns_func
+string(5) "ns_ok"
+string(5) "ns_ok"

--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -467,7 +467,74 @@ PHP_FUNCTION(spl_autoload_functions)
 {
 	ZEND_PARSE_PARAMETERS_NONE();
 
-	zend_autoload_fcc_map_to_callable_zval_map(return_value);
+	zend_autoload_class_fcc_map_to_callable_zval_map(return_value);
+} /* }}} */
+
+/* {{{ Register given function as a function autoloader */
+PHP_FUNCTION(spl_autoload_register_function_loader)
+{
+	zend_fcall_info fci;
+	zend_fcall_info_cache fcc;
+	bool prepend = 0;
+
+	ZEND_PARSE_PARAMETERS_START(1, 2)
+		Z_PARAM_FUNC(fci, fcc)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_BOOL(prepend)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (!ZEND_FCC_INITIALIZED(fcc)) {
+		/* Call trampoline has been cleared by zpp. Refetch it, because we want to deal
+		 * with it ourselves. It is important that it is not refetched on every call,
+		 * because calls may occur from different scopes. */
+		zend_is_callable_ex(&fci.function_name, NULL, IS_CALLABLE_SUPPRESS_DEPRECATIONS, NULL, &fcc, NULL);
+	}
+
+	if (fcc.function_handler->type == ZEND_INTERNAL_FUNCTION &&
+		fcc.function_handler->internal_function.handler == zif_spl_autoload_call_function_loader) {
+		zend_argument_value_error(1, "must not be the spl_autoload_call_function_loader() function");
+		RETURN_THROWS();
+	}
+
+	zend_autoload_register_function_loader(&fcc, prepend);
+	RETURN_TRUE;
+} /* }}} */
+
+/* {{{ Unregister given function as a function autoloader */
+PHP_FUNCTION(spl_autoload_unregister_function_loader)
+{
+	zend_fcall_info fci;
+	zend_fcall_info_cache fcc;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_FUNC_NO_TRAMPOLINE_FREE(fci, fcc)
+	ZEND_PARSE_PARAMETERS_END();
+
+	RETVAL_BOOL(zend_autoload_unregister_function_loader(&fcc));
+	/* Release trampoline */
+	zend_release_fcall_info_cache(&fcc);
+} /* }}} */
+
+/* {{{ Return all registered function autoloader functions */
+PHP_FUNCTION(spl_autoload_function_loaders)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	zend_autoload_function_fcc_map_to_callable_zval_map(return_value);
+} /* }}} */
+
+/* {{{ Try all registered function autoloaders to load the requested function */
+PHP_FUNCTION(spl_autoload_call_function_loader)
+{
+	zend_string *function_name;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(function_name)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zend_string *lc_name = zend_string_tolower(function_name);
+	zend_perform_function_autoload(function_name, lc_name);
+	zend_string_release(lc_name);
 } /* }}} */
 
 /* {{{ Return hash id for given object */

--- a/ext/spl/php_spl.stub.php
+++ b/ext/spl/php_spl.stub.php
@@ -35,6 +35,14 @@ function spl_autoload_register(?callable $callback = null, bool $throw = true, b
 
 function spl_autoload_unregister(callable $callback): bool {}
 
+function spl_autoload_register_function_loader(callable $callback, bool $prepend = false): bool {}
+
+function spl_autoload_unregister_function_loader(callable $callback): bool {}
+
+function spl_autoload_function_loaders(): array {}
+
+function spl_autoload_call_function_loader(string $function_name): void {}
+
 /**
  * @return array<string, string>
  * @refcount 1

--- a/ext/spl/php_spl_arginfo.h
+++ b/ext/spl/php_spl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit php_spl.stub.php instead.
- * Stub hash: 21ec2dcca99c85c90afcd319da76016a9f678dc2 */
+ * Stub hash: cc3c674e48e9fb4cf658dcb9603e78076bfdd56a */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_implements, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, object_or_class)
@@ -36,6 +36,19 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_spl_autoload_unregister, 0, 1, _
 	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_spl_autoload_register_function_loader, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, prepend, _IS_BOOL, 0, "false")
+ZEND_END_ARG_INFO()
+
+#define arginfo_spl_autoload_unregister_function_loader arginfo_spl_autoload_unregister
+
+#define arginfo_spl_autoload_function_loaders arginfo_spl_autoload_functions
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_spl_autoload_call_function_loader, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, function_name, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 #define arginfo_spl_classes arginfo_spl_autoload_functions
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_spl_object_hash, 0, 1, IS_STRING, 0)
@@ -70,6 +83,10 @@ ZEND_FUNCTION(spl_autoload_extensions);
 ZEND_FUNCTION(spl_autoload_functions);
 ZEND_FUNCTION(spl_autoload_register);
 ZEND_FUNCTION(spl_autoload_unregister);
+ZEND_FUNCTION(spl_autoload_register_function_loader);
+ZEND_FUNCTION(spl_autoload_unregister_function_loader);
+ZEND_FUNCTION(spl_autoload_function_loaders);
+ZEND_FUNCTION(spl_autoload_call_function_loader);
 ZEND_FUNCTION(spl_classes);
 ZEND_FUNCTION(spl_object_hash);
 ZEND_FUNCTION(spl_object_id);
@@ -87,6 +104,10 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(spl_autoload_functions, arginfo_spl_autoload_functions)
 	ZEND_FE(spl_autoload_register, arginfo_spl_autoload_register)
 	ZEND_FE(spl_autoload_unregister, arginfo_spl_autoload_unregister)
+	ZEND_FE(spl_autoload_register_function_loader, arginfo_spl_autoload_register_function_loader)
+	ZEND_FE(spl_autoload_unregister_function_loader, arginfo_spl_autoload_unregister_function_loader)
+	ZEND_FE(spl_autoload_function_loaders, arginfo_spl_autoload_function_loaders)
+	ZEND_FE(spl_autoload_call_function_loader, arginfo_spl_autoload_call_function_loader)
 	ZEND_FE(spl_classes, arginfo_spl_classes)
 	ZEND_FE(spl_object_hash, arginfo_spl_object_hash)
 	ZEND_FE(spl_object_id, arginfo_spl_object_id)

--- a/ext/spl/tests/autoloading/spl_autoload_register_function_loader_rejects_call_function_loader.phpt
+++ b/ext/spl/tests/autoloading/spl_autoload_register_function_loader_rejects_call_function_loader.phpt
@@ -1,0 +1,12 @@
+--TEST--
+spl_autoload_register_function_loader() rejects spl_autoload_call_function_loader as callback
+--FILE--
+<?php
+try {
+    spl_autoload_register_function_loader('spl_autoload_call_function_loader');
+} catch (\ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+spl_autoload_register_function_loader(): Argument #1 ($callback) must not be the spl_autoload_call_function_loader() function


### PR DESCRIPTION
This PR implements function autoloading (a counterpart to class autoloading). I have tried to make it as similar to class autoloading as possible.

One note: unlike `class_exists()`, the updated `function_exists()` **does not** invoke function autoloading by default; this is in deference to the ecosystem of polyfill packages that do not expect to trigger an autoloader. I am happy to change the default as needed.

Oh, and one more: `zend_autoload_fcc_map_to_callable_zval_map()` is renamed to `zend_autoload_class_fcc_map_to_callable_zval_map()` to differentiate from the new function loader counterpart `zend_autoload_function_fcc_map_to_callable_zval_map()`. Happy to put that name back if it's too much of a break.