### PR TITLE
Zend: Fix GH-22257 type confusion in Exception::getTraceAsString().

### DIFF
--- a/Zend/tests/gh22257.phpt
+++ b/Zend/tests/gh22257.phpt
@@ -1,0 +1,33 @@
+--TEST--
+GH-22257 (Type confusion / OOB read in Exception::getTraceAsString() with a non-array trace)
+--CREDITS--
+012git012
+--FILE--
+<?php
+/* A crafted, deliberately truncated payload leaves Exception::$trace holding a
+ * non-array value (the typed-property check is skipped on the parse failure path).
+ * The half-built object is then exposed to getTraceAsString() through SplHeap's
+ * delayed __unserialize(), which used to type-confuse the object as a HashTable. */
+$n = "\x00";
+$r = unserialize(
+    'O:9:"Exception":1:{' .
+    's:16:"' . $n . 'Exception' . $n . 'trace";' .
+    'O:8:"stdClass":2:{' .
+    's:1:"0";' .
+    'O:10:"SplMaxHeap":2:{' .
+    'i:0;a:0:{}' .
+    'i:1;a:2:{' .
+    's:5:"flags";i:0;' .
+    's:13:"heap_elements";a:2:{i:0;s:0:"";i:1;R:1;}' .
+    '}' .
+    '}' .
+    'z' .
+    '}}'
+);
+var_dump($r);
+echo "OK\n";
+?>
+--EXPECTF--
+Warning: unserialize(): Error at offset %d of %d bytes in %s on line %d
+bool(false)
+OK

--- a/Zend/tests/gh22257.phpt
+++ b/Zend/tests/gh22257.phpt
@@ -1,14 +1,15 @@
 --TEST--
-GH-22257 (Type confusion / OOB read in Exception::getTraceAsString() with a non-array trace)
+GH-22257 (Type confusion / OOB read unserializing an Exception with a non-array trace)
 --CREDITS--
 Igor Sak-Sakovskiy (Positive Technologies)
 --FILE--
 <?php
-/* A crafted, deliberately truncated payload leaves Exception::$trace holding a
- * non-array value (the typed-property check is skipped on the parse failure path).
- * The half-built object is then exposed to getTraceAsString() through SplHeap's
- * delayed __unserialize(), which used to type-confuse the object as a HashTable.
- * It must throw instead of reading out of bounds. */
+/* A crafted, deliberately truncated payload makes the nested value of the typed
+ * "array $trace" property fail to unserialize. On that failure path the slot used
+ * to keep the half-built (non-array) value, and the partially-built Exception was
+ * then exposed to getTraceAsString() through SplHeap's delayed __unserialize(),
+ * type-confusing the object as a HashTable. The slot is now reset to the property
+ * default, so the run completes without an out-of-bounds read. */
 $n = "\x00";
 try {
     unserialize(
@@ -25,6 +26,4 @@ echo "OK\n";
 ?>
 --EXPECTF--
 Warning: unserialize(): Error at offset %d of %d bytes in %s on line %d
-Exception: Invalid serialization data for SplMaxHeap object
-Error: Exception trace is not an array
 OK

--- a/Zend/tests/gh22257.phpt
+++ b/Zend/tests/gh22257.phpt
@@ -1,7 +1,7 @@
 --TEST--
 GH-22257 (Type confusion / OOB read in Exception::getTraceAsString() with a non-array trace)
 --CREDITS--
-012git012
+Igor Sak-Sakovskiy (Positive Technologies)
 --FILE--
 <?php
 /* A crafted, deliberately truncated payload leaves Exception::$trace holding a

--- a/Zend/tests/gh22257.phpt
+++ b/Zend/tests/gh22257.phpt
@@ -7,27 +7,24 @@ GH-22257 (Type confusion / OOB read in Exception::getTraceAsString() with a non-
 /* A crafted, deliberately truncated payload leaves Exception::$trace holding a
  * non-array value (the typed-property check is skipped on the parse failure path).
  * The half-built object is then exposed to getTraceAsString() through SplHeap's
- * delayed __unserialize(), which used to type-confuse the object as a HashTable. */
+ * delayed __unserialize(), which used to type-confuse the object as a HashTable.
+ * It must throw instead of reading out of bounds. */
 $n = "\x00";
-$r = unserialize(
-    'O:9:"Exception":1:{' .
-    's:16:"' . $n . 'Exception' . $n . 'trace";' .
-    'O:8:"stdClass":2:{' .
-    's:1:"0";' .
-    'O:10:"SplMaxHeap":2:{' .
-    'i:0;a:0:{}' .
-    'i:1;a:2:{' .
-    's:5:"flags";i:0;' .
-    's:13:"heap_elements";a:2:{i:0;s:0:"";i:1;R:1;}' .
-    '}' .
-    '}' .
-    'z' .
-    '}}'
-);
-var_dump($r);
+try {
+    unserialize(
+        'O:9:"Exception":1:{s:16:"' . $n . 'Exception' . $n . 'trace";' .
+        'O:8:"stdClass":2:{s:1:"0";O:10:"SplMaxHeap":2:{i:0;a:0:{}i:1;a:2:{' .
+        's:5:"flags";i:0;s:13:"heap_elements";a:2:{i:0;s:0:"";i:1;R:1;}}}z}}'
+    );
+} catch (\Throwable $e) {
+    for (; $e; $e = $e->getPrevious()) {
+        printf("%s: %s\n", $e::class, $e->getMessage());
+    }
+}
 echo "OK\n";
 ?>
 --EXPECTF--
 Warning: unserialize(): Error at offset %d of %d bytes in %s on line %d
-bool(false)
+Exception: Invalid serialization data for SplMaxHeap object
+Error: Exception trace is not an array
 OK

--- a/Zend/tests/gh22257.phpt
+++ b/Zend/tests/gh22257.phpt
@@ -22,8 +22,17 @@ try {
         printf("%s: %s\n", $e::class, $e->getMessage());
     }
 }
+
+/* By-ref type violation: the slot is reset to the property default. */
+class Test { public int $i; public array $a; }
+try {
+    var_dump(unserialize('O:4:"Test":2:{s:1:"i";N;s:1:"a";R:2;}'));
+} catch (\Throwable $e) {
+    printf("%s: %s\n", $e::class, $e->getMessage());
+}
 echo "OK\n";
 ?>
 --EXPECTF--
 Warning: unserialize(): Error at offset %d of %d bytes in %s on line %d
+TypeError: Cannot assign null to property Test::$i of type int
 OK

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -685,8 +685,9 @@ ZEND_METHOD(Exception, getTraceAsString)
 	}
 
 	ZVAL_DEREF(trace);
-	/* Type should be guaranteed by property type. */
-	ZEND_ASSERT(Z_TYPE_P(trace) == IS_ARRAY);
+	if (UNEXPECTED(Z_TYPE_P(trace) != IS_ARRAY)) {
+		RETURN_EMPTY_STRING();
+	}
 	RETURN_NEW_STR(zend_trace_to_string(Z_ARRVAL_P(trace), /* include_main */ true));
 }
 /* }}} */

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -685,10 +685,8 @@ ZEND_METHOD(Exception, getTraceAsString)
 	}
 
 	ZVAL_DEREF(trace);
-	if (UNEXPECTED(Z_TYPE_P(trace) != IS_ARRAY)) {
-		zend_throw_error(NULL, "Exception trace is not an array");
-		RETURN_THROWS();
-	}
+	/* Type should be guaranteed by property type. */
+	ZEND_ASSERT(Z_TYPE_P(trace) == IS_ARRAY);
 	RETURN_NEW_STR(zend_trace_to_string(Z_ARRVAL_P(trace), /* include_main */ true));
 }
 /* }}} */

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -686,7 +686,8 @@ ZEND_METHOD(Exception, getTraceAsString)
 
 	ZVAL_DEREF(trace);
 	if (UNEXPECTED(Z_TYPE_P(trace) != IS_ARRAY)) {
-		RETURN_EMPTY_STRING();
+		zend_throw_error(NULL, "Exception trace is not an array");
+		RETURN_THROWS();
 	}
 	RETURN_NEW_STR(zend_trace_to_string(Z_ARRVAL_P(trace), /* include_main */ true));
 }

--- a/ext/standard/var_unserializer.re
+++ b/ext/standard/var_unserializer.re
@@ -677,10 +677,17 @@ second_try:
 		}
 
 		if (!php_var_unserialize_internal(data, p, max, var_hash)) {
-			if (info && Z_ISREF_P(data)) {
-				/* Add type source even if we failed to unserialize.
-				 * The data is still stored in the property. */
-				ZEND_REF_ADD_TYPE_SOURCE(Z_REF_P(data), info);
+			if (info) {
+				if (Z_ISREF_P(data)) {
+					ZEND_REF_ADD_TYPE_SOURCE(Z_REF_P(data), info);
+				} else {
+					/* "partially unserialized" value might violate the property
+					 * declared type so we restore the default
+					 */
+					zval *tmp = &obj->ce->default_properties_table[OBJ_PROP_TO_NUM(info->offset)];
+					zval_ptr_dtor(data);
+					ZVAL_COPY_OR_DUP(data, tmp);
+				}
 			}
 			goto failure;
 		}

--- a/ext/standard/var_unserializer.re
+++ b/ext/standard/var_unserializer.re
@@ -152,6 +152,17 @@ static zend_never_inline void var_push_dtor_value(php_unserialize_data_t *var_ha
 	}
 }
 
+static zend_always_inline void var_restore_prop_default(php_unserialize_data_t *var_hash, zend_object *obj, zend_property_info *info, zval *data)
+{
+	/* A partially/incorrectly unserialized value may violate the property's
+	 * declared type, so restore the default and keep the slot consistent. */
+	zval *tmp = &obj->ce->default_properties_table[OBJ_PROP_TO_NUM(info->offset)];
+	if (Z_REFCOUNTED_P(data)) {
+		var_push_dtor_value(var_hash, data);
+	}
+	ZVAL_COPY_OR_DUP_PROP(data, tmp);
+}
+
 static zend_always_inline zval *tmp_var(php_unserialize_data_t *var_hashx, zend_long num)
 {
     var_dtor_entries *var_hash;
@@ -681,13 +692,7 @@ second_try:
 				if (Z_ISREF_P(data)) {
 					ZEND_REF_ADD_TYPE_SOURCE(Z_REF_P(data), info);
 				} else {
-					/* "partially unserialized" value might violate the property
-					 * declared type so we restore the default */
-					zval *tmp = &obj->ce->default_properties_table[OBJ_PROP_TO_NUM(info->offset)];
-					if (Z_REFCOUNTED_P(data)) {
-						var_push_dtor_value(var_hash, data);
-					}
-					ZVAL_COPY_OR_DUP(data, tmp);
+					var_restore_prop_default(var_hash, obj, info, data);
 				}
 			}
 			goto failure;
@@ -695,8 +700,7 @@ second_try:
 
 		if (UNEXPECTED(info)) {
 			if (!zend_verify_prop_assignable_by_ref(info, data, /* strict */ 1)) {
-				zval_ptr_dtor(data);
-				ZVAL_UNDEF(data);
+				var_restore_prop_default(var_hash, obj, info, data);
 				goto failure;
 			}
 

--- a/ext/standard/var_unserializer.re
+++ b/ext/standard/var_unserializer.re
@@ -682,10 +682,11 @@ second_try:
 					ZEND_REF_ADD_TYPE_SOURCE(Z_REF_P(data), info);
 				} else {
 					/* "partially unserialized" value might violate the property
-					 * declared type so we restore the default
-					 */
+					 * declared type so we restore the default */
 					zval *tmp = &obj->ce->default_properties_table[OBJ_PROP_TO_NUM(info->offset)];
-					zval_ptr_dtor(data);
+					if (Z_REFCOUNTED_P(data)) {
+						var_push_dtor_value(var_hash, data);
+					}
 					ZVAL_COPY_OR_DUP(data, tmp);
 				}
 			}


### PR DESCRIPTION
A crafted, deliberately truncated unserialize() payload can leave Exception::$trace holding a non-array value, since the typed-property check is skipped on the parse failure path. getTraceAsString() then reinterpreted the object as a HashTable, causing an out-of-bounds read. Guard against a non-array trace and return an empty string instead.

Fix #22257