### PR TITLE
Fix another `vm_interrupt` bug for tailcall VM

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,9 @@ PHP                                                                        NEWS
     LXB_API as __declspec(dllimport) when linked statically into PHP.
     (Luther Monson)
 
+- Opcache:
+  . Fixed bug GH-22265 (Another tailcall vm_interrupt bug). (Levi Morrison)
+
 - Phar:
   . Fixed a bypass of the magic ".phar" directory protection in
     Phar::addEmptyDir() for paths starting with "/.phar", while allowing

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -4302,8 +4302,15 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_fcall_interrupt(zend_execute_data *ca
 		} \
 	} while (0)
 
+#if ZEND_VM_KIND == ZEND_VM_KIND_TAILCALL
+# define ZEND_VM_KIND_TAILCALL_SAVE_OPLINE() SAVE_OPLINE()
+#else
+# define ZEND_VM_KIND_TAILCALL_SAVE_OPLINE()
+#endif
+
 #define ZEND_VM_LOOP_INTERRUPT_CHECK() do { \
 		if (UNEXPECTED(zend_atomic_bool_load_ex(&EG(vm_interrupt)))) { \
+			ZEND_VM_KIND_TAILCALL_SAVE_OPLINE(); \
 			ZEND_VM_LOOP_INTERRUPT(); \
 		} \
 	} while (0)

--- a/ext/zend_test/tests/observer_vm_interrupt_tailcall_return.phpt
+++ b/ext/zend_test/tests/observer_vm_interrupt_tailcall_return.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Observer: VM interrupt during tailcall return to caller
+--DESCRIPTION--
+This exercises a VM interrupt raised immediately before a user function returns
+to a caller that invoked it through DO_FCALL. On the tailcall VM, the caller's
+saved opline must point to the opcode after DO_FCALL before a pending interrupt
+is handled.
+--EXTENSIONS--
+zend_test
+--INI--
+opcache.jit=0
+zend_test.observer.set_vm_interrupt_on_begin=1
+--FILE--
+<?php
+function interrupt_before_return(VmInterruptComparable $left, VmInterruptComparable $right): void
+{
+    $left < $right;
+}
+
+function call_interrupt_before_return(): void
+{
+    interrupt_before_return(new VmInterruptComparable(2), new VmInterruptComparable(1));
+}
+
+call_interrupt_before_return();
+echo "ok\n";
+?>
+--EXPECT--
+ok


### PR DESCRIPTION
We fixed a bug in the tailcall VM related to vm_interrupt in 8.5.7: #21922. Unfortunately I was able to find another crash, reproducer attached.

Note that the ["return opline" variant](https://github.com/php/php-src/pull/21922/changes/914efebf89b4ada533e9a528943eee96db7733fb) that Arnaud benchmarked passes this test. This PR instead adds a `SAVE_OPLINE` before `ZEND_VM_LOOP_INTERRUPT` in a specific macro. They seemed very close in speed, and @bwoebi preferred this to partially reverting.