### PR TITLE
Clean Lexbor logs before each wither call

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,9 @@ PHP                                                                        NEWS
   . Add LEXBOR_STATIC to CFLAGS_URI on Windows so ext/uri does not see
     LXB_API as __declspec(dllimport) when linked statically into PHP.
     (Luther Monson)
+  . Clean error logs before each Uri\WhatWg\Url wither call so that errors from
+    previous wither calls are not returned the next time a UrlValidationError
+    is thrown. (kocsismate)
 
 - Phar:
   . Fixed a bypass of the magic ".phar" directory protection in

--- a/ext/uri/tests/whatwg/modification/multiple_error_with_warnings.phpt
+++ b/ext/uri/tests/whatwg/modification/multiple_error_with_warnings.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test Uri\WhatWg\Url component modification - error - modifying multiple components with warnings before throwing an exception
+--FILE--
+<?php
+
+$url = new Uri\WhatWg\Url("https://example.com")
+    ->withScheme("\tscheme")
+    ->withHost("\tex.com")
+    ->withQuery("\refoo=bar")
+    ->withFragment("\nfoo");
+
+try {
+    $url->withScheme("0");
+} catch (Throwable $e) {
+    echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+    var_dump($e->errors);
+}
+
+?>
+--EXPECT--
+Uri\WhatWg\InvalidUrlException: The specified scheme is malformed
+array(0) {
+}

--- a/ext/uri/uri_parser_whatwg.c
+++ b/ext/uri/uri_parser_whatwg.c
@@ -265,6 +265,8 @@ static zend_result php_uri_parser_whatwg_scheme_write(void *uri, zval *value, zv
 
 	zval_string_or_null_to_lexbor_str(value, &str);
 
+	lxb_url_parser_clean(&lexbor_parser);
+
 	if (lxb_url_api_protocol_set(lexbor_uri, &lexbor_parser, str.data, str.length) != LXB_STATUS_OK) {
 		throw_invalid_url_exception_during_write(errors, "scheme");
 
@@ -300,6 +302,8 @@ static zend_result php_uri_parser_whatwg_username_write(void *uri, zval *value, 
 
 	zval_string_or_null_to_lexbor_str(value, &str);
 
+	lxb_url_parser_clean(&lexbor_parser);
+
 	if (lxb_url_api_username_set(lexbor_uri, str.data, str.length) != LXB_STATUS_OK) {
 		throw_invalid_url_exception_during_write(errors, "username");
 
@@ -328,6 +332,8 @@ static zend_result php_uri_parser_whatwg_password_write(void *uri, zval *value, 
 	lexbor_str_t str = {0};
 
 	zval_string_or_null_to_lexbor_str(value, &str);
+
+	lxb_url_parser_clean(&lexbor_parser);
 
 	if (lxb_url_api_password_set(lexbor_uri, str.data, str.length) != LXB_STATUS_OK) {
 		throw_invalid_url_exception_during_write(errors, "password");
@@ -389,6 +395,8 @@ static zend_result php_uri_parser_whatwg_host_write(void *uri, zval *value, zval
 
 	zval_string_or_null_to_lexbor_str(value, &str);
 
+	lxb_url_parser_clean(&lexbor_parser);
+
 	if (lxb_url_api_hostname_set(lexbor_uri, &lexbor_parser, str.data, str.length) != LXB_STATUS_OK) {
 		throw_invalid_url_exception_during_write(errors, "host");
 
@@ -417,6 +425,8 @@ static zend_result php_uri_parser_whatwg_port_write(void *uri, zval *value, zval
 	lexbor_str_t str = {0};
 
 	zval_long_or_null_to_lexbor_str(value, &str);
+
+	lxb_url_parser_clean(&lexbor_parser);
 
 	if (lxb_url_api_port_set(lexbor_uri, &lexbor_parser, str.data, str.length) != LXB_STATUS_OK) {
 		throw_invalid_url_exception_during_write(errors, "port");
@@ -447,6 +457,8 @@ static zend_result php_uri_parser_whatwg_path_write(void *uri, zval *value, zval
 
 	zval_string_or_null_to_lexbor_str(value, &str);
 
+	lxb_url_parser_clean(&lexbor_parser);
+
 	if (lxb_url_api_pathname_set(lexbor_uri, &lexbor_parser, str.data, str.length) != LXB_STATUS_OK) {
 		throw_invalid_url_exception_during_write(errors, "path");
 
@@ -476,6 +488,8 @@ static zend_result php_uri_parser_whatwg_query_write(void *uri, zval *value, zva
 
 	zval_string_or_null_to_lexbor_str(value, &str);
 
+	lxb_url_parser_clean(&lexbor_parser);
+
 	if (lxb_url_api_search_set(lexbor_uri, &lexbor_parser, str.data, str.length) != LXB_STATUS_OK) {
 		throw_invalid_url_exception_during_write(errors, "query string");
 
@@ -504,6 +518,8 @@ static zend_result php_uri_parser_whatwg_fragment_write(void *uri, zval *value, 
 	lexbor_str_t str = {0};
 
 	zval_string_or_null_to_lexbor_str(value, &str);
+
+	lxb_url_parser_clean(&lexbor_parser);
 
 	if (lxb_url_api_hash_set(lexbor_uri, &lexbor_parser, str.data, str.length) != LXB_STATUS_OK) {
 		throw_invalid_url_exception_during_write(errors, "fragment");


### PR DESCRIPTION
Otherwise errors from previous wither calls may be recorded and returned the next time a UrlValidationError is created.