### PR TITLE
intl: Fix memory leak in IntlChar::getFC_NFKC_Closure()

### DIFF
--- a/ext/intl/uchar/uchar.c
+++ b/ext/intl/uchar/uchar.c
@@ -525,8 +525,8 @@ IC_METHOD(getFC_NFKC_Closure) {
 
 	error = U_ZERO_ERROR;
 	u8str = intl_convert_utf16_to_utf8(closure, closure_len, &error);
-	INTL_CHECK_STATUS(error, "Failed converting output to UTF8");
 	efree(closure);
+	INTL_CHECK_STATUS(error, "Failed converting output to UTF8");
 	RETVAL_NEW_STR(u8str);
 }
 /* }}} */


### PR DESCRIPTION
If the final UTF-16 to UTF-8 conversion fails, INTL_CHECK_STATUS returns before the closure buffer is freed. It is freed right after the conversion consumes it, as the sibling branch above already does. The conversion does not fail for valid closure output, so this is hardening; the same gap exists on PHP-8.5 (on 8.4 the file is the older uchar.c).