### PR TITLE
Remove stray printf() on invalid DSN version in pdo_dblib

### DIFF
--- a/ext/pdo_dblib/dblib_driver.c
+++ b/ext/pdo_dblib/dblib_driver.c
@@ -539,7 +539,6 @@ static int pdo_dblib_handle_factory(pdo_dbh_t *dbh, zval *driver_options)
 		}
 
 		if (i==nvers) {
-			printf("Invalid version '%s'\n", vars[5].optval);
 			pdo_raise_impl_error(dbh, NULL, "HY000", "PDO_DBLIB: Invalid version specified in connection string.");
 			goto cleanup; /* unknown version specified */
 		}


### PR DESCRIPTION
When the connection string specifies an unrecognized TDS version, pdo_dblib_handle_factory() writes the message to stdout via printf() before raising the proper PDO error, corrupting SAPI output. The pdo_raise_impl_error() call right below already reports the condition; drop the printf().