### PR TITLE
ext/intl: Sync IntlTimeZone object errors for invalid display types

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,8 @@ PHP                                                                        NEWS
   . Fix incorrect argument positions for uninitialized calendar arguments in
     IntlCalendar::equals(), ::before(), ::after(), and ::isEquivalentTo().
     (Weilin Du)
+  . Fixed IntlTimeZone::getDisplayName() to synchronize object error state
+    for invalid display types. (Weilin Du)
   . Fixed Spoofchecker restriction-level APIs to only be exposed with ICU 53
     and later. (Graham Campbell)
 

--- a/ext/intl/tests/timezone_getDisplayName_error.phpt
+++ b/ext/intl/tests/timezone_getDisplayName_error.phpt
@@ -17,7 +17,7 @@ var_dump(intltz_get_display_name(null, IntlTimeZone::DISPLAY_SHORT, false, 'pt_P
 --EXPECTF--
 Warning: IntlTimeZone::getDisplayName(): wrong display type in %s on line %d
 bool(false)
-IntlTimeZone::getDisplayName(): wrong display type: U_ILLEGAL_ARGUMENT_ERROR
+wrong display type: U_ILLEGAL_ARGUMENT_ERROR
 int(1)
 wrong display type: U_ILLEGAL_ARGUMENT_ERROR
 

--- a/ext/intl/tests/timezone_getDisplayName_error.phpt
+++ b/ext/intl/tests/timezone_getDisplayName_error.phpt
@@ -8,12 +8,18 @@ ini_set("intl.error_level", E_WARNING);
 
 $tz = IntlTimeZone::createTimeZone('Europe/Lisbon');
 var_dump($tz->getDisplayName(false, -1));
+echo intl_get_error_message(), PHP_EOL;
+var_dump($tz->getErrorCode());
+echo $tz->getErrorMessage(), PHP_EOL;
 
 var_dump(intltz_get_display_name(null, IntlTimeZone::DISPLAY_SHORT, false, 'pt_PT'));
 ?>
 --EXPECTF--
 Warning: IntlTimeZone::getDisplayName(): wrong display type in %s on line %d
 bool(false)
+IntlTimeZone::getDisplayName(): wrong display type: U_ILLEGAL_ARGUMENT_ERROR
+int(1)
+wrong display type: U_ILLEGAL_ARGUMENT_ERROR
 
 Fatal error: Uncaught TypeError: intltz_get_display_name(): Argument #1 ($timezone) must be of type IntlTimeZone, null given in %s:%d
 Stack trace:

--- a/ext/intl/timezone/timezone_methods.cpp
+++ b/ext/intl/timezone/timezone_methods.cpp
@@ -513,13 +513,15 @@ U_CFUNC PHP_FUNCTION(intltz_get_display_name)
 		RETURN_THROWS();
 	}
 
+	TIMEZONE_METHOD_FETCH_OBJECT;
+
 	bool found = false;
 	for (int i = 0; !found && i < sizeof(display_types)/sizeof(*display_types); i++) {
 		if (display_types[i] == display_type)
 			found = true;
 	}
 	if (!found) {
-		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
+		intl_errors_set(TIMEZONE_ERROR_P(to), U_ILLEGAL_ARGUMENT_ERROR,
 			"wrong display type", 0);
 		RETURN_FALSE;
 	}
@@ -527,8 +529,6 @@ U_CFUNC PHP_FUNCTION(intltz_get_display_name)
 	if (!locale_str) {
 		locale_str = intl_locale_get_default();
 	}
-
-	TIMEZONE_METHOD_FETCH_OBJECT;
 
 	UnicodeString result;
 	to->utimezone->getDisplayName((UBool)daylight, (TimeZone::EDisplayType)display_type,


### PR DESCRIPTION
Now, `IntlTimeZone::getDisplayName()` handled invalid `display_type` values *before* fetching the object, so it only updated the global intl error state.

That is, 
```php
<?php
$tz = IntlTimeZone::createTimeZone('Europe/Lisbon');
var_dump($tz->getDisplayName(false, -1));
var_dump(intl_get_error_message());
var_dump($tz->getErrorCode());
var_dump($tz->getErrorMessage());
```
returns
```
bool(false)
string(76) "IntlTimeZone::getDisplayName(): wrong display type: U_ILLEGAL_ARGUMENT_ERROR"
int(0)
string(12) "U_ZERO_ERROR"
```
but I expect
```
bool(false)
string(76) "IntlTimeZone::getDisplayName(): wrong display type: U_ILLEGAL_ARGUMENT_ERROR"
int(1)
string(44) "wrong display type: U_ILLEGAL_ARGUMENT_ERROR"
```
The solution is to move `TIMEZONE_METHOD_FETCH_OBJECT` after the `intl_errors_set` func being called. So the object error state is correctly changed.