### PR TITLE
Fix SOAP client failing to follow a scheme-less redirect Location

### DIFF
--- a/ext/soap/php_http.c
+++ b/ext/soap/php_http.c
@@ -1162,12 +1162,12 @@ try_again:
 				zend_string_release_ex(http_headers, 0);
 				zend_string_release_ex(http_body, 0);
 				if (new_uri->scheme == NULL && new_uri->path != NULL) {
-					new_uri->scheme = new_uri->scheme ? zend_string_copy(new_uri->scheme) : NULL;
-					new_uri->host = new_uri->host ? zend_string_copy(new_uri->host) : NULL;
-					new_uri->port = new_uri->port;
+					new_uri->scheme = uri->scheme ? zend_string_copy(uri->scheme) : NULL;
+					new_uri->host = uri->host ? zend_string_copy(uri->host) : NULL;
+					new_uri->port = uri->port;
 					if (new_uri->path && ZSTR_VAL(new_uri->path)[0] != '/') {
-						if (new_uri->path) {
-							char *t = ZSTR_VAL(new_uri->path);
+						if (uri->path) {
+							char *t = ZSTR_VAL(uri->path);
 							char *p = strrchr(t, '/');
 							if (p) {
 								zend_string *s = zend_string_alloc((p - t) + ZSTR_LEN(new_uri->path) + 2, 0);

--- a/ext/soap/tests/bugs/relative_redirect.phpt
+++ b/ext/soap/tests/bugs/relative_redirect.phpt
@@ -1,0 +1,49 @@
+--TEST--
+SOAP client follows a redirect with a scheme-less (relative) Location
+--EXTENSIONS--
+soap
+--SKIPIF--
+<?php
+if (!file_exists(__DIR__ . "/../../../../sapi/cli/tests/php_cli_server.inc")) {
+    echo "skip sapi/cli/tests/php_cli_server.inc required but not found";
+}
+?>
+--FILE--
+<?php
+include __DIR__ . "/../../../../sapi/cli/tests/php_cli_server.inc";
+
+$args = ["-d", "extension_dir=" . ini_get("extension_dir"), "-d", "extension=" . (substr(PHP_OS, 0, 3) == "WIN" ? "php_" : "") . "soap." . PHP_SHLIB_SUFFIX];
+if (php_ini_loaded_file()) {
+    $args[] = "-c";
+    $args[] = php_ini_loaded_file();
+}
+
+$code = <<<'PHP'
+if ($_SERVER["REQUEST_URI"] === "/redirected") {
+    header("Content-Type: text/xml; charset=utf-8");
+    echo '<?xml version="1.0" encoding="UTF-8"?>',
+        '<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">',
+        '<SOAP-ENV:Body><fooResponse><result>ok</result></fooResponse></SOAP-ENV:Body>',
+        '</SOAP-ENV:Envelope>';
+} else {
+    http_response_code(302);
+    header("Location: /redirected");
+}
+PHP;
+
+php_cli_server_start($code, null, $args);
+
+$client = new SoapClient(null, [
+    'location' => 'http://' . PHP_CLI_SERVER_ADDRESS . '/start',
+    'uri' => 'test-uri',
+]);
+
+try {
+    $client->__soapCall("foo", []);
+    echo "redirect followed\n";
+} catch (SoapFault $e) {
+    echo "SoapFault: " . $e->getMessage() . "\n";
+}
+?>
+--EXPECT--
+redirect followed

--- a/ext/soap/tests/bugs/relative_redirect_path.phpt
+++ b/ext/soap/tests/bugs/relative_redirect_path.phpt
@@ -1,0 +1,49 @@
+--TEST--
+SOAP client follows a redirect with a relative Location resolved against the request path
+--EXTENSIONS--
+soap
+--SKIPIF--
+<?php
+if (!file_exists(__DIR__ . "/../../../../sapi/cli/tests/php_cli_server.inc")) {
+    echo "skip sapi/cli/tests/php_cli_server.inc required but not found";
+}
+?>
+--FILE--
+<?php
+include __DIR__ . "/../../../../sapi/cli/tests/php_cli_server.inc";
+
+$args = ["-d", "extension_dir=" . ini_get("extension_dir"), "-d", "extension=" . (substr(PHP_OS, 0, 3) == "WIN" ? "php_" : "") . "soap." . PHP_SHLIB_SUFFIX];
+if (php_ini_loaded_file()) {
+    $args[] = "-c";
+    $args[] = php_ini_loaded_file();
+}
+
+$code = <<<'PHP'
+if ($_SERVER["REQUEST_URI"] === "/svc/redirected") {
+    header("Content-Type: text/xml; charset=utf-8");
+    echo '<?xml version="1.0" encoding="UTF-8"?>',
+        '<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">',
+        '<SOAP-ENV:Body><fooResponse><result>ok</result></fooResponse></SOAP-ENV:Body>',
+        '</SOAP-ENV:Envelope>';
+} else {
+    http_response_code(302);
+    header("Location: redirected");
+}
+PHP;
+
+php_cli_server_start($code, null, $args);
+
+$client = new SoapClient(null, [
+    'location' => 'http://' . PHP_CLI_SERVER_ADDRESS . '/svc/start',
+    'uri' => 'test-uri',
+]);
+
+try {
+    $client->__soapCall("foo", []);
+    echo "redirect followed\n";
+} catch (SoapFault $e) {
+    echo "SoapFault: " . $e->getMessage() . "\n";
+}
+?>
+--EXPECT--
+redirect followed


### PR DESCRIPTION
On a 3xx redirect with a scheme-less Location (relative or absolute-path), the redirect handler copied scheme/host/port from the freshly parsed Location URI itself rather than the previous request URI, leaving the host NULL so the retry aborted with "Unable to parse URL". Read the inherited components and the relative-path base from the request URI, restoring the pre-refactor behaviour.