### PR TITLE
date: Fix typo in condition in date_period_init_iso8601_string()

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -5125,7 +5125,7 @@ static bool date_period_init_iso8601_string(php_period_obj *dpobj, zend_class_en
 		zend_string_release(func);
 		return false;
 	}
-	if (dpobj->end == NULL && recurrences == 0) {
+	if (dpobj->end == NULL && *recurrences == 0) {
 		zend_string *func = get_active_function_or_method_name();
 		zend_throw_exception_ex(date_ce_date_malformed_period_string_exception, 0, "%s(): ISO interval must contain an end date or a recurrence count, \"%s\" given", ZSTR_VAL(func), isostr);
 		zend_string_release(func);

--- a/ext/date/tests/date_period_bad_iso_format.phpt
+++ b/ext/date/tests/date_period_bad_iso_format.phpt
@@ -50,5 +50,5 @@ DateMalformedPeriodStringException: DatePeriod::__construct(): ISO interval must
 DateMalformedPeriodStringException: DatePeriod::createFromISO8601String(): ISO interval must contain an interval, "R4/2012-07-01T00:00:00Z" given
 
 Deprecated: Calling DatePeriod::__construct(string $isostr, int $options = 0) is deprecated, use DatePeriod::createFromISO8601String() instead in %s on line %d
-DateMalformedPeriodStringException: DatePeriod::__construct(): Recurrence count must be greater or equal to 1 and lower than %d
-DateMalformedPeriodStringException: DatePeriod::createFromISO8601String(): Recurrence count must be greater or equal to 1 and lower than %d
+DateMalformedPeriodStringException: DatePeriod::__construct(): ISO interval must contain an end date or a recurrence count, "2012-07-01T00:00:00Z/P7D" given
+DateMalformedPeriodStringException: DatePeriod::createFromISO8601String(): ISO interval must contain an end date or a recurrence count, "2012-07-01T00:00:00Z/P7D" given


### PR DESCRIPTION
Now the address is being checked instead of the value, but I believe the value should be checked against 0, not the pointer against NULL.

Found by static analysis.