### PR TITLE
readline: Fix memory leak in interactive shell INI directive

### DIFF
--- a/ext/readline/readline_cli.c
+++ b/ext/readline/readline_cli.c
@@ -662,6 +662,7 @@ static int readline_shell_run(void) /* {{{ */
 				zend_string_release_ex(prompt, 0);
 				/* TODO: This might be wrong! */
 				prompt = cli_get_prompt("php", '>');
+				free(line);
 				continue;
 			}
 		}

--- a/ext/readline/tests/readline_cli_ini_directive.phpt
+++ b/ext/readline/tests/readline_cli_ini_directive.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Interactive shell: setting an INI directive via #name=value
+--EXTENSIONS--
+readline
+--SKIPIF--
+<?php
+if (!function_exists('proc_open')) die('skip proc_open() not available');
+?>
+--FILE--
+<?php
+$php = getenv('TEST_PHP_EXECUTABLE');
+$ini = getenv('TEST_PHP_EXTRA_ARGS');
+$descriptorspec = [['pipe', 'r'], STDOUT, STDERR];
+$proc = proc_open("$php $ini -a", $descriptorspec, $pipes);
+fwrite($pipes[0], "#precision=5\n");
+fwrite($pipes[0], "echo 'INI[' . ini_get('precision') . ']';\n");
+fclose($pipes[0]);
+proc_close($proc);
+?>
+--EXPECTF--
+%AINI[5]%A


### PR DESCRIPTION
In the php -a interactive shell, a line of the form #name=value sets an INI directive and then continues the loop without freeing the readline() buffer, unlike every sibling branch. Reproduces under valgrind (USE_ZEND_ALLOC=0): 9 bytes definitely lost at readline_cli.c per such line.