### PR TITLE
main/poll: Record wait() error on every backend

### DIFF
--- a/main/poll/poll_backend_epoll.c
+++ b/main/poll/poll_backend_epoll.c
@@ -195,6 +195,8 @@ static int epoll_backend_wait(
 			events[i].revents = epoll_events_from_native(backend_data->events[i].events);
 			events[i].data = backend_data->events[i].data.ptr;
 		}
+	} else if (nfds < 0) {
+		php_poll_set_current_errno_error(ctx);
 	}
 
 	return nfds;

--- a/main/poll/poll_backend_kqueue.c
+++ b/main/poll/poll_backend_kqueue.c
@@ -320,6 +320,11 @@ static int kqueue_backend_wait(
 	int nfds = kevent(
 			backend_data->kqueue_fd, NULL, 0, backend_data->events, required_capacity, timeout);
 
+	if (nfds < 0) {
+		php_poll_set_current_errno_error(ctx);
+		return -1;
+	}
+
 	if (nfds > 0) {
 		if (ctx->raw_events) {
 			/* Raw events mode - direct 1:1 mapping, no grouping */

--- a/main/poll/poll_backend_poll.c
+++ b/main/poll/poll_backend_poll.c
@@ -215,8 +215,11 @@ static int poll_backend_wait(
 	int timeout_ms = php_poll_timespec_to_ms(timeout);
 	int nfds = poll(backend_data->temp_fds, fd_count, timeout_ms);
 
-	if (nfds <= 0) {
-		return nfds; /* Return 0 for timeout, -1 for error */
+	if (nfds < 0) {
+		php_poll_set_current_errno_error(ctx);
+		return -1;
+	} else if (nfds == 0) {
+		return 0; /* timeout */
 	}
 
 	/* Process results - iterate through struct pollfd array directly */


### PR DESCRIPTION
`php_poll_wait()` reported a stale error code when a backend's wait syscall failed without recording one. epoll, poll and kqueue returned -1 without setting it, so record it from errno and `php_poll_get_error()` then reflects the real failure. eventport and wsapoll already did this, the latter from `WSAGetLastError()`. Split out of #22316 on review.
