### PR TITLE
TSRM: use local-exec TLS in PIE executables

### DIFF
--- a/TSRM/TSRM.h
+++ b/TSRM/TSRM.h
@@ -155,7 +155,7 @@ TSRM_API bool tsrm_is_managed_thread(void);
 #if !__has_attribute(tls_model) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__MUSL__) || defined(__HAIKU__)
 # define TSRM_TLS_MODEL_ATTR
 # define TSRM_TLS_MODEL_DEFAULT
-#elif __PIC__
+#elif defined(__PIC__) && !defined(__PIE__)
 # define TSRM_TLS_MODEL_ATTR __attribute__((tls_model("initial-exec")))
 # define TSRM_TLS_MODEL_INITIAL_EXEC
 #else


### PR DESCRIPTION
second split PR from https://github.com/php/php-src/pull/22231#issuecomment-4676385409

<table><thead><tr><th>metric</th><th>before (initial-exec)</th><th>after (local-exec)</th><th>Δ</th></tr></thead><tbody><tr><td>PHPStan cycles</td><td>221.87G</td><td>219.49G</td><td>−1.1%</td></tr><tr><td>PHPStan instructions</td><td>281.99G</td><td>282.06G</td><td>+0.03%</td></tr><tr><td>PHPStan wall</td><td>80.13s</td><td>76.54s</td><td>−4.5%</td></tr></tbody></table>

it's a small change, but it comes free. measurement on a local x86_64-linux-gnu machine, ignore the wall time