### PR TITLE
Autotools: Fix out-of-source builds and epoll_pwait2 check

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -1396,7 +1396,11 @@ AC_DEFUN([PHP_POLL_MECHANISMS],
     AC_DEFINE([HAVE_EPOLL], [1], [Define if epoll is available])
     poll_mechanisms="$poll_mechanisms epoll"
 
-    AC_CHECK_FUNCS([epoll_pwait2], [], [], [#include <sys/epoll.h>])
+    AC_CHECK_FUNCS([epoll_pwait2], [],
+      [AC_CHECK_DECL([epoll_pwait2],
+        [AC_DEFINE([HAVE_EPOLL_PWAIT2], [1])],
+        [],
+        [#include <sys/epoll.h>])])
   ])
 
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([

--- a/configure.ac
+++ b/configure.ac
@@ -1817,6 +1817,7 @@ AC_DEFINE([HAVE_BUILD_DEFS_H], [1],
 
 PHP_ADD_BUILD_DIR([
   main
+  main/poll
   main/streams
   scripts
   scripts/man1


### PR DESCRIPTION
* Added main/poll to build directories to enable out-of-source builds.
* AC_CHECK_FUNCS() Autoconf macro doesn't accept 4th argument (it's a link check). Instead, added a AC_CHECK_DECL() fallback check if epoll_pwait2 is defined as a macro (as in glibc at the time of writing in certain scenarios).