### PR TITLE
Fix GH-8739: OPcache restart corrupts SHM in threaded SAPIs (ZTS)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -62,6 +62,9 @@ PHP                                                                        NEWS
 - Opcache:
   . Fixed tracing JIT crash when a VM interrupt is handled during an observed
     user function call. (Levi Morrison)
+  . Fixed bug GH-8739 (OPcache restart corrupts shared memory under threaded
+    SAPIs: fcntl()-based reader tracking cannot see threads of the same
+    process). (Yoan Arnaudov)
   . Fixed bug GH-22004 (Assertion failure at ext/opcache/jit/zend_jit_trace.c).
     (Arnaud)
 

--- a/Zend/zend_atomic.c
+++ b/Zend/zend_atomic.c
@@ -57,6 +57,14 @@ ZEND_API void zend_atomic_int_store(zend_atomic_int *obj, int desired) {
 	zend_atomic_int_store_ex(obj, desired);
 }
 
+ZEND_API int zend_atomic_int_fetch_add(zend_atomic_int *obj, int value) {
+	return zend_atomic_int_fetch_add_ex(obj, value);
+}
+
+ZEND_API int zend_atomic_int_fetch_sub(zend_atomic_int *obj, int value) {
+	return zend_atomic_int_fetch_sub_ex(obj, value);
+}
+
 #if defined(ZEND_WIN32) || defined(HAVE_SYNC_ATOMICS)
 /* On these platforms it is non-const due to underlying APIs. */
 ZEND_API bool zend_atomic_bool_load(zend_atomic_bool *obj) {

--- a/Zend/zend_atomic.h
+++ b/Zend/zend_atomic.h
@@ -88,6 +88,9 @@ BEGIN_EXTERN_C()
 #ifndef InterlockedCompareExchange
 #define InterlockedCompareExchange _InterlockedCompareExchange
 #endif
+#ifndef InterlockedExchangeAdd
+#define InterlockedExchangeAdd _InterlockedExchangeAdd
+#endif
 
 #define ZEND_ATOMIC_BOOL_INIT(obj, desired) ((obj)->value = (desired))
 #define ZEND_ATOMIC_INT_INIT(obj, desired)  ((obj)->value = (desired))
@@ -101,6 +104,14 @@ static zend_always_inline bool zend_atomic_bool_exchange_ex(zend_atomic_bool *ob
 
 static zend_always_inline int zend_atomic_int_exchange_ex(zend_atomic_int *obj, int desired) {
 	return (int) InterlockedExchange(&obj->value, desired);
+}
+
+static zend_always_inline int zend_atomic_int_fetch_add_ex(zend_atomic_int *obj, int value) {
+	return (int) InterlockedExchangeAdd(&obj->value, value);
+}
+
+static zend_always_inline int zend_atomic_int_fetch_sub_ex(zend_atomic_int *obj, int value) {
+	return (int) InterlockedExchangeAdd(&obj->value, -value);
 }
 
 static zend_always_inline bool zend_atomic_bool_compare_exchange_ex(zend_atomic_bool *obj, bool *expected, bool desired) {
@@ -158,6 +169,14 @@ static zend_always_inline int zend_atomic_int_exchange_ex(zend_atomic_int *obj, 
 	return __c11_atomic_exchange(&obj->value, desired, __ATOMIC_SEQ_CST);
 }
 
+static zend_always_inline int zend_atomic_int_fetch_add_ex(zend_atomic_int *obj, int value) {
+	return __c11_atomic_fetch_add(&obj->value, value, __ATOMIC_SEQ_CST);
+}
+
+static zend_always_inline int zend_atomic_int_fetch_sub_ex(zend_atomic_int *obj, int value) {
+	return __c11_atomic_fetch_sub(&obj->value, value, __ATOMIC_SEQ_CST);
+}
+
 static zend_always_inline bool zend_atomic_bool_compare_exchange_ex(zend_atomic_bool *obj, bool *expected, bool desired) {
 	return __c11_atomic_compare_exchange_strong(&obj->value, expected, desired, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
 }
@@ -202,6 +221,14 @@ static zend_always_inline int zend_atomic_int_exchange_ex(zend_atomic_int *obj, 
 	int prev = false;
 	__atomic_exchange(&obj->value, &desired, &prev, __ATOMIC_SEQ_CST);
 	return prev;
+}
+
+static zend_always_inline int zend_atomic_int_fetch_add_ex(zend_atomic_int *obj, int value) {
+	return __atomic_fetch_add(&obj->value, value, __ATOMIC_SEQ_CST);
+}
+
+static zend_always_inline int zend_atomic_int_fetch_sub_ex(zend_atomic_int *obj, int value) {
+	return __atomic_fetch_sub(&obj->value, value, __ATOMIC_SEQ_CST);
 }
 
 static zend_always_inline bool zend_atomic_bool_compare_exchange_ex(zend_atomic_bool *obj, bool *expected, bool desired) {
@@ -258,6 +285,14 @@ static zend_always_inline int zend_atomic_int_exchange_ex(zend_atomic_int *obj, 
 	 */
 	__sync_synchronize();
 	return prev;
+}
+
+static zend_always_inline int zend_atomic_int_fetch_add_ex(zend_atomic_int *obj, int value) {
+	return __sync_fetch_and_add(&obj->value, value);
+}
+
+static zend_always_inline int zend_atomic_int_fetch_sub_ex(zend_atomic_int *obj, int value) {
+	return __sync_fetch_and_sub(&obj->value, value);
 }
 
 static zend_always_inline bool zend_atomic_bool_compare_exchange_ex(zend_atomic_bool *obj, bool *expected, bool desired) {
@@ -362,6 +397,18 @@ static zend_always_inline int zend_atomic_int_exchange_ex(zend_atomic_int *obj, 
 	return prev;
 }
 
+static zend_always_inline int zend_atomic_int_fetch_add_ex(zend_atomic_int *obj, int value) {
+	int prev = obj->value;
+	obj->value = prev + value;
+	return prev;
+}
+
+static zend_always_inline int zend_atomic_int_fetch_sub_ex(zend_atomic_int *obj, int value) {
+	int prev = obj->value;
+	obj->value = prev - value;
+	return prev;
+}
+
 #endif
 
 ZEND_API void zend_atomic_bool_init(zend_atomic_bool *obj, bool desired);
@@ -375,6 +422,9 @@ ZEND_API bool zend_atomic_int_compare_exchange(zend_atomic_int *obj, int *expect
 
 ZEND_API void zend_atomic_bool_store(zend_atomic_bool *obj, bool desired);
 ZEND_API void zend_atomic_int_store(zend_atomic_int *obj, int desired);
+
+ZEND_API int zend_atomic_int_fetch_add(zend_atomic_int *obj, int value);
+ZEND_API int zend_atomic_int_fetch_sub(zend_atomic_int *obj, int value);
 
 #if defined(ZEND_WIN32) || defined(HAVE_SYNC_ATOMICS)
 /* On these platforms it is non-const due to underlying APIs. */

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -338,7 +338,7 @@ static inline zend_result accel_activate_add(void)
 {
 #ifdef ZEND_WIN32
 	SHM_UNPROTECT();
-	INCREMENT(mem_usage);
+	zend_atomic_int_fetch_add_ex(&ZCSG(mem_usage), 1);
 	SHM_PROTECT();
 #else
 	struct flock mem_usage_lock;
@@ -362,7 +362,7 @@ static inline void accel_deactivate_sub(void)
 #ifdef ZEND_WIN32
 	if (ZCG(counted)) {
 		SHM_UNPROTECT();
-		DECREMENT(mem_usage);
+		zend_atomic_int_fetch_sub_ex(&ZCSG(mem_usage), 1);
 		ZCG(counted) = false;
 		SHM_PROTECT();
 	}
@@ -403,33 +403,26 @@ static inline void accel_unlock_all(void)
 }
 
 #if defined(ZTS) && !defined(ZEND_WIN32)
-/* In threaded SAPIs (FrankenPHP, mod_php with a threaded MPM, ...) requests
- * run as threads of one process. The fcntl() record locks used by
- * accel_activate_add()/accel_is_inactive() are per-process: a process never
- * conflicts with its own locks, so in-flight readers running as threads are
- * invisible to accel_is_inactive(). It then wrongly reports the cache as
- * inactive and a scheduled restart wipes SHM (hash table + interned strings)
- * under running requests, corrupting the heap (GH-8739, GH-14471, GH-18517).
- *
- * Mirror the approach ZEND_WIN32 already uses for the same reason (threaded
- * SAPIs): track in-flight requests with an atomic counter in SHM and have
- * accel_is_inactive() refuse to restart while it is non-zero. Registration
- * is gated on ZCG(accelerator_enabled), so once a restart is pending (the
- * accelerator is disabled) new requests no longer register and the counter
- * drains within the duration of the longest in-flight request. */
-static zend_always_inline void accel_ts_request_enter(void)
+/* Threaded POSIX SAPIs (e.g. FrankenPHP) run requests as threads of one
+ * process. fcntl() locks are per-process, so accel_is_inactive() can't see
+ * sibling threads still reading SHM (GH-8739). Mirror what Windows does with
+ * the atomic mem_usage counter, but keep it process-local: cross-process
+ * coordination stays on fcntl(), which self-heals if a process dies. */
+static zend_atomic_int accel_active_readers;
+
+static zend_always_inline void accel_reader_enter(void)
 {
-	if (!ZCG(ts_reader_registered)) {
-		__atomic_add_fetch(&ZCSG(ts_active_requests), 1, __ATOMIC_SEQ_CST);
-		ZCG(ts_reader_registered) = true;
+	if (!ZCG(reader_counted)) {
+		zend_atomic_int_fetch_add_ex(&accel_active_readers, 1);
+		ZCG(reader_counted) = true;
 	}
 }
 
-static zend_always_inline void accel_ts_request_leave(void)
+static zend_always_inline void accel_reader_leave(void)
 {
-	if (ZCG(ts_reader_registered)) {
-		__atomic_sub_fetch(&ZCSG(ts_active_requests), 1, __ATOMIC_SEQ_CST);
-		ZCG(ts_reader_registered) = false;
+	if (ZCG(reader_counted)) {
+		zend_atomic_int_fetch_sub_ex(&accel_active_readers, 1);
+		ZCG(reader_counted) = false;
 	}
 }
 #endif
@@ -926,13 +919,6 @@ static inline void kill_all_lockers(struct flock *mem_usage_check)
 
 static inline bool accel_is_inactive(void)
 {
-#if defined(ZTS) && !defined(ZEND_WIN32)
-	/* Threads of this process may still be inside requests registered as
-	 * SHM readers; the fcntl() probe below cannot detect them. */
-	if (__atomic_load_n(&ZCSG(ts_active_requests), __ATOMIC_SEQ_CST) != 0) {
-		return false;
-	}
-#endif
 #ifdef ZEND_WIN32
 	/* on Windows, we don't need kill_all_lockers() because SAPIs
 	   that work on Windows don't manage child processes (and we
@@ -941,10 +927,19 @@ static inline bool accel_is_inactive(void)
 	   instead of flocks (atomics are much faster but they don't
 	   provide us with the PID of locker processes) */
 
-	if (LOCKVAL(mem_usage) == 0) {
+	if (zend_atomic_int_load_ex(&ZCSG(mem_usage)) == 0) {
 		return true;
 	}
 #else
+#if defined(ZTS)
+	/* Sibling threads of this process are invisible to the fcntl() probe below
+	 * (locks are per-process), so consult the process-local reader counter
+	 * first. Acts as the whole check for single-process SAPIs like FrankenPHP;
+	 * for multi-process ones the fcntl() probe still covers other processes. */
+	if (zend_atomic_int_load_ex(&accel_active_readers) != 0) {
+		return false;
+	}
+#endif
 	struct flock mem_usage_check;
 
 	mem_usage_check.l_type = F_WRLCK;
@@ -2782,11 +2777,18 @@ ZEND_RINIT_FUNCTION(zend_accelerator)
 	ZCG(accelerator_enabled) = ZCSG(accelerator_enabled);
 
 #if defined(ZTS) && !defined(ZEND_WIN32)
+	/* Register as an active SHM reader for the duration of this request so a
+	 * restart scheduled while we run waits for us (see accel_is_inactive()).
+	 * Done after the restart block above, so the restarting thread never counts
+	 * itself. Gated on accelerator_enabled: once a restart is pending the
+	 * accelerator is disabled, new requests stop registering and the counter
+	 * drains to zero. */
 	if (ZCG(accelerator_enabled)) {
-		accel_ts_request_enter();
+		accel_reader_enter();
 		if (UNEXPECTED(ZCSG(restart_in_progress))) {
-			/* lost the race against a restart that passed accel_is_inactive()
-			 * before our registration became visible; run uncached */
+			/* A restart passed accel_is_inactive() before our increment became
+			 * visible and is wiping SHM now; back out and run uncached. */
+			accel_reader_leave();
 			ZCG(accelerator_enabled) = false;
 		}
 	}
@@ -2830,6 +2832,12 @@ void accel_deactivate(void)
 
 zend_result accel_post_deactivate(void)
 {
+#if defined(ZTS) && !defined(ZEND_WIN32)
+	/* Stop counting as an active SHM reader (balances accel_reader_enter() in
+	 * RINIT). A no-op if this request never registered. */
+	accel_reader_leave();
+#endif
+
 	if (ZCG(cwd)) {
 		zend_string_release_ex(ZCG(cwd), 0);
 		ZCG(cwd) = NULL;
@@ -2842,14 +2850,6 @@ zend_result accel_post_deactivate(void)
 	zend_shared_alloc_safe_unlock(); /* be sure we didn't leave cache locked */
 	accel_unlock_all();
 	ZCG(counted) = false;
-
-#if defined(ZTS) && !defined(ZEND_WIN32)
-	if (!file_cache_only && accel_shared_globals) {
-		SHM_UNPROTECT();
-		accel_ts_request_leave();
-		SHM_PROTECT();
-	}
-#endif
 
 	return SUCCESS;
 }

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -402,6 +402,38 @@ static inline void accel_unlock_all(void)
 #endif
 }
 
+#if defined(ZTS) && !defined(ZEND_WIN32)
+/* In threaded SAPIs (FrankenPHP, mod_php with a threaded MPM, ...) requests
+ * run as threads of one process. The fcntl() record locks used by
+ * accel_activate_add()/accel_is_inactive() are per-process: a process never
+ * conflicts with its own locks, so in-flight readers running as threads are
+ * invisible to accel_is_inactive(). It then wrongly reports the cache as
+ * inactive and a scheduled restart wipes SHM (hash table + interned strings)
+ * under running requests, corrupting the heap (GH-8739, GH-14471, GH-18517).
+ *
+ * Mirror the approach ZEND_WIN32 already uses for the same reason (threaded
+ * SAPIs): track in-flight requests with an atomic counter in SHM and have
+ * accel_is_inactive() refuse to restart while it is non-zero. Registration
+ * is gated on ZCG(accelerator_enabled), so once a restart is pending (the
+ * accelerator is disabled) new requests no longer register and the counter
+ * drains within the duration of the longest in-flight request. */
+static zend_always_inline void accel_ts_request_enter(void)
+{
+	if (!ZCG(ts_reader_registered)) {
+		__atomic_add_fetch(&ZCSG(ts_active_requests), 1, __ATOMIC_SEQ_CST);
+		ZCG(ts_reader_registered) = true;
+	}
+}
+
+static zend_always_inline void accel_ts_request_leave(void)
+{
+	if (ZCG(ts_reader_registered)) {
+		__atomic_sub_fetch(&ZCSG(ts_active_requests), 1, __ATOMIC_SEQ_CST);
+		ZCG(ts_reader_registered) = false;
+	}
+}
+#endif
+
 /* Interned strings support */
 
 /* O+ disables creation of interned strings by regular PHP compiler, instead,
@@ -894,6 +926,13 @@ static inline void kill_all_lockers(struct flock *mem_usage_check)
 
 static inline bool accel_is_inactive(void)
 {
+#if defined(ZTS) && !defined(ZEND_WIN32)
+	/* Threads of this process may still be inside requests registered as
+	 * SHM readers; the fcntl() probe below cannot detect them. */
+	if (__atomic_load_n(&ZCSG(ts_active_requests), __ATOMIC_SEQ_CST) != 0) {
+		return false;
+	}
+#endif
 #ifdef ZEND_WIN32
 	/* on Windows, we don't need kill_all_lockers() because SAPIs
 	   that work on Windows don't manage child processes (and we
@@ -2742,6 +2781,17 @@ ZEND_RINIT_FUNCTION(zend_accelerator)
 
 	ZCG(accelerator_enabled) = ZCSG(accelerator_enabled);
 
+#if defined(ZTS) && !defined(ZEND_WIN32)
+	if (ZCG(accelerator_enabled)) {
+		accel_ts_request_enter();
+		if (UNEXPECTED(ZCSG(restart_in_progress))) {
+			/* lost the race against a restart that passed accel_is_inactive()
+			 * before our registration became visible; run uncached */
+			ZCG(accelerator_enabled) = false;
+		}
+	}
+#endif
+
 	SHM_PROTECT();
 	HANDLE_UNBLOCK_INTERRUPTIONS();
 
@@ -2792,6 +2842,14 @@ zend_result accel_post_deactivate(void)
 	zend_shared_alloc_safe_unlock(); /* be sure we didn't leave cache locked */
 	accel_unlock_all();
 	ZCG(counted) = false;
+
+#if defined(ZTS) && !defined(ZEND_WIN32)
+	if (!file_cache_only && accel_shared_globals) {
+		SHM_UNPROTECT();
+		accel_ts_request_leave();
+		SHM_PROTECT();
+	}
+#endif
 
 	return SUCCESS;
 }

--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -51,6 +51,7 @@
 #include "zend_extensions.h"
 #include "zend_compile.h"
 #include "zend_API.h"
+#include "zend_atomic.h"
 
 #include "Optimizer/zend_optimizer.h"
 #include "zend_accelerator_hash.h"
@@ -197,7 +198,9 @@ typedef struct _zend_accel_directives {
 
 typedef struct _zend_accel_globals {
 	bool               counted;   /* the process uses shared memory */
-	bool               ts_reader_registered; /* this request is counted in ZCSG(ts_active_requests) (ZTS only) */
+#if defined(ZTS) && !defined(ZEND_WIN32)
+	bool               reader_counted; /* this request is counted in accel_active_readers */
+#endif
 	bool               enabled;
 	bool               locked;    /* thread obtained exclusive lock */
 	bool               accelerator_enabled; /* accelerator enabled for current request */
@@ -266,14 +269,12 @@ typedef struct _zend_accel_shared_globals {
 	zend_accel_restart_reason restart_reason;
 	bool       cache_status_before_restart;
 #ifdef ZEND_WIN32
-	LONGLONG   mem_usage;
+	/* Count of requests currently reading SHM. Windows threaded SAPIs run in a
+	 * single process, so this atomic counter alone tells us when it is safe to
+	 * restart (see accel_is_inactive()). POSIX uses fcntl() locks instead, with
+	 * an additional process-local counter under ZTS (see accel_active_readers). */
+	zend_atomic_int mem_usage;
 	LONGLONG   restart_in;
-#elif defined(ZTS)
-	/* In-flight requests registered as SHM readers. POSIX fcntl() record
-	 * locks cannot track readers that are threads of one process (a process
-	 * never conflicts with its own locks), so threaded SAPIs need an
-	 * explicit counter — mirroring what ZEND_WIN32 does with mem_usage. */
-	uint32_t   ts_active_requests;
 #endif
 	bool       restart_in_progress;
 	bool       jit_counters_stopped;

--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -197,6 +197,7 @@ typedef struct _zend_accel_directives {
 
 typedef struct _zend_accel_globals {
 	bool               counted;   /* the process uses shared memory */
+	bool               ts_reader_registered; /* this request is counted in ZCSG(ts_active_requests) (ZTS only) */
 	bool               enabled;
 	bool               locked;    /* thread obtained exclusive lock */
 	bool               accelerator_enabled; /* accelerator enabled for current request */
@@ -267,6 +268,12 @@ typedef struct _zend_accel_shared_globals {
 #ifdef ZEND_WIN32
 	LONGLONG   mem_usage;
 	LONGLONG   restart_in;
+#elif defined(ZTS)
+	/* In-flight requests registered as SHM readers. POSIX fcntl() record
+	 * locks cannot track readers that are threads of one process (a process
+	 * never conflicts with its own locks), so threaded SAPIs need an
+	 * explicit counter — mirroring what ZEND_WIN32 does with mem_usage. */
+	uint32_t   ts_active_requests;
 #endif
 	bool       restart_in_progress;
 	bool       jit_counters_stopped;


### PR DESCRIPTION
## Summary

In threaded SAPIs (FrankenPHP, `mod_php` with a threaded MPM), any OPcache restart — out-of-memory, hash overflow, or `opcache_reset()` — wipes shared memory while other threads are still executing code from it, crashing the whole server with `zend_mm_heap corrupted` (SIGABRT) or SIGSEGV. This is the ZTS manifestation of GH-8739 (GH-18517 and GH-14471 were closed as duplicates of it; also reported as dunglas/frankenphp#2170, dunglas/frankenphp#1737).

## Root cause

`accel_is_inactive()` gates restart execution on "no in-flight SHM readers". On POSIX this is implemented with fcntl() record locks: readers take `F_RDLCK` in `accel_activate_add()`, and the restarting thread probes with `F_GETLK`.

**POSIX record locks are per-process — a process never conflicts with its own locks.** When all requests are threads of one process, `F_GETLK` reports no conflict, `accel_is_inactive()` always returns `true`, and the restart memsets `ZCSG(hash)` and resets the interned-strings buffer under hundreds of live readers.

This is 100 % reproducible: warm cache + ~120 concurrent requests + one `opcache_reset()` call crashes FrankenPHP within a second (3–4 threads typically report `zend_mm_heap corrupted` simultaneously). The OOM path crashes identically once accumulated wasted memory exhausts the SHM — for us this killed a production server roughly daily, on every PHP deployment cycle.

## The fix

Windows already solved this exact problem: because Windows SAPIs are threaded, `accel_is_inactive()` there uses an atomic SHM counter (`ZCSG(mem_usage)`) instead of fcntl. This PR gives POSIX ZTS builds the equivalent:

- `ZCSG(ts_active_requests)` — atomic counter of in-flight requests (ZTS non-Windows only).
- Requests register in `RINIT` *after* the restart-pending block (so a thread never blocks its own restart check) and only while `ZCG(accelerator_enabled)` is true — so once a restart is scheduled, new requests stop registering and the counter drains within the duration of the longest in-flight request, even under saturation.
- Deregistration in `accel_post_deactivate()`, paired via a per-thread flag (`ZCG(ts_reader_registered)`), so the counter stays balanced across early-return paths.
- `accel_is_inactive()` returns `false` while the counter is non-zero.
- After registering, the request re-checks `ZCSG(restart_in_progress)` and falls back to uncached execution if it lost the race against an already-running restart.

NTS builds are completely unaffected (no code change compiles in), so php-fpm/prefork keep the fcntl mechanism and its kernel-side crash cleanup. There is no per-request lock added — readers stay lock-free; the cost is one atomic add and one atomic sub per request.

## Why not the EBR approach of #21778

I tested #21778 against the reproducer below first: it still crashes identically, because its deferral branch is only reachable as the `else` of `if (accel_is_inactive())` — and under ZTS that check always returns `true`, so the original unsafe path runs before the new machinery is ever consulted (with `opcache.log_verbosity_level=4`, `Restart Scheduled!` and `Restarting!` appear in the same second with ~120 requests in flight, and the patch's "Deferring opcache restart" message never fires). The epoch/slot machinery also isn't needed for this problem: OPcache already prevents *new* readers during a pending restart via `accelerator_enabled = false`, so a plain drain counter is sufficient.

## Validation

Real-world workload: FrankenPHP v1.12.2 static (PHP 8.4.20 + this patch), classic mode, 256 threads, Symfony 6.4 production mirror, ~120 concurrent requests replaying live URLs, ~3300 cached scripts:

| scenario | unpatched | with this fix |
|---|---|---|
| `opcache_reset()` under load | crash on 1st call (`zend_mm_heap corrupted` ×3, SIGABRT/SIGSEGV) | 5/5 survived; log shows `Restart Scheduled!` → 1–8 s reader drain → `Restarting!` |
| wasted-memory exhaustion (mass invalidation cycles with `validate_timestamps=1`) | crash when free SHM hits 0 | clean deferred restart (`oom_restarts: 1`), cache rebuilds, server healthy |

`make test` is unaffected (the counter path requires ZTS *and* concurrency; single-threaded `.phpt` tests cannot exercise the race — the existing behavior of all opcache tests is unchanged). I'm happy to retest revisions against the FrankenPHP reproducer harness — turnaround is ~15 minutes.

## Known residual

A nanoseconds-wide TOCTOU remains between a thread snapshotting `accelerator_enabled` and its registration becoming visible to a concurrently executing restart. The `restart_in_progress` re-check narrows it, and the same window exists in the battle-tested fcntl protocol used by process-based SAPIs — this patch brings ZTS to parity with that behavior. Closing it completely would require taking the shared-alloc lock in the reader path, which was already rejected in #14803 for performance reasons.
