### PR TITLE
Fix freeing uninitialized memory in LDAP sort control parsing

### DIFF
--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -564,6 +564,7 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 
 			num_keys = zend_hash_num_elements(Z_ARRVAL_P(val));
 			sort_keys = safe_emalloc((num_keys+1), sizeof(LDAPSortKey*), 0);
+			memset(sort_keys, 0, (num_keys+1) * sizeof(LDAPSortKey*));
 			tmpstrings1 = safe_emalloc(num_keys, sizeof(zend_string*), 0);
 			tmpstrings2 = safe_emalloc(num_keys, sizeof(zend_string*), 0);
 			num_tmpstrings1 = 0;

--- a/ext/ldap/tests/ldap_sort_control_missing_attr.phpt
+++ b/ext/ldap/tests/ldap_sort_control_missing_attr.phpt
@@ -1,0 +1,30 @@
+--TEST--
+ldap_search(): malformed sort control (sort key missing "attr") must not free uninitialized memory
+--EXTENSIONS--
+ldap
+--FILE--
+<?php
+// No server needed: the control array is validated before the search is sent.
+// A sort key missing "attr" makes php_ldap_control_from_array() bail mid-loop;
+// the failure cleanup must not walk/free the partially built sort_keys array.
+$ld = ldap_connect("ldap://127.0.0.1:389");
+
+try {
+    ldap_search($ld, "dc=example,dc=com", "(objectClass=*)", [], 0, -1, -1, LDAP_DEREF_NEVER, [
+        [
+            'oid' => LDAP_CONTROL_SORTREQUEST,
+            'value' => [
+                ['attr' => 'cn'],
+                ['reverse' => true],
+            ],
+        ],
+    ]);
+} catch (\ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+echo "ok\n";
+?>
+--EXPECT--
+ldap_search(): Sort key list must have an "attr" key
+ok


### PR DESCRIPTION
_php_ldap_control_from_array() allocated the sort_keys array with safe_emalloc() and wrote its NULL terminator only after the per-key loop. A sort key missing the "attr" entry bails out of the loop early, so the array is partially uninitialized when the failure cleanup walks it as a NULL-terminated list and efree()s the unwritten slots. Allocate it zeroed with ecalloc() so those slots read NULL; the sibling tmpstrings arrays are freed by a counter and stay safe_emalloc. Reachable from userland via the $controls argument of ldap_search() and the other control-taking LDAP functions.