### PR TITLE
Fix leak of resolved address list in snmp_session_init()

### DIFF
--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -910,6 +910,7 @@ static bool netsnmp_session_init(php_snmp_session **session_p, int version, zend
 
 	if (strlen(session->peername) == 0) {
 		php_error_docref(NULL, E_WARNING, "Unknown failure while resolving '%s'", ZSTR_VAL(hostname));
+		php_network_freeaddresses(psal);
 		return false;
 	}
 	/* XXX FIXME

--- a/ext/snmp/tests/snmp_resolve_fail_leak.phpt
+++ b/ext/snmp/tests/snmp_resolve_fail_leak.phpt
@@ -1,0 +1,16 @@
+--TEST--
+snmp: resolved address list is freed when peername resolution drains empty
+--EXTENSIONS--
+snmp
+--FILE--
+<?php
+// Bracketed (IPv6) syntax over an IPv4-only literal forces IPv6 resolution,
+// which drains to no usable address, hitting the "Unknown failure while
+// resolving" path. That path must free the address list from
+// php_network_getaddresses() (it previously leaked it). No SNMP agent needed:
+// the function fails at peername resolution before any query is sent.
+var_dump(snmpget("[127.0.0.1]", "public", ".1.3.6.1.2.1.1.1.0"));
+?>
+--EXPECTF--
+Warning: snmpget(): Unknown failure while resolving '[127.0.0.1]' in %s on line %d
+bool(false)


### PR DESCRIPTION
When php_network_getaddresses() succeeds but no resolved address yields a usable peer name (for example bracketed IPv6 syntax over an IPv4-only host), snmp_session_init() returned without php_network_freeaddresses(), leaking the address list on every such call. Free it on that error path, matching the success path and the convention in main/network.c.