### PR TITLE
fix oob read on malformed length field in dba flatfile handler

### DIFF
--- a/ext/dba/libflatfile/flatfile.c
+++ b/ext/dba/libflatfile/flatfile.c
@@ -35,6 +35,18 @@
 
 #define FLATFILE_BLOCK_SIZE 1024
 
+/* Parse the length prefix in `buf` into `num` and grow `buf` to hold it.
+ * atoi() narrows a malformed (e.g. negative) length to a huge size_t whose
+ * `+ FLATFILE_BLOCK_SIZE` would overflow erealloc(); the macro yields true in
+ * that case so the caller stops reading and the read stays within `buf_size`. */
+#define FLATFILE_GROW_BUF(num, buf, buf_size) ( \
+	(num) = atoi(buf), \
+	(num) >= (buf_size) && ( \
+		(num) > SIZE_MAX - FLATFILE_BLOCK_SIZE \
+		|| ((buf) = erealloc((buf), (buf_size) = (num) + FLATFILE_BLOCK_SIZE), 0) \
+	) \
+)
+
 /*
  * ret = -1 means that database was opened for read-only
  * ret = 0  success
@@ -110,13 +122,8 @@ int flatfile_delete(flatfile *dba, datum key_datum) {
 		if (!php_stream_gets(dba->fp, buf, 15)) {
 			break;
 		}
-		num = atoi(buf);
-		if (num >= buf_size) {
-			if (num > SIZE_MAX - FLATFILE_BLOCK_SIZE) {
-				break;
-			}
-			buf_size = num + FLATFILE_BLOCK_SIZE;
-			buf = erealloc(buf, buf_size);
+		if (FLATFILE_GROW_BUF(num, buf, buf_size)) {
+			break;
 		}
 		pos = php_stream_tell(dba->fp);
 
@@ -136,13 +143,8 @@ int flatfile_delete(flatfile *dba, datum key_datum) {
 		if (!php_stream_gets(dba->fp, buf, 15)) {
 			break;
 		}
-		num = atoi(buf);
-		if (num >= buf_size) {
-			if (num > SIZE_MAX - FLATFILE_BLOCK_SIZE) {
-				break;
-			}
-			buf_size = num + FLATFILE_BLOCK_SIZE;
-			buf = erealloc(buf, buf_size);
+		if (FLATFILE_GROW_BUF(num, buf, buf_size)) {
+			break;
 		}
 		/* read in the value */
 		num = php_stream_read(dba->fp, buf, num);
@@ -166,13 +168,8 @@ int flatfile_findkey(flatfile *dba, datum key_datum) {
 		if (!php_stream_gets(dba->fp, buf, 15)) {
 			break;
 		}
-		num = atoi(buf);
-		if (num >= buf_size) {
-			if (num > SIZE_MAX - FLATFILE_BLOCK_SIZE) {
-				break;
-			}
-			buf_size = num + FLATFILE_BLOCK_SIZE;
-			buf = erealloc(buf, buf_size);
+		if (FLATFILE_GROW_BUF(num, buf, buf_size)) {
+			break;
 		}
 		num = php_stream_read(dba->fp, buf, num);
 
@@ -185,13 +182,8 @@ int flatfile_findkey(flatfile *dba, datum key_datum) {
 		if (!php_stream_gets(dba->fp, buf, 15)) {
 			break;
 		}
-		num = atoi(buf);
-		if (num >= buf_size) {
-			if (num > SIZE_MAX - FLATFILE_BLOCK_SIZE) {
-				break;
-			}
-			buf_size = num + FLATFILE_BLOCK_SIZE;
-			buf = erealloc(buf, buf_size);
+		if (FLATFILE_GROW_BUF(num, buf, buf_size)) {
+			break;
 		}
 		num = php_stream_read(dba->fp, buf, num);
 	}
@@ -212,13 +204,8 @@ datum flatfile_firstkey(flatfile *dba) {
 		if (!php_stream_gets(dba->fp, buf, 15)) {
 			break;
 		}
-		num = atoi(buf);
-		if (num >= buf_size) {
-			if (num > SIZE_MAX - FLATFILE_BLOCK_SIZE) {
-				break;
-			}
-			buf_size = num + FLATFILE_BLOCK_SIZE;
-			buf = erealloc(buf, buf_size);
+		if (FLATFILE_GROW_BUF(num, buf, buf_size)) {
+			break;
 		}
 		num = php_stream_read(dba->fp, buf, num);
 
@@ -231,13 +218,8 @@ datum flatfile_firstkey(flatfile *dba) {
 		if (!php_stream_gets(dba->fp, buf, 15)) {
 			break;
 		}
-		num = atoi(buf);
-		if (num >= buf_size) {
-			if (num > SIZE_MAX - FLATFILE_BLOCK_SIZE) {
-				break;
-			}
-			buf_size = num + FLATFILE_BLOCK_SIZE;
-			buf = erealloc(buf, buf_size);
+		if (FLATFILE_GROW_BUF(num, buf, buf_size)) {
+			break;
 		}
 		num = php_stream_read(dba->fp, buf, num);
 	}
@@ -260,26 +242,16 @@ datum flatfile_nextkey(flatfile *dba) {
 		if (!php_stream_gets(dba->fp, buf, 15)) {
 			break;
 		}
-		num = atoi(buf);
-		if (num >= buf_size) {
-			if (num > SIZE_MAX - FLATFILE_BLOCK_SIZE) {
-				break;
-			}
-			buf_size = num + FLATFILE_BLOCK_SIZE;
-			buf = erealloc(buf, buf_size);
+		if (FLATFILE_GROW_BUF(num, buf, buf_size)) {
+			break;
 		}
 		num = php_stream_read(dba->fp, buf, num);
 
 		if (!php_stream_gets(dba->fp, buf, 15)) {
 			break;
 		}
-		num = atoi(buf);
-		if (num >= buf_size) {
-			if (num > SIZE_MAX - FLATFILE_BLOCK_SIZE) {
-				break;
-			}
-			buf_size = num + FLATFILE_BLOCK_SIZE;
-			buf = erealloc(buf, buf_size);
+		if (FLATFILE_GROW_BUF(num, buf, buf_size)) {
+			break;
 		}
 		num = php_stream_read(dba->fp, buf, num);
 

--- a/ext/dba/libflatfile/flatfile.c
+++ b/ext/dba/libflatfile/flatfile.c
@@ -112,6 +112,9 @@ int flatfile_delete(flatfile *dba, datum key_datum) {
 		}
 		num = atoi(buf);
 		if (num >= buf_size) {
+			if (num > SIZE_MAX - FLATFILE_BLOCK_SIZE) {
+				break;
+			}
 			buf_size = num + FLATFILE_BLOCK_SIZE;
 			buf = erealloc(buf, buf_size);
 		}
@@ -135,6 +138,9 @@ int flatfile_delete(flatfile *dba, datum key_datum) {
 		}
 		num = atoi(buf);
 		if (num >= buf_size) {
+			if (num > SIZE_MAX - FLATFILE_BLOCK_SIZE) {
+				break;
+			}
 			buf_size = num + FLATFILE_BLOCK_SIZE;
 			buf = erealloc(buf, buf_size);
 		}
@@ -162,6 +168,9 @@ int flatfile_findkey(flatfile *dba, datum key_datum) {
 		}
 		num = atoi(buf);
 		if (num >= buf_size) {
+			if (num > SIZE_MAX - FLATFILE_BLOCK_SIZE) {
+				break;
+			}
 			buf_size = num + FLATFILE_BLOCK_SIZE;
 			buf = erealloc(buf, buf_size);
 		}
@@ -178,6 +187,9 @@ int flatfile_findkey(flatfile *dba, datum key_datum) {
 		}
 		num = atoi(buf);
 		if (num >= buf_size) {
+			if (num > SIZE_MAX - FLATFILE_BLOCK_SIZE) {
+				break;
+			}
 			buf_size = num + FLATFILE_BLOCK_SIZE;
 			buf = erealloc(buf, buf_size);
 		}
@@ -202,6 +214,9 @@ datum flatfile_firstkey(flatfile *dba) {
 		}
 		num = atoi(buf);
 		if (num >= buf_size) {
+			if (num > SIZE_MAX - FLATFILE_BLOCK_SIZE) {
+				break;
+			}
 			buf_size = num + FLATFILE_BLOCK_SIZE;
 			buf = erealloc(buf, buf_size);
 		}
@@ -218,6 +233,9 @@ datum flatfile_firstkey(flatfile *dba) {
 		}
 		num = atoi(buf);
 		if (num >= buf_size) {
+			if (num > SIZE_MAX - FLATFILE_BLOCK_SIZE) {
+				break;
+			}
 			buf_size = num + FLATFILE_BLOCK_SIZE;
 			buf = erealloc(buf, buf_size);
 		}
@@ -244,6 +262,9 @@ datum flatfile_nextkey(flatfile *dba) {
 		}
 		num = atoi(buf);
 		if (num >= buf_size) {
+			if (num > SIZE_MAX - FLATFILE_BLOCK_SIZE) {
+				break;
+			}
 			buf_size = num + FLATFILE_BLOCK_SIZE;
 			buf = erealloc(buf, buf_size);
 		}
@@ -254,6 +275,9 @@ datum flatfile_nextkey(flatfile *dba) {
 		}
 		num = atoi(buf);
 		if (num >= buf_size) {
+			if (num > SIZE_MAX - FLATFILE_BLOCK_SIZE) {
+				break;
+			}
 			buf_size = num + FLATFILE_BLOCK_SIZE;
 			buf = erealloc(buf, buf_size);
 		}

--- a/ext/dba/tests/dba_flatfile_oob.phpt
+++ b/ext/dba/tests/dba_flatfile_oob.phpt
@@ -1,0 +1,31 @@
+--TEST--
+DBA FlatFile handler bounds with a malformed (negative) length field
+--EXTENSIONS--
+dba
+--SKIPIF--
+<?php
+require_once __DIR__ . '/setup/setup_dba_tests.inc';
+check_skip('flatfile');
+?>
+--FILE--
+<?php
+$db_file = __DIR__ . '/dba_flatfile_oob.db';
+// A negative length narrows to a huge size_t and previously overran the read buffer.
+file_put_contents($db_file, "-1\n" . str_repeat('A', 200000));
+
+$db = dba_open($db_file, 'r', 'flatfile');
+var_dump(dba_firstkey($db));
+var_dump(dba_exists("AAAA", $db));
+var_dump(dba_fetch("AAAA", $db));
+dba_close($db);
+echo "done\n";
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/dba_flatfile_oob.db');
+?>
+--EXPECT--
+bool(false)
+bool(false)
+bool(false)
+done


### PR DESCRIPTION
A flatfile opened read-only parses an attacker-controlled record length, and a negative value overruns the read buffer.

1. `num` is a `size_t` but is assigned from `atoi(buf)`, so a length line of `-1` becomes `SIZE_MAX`.
2. the grow step then does `buf_size = num + FLATFILE_BLOCK_SIZE`, which wraps to a tiny value and `erealloc` shrinks `buf`.
3. `php_stream_read(dba->fp, buf, num)` then reads the rest of the file (`num` is still `SIZE_MAX`) into the small buffer.

`repro:` `file_put_contents('x', "-1\n" . str_repeat('A', 200000)); $db = dba_open('x', 'r', 'flatfile'); dba_firstkey($db);`
`expected:` `bool(false)`
`actual:` `zend_mm_heap corrupted` (SIGABRT)

Reachable from `dba_firstkey`/`dba_nextkey`/`dba_fetch`/`dba_exists`/`dba_delete`. The same idiom is repeated in `flatfile_delete`, `flatfile_findkey`, `flatfile_firstkey` and `flatfile_nextkey`, so the guard goes in each. Added a regression test.
