### PR TITLE
main/poll: Cap kqueue grouped-event buffer write at runtime

### DIFF
--- a/main/poll/poll_backend_kqueue.c
+++ b/main/poll/poll_backend_kqueue.c
@@ -382,12 +382,13 @@ static int kqueue_backend_wait(
 
 				if (!found) {
 					/* New FD, create new event */
-					ZEND_ASSERT(unique_events < max_events);
-					events[unique_events].fd = fd;
-					events[unique_events].events = 0;
-					events[unique_events].revents = revents;
-					events[unique_events].data = data;
-					unique_events++;
+					if (unique_events < max_events) {
+						events[unique_events].fd = fd;
+						events[unique_events].events = 0;
+						events[unique_events].revents = revents;
+						events[unique_events].data = data;
+						unique_events++;
+					}
 
 					/* Handle oneshot tracking */
 					if (is_oneshot) {


### PR DESCRIPTION
The kqueue grouped-event path bounded the result buffer only with a `ZEND_ASSERT`, allowing an out-of-bounds write in release builds when more distinct descriptors were ready than the caller's `maxEvents`. This caps the buffer write at runtime while still running the oneshot bookkeeping so the backend's tracking stays in sync. An alternative is to cap the `kevent()` request to `maxEvents` so the dedup can't exceed the buffer; this takes the minimal in-place fix. kqueue isn't compiled on Linux, so it rides macOS CI. Split out of #22316 on review.
