### PR TITLE
ext/spl: ignore leading namespace separator in spl_autoload()

### DIFF
--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -310,7 +310,12 @@ PHP_FUNCTION(spl_autoload)
 		pos_len = (int)ZSTR_LEN(file_exts);
 	}
 
-	lc_name = zend_string_tolower(class_name);
+	if (ZSTR_VAL(class_name)[0] == '\\') {
+		lc_name = zend_string_alloc(ZSTR_LEN(class_name) - 1, 0);
+		zend_str_tolower_copy(ZSTR_VAL(lc_name), ZSTR_VAL(class_name) + 1, ZSTR_LEN(class_name) - 1);
+	} else {
+		lc_name = zend_string_tolower(class_name);
+	}
 	while (pos && *pos && !EG(exception)) {
 		pos1 = strchr(pos, ',');
 		if (pos1) {

--- a/ext/spl/tests/spl_autoload_leading_backslash.phpt
+++ b/ext/spl/tests/spl_autoload_leading_backslash.phpt
@@ -1,0 +1,18 @@
+--TEST--
+spl_autoload(): a leading "\" in the class name is ignored
+--FILE--
+<?php
+
+set_include_path(__DIR__);
+spl_autoload_extensions(".inc");
+
+spl_autoload("DualIterator");
+var_dump(class_exists("DualIterator", false));
+
+spl_autoload("\\RecursiveDualIterator");
+var_dump(class_exists("RecursiveDualIterator", false));
+
+?>
+--EXPECT--
+bool(true)
+bool(true)


### PR DESCRIPTION
Extracted from https://github.com/php/php-src/pull/22260

Strip a leading "\\" before lowercasing, mirroring zend_lookup_class_ex(), so both spellings resolve identically.

Closes https://github.com/php/php-src/issues/22322