### PR TITLE
zend: fix missing return in global register detection (GH-22206)

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -317,6 +317,7 @@ int emu(const opcode_handler_t *ip, void *fp) {
   while ((*ip)());
   FP = orig_fp;
   IP = orig_ip;
+  return 0;
 }], [])],
   [php_cv_have_global_register_vars=yes],
   [php_cv_have_global_register_vars=no])


### PR DESCRIPTION
Hi,
this pull request add a missing return statement to zend global registers detection, fixing a build failure with `-Werror=return-type` with GCC 16.

When building with `-Werror=return-type`, the global registers detection ends with an error, even though global registers are supported. The `preserve_none` attribute is newly supported, which along with "unsupported" global registers leads to `ZEND_VM_KIND` being set to `ZEND_VM_KIND_TAILCALL`, which later produces the error described in the linked issue. This pull request fixes that.