### PR TITLE
Fix MIME charset sniffing advancing by name length not value length

### DIFF
--- a/ext/dom/tests/modern/html/encoding/HTMLDocument_createFromFile_http_header.phpt
+++ b/ext/dom/tests/modern/html/encoding/HTMLDocument_createFromFile_http_header.phpt
@@ -46,6 +46,7 @@ $tests = [
         "text/html; ;;   ; ;; Charset=\"ISO-8859-1\"",
         "text/html;Charset=\"ISO-8859-1",
         "tex.t/h#\$%!&'*%2B-.^_`|~tml;Charset=\"ISO-8859-1\"", // Note: have to encode + as 2B because of implementation details of http_server()
+        "text/html; abcd=ef;charset=ISO-8859-1",
     ],
     "Valid input, but invalid encoding name" => [
         "text/html;Charset=\"ISO-8859-1\\",
@@ -88,6 +89,7 @@ foreach ($tests as $name => $headers) {
 ���
 ���
 --- All valid inputs ---
+äöü
 äöü
 äöü
 äöü

--- a/ext/libxml/mime_sniff.c
+++ b/ext/libxml/mime_sniff.c
@@ -273,7 +273,7 @@ PHP_LIBXML_API zend_string *php_libxml_sniff_charset_from_string(const char *sta
 			/* 11.9.1. Set parameterValue to the result of collecting a sequence of code points that are not ';' */
 			size_t parameter_value_length = collect_a_sequence_of_code_points(start, end, is_not_semicolon);
 			parameter_value = zend_string_init(start, parameter_value_length, false);
-			start += parameter_name_length;
+			start += parameter_value_length;
 
 			/* 11.9.2. Remove trailing HTTP whitespace from parameterValue */
 			while (ZSTR_LEN(parameter_value) > 0 && is_http_whitespace(ZSTR_VAL(parameter_value)[ZSTR_LEN(parameter_value) - 1])) {


### PR DESCRIPTION
php_libxml_sniff_charset_from_string() advanced the parse cursor by the parameter name length after collecting an unquoted parameter value (WHATWG mime-sniff step 11.9.1), instead of the value length. A Content-Type whose parameter before charset has a name and value of different lengths (for example "text/html; abcd=ef;charset=ISO-8859-1") misaligns the cursor so the charset parameter is missed, and Dom\HTMLDocument loading falls back to the wrong encoding. The existing createFromFile HTTP-header test only used equal-length name=value pairs, which masked it.