### PR TITLE
ext/phar: Fix ZIP extra field length underflow in Phar

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -56,6 +56,7 @@ PHP                                                                        NEWS
   . Fixed a bypass of the magic ".phar" directory protection in
     Phar::addEmptyDir() for paths starting with "/.phar", while allowing
     non-magic directory names that merely share the ".phar" prefix. (Weilin Du)
+  . Fixed an integer underflow when parsing ZIP extra fields. (Weilin Du)
 
 - Reflection:
   . Preserve class-name case in ReflectionClass::getProperty() error messages

--- a/ext/phar/tests/zip/zip_extra_underflow.phpt
+++ b/ext/phar/tests/zip/zip_extra_underflow.phpt
@@ -1,0 +1,91 @@
+--TEST--
+Phar: ZIP extra field length must not underflow
+--EXTENSIONS--
+phar
+--FILE--
+<?php
+function uint16($value) {
+    return pack('v', $value);
+}
+
+function uint32($value) {
+    return pack('V', $value);
+}
+
+$filename = __DIR__ . '/zip_extra_underflow.zip';
+$entry = 'test.txt';
+$contents = 'hello';
+$crc = crc32($contents);
+
+$local = uint32(0x04034b50)
+    . uint16(20)
+    . uint16(0)
+    . uint16(0)
+    . uint16(0)
+    . uint16(0)
+    . uint32($crc)
+    . uint32(strlen($contents))
+    . uint32(strlen($contents))
+    . uint16(strlen($entry))
+    . uint16(0)
+    . $entry
+    . $contents;
+
+$extra = 'XX' . uint16(1);
+
+/* Old code seeks one byte past the extra field and parses this as another extra header. */
+$commentPrefix = 'A'
+    . 'UT'
+    . uint16(5)
+    . "\x01"
+    . uint32(946684800)
+    . 'ZZ'
+    . uint16(65522);
+$comment = $commentPrefix . str_repeat('B', 65535 - strlen($commentPrefix));
+
+$central = uint32(0x02014b50)
+    . uint16(20)
+    . uint16(20)
+    . uint16(0)
+    . uint16(0)
+    . uint16(0)
+    . uint16(0)
+    . uint32($crc)
+    . uint32(strlen($contents))
+    . uint32(strlen($contents))
+    . uint16(strlen($entry))
+    . uint16(strlen($extra))
+    . uint16(strlen($comment))
+    . uint16(0)
+    . uint16(0)
+    . uint32(0)
+    . uint32(0)
+    . $entry
+    . $extra
+    . $comment;
+
+$eocd = uint32(0x06054b50)
+    . uint16(0)
+    . uint16(0)
+    . uint16(1)
+    . uint16(1)
+    . uint32(strlen($central))
+    . uint32(strlen($local))
+    . uint16(0);
+
+file_put_contents($filename, $local . $central . $eocd);
+
+try {
+    $phar = new PharData($filename);
+    echo "Loaded corrupt ZIP\n";
+    echo $phar[$entry]->getMTime(), "\n";
+} catch (Exception $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/zip_extra_underflow.zip');
+?>
+--EXPECTF--
+phar error: Unable to process extra field header for file in central directory in zip-based phar "%szip_extra_underflow.zip"

--- a/ext/phar/zip.c
+++ b/ext/phar/zip.c
@@ -41,17 +41,28 @@ static inline void phar_write_16(char buffer[2], uint32_t value)
 # define PHAR_SET_32(var, value) phar_write_32(var, (uint32_t) (value));
 # define PHAR_SET_16(var, value) phar_write_16(var, (uint16_t) (value));
 
-static int phar_zip_process_extra(php_stream *fp, phar_entry_info *entry, uint16_t len) /* {{{ */
+static int phar_zip_process_extra(php_stream *fp, phar_entry_info *entry, uint16_t extra_len) /* {{{ */
 {
 	union {
 		phar_zip_extra_field_header header;
 		phar_zip_unix3 unix3;
 		phar_zip_unix_time time;
 	} h;
+	size_t len = extra_len;
 	size_t read;
 
-	do {
+	while (len) {
+		size_t header_size;
+
+		if (len < sizeof(h.header)) {
+			return FAILURE;
+		}
 		if (sizeof(h.header) != php_stream_read(fp, (char *) &h.header, sizeof(h.header))) {
+			return FAILURE;
+		}
+		len -= sizeof(h.header);
+		header_size = PHAR_GET_16(h.header.size);
+		if (header_size > len) {
 			return FAILURE;
 		}
 
@@ -62,7 +73,6 @@ static int phar_zip_process_extra(php_stream *fp, phar_entry_info *entry, uint16
 			 * We only store the modification time in the entry, so only read that.
 			 */
 			const size_t min_size = 5;
-			uint16_t header_size = PHAR_GET_16(h.header.size);
 			if (header_size >= min_size) {
 				read = php_stream_read(fp, &h.time.flags, min_size);
 				if (read != min_size) {
@@ -73,12 +83,11 @@ static int phar_zip_process_extra(php_stream *fp, phar_entry_info *entry, uint16
 					entry->timestamp = PHAR_GET_32(h.time.time);
 				}
 
-				len -= header_size + 4;
-
 				/* Consume remaining bytes */
-				if (header_size != read) {
-					php_stream_seek(fp, header_size - read, SEEK_CUR);
+				if (header_size != read && -1 == php_stream_seek(fp, header_size - read, SEEK_CUR)) {
+					return FAILURE;
 				}
+				len -= header_size;
 				continue;
 			}
 			/* Fallthrough to next if to skip header */
@@ -86,23 +95,36 @@ static int phar_zip_process_extra(php_stream *fp, phar_entry_info *entry, uint16
 
 		if (h.header.tag[0] != 'n' || h.header.tag[1] != 'u') {
 			/* skip to next header */
-			php_stream_seek(fp, PHAR_GET_16(h.header.size), SEEK_CUR);
-			len -= PHAR_GET_16(h.header.size) + 4;
+			if (header_size && -1 == php_stream_seek(fp, header_size, SEEK_CUR)) {
+				return FAILURE;
+			}
+			len -= header_size;
 			continue;
 		}
 
 		/* unix3 header found */
-		read = php_stream_read(fp, (char *) &(h.unix3.crc32), sizeof(h.unix3) - sizeof(h.header));
-		len -= read + 4;
-
-		if (sizeof(h.unix3) - sizeof(h.header) != read) {
+		size_t unix3_size = sizeof(h.unix3) - sizeof(h.header);
+		size_t field_size = header_size;
+		if (field_size == unix3_size - sizeof(h.unix3.crc32)) {
+			/* Some archives omit the CRC32 from the unix3 size field. */
+			field_size = unix3_size;
+		}
+		if (field_size < unix3_size || field_size > len) {
 			return FAILURE;
 		}
 
-		if (PHAR_GET_16(h.unix3.size) > sizeof(h.unix3) - 4) {
-			/* skip symlink filename - we may add this support in later */
-			php_stream_seek(fp, PHAR_GET_16(h.unix3.size) - sizeof(h.unix3.size), SEEK_CUR);
+		read = php_stream_read(fp, (char *) &(h.unix3.crc32), unix3_size);
+		if (unix3_size != read) {
+			return FAILURE;
 		}
+
+		if (field_size > unix3_size) {
+			/* skip symlink filename - we may add this support in later */
+			if (-1 == php_stream_seek(fp, field_size - unix3_size, SEEK_CUR)) {
+				return FAILURE;
+			}
+		}
+		len -= field_size;
 
 		/* set permissions */
 		entry->flags &= PHAR_ENT_COMPRESSION_MASK;
@@ -113,7 +135,7 @@ static int phar_zip_process_extra(php_stream *fp, phar_entry_info *entry, uint16
 			entry->flags |= PHAR_GET_16(h.unix3.perms) & PHAR_ENT_PERM_MASK;
 		}
 
-	} while (len);
+	}
 
 	return SUCCESS;
 }


### PR DESCRIPTION
Now the parser used a `uint16_t` remaining-length counter and subtracted the extra field payload size plus header size without first validating that the parsing data past the extra field boundary.

So, a malformed zip .phar file can trigger an underflow. See
```php
  <?php
  function u16($v) { return pack('v', $v); }
  function u32($v) { return pack('V', $v); }

  $f = __DIR__ . '/poc.zip';
  $name = 'a';
  $data = 'x';
  $crc = crc32($data);

  $local = u32(0x04034b50) . u16(20) . u16(0) . u16(0) . u16(0) . u16(0)
      . u32($crc) . u32(strlen($data)) . u32(strlen($data))
      . u16(strlen($name)) . u16(0) . $name . $data;

  /* extra_len = 4, but sub-header says payload size = 1. */
  $extra = 'XX' . u16(1);

  /* Old parser seeks 1 byte past the extra field, then parses this comment data. */
  $prefix = 'A' . 'UT' . u16(5) . "\x01" . u32(114514000) . 'ZZ' . u16(65522);
  $comment = $prefix . str_repeat('B', 65535 - strlen($prefix));

  $central = u32(0x02014b50) . u16(20) . u16(20) . u16(0) . u16(0) . u16(0) . u16(0)
      . u32($crc) . u32(strlen($data)) . u32(strlen($data))
      . u16(strlen($name)) . u16(strlen($extra)) . u16(strlen($comment))
      . u16(0) . u16(0) . u32(0) . u32(0)
      . $name . $extra . $comment;

  $eocd = u32(0x06054b50) . u16(0) . u16(0) . u16(1) . u16(1)
      . u32(strlen($central)) . u32(strlen($local)) . u16(0);

  file_put_contents($f, $local . $central . $eocd);

  try {
      $p = new PharData($f);
      echo "BUG: corrupt zip loaded\n";
      echo "mtime: ", $p[$name]->getMTime(), "\n";
  } catch (Exception $e) {
      echo "fixed: ", $e->getMessage(), "\n";
  }
```
the `mtime` will become a controlled 114514191. The malformed ZIP has central extra_len = 4, but the first extra sub-header declares size = 1. The old parser subtracts 5 from a uint16_t length counter, underflows, then continues parsing past the extra field boundary. So it parses file comment bytes as a UT extra field, which makes the mtime 114514191.

```
BUG: corrupt zip loaded
mtime: 114514000
```

The fix is to validate each extra field sub-header before consuming it.

p.s. the gpg sign is now fixed.
