### PR TITLE
ext/intl: Fix typos in error conventions

### DIFF
--- a/ext/intl/ERROR_CONVENTIONS.md
+++ b/ext/intl/ERROR_CONVENTIONS.md
@@ -6,14 +6,14 @@ conventions are enumerated in this document.
 * The last error is always stored globally.
 
 The global error code can be obtained in userland with `intl_get_error_code()`.
-This is a `U_*` error code defined by ICU, but it does not have necessarily to
-be returned obtained after a call to an ICU function. That is to say, the
+This is a `U_*` error code defined by ICU, but it is not necessarily obtained
+from a call to an ICU function. That is to say, the
 internal PHP wrapper functions can set these error codes when appropriate. For
 instance, in response to bad arguments (e.g. `zend_parse_parameters()` failure),
 the PHP wrapper function should set the global error code to
-`U_ILLEGAL_ARGUMENT_ERROR`).
+`U_ILLEGAL_ARGUMENT_ERROR`.
 
-The error code (an integer) can be converter to the corresponding enum name
+The error code (an integer) can be converted to the corresponding enum name
 string in userland with `intl_error_name()`.
 
 The associated message can be obtained with `intl_get_error_message()`. This is
@@ -60,7 +60,7 @@ void intl_errors_set(intl_error* err, UErrorCode code, char* msg, int copyMsg);
 ```
 
 by passing a pointer to the object's `intl_error` as the first parameter.
-Node the extra `s` in the functions' names (`errors`, not `error`).
+Note the extra `s` in the functions' names (`errors`, not `error`).
 
 Static methods should only set the global error.
 
@@ -68,15 +68,15 @@ Static methods should only set the global error.
   `getErrorMessage()` methods.
 
 These methods are used to retrieve the error codes stored in the object's
-private `intl_error` structured and mirror the global `intl_get_error_code()`
+private `intl_error` structure and mirror the global `intl_get_error_code()`
 and `intl_get_error_message()`.
 
 * Intl methods and functions should return `FALSE` on error (even argument
   parsing errors), not `NULL`. Constructors and factory methods are the
   exception; these should return `NULL`, not `FALSE`.
 
-Note that constructors in Intl generally (always?) don't throws exceptions. They
-instead destroy the object to that the result of new `IntlClass()` can be
+Note that constructors in Intl generally (always?) do not throw exceptions. They
+instead destroy the object so that the result of new `IntlClass()` can be
 `NULL`. This may be surprising.
 
 * Intl functions and methods should reset the global error before doing anything

--- a/ext/intl/tests/bug75317.phpt
+++ b/ext/intl/tests/bug75317.phpt
@@ -29,7 +29,7 @@ var_dump($c->setSourceEncoding('utf-32'));
 printResult($c->getDestinationEncoding(), $utf8);
 printResult($c->getSourceEncoding(), $utf32);
 
-// test invalid inputs dont change values
+// test invalid inputs don't change values
 var_dump($c->setDestinationEncoding('foobar') === false);
 var_dump($c->setSourceEncoding('foobar') === false);
 printResult($c->getDestinationEncoding(), $utf8);


### PR DESCRIPTION
Fixes several typos and small grammar issues in ext/intl/ERROR_CONVENTIONS.md, and a typo in an intl test comment.

No tests run, documentation/comment-only change.