### PR TITLE
Windows: Skip installing main/poll/* headers

### DIFF
--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -312,7 +312,7 @@ ADD_SOURCES("win32", "dllmain.c readdir.c \
 
 ADD_FLAG("CFLAGS_BD_WIN32", "/D ZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 
-PHP_INSTALL_HEADERS("", "Zend/ TSRM/ main/ main/poll/ main/streams/ win32/");
+PHP_INSTALL_HEADERS("", "Zend/ TSRM/ main/ main/streams/ win32/");
 PHP_INSTALL_HEADERS("Zend/Optimizer", "zend_call_graph.h zend_cfg.h zend_dfg.h zend_dump.h zend_func_info.h zend_inference.h zend_optimizer.h zend_ssa.h zend_worklist.h");
 
 STDOUT.WriteBlankLines(1);


### PR DESCRIPTION
In Autotools these aren't installed and neither are there any public headers.

Follow up of https://github.com/php/php-src/pull/19572