### PR TITLE
ext/reflection: ignore leading namespace separator in ReflectionParameter

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -2480,9 +2480,20 @@ ZEND_METHOD(ReflectionParameter, __construct)
 	switch (Z_TYPE_P(reference)) {
 		case IS_STRING:
 			{
-				zend_string *lcname = zend_string_tolower(Z_STR_P(reference));
-				fptr = zend_hash_find_ptr(EG(function_table), lcname);
-				zend_string_release(lcname);
+				zend_string *fname = Z_STR_P(reference);
+				zend_string *lcname;
+				if (UNEXPECTED(ZSTR_VAL(fname)[0] == '\\')) {
+					/* Ignore leading "\" */
+					ALLOCA_FLAG(use_heap)
+					ZSTR_ALLOCA_ALLOC(lcname, ZSTR_LEN(fname) - 1, use_heap);
+					zend_str_tolower_copy(ZSTR_VAL(lcname), ZSTR_VAL(fname) + 1, ZSTR_LEN(fname) - 1);
+					fptr = zend_fetch_function(lcname);
+					ZSTR_ALLOCA_FREE(lcname, use_heap);
+				} else {
+					lcname = zend_string_tolower(fname);
+					fptr = zend_fetch_function(lcname);
+					zend_string_release(lcname);
+				}
 				if (!fptr) {
 					zend_throw_exception_ex(reflection_exception_ptr, 0,
 						"Function %s() does not exist", Z_STRVAL_P(reference));

--- a/ext/reflection/tests/ReflectionParameter_leading_backslash.phpt
+++ b/ext/reflection/tests/ReflectionParameter_leading_backslash.phpt
@@ -1,0 +1,17 @@
+--TEST--
+ReflectionParameter::__construct(): a leading "\" in the function name is ignored
+--FILE--
+<?php
+
+function demo(string $arg) {}
+
+$p = new ReflectionParameter("\\demo", 0);
+var_dump($p->getName());
+
+$p = new ReflectionParameter("demo", 0);
+var_dump($p->getName());
+
+?>
+--EXPECT--
+string(3) "arg"
+string(3) "arg"


### PR DESCRIPTION
Extracted from https://github.com/php/php-src/pull/22260

Strip a leading '\\' before lowercasing, matching ReflectionFunction::__construct().

Closes https://github.com/php/php-src/issues/22324