### PR TITLE
Fix use-after-free when ArrayObject sort comparator replaces backing store

### DIFF
--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -927,6 +927,10 @@ static zend_result spl_array_skip_protected(spl_array_object *intern, HashTable 
 static void spl_array_set_array(zval *object, spl_array_object *intern, zval *array, zend_long ar_flags, bool just_array) {
 	/* Handled by ZPP prior to this, or for __unserialize() before passing to here */
 	ZEND_ASSERT(Z_TYPE_P(array) == IS_ARRAY || Z_TYPE_P(array) == IS_OBJECT);
+	if (intern->nApplyCount > 0) {
+		zend_throw_error(NULL, "Modification of ArrayObject during sorting is prohibited");
+		return;
+	}
 	zval garbage;
 	ZVAL_UNDEF(&garbage);
 	if (Z_TYPE_P(array) == IS_ARRAY) {

--- a/ext/spl/tests/ArrayObject_construct_during_sorting.phpt
+++ b/ext/spl/tests/ArrayObject_construct_during_sorting.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Can't use __construct() to replace the backing store while ArrayObject is being sorted
+--FILE--
+<?php
+
+$ao = new ArrayObject([1, 2, 3]);
+$other = new ArrayObject([4, 5, 6]);
+$i = 0;
+$ao->uasort(function($a, $b) use ($ao, $other, &$i) {
+    if ($i++ == 0) {
+        try {
+            $ao->__construct($other);
+        } catch (Error $e) {
+            echo $e->getMessage(), "\n";
+        }
+    }
+    return $a <=> $b;
+});
+var_dump($ao);
+
+?>
+--EXPECT--
+Modification of ArrayObject during sorting is prohibited
+object(ArrayObject)#1 (1) {
+  ["storage":"ArrayObject":private]=>
+  array(3) {
+    [0]=>
+    int(1)
+    [1]=>
+    int(2)
+    [2]=>
+    int(3)
+  }
+}


### PR DESCRIPTION
spl_array_method() caches the backing HashTable pointer across the user-supplied sort comparator. A comparator that re-enters __construct() (or __unserialize()) routes through spl_array_set_array(), which unlike the other ArrayObject mutators had no nApplyCount guard, so it swaps intern->array out from under the cached pointer and the post-sort cleanup releases then dereferences freed memory. Reachable from pure userland; valgrind reports an invalid read and the process segfaults. Add the nApplyCount guard the dimension writers and exchangeArray() already use.

```php
$ao = new ArrayObject([3, 1, 2]);
$o = new ArrayObject([9, 8, 7]);
$ao->uasort(function ($a, $b) use ($ao, $o) {
    static $n = 0;
    if ($n++ === 0) { $ao->__construct($o); }
    return $a <=> $b;
});
var_dump($ao->getArrayCopy()); // segfaults before the patch
```
