### PR TITLE
ext/uri, ext/standard – URL parsing: improve error reporting using detailed url_error codes

### DIFF
--- a/ext/standard/tests/url/bug55399.phpt
+++ b/ext/standard/tests/url/bug55399.phpt
@@ -6,5 +6,6 @@ Bug #55399 (parse_url() incorrectly treats ':' as a valid path)
 var_dump(parse_url(":"));
 
 ?>
---EXPECT--
+--EXPECTF--
+Warning: parse_url(): Trailing colon without port in URL in %s on line %d
 bool(false)

--- a/ext/standard/tests/url/parse_url_basic_001.phpt
+++ b/ext/standard/tests/url/parse_url_basic_001.phpt
@@ -14,7 +14,7 @@ foreach ($urls as $url) {
 
 echo "Done";
 ?>
---EXPECT--
+--EXPECTF--
 --> 64.246.30.37: array(1) {
   ["path"]=>
   string(12) "64.246.30.37"
@@ -762,7 +762,9 @@ echo "Done";
   string(9) "/blah.com"
 }
 
---> x://::abc/?: bool(false)
+--> x://::abc/?: 
+Warning: parse_url(): Invalid port in URL in %s on line %d
+bool(false)
 
 --> http://::?: array(3) {
   ["scheme"]=>
@@ -791,9 +793,13 @@ echo "Done";
   int(6)
 }
 
---> http://?:/: bool(false)
+--> http://?:/: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
---> http://@?:/: bool(false)
+--> http://@?:/: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
 --> file:///:: array(2) {
   ["scheme"]=>
@@ -884,31 +890,59 @@ echo "Done";
   string(1) "/"
 }
 
---> http:///blah.com: bool(false)
+--> http:///blah.com: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
---> http://:80: bool(false)
+--> http://:80: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
---> http://user@:80: bool(false)
+--> http://user@:80: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
---> http://user:pass@:80: bool(false)
+--> http://user:pass@:80: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
---> http://:: bool(false)
+--> http://:: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
---> http://@/: bool(false)
+--> http://@/: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
---> http://@:/: bool(false)
+--> http://@:/: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
---> http://:/: bool(false)
+--> http://:/: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
---> http://?: bool(false)
+--> http://?: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
---> http://#: bool(false)
+--> http://#: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
---> http://?:: bool(false)
+--> http://?:: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
---> http://:?: bool(false)
+--> http://:?: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
---> http://blah.com:123456: bool(false)
+--> http://blah.com:123456: 
+Warning: parse_url(): Port number too long in URL in %s on line %d
+bool(false)
 
---> http://blah.com:abcdef: bool(false)
+--> http://blah.com:abcdef: 
+Warning: parse_url(): Port number too long in URL in %s on line %d
+bool(false)
 Done

--- a/ext/standard/tests/url/parse_url_basic_002.phpt
+++ b/ext/standard/tests/url/parse_url_basic_002.phpt
@@ -15,7 +15,7 @@ foreach ($urls as $url) {
 
 echo "Done";
 ?>
---EXPECT--
+--EXPECTF--
 --> 64.246.30.37   : NULL
 --> http://64.246.30.37   : string(4) "http"
 --> http://64.246.30.37/   : string(4) "http"
@@ -89,12 +89,18 @@ echo "Done";
 --> http://x:?   : string(4) "http"
 --> x:blah.com   : string(1) "x"
 --> x:/blah.com   : string(1) "x"
---> x://::abc/?   : bool(false)
+--> x://::abc/?   : 
+Warning: parse_url(): Invalid port in URL in %s on line %d
+bool(false)
 --> http://::?   : string(4) "http"
 --> http://::#   : string(4) "http"
 --> x://::6.5   : string(1) "x"
---> http://?:/   : bool(false)
---> http://@?:/   : bool(false)
+--> http://?:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://@?:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 --> file:///:   : string(4) "file"
 --> file:///a:/   : string(4) "file"
 --> file:///ab:/   : string(4) "file"
@@ -108,18 +114,46 @@ echo "Done";
 --> /rest/Users?filter={"id":"123"}   : NULL
 --> %:x   : NULL
 --> https://example.com:0/   : string(5) "https"
---> http:///blah.com   : bool(false)
---> http://:80   : bool(false)
---> http://user@:80   : bool(false)
---> http://user:pass@:80   : bool(false)
---> http://:   : bool(false)
---> http://@/   : bool(false)
---> http://@:/   : bool(false)
---> http://:/   : bool(false)
---> http://?   : bool(false)
---> http://#   : bool(false)
---> http://?:   : bool(false)
---> http://:?   : bool(false)
---> http://blah.com:123456   : bool(false)
---> http://blah.com:abcdef   : bool(false)
+--> http:///blah.com   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:80   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://user@:80   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://user:pass@:80   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://@/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://@:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://?   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://#   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://?:   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:?   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://blah.com:123456   : 
+Warning: parse_url(): Port number too long in URL in %s on line %d
+bool(false)
+--> http://blah.com:abcdef   : 
+Warning: parse_url(): Port number too long in URL in %s on line %d
+bool(false)
 Done

--- a/ext/standard/tests/url/parse_url_basic_003.phpt
+++ b/ext/standard/tests/url/parse_url_basic_003.phpt
@@ -14,7 +14,7 @@ foreach ($urls as $url) {
 
 echo "Done";
 ?>
---EXPECT--
+--EXPECTF--
 --> 64.246.30.37   : NULL
 --> http://64.246.30.37   : string(12) "64.246.30.37"
 --> http://64.246.30.37/   : string(12) "64.246.30.37"
@@ -88,12 +88,18 @@ echo "Done";
 --> http://x:?   : string(1) "x"
 --> x:blah.com   : NULL
 --> x:/blah.com   : NULL
---> x://::abc/?   : bool(false)
+--> x://::abc/?   : 
+Warning: parse_url(): Invalid port in URL in %s on line %d
+bool(false)
 --> http://::?   : string(1) ":"
 --> http://::#   : string(1) ":"
 --> x://::6.5   : string(1) ":"
---> http://?:/   : bool(false)
---> http://@?:/   : bool(false)
+--> http://?:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://@?:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 --> file:///:   : NULL
 --> file:///a:/   : NULL
 --> file:///ab:/   : NULL
@@ -107,18 +113,46 @@ echo "Done";
 --> /rest/Users?filter={"id":"123"}   : NULL
 --> %:x   : NULL
 --> https://example.com:0/   : string(11) "example.com"
---> http:///blah.com   : bool(false)
---> http://:80   : bool(false)
---> http://user@:80   : bool(false)
---> http://user:pass@:80   : bool(false)
---> http://:   : bool(false)
---> http://@/   : bool(false)
---> http://@:/   : bool(false)
---> http://:/   : bool(false)
---> http://?   : bool(false)
---> http://#   : bool(false)
---> http://?:   : bool(false)
---> http://:?   : bool(false)
---> http://blah.com:123456   : bool(false)
---> http://blah.com:abcdef   : bool(false)
+--> http:///blah.com   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:80   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://user@:80   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://user:pass@:80   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://@/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://@:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://?   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://#   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://?:   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:?   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://blah.com:123456   : 
+Warning: parse_url(): Port number too long in URL in %s on line %d
+bool(false)
+--> http://blah.com:abcdef   : 
+Warning: parse_url(): Port number too long in URL in %s on line %d
+bool(false)
 Done

--- a/ext/standard/tests/url/parse_url_basic_004.phpt
+++ b/ext/standard/tests/url/parse_url_basic_004.phpt
@@ -14,7 +14,7 @@ foreach ($urls as $url) {
 
 echo "Done";
 ?>
---EXPECT--
+--EXPECTF--
 --> 64.246.30.37   : NULL
 --> http://64.246.30.37   : NULL
 --> http://64.246.30.37/   : NULL
@@ -88,12 +88,18 @@ echo "Done";
 --> http://x:?   : NULL
 --> x:blah.com   : NULL
 --> x:/blah.com   : NULL
---> x://::abc/?   : bool(false)
+--> x://::abc/?   : 
+Warning: parse_url(): Invalid port in URL in %s on line %d
+bool(false)
 --> http://::?   : NULL
 --> http://::#   : NULL
 --> x://::6.5   : int(6)
---> http://?:/   : bool(false)
---> http://@?:/   : bool(false)
+--> http://?:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://@?:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 --> file:///:   : NULL
 --> file:///a:/   : NULL
 --> file:///ab:/   : NULL
@@ -107,18 +113,46 @@ echo "Done";
 --> /rest/Users?filter={"id":"123"}   : NULL
 --> %:x   : NULL
 --> https://example.com:0/   : int(0)
---> http:///blah.com   : bool(false)
---> http://:80   : bool(false)
---> http://user@:80   : bool(false)
---> http://user:pass@:80   : bool(false)
---> http://:   : bool(false)
---> http://@/   : bool(false)
---> http://@:/   : bool(false)
---> http://:/   : bool(false)
---> http://?   : bool(false)
---> http://#   : bool(false)
---> http://?:   : bool(false)
---> http://:?   : bool(false)
---> http://blah.com:123456   : bool(false)
---> http://blah.com:abcdef   : bool(false)
+--> http:///blah.com   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:80   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://user@:80   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://user:pass@:80   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://@/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://@:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://?   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://#   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://?:   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:?   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://blah.com:123456   : 
+Warning: parse_url(): Port number too long in URL in %s on line %d
+bool(false)
+--> http://blah.com:abcdef   : 
+Warning: parse_url(): Port number too long in URL in %s on line %d
+bool(false)
 Done

--- a/ext/standard/tests/url/parse_url_basic_005.phpt
+++ b/ext/standard/tests/url/parse_url_basic_005.phpt
@@ -14,7 +14,7 @@ foreach ($urls as $url) {
 
 echo "Done";
 ?>
---EXPECT--
+--EXPECTF--
 --> 64.246.30.37   : NULL
 --> http://64.246.30.37   : NULL
 --> http://64.246.30.37/   : NULL
@@ -88,12 +88,18 @@ echo "Done";
 --> http://x:?   : NULL
 --> x:blah.com   : NULL
 --> x:/blah.com   : NULL
---> x://::abc/?   : bool(false)
+--> x://::abc/?   : 
+Warning: parse_url(): Invalid port in URL in %s on line %d
+bool(false)
 --> http://::?   : NULL
 --> http://::#   : NULL
 --> x://::6.5   : NULL
---> http://?:/   : bool(false)
---> http://@?:/   : bool(false)
+--> http://?:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://@?:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 --> file:///:   : NULL
 --> file:///a:/   : NULL
 --> file:///ab:/   : NULL
@@ -107,18 +113,46 @@ echo "Done";
 --> /rest/Users?filter={"id":"123"}   : NULL
 --> %:x   : NULL
 --> https://example.com:0/   : NULL
---> http:///blah.com   : bool(false)
---> http://:80   : bool(false)
---> http://user@:80   : bool(false)
---> http://user:pass@:80   : bool(false)
---> http://:   : bool(false)
---> http://@/   : bool(false)
---> http://@:/   : bool(false)
---> http://:/   : bool(false)
---> http://?   : bool(false)
---> http://#   : bool(false)
---> http://?:   : bool(false)
---> http://:?   : bool(false)
---> http://blah.com:123456   : bool(false)
---> http://blah.com:abcdef   : bool(false)
+--> http:///blah.com   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:80   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://user@:80   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://user:pass@:80   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://@/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://@:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://?   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://#   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://?:   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:?   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://blah.com:123456   : 
+Warning: parse_url(): Port number too long in URL in %s on line %d
+bool(false)
+--> http://blah.com:abcdef   : 
+Warning: parse_url(): Port number too long in URL in %s on line %d
+bool(false)
 Done

--- a/ext/standard/tests/url/parse_url_basic_006.phpt
+++ b/ext/standard/tests/url/parse_url_basic_006.phpt
@@ -14,7 +14,7 @@ foreach ($urls as $url) {
 
 echo "Done";
 ?>
---EXPECT--
+--EXPECTF--
 --> 64.246.30.37   : NULL
 --> http://64.246.30.37   : NULL
 --> http://64.246.30.37/   : NULL
@@ -88,12 +88,18 @@ echo "Done";
 --> http://x:?   : NULL
 --> x:blah.com   : NULL
 --> x:/blah.com   : NULL
---> x://::abc/?   : bool(false)
+--> x://::abc/?   : 
+Warning: parse_url(): Invalid port in URL in %s on line %d
+bool(false)
 --> http://::?   : NULL
 --> http://::#   : NULL
 --> x://::6.5   : NULL
---> http://?:/   : bool(false)
---> http://@?:/   : bool(false)
+--> http://?:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://@?:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 --> file:///:   : NULL
 --> file:///a:/   : NULL
 --> file:///ab:/   : NULL
@@ -107,18 +113,46 @@ echo "Done";
 --> /rest/Users?filter={"id":"123"}   : NULL
 --> %:x   : NULL
 --> https://example.com:0/   : NULL
---> http:///blah.com   : bool(false)
---> http://:80   : bool(false)
---> http://user@:80   : bool(false)
---> http://user:pass@:80   : bool(false)
---> http://:   : bool(false)
---> http://@/   : bool(false)
---> http://@:/   : bool(false)
---> http://:/   : bool(false)
---> http://?   : bool(false)
---> http://#   : bool(false)
---> http://?:   : bool(false)
---> http://:?   : bool(false)
---> http://blah.com:123456   : bool(false)
---> http://blah.com:abcdef   : bool(false)
+--> http:///blah.com   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:80   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://user@:80   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://user:pass@:80   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://@/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://@:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://?   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://#   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://?:   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:?   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://blah.com:123456   : 
+Warning: parse_url(): Port number too long in URL in %s on line %d
+bool(false)
+--> http://blah.com:abcdef   : 
+Warning: parse_url(): Port number too long in URL in %s on line %d
+bool(false)
 Done

--- a/ext/standard/tests/url/parse_url_basic_007.phpt
+++ b/ext/standard/tests/url/parse_url_basic_007.phpt
@@ -14,7 +14,7 @@ foreach ($urls as $url) {
 
 echo "Done";
 ?>
---EXPECT--
+--EXPECTF--
 --> 64.246.30.37   : string(12) "64.246.30.37"
 --> http://64.246.30.37   : NULL
 --> http://64.246.30.37/   : string(1) "/"
@@ -88,12 +88,18 @@ echo "Done";
 --> http://x:?   : NULL
 --> x:blah.com   : string(8) "blah.com"
 --> x:/blah.com   : string(9) "/blah.com"
---> x://::abc/?   : bool(false)
+--> x://::abc/?   : 
+Warning: parse_url(): Invalid port in URL in %s on line %d
+bool(false)
 --> http://::?   : NULL
 --> http://::#   : NULL
 --> x://::6.5   : NULL
---> http://?:/   : bool(false)
---> http://@?:/   : bool(false)
+--> http://?:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://@?:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 --> file:///:   : string(2) "/:"
 --> file:///a:/   : string(3) "a:/"
 --> file:///ab:/   : string(5) "/ab:/"
@@ -107,18 +113,46 @@ echo "Done";
 --> /rest/Users?filter={"id":"123"}   : string(11) "/rest/Users"
 --> %:x   : string(3) "%:x"
 --> https://example.com:0/   : string(1) "/"
---> http:///blah.com   : bool(false)
---> http://:80   : bool(false)
---> http://user@:80   : bool(false)
---> http://user:pass@:80   : bool(false)
---> http://:   : bool(false)
---> http://@/   : bool(false)
---> http://@:/   : bool(false)
---> http://:/   : bool(false)
---> http://?   : bool(false)
---> http://#   : bool(false)
---> http://?:   : bool(false)
---> http://:?   : bool(false)
---> http://blah.com:123456   : bool(false)
---> http://blah.com:abcdef   : bool(false)
+--> http:///blah.com   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:80   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://user@:80   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://user:pass@:80   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://@/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://@:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://?   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://#   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://?:   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:?   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://blah.com:123456   : 
+Warning: parse_url(): Port number too long in URL in %s on line %d
+bool(false)
+--> http://blah.com:abcdef   : 
+Warning: parse_url(): Port number too long in URL in %s on line %d
+bool(false)
 Done

--- a/ext/standard/tests/url/parse_url_basic_008.phpt
+++ b/ext/standard/tests/url/parse_url_basic_008.phpt
@@ -14,7 +14,7 @@ foreach ($urls as $url) {
 
 echo "Done";
 ?>
---EXPECT--
+--EXPECTF--
 --> 64.246.30.37   : NULL
 --> http://64.246.30.37   : NULL
 --> http://64.246.30.37/   : NULL
@@ -88,12 +88,18 @@ echo "Done";
 --> http://x:?   : string(0) ""
 --> x:blah.com   : NULL
 --> x:/blah.com   : NULL
---> x://::abc/?   : bool(false)
+--> x://::abc/?   : 
+Warning: parse_url(): Invalid port in URL in %s on line %d
+bool(false)
 --> http://::?   : string(0) ""
 --> http://::#   : NULL
 --> x://::6.5   : NULL
---> http://?:/   : bool(false)
---> http://@?:/   : bool(false)
+--> http://?:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://@?:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 --> file:///:   : NULL
 --> file:///a:/   : NULL
 --> file:///ab:/   : NULL
@@ -107,18 +113,46 @@ echo "Done";
 --> /rest/Users?filter={"id":"123"}   : string(19) "filter={"id":"123"}"
 --> %:x   : NULL
 --> https://example.com:0/   : NULL
---> http:///blah.com   : bool(false)
---> http://:80   : bool(false)
---> http://user@:80   : bool(false)
---> http://user:pass@:80   : bool(false)
---> http://:   : bool(false)
---> http://@/   : bool(false)
---> http://@:/   : bool(false)
---> http://:/   : bool(false)
---> http://?   : bool(false)
---> http://#   : bool(false)
---> http://?:   : bool(false)
---> http://:?   : bool(false)
---> http://blah.com:123456   : bool(false)
---> http://blah.com:abcdef   : bool(false)
+--> http:///blah.com   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:80   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://user@:80   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://user:pass@:80   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://@/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://@:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://?   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://#   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://?:   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:?   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://blah.com:123456   : 
+Warning: parse_url(): Port number too long in URL in %s on line %d
+bool(false)
+--> http://blah.com:abcdef   : 
+Warning: parse_url(): Port number too long in URL in %s on line %d
+bool(false)
 Done

--- a/ext/standard/tests/url/parse_url_basic_009.phpt
+++ b/ext/standard/tests/url/parse_url_basic_009.phpt
@@ -14,7 +14,7 @@ foreach ($urls as $url) {
 
 echo "Done";
 ?>
---EXPECT--
+--EXPECTF--
 --> 64.246.30.37   : NULL
 --> http://64.246.30.37   : NULL
 --> http://64.246.30.37/   : NULL
@@ -88,12 +88,18 @@ echo "Done";
 --> http://x:?   : NULL
 --> x:blah.com   : NULL
 --> x:/blah.com   : NULL
---> x://::abc/?   : bool(false)
+--> x://::abc/?   : 
+Warning: parse_url(): Invalid port in URL in %s on line %d
+bool(false)
 --> http://::?   : NULL
 --> http://::#   : string(0) ""
 --> x://::6.5   : NULL
---> http://?:/   : bool(false)
---> http://@?:/   : bool(false)
+--> http://?:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://@?:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 --> file:///:   : NULL
 --> file:///a:/   : NULL
 --> file:///ab:/   : NULL
@@ -107,18 +113,46 @@ echo "Done";
 --> /rest/Users?filter={"id":"123"}   : NULL
 --> %:x   : NULL
 --> https://example.com:0/   : NULL
---> http:///blah.com   : bool(false)
---> http://:80   : bool(false)
---> http://user@:80   : bool(false)
---> http://user:pass@:80   : bool(false)
---> http://:   : bool(false)
---> http://@/   : bool(false)
---> http://@:/   : bool(false)
---> http://:/   : bool(false)
---> http://?   : bool(false)
---> http://#   : bool(false)
---> http://?:   : bool(false)
---> http://:?   : bool(false)
---> http://blah.com:123456   : bool(false)
---> http://blah.com:abcdef   : bool(false)
+--> http:///blah.com   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:80   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://user@:80   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://user:pass@:80   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://@/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://@:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:/   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://?   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://#   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://?:   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://:?   : 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
+--> http://blah.com:123456   : 
+Warning: parse_url(): Port number too long in URL in %s on line %d
+bool(false)
+--> http://blah.com:abcdef   : 
+Warning: parse_url(): Port number too long in URL in %s on line %d
+bool(false)
 Done

--- a/ext/standard/tests/url/parse_url_unterminated.phpt
+++ b/ext/standard/tests/url/parse_url_unterminated.phpt
@@ -768,7 +768,9 @@ echo "Done";
   string(9) "/blah.com"
 }
 
---> x://::abc/?: bool(false)
+--> x://::abc/?: 
+Warning: parse_url(): Invalid port in URL in %s on line %d
+bool(false)
 
 --> http://::?: array(3) {
   ["scheme"]=>

--- a/ext/standard/tests/url/parse_url_unterminated.phpt
+++ b/ext/standard/tests/url/parse_url_unterminated.phpt
@@ -20,7 +20,7 @@ foreach ($urls as $url) {
 
 echo "Done";
 ?>
---EXPECT--
+--EXPECTF--
 --> 64.246.30.37: array(1) {
   ["path"]=>
   string(12) "64.246.30.37"
@@ -799,9 +799,13 @@ bool(false)
   int(6)
 }
 
---> http://?:/: bool(false)
+--> http://?:/: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
---> http://@?:/: bool(false)
+--> http://@?:/: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
 --> file:///:: array(2) {
   ["scheme"]=>
@@ -892,31 +896,59 @@ bool(false)
   string(1) "/"
 }
 
---> http:///blah.com: bool(false)
+--> http:///blah.com: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
---> http://:80: bool(false)
+--> http://:80: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
---> http://user@:80: bool(false)
+--> http://user@:80: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
---> http://user:pass@:80: bool(false)
+--> http://user:pass@:80: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
---> http://:: bool(false)
+--> http://:: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
---> http://@/: bool(false)
+--> http://@/: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
---> http://@:/: bool(false)
+--> http://@:/: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
---> http://:/: bool(false)
+--> http://:/: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
---> http://?: bool(false)
+--> http://?: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
---> http://#: bool(false)
+--> http://#: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
---> http://?:: bool(false)
+--> http://?:: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
---> http://:?: bool(false)
+--> http://:?: 
+Warning: parse_url(): Empty host in URL in %s on line %d
+bool(false)
 
---> http://blah.com:123456: bool(false)
+--> http://blah.com:123456: 
+Warning: parse_url(): Port number too long in URL in %s on line %d
+bool(false)
 
---> http://blah.com:abcdef: bool(false)
+--> http://blah.com:abcdef: 
+Warning: parse_url(): Port number too long in URL in %s on line %d
+bool(false)
 Done

--- a/ext/standard/url.c
+++ b/ext/standard/url.c
@@ -60,9 +60,9 @@ static void php_replace_controlchars(char *str, size_t len)
 	}
 }
 
-PHPAPI php_url *php_url_parse(char const *str)
+PHPAPI php_url *php_url_parse(char const *str, php_url_error *url_error)
 {
-	return php_url_parse_ex(str, strlen(str));
+	return php_url_parse_ex(str, strlen(str), url_error);
 }
 
 static const char *binary_strcspn(const char *s, const char *e, const char *chars) {
@@ -77,15 +77,15 @@ static const char *binary_strcspn(const char *s, const char *e, const char *char
 }
 
 /* {{{ php_url_parse */
-PHPAPI php_url *php_url_parse_ex(char const *str, size_t length)
+PHPAPI php_url *php_url_parse_ex(char const *str, size_t length, php_url_error *error)
 {
 	bool has_port;
-	return php_url_parse_ex2(str, length, &has_port);
+	return php_url_parse_ex2(str, length, &has_port, error);
 }
 
 /* {{{ php_url_parse_ex2
  */
-PHPAPI php_url *php_url_parse_ex2(char const *str, size_t length, bool *has_port)
+PHPAPI php_url *php_url_parse_ex2(char const *str, size_t length, bool *has_port, php_url_error *url_error)
 {
 	char port_buf[6];
 	php_url *ret = ecalloc(1, sizeof(php_url));
@@ -188,10 +188,12 @@ PHPAPI php_url *php_url_parse_ex2(char const *str, size_t length, bool *has_port
 				}
 			} else {
 				php_url_free(ret);
+				*url_error = PHP_URL_ERR_INVALID_PORT;
 				return NULL;
 			}
 		} else if (p == pp && pp == ue) {
 			php_url_free(ret);
+			*url_error = PHP_URL_ERR_TRAILING_COLON;
 			return NULL;
 		} else if (s + 1 < ue && *s == '/' && *(s + 1) == '/') { /* relative-scheme URL */
 			s += 2;
@@ -239,6 +241,7 @@ parse_host:
 			p++;
 			if (e-p > 5) { /* port cannot be longer then 5 characters */
 				php_url_free(ret);
+				*url_error = PHP_URL_ERR_PORT_TOO_LONG;
 				return NULL;
 			} else if (e - p > 0) {
 				zend_long port;
@@ -251,6 +254,7 @@ parse_host:
 					ret->port = (unsigned short)port;
 				} else {
 					php_url_free(ret);
+					*url_error = PHP_URL_ERR_INVALID_PORT;
 					return NULL;
 				}
 			}
@@ -262,6 +266,7 @@ parse_host:
 
 	/* check if we have a valid host, if we don't reject the string as url */
 	if ((p-s) < 1) {
+		*url_error = PHP_URL_ERR_EMPTY_HOST;
 		php_url_free(ret);
 		return NULL;
 	}
@@ -320,16 +325,33 @@ PHP_FUNCTION(parse_url)
 	zend_long key = -1;
 	zval tmp;
 	bool has_port;
-
+    php_url_error url_error = PHP_URL_ERR_NONE;
+	
 	ZEND_PARSE_PARAMETERS_START(1, 2)
 		Z_PARAM_STRING(str, str_len)
 		Z_PARAM_OPTIONAL
 		Z_PARAM_LONG(key)
 	ZEND_PARSE_PARAMETERS_END();
 
-	resource = php_url_parse_ex2(str, str_len, &has_port);
+	resource = php_url_parse_ex2(str, str_len, &has_port, &url_error);
 	if (resource == NULL) {
-		/* @todo Find a method to determine why php_url_parse_ex() failed */
+		 switch (url_error) {
+            case PHP_URL_ERR_INVALID_PORT:
+                php_error_docref(NULL, E_WARNING, "Invalid port in URL");
+                break;
+            case PHP_URL_ERR_TRAILING_COLON:
+                php_error_docref(NULL, E_WARNING, "Trailing colon without port in URL");
+                break;
+            case PHP_URL_ERR_PORT_TOO_LONG:
+                php_error_docref(NULL, E_WARNING, "Port number too long in URL");
+                break;
+            case PHP_URL_ERR_EMPTY_HOST:
+                php_error_docref(NULL, E_WARNING, "Empty host in URL");
+                break;
+            default:
+                php_error_docref(NULL, E_WARNING, "Unable to parse URL");
+                break;
+        }
 		RETURN_FALSE;
 	}
 

--- a/ext/standard/url.h
+++ b/ext/standard/url.h
@@ -26,10 +26,18 @@ typedef struct php_url {
 	zend_string *fragment;
 } php_url;
 
+typedef enum {
+  PHP_URL_ERR_NONE = 0,
+  PHP_URL_ERR_EMPTY_HOST,
+  PHP_URL_ERR_INVALID_PORT,
+  PHP_URL_ERR_PORT_TOO_LONG,
+  PHP_URL_ERR_TRAILING_COLON,
+} php_url_error;
+
 PHPAPI void php_url_free(php_url *theurl);
-PHPAPI php_url *php_url_parse(char const *str);
-PHPAPI php_url *php_url_parse_ex(char const *str, size_t length);
-PHPAPI php_url *php_url_parse_ex2(char const *str, size_t length, bool *has_port);
+PHPAPI php_url *php_url_parse(char const *str, php_url_error *url_error);
+PHPAPI php_url *php_url_parse_ex(char const *str, size_t length, php_url_error *url_error);
+PHPAPI php_url *php_url_parse_ex2(char const *str, size_t length, bool *has_port, php_url_error *url_error);
 PHPAPI size_t php_url_decode(char *str, size_t len); /* return value: length of decoded string */
 PHPAPI size_t php_url_decode_ex(char *dest, const char *src, size_t src_len);
 PHPAPI size_t php_raw_url_decode(char *str, size_t len); /* return value: length of decoded string */

--- a/ext/standard/url_scanner_ex.re
+++ b/ext/standard/url_scanner_ex.re
@@ -191,7 +191,9 @@ static inline void append_modified_url(smart_str *url, smart_str *dest, smart_st
 	php_url *url_parts;
 
 	smart_str_0(url); /* FIXME: Bug #70480 php_url_parse_ex() crashes by processing chars exceed len */
-	url_parts = php_url_parse_ex(ZSTR_VAL(url->s), ZSTR_LEN(url->s));
+	php_url_error url_error = PHP_URL_ERR_NONE;
+
+	url_parts = php_url_parse_ex(ZSTR_VAL(url->s), ZSTR_LEN(url->s), &url_error);
 
 	/* Ignore malformed URLs */
 	if (!url_parts) {
@@ -383,11 +385,12 @@ static zend_result check_host_whitelist(url_adapt_state_ex_t *ctx)
 {
 	php_url *url_parts = NULL;
 	HashTable *allowed_hosts = ctx->type ? &BG(url_adapt_session_hosts_ht) : &BG(url_adapt_output_hosts_ht);
+    php_url_error url_error = PHP_URL_ERR_NONE;
 
 	ZEND_ASSERT(ctx->tag_type == TAG_FORM);
 
 	if (ctx->attr_val.s && ZSTR_LEN(ctx->attr_val.s)) {
-		url_parts = php_url_parse_ex(ZSTR_VAL(ctx->attr_val.s), ZSTR_LEN(ctx->attr_val.s));
+		url_parts = php_url_parse_ex(ZSTR_VAL(ctx->attr_val.s), ZSTR_LEN(ctx->attr_val.s), &url_error);
 	} else {
 		return SUCCESS; /* empty URL is valid */
 	}

--- a/ext/uri/uri_parser_php_parse_url.c
+++ b/ext/uri/uri_parser_php_parse_url.c
@@ -143,8 +143,9 @@ static zend_result uri_parser_php_parse_url_fragment_read(void *uri, php_uri_com
 static void *uri_parser_php_parse_url_parse(const char *uri_str, size_t uri_str_len, const void *base_url, zval *errors, bool silent)
 {
 	bool has_port;
+    php_url_error url_error = PHP_URL_ERR_NONE;
 
-	php_url *url = php_url_parse_ex2(uri_str, uri_str_len, &has_port);
+	php_url *url = php_url_parse_ex2(uri_str, uri_str_len, &has_port, &url_error);
 	if (url == NULL && !silent) {
 		zend_throw_exception(php_uri_ce_invalid_uri_exception, "The specified URI is malformed", 0);
 	}


### PR DESCRIPTION
Replace generic URL parse failure warning with specific error messages
based on `php_url_parse_ex2()` error codes (invalid port, trailing colon,
port too long, empty host, etc.).

```diff
+		 switch (url_error) {
+            case PHP_URL_ERR_INVALID_PORT:
+                php_error_docref(NULL, E_WARNING, "Invalid port in URL");
+                break;
+            case PHP_URL_ERR_TRAILING_COLON:
+                php_error_docref(NULL, E_WARNING, "Trailing colon without port in URL");
+                break;
+            case PHP_URL_ERR_PORT_TOO_LONG:
+                php_error_docref(NULL, E_WARNING, "Port number too long in URL");
+                break;
+            case PHP_URL_ERR_EMPTY_HOST:
+                php_error_docref(NULL, E_WARNING, "Empty host in URL");
+                break;
+            default:
+                php_error_docref(NULL, E_WARNING, "Unable to parse URL");
+                break;
+        }
```