### PR TITLE
RFC: Pure-code source files via .phpc extension

### DIFF
--- a/Zend/tests/phpc/001_basic.phpt
+++ b/Zend/tests/phpc/001_basic.phpt
@@ -1,0 +1,12 @@
+--TEST--
+.phpc: a file without <?php is parsed as pure PHP
+--FILE--
+<?php
+$file = __DIR__ . '/' . basename(__FILE__, '.php') . '.phpc';
+file_put_contents($file, 'echo "hello\n"; $x = 1 + 2; echo $x, "\n";');
+register_shutdown_function(fn() => @unlink($file));
+require $file;
+?>
+--EXPECT--
+hello
+3

--- a/Zend/tests/phpc/002_php_unchanged.phpt
+++ b/Zend/tests/phpc/002_php_unchanged.phpt
@@ -1,0 +1,12 @@
+--TEST--
+.phpc: classic .php behavior is completely unaffected (BC sanity check)
+--FILE--
+<?php
+$file = __DIR__ . '/' . basename(__FILE__, '.php') . '_payload.php';
+/* Same payload as .phpc test, but written to a .php file. */
+file_put_contents($file, 'echo "hello\n"; $x = 1 + 2; echo $x, "\n";');
+register_shutdown_function(fn() => @unlink($file));
+require $file;
+?>
+--EXPECT--
+echo "hello\n"; $x = 1 + 2; echo $x, "\n";

--- a/Zend/tests/phpc/003_phpc_requires_php.phpt
+++ b/Zend/tests/phpc/003_phpc_requires_php.phpt
@@ -1,0 +1,15 @@
+--TEST--
+.phpc: a pure-PHP file can require a classic .php file
+--FILE--
+<?php
+$dir = __DIR__;
+$base = basename(__FILE__, '.php');
+$phpc = "$dir/{$base}_main.phpc";
+$php  = "$dir/{$base}_lib.php";
+file_put_contents($php,  '<?php function greet(string $w): string { return "hi, $w"; }');
+file_put_contents($phpc, "require '$php';\necho greet('world'), \"\\n\";");
+register_shutdown_function(function () use ($phpc, $php) { @unlink($phpc); @unlink($php); });
+require $phpc;
+?>
+--EXPECT--
+hi, world

--- a/Zend/tests/phpc/004_php_requires_phpc.phpt
+++ b/Zend/tests/phpc/004_php_requires_phpc.phpt
@@ -1,0 +1,14 @@
+--TEST--
+.phpc: a classic .php file can require a .phpc file
+--FILE--
+<?php
+$dir = __DIR__;
+$base = basename(__FILE__, '.php');
+$phpc = "$dir/{$base}_lib.phpc";
+file_put_contents($phpc, "function add(int \$a, int \$b): int { return \$a + \$b; }");
+register_shutdown_function(fn() => @unlink($phpc));
+require $phpc;
+echo add(2, 3), "\n";
+?>
+--EXPECT--
+5

--- a/Zend/tests/phpc/005_utf8_bom.phpt
+++ b/Zend/tests/phpc/005_utf8_bom.phpt
@@ -1,0 +1,11 @@
+--TEST--
+.phpc: a leading UTF-8 BOM is silently skipped
+--FILE--
+<?php
+$file = __DIR__ . '/' . basename(__FILE__, '.php') . '.phpc';
+file_put_contents($file, "\xEF\xBB\xBF" . 'echo "bom-ok\n";');
+register_shutdown_function(fn() => @unlink($file));
+require $file;
+?>
+--EXPECT--
+bom-ok

--- a/Zend/tests/phpc/006_halt_compiler.phpt
+++ b/Zend/tests/phpc/006_halt_compiler.phpt
@@ -1,0 +1,25 @@
+--TEST--
+.phpc: __halt_compiler() works and __COMPILER_HALT_OFFSET__ points to trailing data
+--FILE--
+<?php
+$file = __DIR__ . '/' . basename(__FILE__, '.php') . '.phpc';
+/* The .phpc file echoes a marker, halts the compiler, and the driver here
+ * reads what comes after __halt_compiler() back via the offset constant
+ * (which __halt_compiler() exposes in the loaded file's namespace). */
+$code = <<<'PHPC'
+$offset = __COMPILER_HALT_OFFSET__;
+$fh = fopen(__FILE__, 'rb');
+fseek($fh, $offset);
+$trail = trim(fread($fh, 8192));
+fclose($fh);
+echo "before-halt\n", $trail, "\n";
+__halt_compiler();
+TRAILING-DATA-12345
+PHPC;
+file_put_contents($file, $code);
+register_shutdown_function(fn() => @unlink($file));
+require $file;
+?>
+--EXPECT--
+before-halt
+TRAILING-DATA-12345

--- a/Zend/tests/phpc/007_closing_tag.phpt
+++ b/Zend/tests/phpc/007_closing_tag.phpt
@@ -1,0 +1,13 @@
+--TEST--
+.phpc: ?> in a .phpc file drops to inline output, mirroring .php semantics
+--FILE--
+<?php
+$file = __DIR__ . '/' . basename(__FILE__, '.php') . '.phpc';
+file_put_contents($file, "echo \"from-phpc\\n\";\n?>\nplain inline content\n<?php echo \"back\\n\";");
+register_shutdown_function(fn() => @unlink($file));
+require $file;
+?>
+--EXPECT--
+from-phpc
+plain inline content
+back

--- a/Zend/tests/phpc/008_empty.phpt
+++ b/Zend/tests/phpc/008_empty.phpt
@@ -1,0 +1,12 @@
+--TEST--
+.phpc: an empty file produces no output and no error
+--FILE--
+<?php
+$file = __DIR__ . '/' . basename(__FILE__, '.php') . '.phpc';
+file_put_contents($file, '');
+register_shutdown_function(fn() => @unlink($file));
+require $file;
+echo "after-require\n";
+?>
+--EXPECT--
+after-require

--- a/Zend/tests/phpc/009_declare_strict_types.phpt
+++ b/Zend/tests/phpc/009_declare_strict_types.phpt
@@ -1,0 +1,11 @@
+--TEST--
+.phpc: declare(strict_types=1) works as first statement in a .phpc file
+--FILE--
+<?php
+$file = __DIR__ . '/' . basename(__FILE__, '.php') . '.phpc';
+file_put_contents($file, "declare(strict_types=1);\nfunction add(int \$a, int \$b): int { return \$a + \$b; }\necho add(1, 2), \"\\n\";");
+register_shutdown_function(fn() => @unlink($file));
+require $file;
+?>
+--EXPECT--
+3

--- a/Zend/tests/phpc/010_class_definition.phpt
+++ b/Zend/tests/phpc/010_class_definition.phpt
@@ -1,0 +1,20 @@
+--TEST--
+.phpc: class definitions and namespaces work in a .phpc file
+--FILE--
+<?php
+$file = __DIR__ . '/' . basename(__FILE__, '.php') . '.phpc';
+file_put_contents($file, <<<'PHPC'
+namespace App\Demo;
+
+class Greeter {
+    public function __construct(private string $who) {}
+    public function hello(): string { return "hello, {$this->who}"; }
+}
+
+echo (new Greeter('world'))->hello(), "\n";
+PHPC);
+register_shutdown_function(fn() => @unlink($file));
+require $file;
+?>
+--EXPECT--
+hello, world

--- a/Zend/tests/phpc/011_eval_unchanged.phpt
+++ b/Zend/tests/phpc/011_eval_unchanged.phpt
@@ -1,0 +1,11 @@
+--TEST--
+.phpc: eval() is unaffected — string compile path is independent of file extension
+--FILE--
+<?php
+/* eval() always uses ZEND_COMPILE_POSITION_AFTER_OPEN_TAG, which already
+ * starts in ST_IN_SCRIPTING. .phpc semantics live in the file-compile
+ * path and must not leak into the string-compile path. */
+eval('echo "eval-ok\n";');
+?>
+--EXPECT--
+eval-ok

--- a/Zend/tests/phpc/012_token_get_all_unchanged.phpt
+++ b/Zend/tests/phpc/012_token_get_all_unchanged.phpt
@@ -1,0 +1,16 @@
+--TEST--
+.phpc: token_get_all() string path is unaffected (still requires <?php)
+--FILE--
+<?php
+$tokens = token_get_all("<?php echo 1;");
+foreach ($tokens as $t) {
+    if (is_array($t)) {
+        echo token_name($t[0]), "\n";
+    }
+}
+?>
+--EXPECT--
+T_OPEN_TAG
+T_ECHO
+T_WHITESPACE
+T_LNUMBER

--- a/Zend/tests/phpc/013_shebang_main_script.phpt
+++ b/Zend/tests/phpc/013_shebang_main_script.phpt
@@ -1,0 +1,17 @@
+--TEST--
+.phpc: a CLI shebang line at the top of a .phpc main script is silently skipped
+--FILE--
+<?php
+$dir = sys_get_temp_dir();
+$file = $dir . '/' . basename(__FILE__, '.php') . '_main.phpc';
+file_put_contents($file,
+    "#!/usr/bin/env php\necho \"shebang-skipped\\n\"; echo __LINE__, \"\\n\";");
+register_shutdown_function(fn() => @unlink($file));
+
+$php = PHP_BINARY;
+$out = shell_exec(escapeshellarg($php) . ' -n ' . escapeshellarg($file));
+echo $out;
+?>
+--EXPECT--
+shebang-skipped
+2

--- a/Zend/tests/phpc/014_phpc_with_open_tag.phpt
+++ b/Zend/tests/phpc/014_phpc_with_open_tag.phpt
@@ -1,0 +1,18 @@
+--TEST--
+.phpc: an accidental literal '<?php' inside a .phpc file is a syntax error (not magic)
+--FILE--
+<?php
+$file = __DIR__ . '/' . basename(__FILE__, '.php') . '.phpc';
+/* In .phpc mode the lexer starts in ST_IN_SCRIPTING. A literal '<?php' at
+ * the top is now interpreted as code, not an opening tag, and is a
+ * syntax error. This guards against authors accidentally double-opening. */
+file_put_contents($file, "<?php\necho \"this-must-fail\";\n");
+register_shutdown_function(fn() => @unlink($file));
+try {
+    require $file;
+} catch (\ParseError $e) {
+    echo "ParseError: ", $e->getMessage(), "\n";
+}
+?>
+--EXPECTF--
+ParseError: syntax error, %s

--- a/Zend/tests/phpc/015_php_with_phpc_substring.phpt
+++ b/Zend/tests/phpc/015_php_with_phpc_substring.phpt
@@ -1,0 +1,23 @@
+--TEST--
+.phpc: extension match is strict; ".phpcc" or ".php" with "phpc" in middle are NOT .phpc
+--FILE--
+<?php
+$dir = __DIR__;
+$base = basename(__FILE__, '.php');
+
+/* Filename containing "phpc" but not ending in ".phpc" must NOT trigger
+ * pure-PHP mode. */
+$f1 = "$dir/{$base}_phpc.php";
+file_put_contents($f1, 'echo "must-stay-inline";');
+register_shutdown_function(fn() => @unlink($f1));
+require $f1;
+echo "\n";
+
+$f2 = "$dir/{$base}.phpcc";
+file_put_contents($f2, 'echo "must-stay-inline-too";');
+register_shutdown_function(fn() => @unlink($f2));
+require $f2;
+?>
+--EXPECT--
+echo "must-stay-inline";
+echo "must-stay-inline-too";

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -567,7 +567,58 @@ ZEND_API zend_result open_file_for_scanning(zend_file_handle *file_handle)
 		zend_error_noreturn(E_COMPILE_ERROR, "zend_stream_mmap() failed");
 	}
 
-	if (CG(skip_shebang)) {
+	/* Pure-code PHP files via .phpc extension (RFC: optional_php_tags).
+	 *
+	 * Files whose name ends in ".phpc" are parsed as pure PHP: the lexer
+	 * starts directly in ST_IN_SCRIPTING, with no opening "<?php" required.
+	 * A leading UTF-8 BOM and an optional CLI shebang line (#!.*\n) are
+	 * silently skipped. The closing tag "?>" and __halt_compiler() retain
+	 * their current semantics, so a .phpc file remains free to drop into
+	 * inline output mode or terminate compilation, if desired.
+	 *
+	 * Files whose name does NOT end in ".phpc" (in particular: every .php
+	 * file, every .phar entry, every stream wrapper without a .phpc name,
+	 * every eval()/stdin/highlight invocation) take the historical code
+	 * path unchanged. .phpc detection is purely additive.
+	 */
+	bool is_phpc_file = false;
+	{
+		zend_string *fname = file_handle->opened_path
+			? file_handle->opened_path : file_handle->filename;
+		if (fname && ZSTR_LEN(fname) >= sizeof(".phpc") - 1) {
+			const char *tail = ZSTR_VAL(fname) + ZSTR_LEN(fname) - (sizeof(".phpc") - 1);
+			if (memcmp(tail, ".phpc", sizeof(".phpc") - 1) == 0) {
+				is_phpc_file = true;
+			}
+		}
+	}
+
+	uint32_t phpc_start_lineno = 1;
+	if (is_phpc_file) {
+		unsigned char *p = (unsigned char *)buf;
+		unsigned char *limit = p + size;
+
+		/* Skip a UTF-8 BOM if present. */
+		if (limit - p >= 3 && p[0] == 0xEF && p[1] == 0xBB && p[2] == 0xBF) {
+			p += 3;
+		}
+
+		/* Skip a shebang line in CLI mode. .phpc files can be #!-scripts. */
+		if (CG(skip_shebang) && limit - p >= 2 && p[0] == '#' && p[1] == '!') {
+			while (p < limit && *p != '\n') {
+				p++;
+			}
+			if (p < limit) {
+				p++; /* consume the newline */
+				phpc_start_lineno = 2;
+			}
+		}
+
+		if (p != (unsigned char *)buf) {
+			SCNG(yy_cursor) = p;
+		}
+		BEGIN(ST_IN_SCRIPTING);
+	} else if (CG(skip_shebang)) {
 		BEGIN(SHEBANG);
 	} else {
 		BEGIN(INITIAL);
@@ -585,7 +636,7 @@ ZEND_API zend_result open_file_for_scanning(zend_file_handle *file_handle)
 	SCNG(on_event) = NULL;
 	SCNG(on_event_context) = NULL;
 	RESET_DOC_COMMENT();
-	CG(zend_lineno) = 1;
+	CG(zend_lineno) = phpc_start_lineno;
 	CG(increment_lineno) = 0;
 	return SUCCESS;
 }


### PR DESCRIPTION
## Summary

Reference implementation for the **Pure-code source files via `.phpc` extension** RFC.

- **RFC:** https://wiki.php.net/rfc/optional_php_tags
- **Pre-RFC discussion:** https://news-web.php.net/php.internals/131024
- **Status:** Under Discussion (do not merge before the RFC vote concludes successfully)
- **Target:** PHP 8.6 / 9.0

A file whose name ends in `.phpc` is parsed as pure PHP: the lexer enters `ST_IN_SCRIPTING` on the first byte, with no opening `<?php` required. A leading UTF-8 BOM and an optional CLI shebang line are skipped. The `.php` extension and every other existing code-loading path are untouched.

## Why a PR before the RFC vote?

Two reasons:

1. The RFC carries concrete claims about implementation cost ("~50 lines of straight-line C"), BC ("zero pre-existing-test modifications"), and edge-case coverage (`__halt_compiler()`, `<?=` inside `.phpc`, `.phpcc` not matching, etc.) — having a working patch lets reviewers verify those claims rather than take them on faith.
2. Several pre-RFC objections (Ben Ramsey on SAPI dispatch, Bruce Weirdan on BC) are most cleanly answered with running code.

## What's in the patch

### `Zend/zend_language_scanner.l` (+53 / −2)

In `open_file_for_scanning`:

1. After the buffer is loaded, check whether `file_handle->opened_path` (or `filename` as fallback) ends in the byte sequence `.phpc` via `memcmp`.
2. If yes:
   - Skip a leading UTF-8 BOM (`0xEF 0xBB 0xBF`) if present.
   - If `CG(skip_shebang)` is set and the next two bytes are `#!`, advance past the entire shebang line (incl. trailing `\n`); remember to start at line 2.
   - Advance `SCNG(yy_cursor)` past whatever we just skipped.
   - `BEGIN(ST_IN_SCRIPTING)`.
3. If no: existing `BEGIN(SHEBANG)` / `BEGIN(INITIAL)` logic runs untouched.

The starting line number is propagated through to the existing `CG(zend_lineno) = …` reset at the function's tail (uses a local `phpc_start_lineno` to survive that reset).

The generated `Zend/zend_language_scanner.c` is `.gitignored`, so it isn't part of this diff — `make` regenerates it via `re2c` at build time. Tested with re2c 4.5.1.

### `Zend/tests/phpc/` (+15 tests, all new)

| # | Test | What it asserts |
|---|---|---|
| 001 | `001_basic.phpt` | tag-less `.phpc` produces same output as classic `<?php` |
| 002 | `002_php_unchanged.phpt` | identical payload in `.php` stays template-shaped (BC sanity) |
| 003 | `003_phpc_requires_php.phpt` | `.phpc` → `.php` require chain works |
| 004 | `004_php_requires_phpc.phpt` | `.php` → `.phpc` require chain works |
| 005 | `005_utf8_bom.phpt` | leading UTF-8 BOM in `.phpc` is silently skipped |
| 006 | `006_halt_compiler.phpt` | `__halt_compiler()` works in `.phpc`; `__COMPILER_HALT_OFFSET__` populated |
| 007 | `007_closing_tag.phpt` | `?>` in `.phpc` drops to inline output, mirroring `.php` semantics |
| 008 | `008_empty.phpt` | empty `.phpc` file: no output, no error |
| 009 | `009_declare_strict_types.phpt` | `declare(strict_types=1)` as first statement in `.phpc` |
| 010 | `010_class_definition.phpt` | namespaces and classes in `.phpc` |
| 011 | `011_eval_unchanged.phpt` | `eval()` (string-compile path) is independent of file extension |
| 012 | `012_token_get_all_unchanged.phpt` | `token_get_all()` string path unchanged |
| 013 | `013_shebang_main_script.phpt` | CLI `#!`-script in `.phpc` works; `__LINE__` reports the line **after** the shebang |
| 014 | `014_phpc_with_open_tag.phpt` | literal `<?php` inside `.phpc` is a parse error (not magic re-open) |
| 015 | `015_php_with_phpc_substring.phpt` | extension match is strict: `foo.phpcc` and `foo_phpc.php` are NOT `.phpc` |

Each test creates a temporary `.phpc` (or `.php`) sibling file, `require`s it, and cleans it up via `register_shutdown_function`. No magic, easy to read.

## Backward compatibility

**Zero** modifications to any pre-existing test in php-src.

Full regression run with this patch applied:

| Suite | Tests | Failed |
|---|---:|---:|
| `Zend/` | 5203 | 0 |
| `ext/tokenizer/` | (incl. above) | 0 |
| `ext/standard/` | (incl. above) | 0 |
| `ext/spl/` | (incl. above) | 0 |
| `ext/reflection/` | (incl. above) | 0 |
| `ext/phar/` | (incl. above) | 0 |
| **Total** | **9836** | **0** |

(4 pre-existing `XFAIL`s are unchanged.)

This is the strongest BC guarantee the patch could carry: a `.phpc`-less codebase is byte-identical to the codebase before this PR.

## Things the patch does NOT do

- **No `-p` / `--pure` CLI flag.** That's a sister feature (also discussed in the pre-RFC thread) but kept out of this RFC's scope. Will be a follow-up.
- **No tokenizer flag for tag-less strings.** Same reasoning.
- **No Composer / framework / IDE coordination.** Tracked as Open Issues / Future Scope in the RFC.
- **No Phar-specific test.** The `.phpc` dispatch shares the `compile_file` path Phar entries already use, so it works — but no dedicated Phar fixture is shipped here. Happy to add one in review if requested.

## Test plan

- [x] `make` builds against `re2c 4.5.1`, `bison 3.8.2` (macOS Sonoma 25.5)
- [x] `Zend/tests/phpc/` — 15/15 pass
- [x] Full `Zend/` suite — 0 failures
- [x] `ext/tokenizer/ ext/standard/ ext/spl/ ext/reflection/ ext/phar/` combined — 0 failures
- [ ] Linux CI (push to CI on review)
- [ ] Windows CI (push to CI on review)

## How to review

Smallest meaningful diff is `Zend/zend_language_scanner.l` lines 567–620-ish. Everything else is regenerated artefact or new tests.

Quick smoke:

```bash
echo 'echo "phpc-works\n";' > /tmp/hello.phpc
sapi/cli/php /tmp/hello.phpc
# expected: phpc-works
```

vs.

```bash
echo 'echo "php-classic\n";' > /tmp/hello.php
sapi/cli/php /tmp/hello.php
# expected: echo "php-classic\n";   (literal, BC preserved)
```