### PR TITLE
Mark the value param with const modifier in the ext/uri write handler

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -180,6 +180,11 @@ PHP 8.6 INTERNALS UPGRADE NOTES
   . _php_error_log_ex() has been removed.
   . php_mail()'s extra_cmd parameter is now a zend_string*.
 
+- ext/uri:
+  . The value parameter of the php_uri_property_handler_write callback is now
+    const zval * instead of zval *, reflecting that write handlers must
+    not modify the input zval.
+
 - ext/xml:
   . Removed the XML_ExpatVersion() libxml compatibility wrapper,
     as it was unused.

--- a/ext/uri/php_uri_common.c
+++ b/ext/uri/php_uri_common.c
@@ -55,7 +55,7 @@ void php_uri_property_read_helper(INTERNAL_FUNCTION_PARAMETERS, php_uri_property
 	}
 }
 
-static void php_uri_property_write_helper(INTERNAL_FUNCTION_PARAMETERS, php_uri_property_name property_name, zval *property_zv)
+static void php_uri_property_write_helper(INTERNAL_FUNCTION_PARAMETERS, php_uri_property_name property_name, const zval *property_zv)
 {
 	php_uri_object *old_uri_object = Z_URI_OBJECT_P(ZEND_THIS);
 	ZEND_ASSERT(old_uri_object->uri != NULL);

--- a/ext/uri/php_uri_common.h
+++ b/ext/uri/php_uri_common.h
@@ -45,7 +45,7 @@ typedef enum php_uri_component_read_mode {
 
 typedef zend_result (*php_uri_property_handler_read)(void *uri, php_uri_component_read_mode read_mode, zval *retval);
 
-typedef zend_result (*php_uri_property_handler_write)(void *uri, zval *value, zval *errors);
+typedef zend_result (*php_uri_property_handler_write)(void *uri, const zval *value, zval *errors);
 
 typedef enum php_uri_property_name {
 	PHP_URI_PROPERTY_NAME_SCHEME,

--- a/ext/uri/uri_parser_rfc3986.c
+++ b/ext/uri/uri_parser_rfc3986.c
@@ -153,7 +153,7 @@ ZEND_ATTRIBUTE_NONNULL static zend_result php_uri_parser_rfc3986_scheme_read(voi
 	return SUCCESS;
 }
 
-static zend_result php_uri_parser_rfc3986_scheme_write(void *uri, zval *value, zval *errors)
+static zend_result php_uri_parser_rfc3986_scheme_write(void *uri, const zval *value, zval *errors)
 {
 	UriUriA *uriparser_uri = get_uri_for_writing(uri);
 	int result;
@@ -305,7 +305,7 @@ ZEND_ATTRIBUTE_NONNULL void php_uri_parser_rfc3986_host_type_read(php_uri_parser
 	ZVAL_OBJ_COPY(retval, zend_enum_get_case_cstr(php_uri_ce_rfc3986_uri_host_type, type));
 }
 
-static zend_result php_uri_parser_rfc3986_host_write(void *uri, zval *value, zval *errors)
+static zend_result php_uri_parser_rfc3986_host_write(void *uri, const zval *value, zval *errors)
 {
 	UriUriA *uriparser_uri = get_uri_for_writing(uri);
 	int result;
@@ -366,7 +366,7 @@ ZEND_ATTRIBUTE_NONNULL static zend_result php_uri_parser_rfc3986_port_read(void 
 	return SUCCESS;
 }
 
-static zend_result php_uri_parser_rfc3986_port_write(void *uri, zval *value, zval *errors)
+static zend_result php_uri_parser_rfc3986_port_write(void *uri, const zval *value, zval *errors)
 {
 	UriUriA *uriparser_uri = get_uri_for_writing(uri);
 	int result;
@@ -439,7 +439,7 @@ ZEND_ATTRIBUTE_NONNULL static zend_result php_uri_parser_rfc3986_path_read(void 
 	return SUCCESS;
 }
 
-static zend_result php_uri_parser_rfc3986_path_write(void *uri, zval *value, zval *errors)
+static zend_result php_uri_parser_rfc3986_path_write(void *uri, const zval *value, zval *errors)
 {
 	UriUriA *uriparser_uri = get_uri_for_writing(uri);
 	int result;
@@ -476,7 +476,7 @@ ZEND_ATTRIBUTE_NONNULL static zend_result php_uri_parser_rfc3986_query_read(void
 	return SUCCESS;
 }
 
-static zend_result php_uri_parser_rfc3986_query_write(void *uri, zval *value, zval *errors)
+static zend_result php_uri_parser_rfc3986_query_write(void *uri, const zval *value, zval *errors)
 {
 	UriUriA *uriparser_uri = get_uri_for_writing(uri);
 	int result;
@@ -513,7 +513,7 @@ ZEND_ATTRIBUTE_NONNULL static zend_result php_uri_parser_rfc3986_fragment_read(v
 	return SUCCESS;
 }
 
-static zend_result php_uri_parser_rfc3986_fragment_write(void *uri, zval *value, zval *errors)
+static zend_result php_uri_parser_rfc3986_fragment_write(void *uri, const zval *value, zval *errors)
 {
 	UriUriA *uriparser_uri = get_uri_for_writing(uri);
 	int result;

--- a/ext/uri/uri_parser_whatwg.c
+++ b/ext/uri/uri_parser_whatwg.c
@@ -28,7 +28,7 @@ ZEND_TLS lxb_unicode_idna_t lexbor_idna = {0};
 
 static const size_t lexbor_mraw_byte_size = 8192;
 
-static zend_always_inline void zval_string_or_null_to_lexbor_str(zval *value, lexbor_str_t *lexbor_str)
+static zend_always_inline void zval_string_or_null_to_lexbor_str(const zval *value, lexbor_str_t *lexbor_str)
 {
 	if (Z_TYPE_P(value) == IS_STRING && Z_STRLEN_P(value) > 0) {
 		lexbor_str->data = (lxb_char_t *) Z_STRVAL_P(value);
@@ -40,12 +40,12 @@ static zend_always_inline void zval_string_or_null_to_lexbor_str(zval *value, le
 	}
 }
 
-static zend_always_inline void zval_long_or_null_to_lexbor_str(zval *value, lexbor_str_t *lexbor_str)
+static zend_always_inline void zval_long_or_null_to_lexbor_str(const zval *value, lexbor_str_t *lexbor_str)
 {
 	if (Z_TYPE_P(value) == IS_LONG) {
-		ZVAL_STR(value, zend_long_to_str(Z_LVAL_P(value)));
-		lexbor_str_init_append(lexbor_str, lexbor_parser.mraw, (const lxb_char_t *) Z_STRVAL_P(value), Z_STRLEN_P(value));
-		zval_ptr_dtor_str(value);
+		zend_string *tmp = zend_long_to_str(Z_LVAL_P(value));
+		lexbor_str_init_append(lexbor_str, lexbor_parser.mraw, (const lxb_char_t *) ZSTR_VAL(tmp), ZSTR_LEN(tmp));
+		zend_string_release(tmp);
 	} else {
 		ZEND_ASSERT(Z_ISNULL_P(value));
 		lexbor_str->data = (lxb_char_t *) "";
@@ -257,7 +257,7 @@ static zend_result php_uri_parser_whatwg_scheme_read(void *uri, php_uri_componen
 	return SUCCESS;
 }
 
-static zend_result php_uri_parser_whatwg_scheme_write(void *uri, zval *value, zval *errors)
+static zend_result php_uri_parser_whatwg_scheme_write(void *uri, const zval *value, zval *errors)
 {
 	lxb_url_t *lexbor_uri = uri;
 	lexbor_str_t str = {0};
@@ -297,7 +297,7 @@ static zend_result php_uri_parser_whatwg_username_read(void *uri, php_uri_compon
 	return SUCCESS;
 }
 
-static zend_result php_uri_parser_whatwg_username_write(void *uri, zval *value, zval *errors)
+static zend_result php_uri_parser_whatwg_username_write(void *uri, const zval *value, zval *errors)
 {
 	lxb_url_t *lexbor_uri = uri;
 	lexbor_str_t str = {0};
@@ -326,7 +326,7 @@ static zend_result php_uri_parser_whatwg_password_read(void *uri, php_uri_compon
 	return SUCCESS;
 }
 
-static zend_result php_uri_parser_whatwg_password_write(void *uri, zval *value, zval *errors)
+static zend_result php_uri_parser_whatwg_password_write(void *uri, const zval *value, zval *errors)
 {
 	lxb_url_t *lexbor_uri = uri;
 	lexbor_str_t str = {0};
@@ -411,7 +411,7 @@ ZEND_ATTRIBUTE_NONNULL void php_uri_parser_whatwg_host_type_read(const lxb_url_t
 	}
 }
 
-static zend_result php_uri_parser_whatwg_host_write(void *uri, zval *value, zval *errors)
+static zend_result php_uri_parser_whatwg_host_write(void *uri, const zval *value, zval *errors)
 {
 	lxb_url_t *lexbor_uri = uri;
 	lexbor_str_t str = {0};
@@ -440,7 +440,7 @@ static zend_result php_uri_parser_whatwg_port_read(void *uri, php_uri_component_
 	return SUCCESS;
 }
 
-static zend_result php_uri_parser_whatwg_port_write(void *uri, zval *value, zval *errors)
+static zend_result php_uri_parser_whatwg_port_write(void *uri, const zval *value, zval *errors)
 {
 	lxb_url_t *lexbor_uri = uri;
 	lexbor_str_t str = {0};
@@ -469,7 +469,7 @@ static zend_result php_uri_parser_whatwg_path_read(void *uri, php_uri_component_
 	return SUCCESS;
 }
 
-static zend_result php_uri_parser_whatwg_path_write(void *uri, zval *value, zval *errors)
+static zend_result php_uri_parser_whatwg_path_write(void *uri, const zval *value, zval *errors)
 {
 	lxb_url_t *lexbor_uri = uri;
 	lexbor_str_t str = {0};
@@ -498,7 +498,7 @@ static zend_result php_uri_parser_whatwg_query_read(void *uri, php_uri_component
 	return SUCCESS;
 }
 
-static zend_result php_uri_parser_whatwg_query_write(void *uri, zval *value, zval *errors)
+static zend_result php_uri_parser_whatwg_query_write(void *uri, const zval *value, zval *errors)
 {
 	lxb_url_t *lexbor_uri = uri;
 	lexbor_str_t str = {0};
@@ -527,7 +527,7 @@ static zend_result php_uri_parser_whatwg_fragment_read(void *uri, php_uri_compon
 	return SUCCESS;
 }
 
-static zend_result php_uri_parser_whatwg_fragment_write(void *uri, zval *value, zval *errors)
+static zend_result php_uri_parser_whatwg_fragment_write(void *uri, const zval *value, zval *errors)
 {
 	lxb_url_t *lexbor_uri = uri;
 	lexbor_str_t str = {0};


### PR DESCRIPTION
This is basically a question/proposal carved out from https://github.com/php/php-src/pull/22173#discussion_r3330943588. Is it OK to make this API break?