### PR TITLE
Fix missing semicolon in mm session validate_sid handler

### DIFF
--- a/ext/session/mod_mm.c
+++ b/ext/session/mod_mm.c
@@ -481,7 +481,7 @@ PS_VALIDATE_SID_FUNC(mm)
 	PS_MM_DATA;
 
 	mm_lock(data->mm, MM_LOCK_RD);
-	zend_result ret = ps_mm_key_exists(data, key)
+	zend_result ret = ps_mm_key_exists(data, key);
 	mm_unlock(data->mm);
 	return ret;
 }


### PR DESCRIPTION
PS_VALIDATE_SID_FUNC(mm) is missing the semicolon after the ps_mm_key_exists() assignment, so ext/session/mod_mm.c fails to compile under --with-mm. The handler is gated behind HAVE_LIBMM, so default builds and CI never exercise it.
