### PR TITLE
aarch64: use -mtls-size=12 for faster tls reads

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -178,6 +178,22 @@ AC_MSG_RESULT([$ZEND_ZTS])
 AS_VAR_IF([ZEND_ZTS], [yes], [
   AC_DEFINE([ZTS], [1], [Define to 1 if thread safety (ZTS) is enabled.])
   AS_VAR_APPEND([CFLAGS], [" -DZTS"])
+
+  dnl -mtls-size=12 drops the dead high-bits offset add from TLS access,
+  dnl valid while the thread-local block stays under 4 KiB.
+  AC_CACHE_CHECK([whether -mtls-size=12 compiles and links],
+    [php_cv_flag_mtls_size_12],
+    [save_CFLAGS=$CFLAGS
+     AS_VAR_IF([GCC], [yes], [php_tls_size_werror=-Werror], [php_tls_size_werror=])
+     CFLAGS="$CFLAGS -mtls-size=12 $php_tls_size_werror"
+     AC_LINK_IFELSE([AC_LANG_PROGRAM(
+       [[static __thread void *tls_probe __attribute__((tls_model("local-exec")));]],
+       [[tls_probe = &tls_probe; return !!tls_probe;]])],
+       [php_cv_flag_mtls_size_12=yes],
+       [php_cv_flag_mtls_size_12=no])
+     CFLAGS=$save_CFLAGS])
+  AS_VAR_IF([php_cv_flag_mtls_size_12], [yes],
+    [AS_VAR_APPEND([CFLAGS], [" -mtls-size=12"])])
 ])
 
 AC_MSG_CHECKING([whether to enable Zend debugging])


### PR DESCRIPTION
picked out from https://github.com/php/php-src/pull/22231
will help most with https://github.com/php/php-src/pull/22278

benchmarked on aarch64-linux-gnu oracle cloud:

<table><thead><tr><th>build</th><th>PHPStan instr</th><th>PHPStan wall</th><th>phpbench (no JIT)</th><th>phpbench (JIT)</th></tr></thead><tbody> <tr><td>NTS (base)</td><td>840.5827 B</td><td>68.6s</td><td>709168</td><td>1179326</td></tr> <tr><td>ZTS before (gcc)</td><td>881.9715 B</td><td>68.0s</td><td>669379</td><td>1130824</td></tr> <tr><td>ZTS after — variant (gcc)</td><td>872.8856 B (−1.030%)</td><td>67.8s (−0.294%)</td><td>678451 (+1.36%)</td><td>1130269 (−0.05%)</td></tr> <tr><td>NTS (base)</td><td>846.6887 B</td><td>65.7s</td><td>705634</td><td>1141506</td></tr> <tr><td>ZTS before (clang)</td><td>898.4707 B</td><td>68.4s</td><td>670086</td><td>1089468</td></tr> <tr><td>ZTS after — variant (clang)</td><td>890.2960 B (−0.910%)</td><td>67.4s (−1.462%)</td><td>672020 (+0.29%)</td><td>1091158 (+0.16%)</td></tr> </tbody></table>

Initially went with a compile check, but tried cross-compiling for aarch64 and while it passed the compiler flag, the linker failed with unknown relocation (550).