### PR TITLE
ext/intl: Guard Spoofchecker restriction-level APIs at ICU 53 (fix build on ICU 50.x)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,8 @@ PHP                                                                        NEWS
   . Fix incorrect argument positions for uninitialized calendar arguments in
     IntlCalendar::equals(), ::before(), ::after(), and ::isEquivalentTo().
     (Weilin Du)
+  . Fixed Spoofchecker restriction-level APIs to only be exposed with ICU 53
+    and later. (Graham Campbell)
 
 - Phar:
   . Fixed a bypass of the magic ".phar" directory protection in

--- a/ext/intl/spoofchecker/spoofchecker.stub.php
+++ b/ext/intl/spoofchecker/spoofchecker.stub.php
@@ -19,6 +19,7 @@ class Spoofchecker
     public const int INVISIBLE = UNKNOWN;
     /** @cvalue USPOOF_CHAR_LIMIT */
     public const int CHAR_LIMIT = UNKNOWN;
+#if U_ICU_VERSION_MAJOR_NUM >= 53
     /** @cvalue USPOOF_ASCII */
     public const int ASCII = UNKNOWN;
     /** @cvalue USPOOF_HIGHLY_RESTRICTIVE */
@@ -33,6 +34,7 @@ class Spoofchecker
     public const int SINGLE_SCRIPT_RESTRICTIVE = UNKNOWN;
     /** @cvalue USPOOF_MIXED_NUMBERS */
     public const int MIXED_NUMBERS = UNKNOWN;
+#endif
 #if U_ICU_VERSION_MAJOR_NUM >= 62
     /** @cvalue USPOOF_HIDDEN_OVERLAY */
     public const int HIDDEN_OVERLAY = UNKNOWN;
@@ -69,7 +71,9 @@ class Spoofchecker
     /** @tentative-return-type */
     public function setChecks(int $checks): void {}
 
+#if U_ICU_VERSION_MAJOR_NUM >= 53
     /** @tentative-return-type */
     public function setRestrictionLevel(int $level): void {}
+#endif
     public function setAllowedChars(string $pattern, int $patternOptions = 0): void {}
 }

--- a/ext/intl/spoofchecker/spoofchecker_arginfo.h
+++ b/ext/intl/spoofchecker/spoofchecker_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 4634f8ef9157fb3670a2ddc5e3246340660fc68c */
+ * Stub hash: d01a6d58d52e8b38a7854626d9649d5915ec7e5c */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Spoofchecker___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -23,9 +23,11 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Spoofchecker_set
 	ZEND_ARG_TYPE_INFO(0, checks, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
+#if U_ICU_VERSION_MAJOR_NUM >= 53
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Spoofchecker_setRestrictionLevel, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, level, IS_LONG, 0)
 ZEND_END_ARG_INFO()
+#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Spoofchecker_setAllowedChars, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, pattern, IS_STRING, 0)
@@ -37,7 +39,9 @@ ZEND_METHOD(Spoofchecker, isSuspicious);
 ZEND_METHOD(Spoofchecker, areConfusable);
 ZEND_METHOD(Spoofchecker, setAllowedLocales);
 ZEND_METHOD(Spoofchecker, setChecks);
+#if U_ICU_VERSION_MAJOR_NUM >= 53
 ZEND_METHOD(Spoofchecker, setRestrictionLevel);
+#endif
 ZEND_METHOD(Spoofchecker, setAllowedChars);
 
 static const zend_function_entry class_Spoofchecker_methods[] = {
@@ -46,7 +50,9 @@ static const zend_function_entry class_Spoofchecker_methods[] = {
 	ZEND_ME(Spoofchecker, areConfusable, arginfo_class_Spoofchecker_areConfusable, ZEND_ACC_PUBLIC)
 	ZEND_ME(Spoofchecker, setAllowedLocales, arginfo_class_Spoofchecker_setAllowedLocales, ZEND_ACC_PUBLIC)
 	ZEND_ME(Spoofchecker, setChecks, arginfo_class_Spoofchecker_setChecks, ZEND_ACC_PUBLIC)
+#if U_ICU_VERSION_MAJOR_NUM >= 53
 	ZEND_ME(Spoofchecker, setRestrictionLevel, arginfo_class_Spoofchecker_setRestrictionLevel, ZEND_ACC_PUBLIC)
+#endif
 	ZEND_ME(Spoofchecker, setAllowedChars, arginfo_class_Spoofchecker_setAllowedChars, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
@@ -99,48 +105,62 @@ static zend_class_entry *register_class_Spoofchecker(void)
 	zend_string *const_CHAR_LIMIT_name = zend_string_init_interned("CHAR_LIMIT", sizeof("CHAR_LIMIT") - 1, 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_LIMIT_name, &const_CHAR_LIMIT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_LIMIT_name);
+#if U_ICU_VERSION_MAJOR_NUM >= 53
 
 	zval const_ASCII_value;
 	ZVAL_LONG(&const_ASCII_value, USPOOF_ASCII);
 	zend_string *const_ASCII_name = zend_string_init_interned("ASCII", sizeof("ASCII") - 1, 1);
 	zend_declare_typed_class_constant(class_entry, const_ASCII_name, &const_ASCII_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ASCII_name);
+#endif
+#if U_ICU_VERSION_MAJOR_NUM >= 53
 
 	zval const_HIGHLY_RESTRICTIVE_value;
 	ZVAL_LONG(&const_HIGHLY_RESTRICTIVE_value, USPOOF_HIGHLY_RESTRICTIVE);
 	zend_string *const_HIGHLY_RESTRICTIVE_name = zend_string_init_interned("HIGHLY_RESTRICTIVE", sizeof("HIGHLY_RESTRICTIVE") - 1, 1);
 	zend_declare_typed_class_constant(class_entry, const_HIGHLY_RESTRICTIVE_name, &const_HIGHLY_RESTRICTIVE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_HIGHLY_RESTRICTIVE_name);
+#endif
+#if U_ICU_VERSION_MAJOR_NUM >= 53
 
 	zval const_MODERATELY_RESTRICTIVE_value;
 	ZVAL_LONG(&const_MODERATELY_RESTRICTIVE_value, USPOOF_MODERATELY_RESTRICTIVE);
 	zend_string *const_MODERATELY_RESTRICTIVE_name = zend_string_init_interned("MODERATELY_RESTRICTIVE", sizeof("MODERATELY_RESTRICTIVE") - 1, 1);
 	zend_declare_typed_class_constant(class_entry, const_MODERATELY_RESTRICTIVE_name, &const_MODERATELY_RESTRICTIVE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MODERATELY_RESTRICTIVE_name);
+#endif
+#if U_ICU_VERSION_MAJOR_NUM >= 53
 
 	zval const_MINIMALLY_RESTRICTIVE_value;
 	ZVAL_LONG(&const_MINIMALLY_RESTRICTIVE_value, USPOOF_MINIMALLY_RESTRICTIVE);
 	zend_string *const_MINIMALLY_RESTRICTIVE_name = zend_string_init_interned("MINIMALLY_RESTRICTIVE", sizeof("MINIMALLY_RESTRICTIVE") - 1, 1);
 	zend_declare_typed_class_constant(class_entry, const_MINIMALLY_RESTRICTIVE_name, &const_MINIMALLY_RESTRICTIVE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MINIMALLY_RESTRICTIVE_name);
+#endif
+#if U_ICU_VERSION_MAJOR_NUM >= 53
 
 	zval const_UNRESTRICTIVE_value;
 	ZVAL_LONG(&const_UNRESTRICTIVE_value, USPOOF_UNRESTRICTIVE);
 	zend_string *const_UNRESTRICTIVE_name = zend_string_init_interned("UNRESTRICTIVE", sizeof("UNRESTRICTIVE") - 1, 1);
 	zend_declare_typed_class_constant(class_entry, const_UNRESTRICTIVE_name, &const_UNRESTRICTIVE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_UNRESTRICTIVE_name);
+#endif
+#if U_ICU_VERSION_MAJOR_NUM >= 53
 
 	zval const_SINGLE_SCRIPT_RESTRICTIVE_value;
 	ZVAL_LONG(&const_SINGLE_SCRIPT_RESTRICTIVE_value, USPOOF_SINGLE_SCRIPT_RESTRICTIVE);
 	zend_string *const_SINGLE_SCRIPT_RESTRICTIVE_name = zend_string_init_interned("SINGLE_SCRIPT_RESTRICTIVE", sizeof("SINGLE_SCRIPT_RESTRICTIVE") - 1, 1);
 	zend_declare_typed_class_constant(class_entry, const_SINGLE_SCRIPT_RESTRICTIVE_name, &const_SINGLE_SCRIPT_RESTRICTIVE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SINGLE_SCRIPT_RESTRICTIVE_name);
+#endif
+#if U_ICU_VERSION_MAJOR_NUM >= 53
 
 	zval const_MIXED_NUMBERS_value;
 	ZVAL_LONG(&const_MIXED_NUMBERS_value, USPOOF_MIXED_NUMBERS);
 	zend_string *const_MIXED_NUMBERS_name = zend_string_init_interned("MIXED_NUMBERS", sizeof("MIXED_NUMBERS") - 1, 1);
 	zend_declare_typed_class_constant(class_entry, const_MIXED_NUMBERS_name, &const_MIXED_NUMBERS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MIXED_NUMBERS_name);
+#endif
 #if U_ICU_VERSION_MAJOR_NUM >= 62
 
 	zval const_HIDDEN_OVERLAY_value;

--- a/ext/intl/spoofchecker/spoofchecker_main.c
+++ b/ext/intl/spoofchecker/spoofchecker_main.c
@@ -135,6 +135,7 @@ PHP_METHOD(Spoofchecker, setChecks)
 }
 /* }}} */
 
+#if U_ICU_VERSION_MAJOR_NUM >= 53
 /* TODO Document this method on PHP.net */
 /* {{{ Set the loosest restriction level allowed for strings. */
 PHP_METHOD(Spoofchecker, setRestrictionLevel)
@@ -163,6 +164,7 @@ PHP_METHOD(Spoofchecker, setRestrictionLevel)
 	uspoof_setRestrictionLevel(co->uspoof, (URestrictionLevel)level);
 }
 /* }}} */
+#endif
 
 PHP_METHOD(Spoofchecker, setAllowedChars)
 {

--- a/ext/intl/tests/spoofchecker_007.phpt
+++ b/ext/intl/tests/spoofchecker_007.phpt
@@ -7,7 +7,7 @@ intl
 <?php
     $r = new ReflectionClass("SpoofChecker");
     if (false === $r->getConstant("SINGLE_SCRIPT_RESTRICTIVE")) {
-        die("skip Incompatible ICU version");
+        die("skip for ICU version < 53");
     }
 ?>
 --FILE--

--- a/ext/intl/tests/spoofchecker_007.phpt
+++ b/ext/intl/tests/spoofchecker_007.phpt
@@ -4,6 +4,12 @@ spoofchecker with restriction level
 intl
 --SKIPIF--
 <?php if(!class_exists("Spoofchecker")) print 'skip'; ?>
+<?php
+    $r = new ReflectionClass("SpoofChecker");
+    if (false === $r->getConstant("SINGLE_SCRIPT_RESTRICTIVE")) {
+        die("skip Incompatible ICU version");
+    }
+?>
 --FILE--
 <?php
 

--- a/ext/intl/tests/spoofchecker_supported_icu57_apis.phpt
+++ b/ext/intl/tests/spoofchecker_supported_icu57_apis.phpt
@@ -7,7 +7,7 @@ intl
 <?php
     $r = new ReflectionClass("Spoofchecker");
     if (false === $r->getConstant("SINGLE_SCRIPT_RESTRICTIVE")) {
-        die("skip Incompatible ICU version");
+        die("skip for ICU version < 53");
     }
 ?>
 --FILE--

--- a/ext/intl/tests/spoofchecker_supported_icu57_apis.phpt
+++ b/ext/intl/tests/spoofchecker_supported_icu57_apis.phpt
@@ -4,6 +4,12 @@ Spoofchecker exposes restriction-level APIs on all supported ICU versions
 intl
 --SKIPIF--
 <?php if (!class_exists("Spoofchecker")) print 'skip'; ?>
+<?php
+    $r = new ReflectionClass("Spoofchecker");
+    if (false === $r->getConstant("SINGLE_SCRIPT_RESTRICTIVE")) {
+        die("skip Incompatible ICU version");
+    }
+?>
 --FILE--
 <?php
 $r = new ReflectionClass("Spoofchecker");

--- a/ext/intl/tests/spoofchecker_unknown_restriction_level.phpt
+++ b/ext/intl/tests/spoofchecker_unknown_restriction_level.phpt
@@ -6,7 +6,7 @@ intl
 <?php
 if (!class_exists("Spoofchecker")) print 'skip';
 
-if (!method_exists(new Spoofchecker(), 'setRestrictionLevel')) print 'skip ICU version < 53';
+if (!method_exists(new Spoofchecker(), 'setRestrictionLevel')) print 'skip for ICU version < 53';
 ?>
 --FILE--
 <?php

--- a/ext/intl/tests/spoofchecker_unknown_restriction_level.phpt
+++ b/ext/intl/tests/spoofchecker_unknown_restriction_level.phpt
@@ -5,6 +5,8 @@ intl
 --SKIPIF--
 <?php
 if (!class_exists("Spoofchecker")) print 'skip';
+
+if (!method_exists(new Spoofchecker(), 'setRestrictionLevel')) print 'skip ICU version < 53';
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
PHP 8.4.22 fails to compile the intl extension when the system ICU is older than 53 — on Amazon Linux 2 (system ICU 50.2) the build breaks with `USPOOF_ASCII`, the other `Spoofchecker` restriction-level constants, and `URestrictionLevel` undeclared. The cause is GH-22055 (fixing #22053), which removed the `#if U_ICU_VERSION_MAJOR_NUM >= 58` guards around the `Spoofchecker` restriction-level constants and the `setRestrictionLevel()` method, so they are now referenced unconditionally.

This is fine on master and PHP-8.5 (`icu-uc >= 57.1`) but not on PHP-8.4, which still accepts `icu-uc >= 50.1`. The symbols have existed since ICU 51 except `USPOOF_SINGLE_SCRIPT_RESTRICTIVE` (ICU 53, used in the `setRestrictionLevel()` body); since 50.2 satisfies the `50.1` minimum, `configure` passes and only the compile fails. ICU 53 is therefore the right floor: guarding at `>= 53` builds on every ICU PHP-8.4 supports while still exposing the API on ICU 53+ — which is what GH-22055 wanted, since its `>= 58` guard was too strict and hid the API on ICU 57.x.

The fix restores the guard at `#if U_ICU_VERSION_MAJOR_NUM >= 53` around the constants and `setRestrictionLevel()` in `spoofchecker.stub.php` (regenerating `spoofchecker_arginfo.h`) and around the `setRestrictionLevel()` body in `spoofchecker_main.c`. The unrelated `setAllowedChars()` message change is kept.
