### PR TITLE
sockets: Fix memory leak in socket_recvfrom()

### DIFF
--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -1646,6 +1646,7 @@ PHP_FUNCTION(socket_recvfrom)
 			*/
 #endif
 		default:
+			zend_string_efree(recv_buf);
 			zend_argument_value_error(1, "must be one of AF_UNIX, AF_INET, or AF_INET6");
 			RETURN_THROWS();
 	}


### PR DESCRIPTION
recv_buf is allocated before the address-family switch but not freed on the default case, which every other case does. The default is not reachable in practice (socket_create and socket_import_stream restrict the family to the handled set), so this is hardening; the same gap is present on the stable branches.