### PR TITLE
Fix SplObjectStorage getHash() guard leaking across a bailout

### DIFF
--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -563,6 +563,7 @@ PHP_MINIT_FUNCTION(spl)
 PHP_RINIT_FUNCTION(spl) /* {{{ */
 {
 	spl_autoload_extensions = NULL;
+	spl_object_storage_reset_get_hash_depth();
 	return SUCCESS;
 } /* }}} */
 

--- a/ext/spl/spl_observer.c
+++ b/ext/spl/spl_observer.c
@@ -47,6 +47,11 @@ static zend_object_handlers spl_handler_MultipleIterator;
 
 ZEND_TLS uint32_t spl_object_storage_get_hash_depth;
 
+void spl_object_storage_reset_get_hash_depth(void)
+{
+	spl_object_storage_get_hash_depth = 0;
+}
+
 typedef struct _spl_SplObjectStorage { /* {{{ */
 	HashTable         storage;
 	zend_long         index;

--- a/ext/spl/spl_observer.h
+++ b/ext/spl/spl_observer.h
@@ -31,4 +31,6 @@ extern PHPAPI zend_class_entry *spl_ce_MultipleIterator;
 
 PHP_MINIT_FUNCTION(spl_observer);
 
+void spl_object_storage_reset_get_hash_depth(void);
+
 #endif /* SPL_OBSERVER_H */

--- a/ext/spl/tests/spl_object_storage_gethash_bailout.phpt
+++ b/ext/spl/tests/spl_object_storage_gethash_bailout.phpt
@@ -1,0 +1,44 @@
+--TEST--
+SplObjectStorage getHash() depth counter is reset after a bailout in a user getHash()
+--SKIPIF--
+<?php
+if (!file_exists(__DIR__ . "/../../../sapi/cli/tests/php_cli_server.inc")) {
+    die("skip sapi/cli/tests/php_cli_server.inc required but not found");
+}
+?>
+--INI--
+allow_url_fopen=1
+--FILE--
+<?php
+include __DIR__ . "/../../../sapi/cli/tests/php_cli_server.inc";
+
+$code = <<<'PHP'
+if ($_SERVER["REQUEST_URI"] === "/poison") {
+    class Poison extends SplObjectStorage {
+        public function getHash($o): string {
+            ini_set("memory_limit", "2M");
+            str_repeat("a", 100 * 1024 * 1024);
+            return "x";
+        }
+    }
+    (new Poison())->offsetSet(new stdClass());
+    echo "poison";
+} else {
+    $s = new SplObjectStorage();
+    $s->offsetSet(new stdClass());
+    echo "check-ok count=", count($s);
+}
+PHP;
+
+php_cli_server_start($code, 'router.php');
+
+$base = 'http://' . PHP_CLI_SERVER_ADDRESS;
+// Request 1 bails out (OOM) inside the overridden getHash() mid-offsetSet.
+@file_get_contents($base . '/poison');
+// A later request on the same worker must not be poisoned by a stuck counter.
+echo @file_get_contents($base . '/check'), "\n";
+echo @file_get_contents($base . '/check'), "\n";
+?>
+--EXPECT--
+check-ok count=1
+check-ok count=1


### PR DESCRIPTION
The getHash() recursion guard bumps a request-persistent counter around the userland getHash() call but only decrements it on the normal return. A bailout inside an overridden getHash() (out of memory, timeout, any fatal) skips the decrement, and nothing resets the counter per request, so on a persistent SAPI every later request on the same worker wrongly throws "Modification of SplObjectStorage during getHash() is prohibited". Decrement inside a zend_catch and re-raise the bailout so the counter is balanced on every exit.

```php
class P extends SplObjectStorage {
    public function getHash($o): string {
        ini_set('memory_limit', '2M');
        str_repeat('a', 100 * 1024 * 1024); // OOM bailout
        return 'x';
    }
}
(new P())->offsetSet(new stdClass());           // request 1 bails out
(new SplObjectStorage())->offsetSet(new stdClass()); // later request, no override: throws before the patch
```
