### PR TITLE
Fix buffer overflow converting @@IDENTITY in pdo_dblib lastInsertId

### DIFF
--- a/ext/pdo_dblib/dblib_driver.c
+++ b/ext/pdo_dblib/dblib_driver.c
@@ -267,8 +267,8 @@ zend_string *dblib_handle_last_id(pdo_dbh_t *dbh, const zend_string *name)
 		return NULL;
 	}
 
-	id = emalloc(32);
-	len = dbconvert(NULL, (dbcoltype(H->link, 1)) , (dbdata(H->link, 1)) , (dbdatlen(H->link, 1)), SQLCHAR, (BYTE *)id, (DBINT)-1);
+	id = emalloc(40);
+	len = dbconvert(NULL, (dbcoltype(H->link, 1)) , (dbdata(H->link, 1)) , (dbdatlen(H->link, 1)), SQLCHAR, (BYTE *)id, (DBINT)40);
 	dbcancel(H->link);
 
 	ret_id = zend_string_init(id, len, 0);


### PR DESCRIPTION
dblib_handle_last_id() converts @@IDENTITY into a 32-byte buffer with dbconvert()'s destination length set to -1, which disables FreeTDS's destination bounds check. A numeric(p,0) IDENTITY column with precision above 30 produces a textual form longer than 32 bytes (31 digits plus a sign plus the NUL), overflowing the buffer.

Size the buffer for the widest @@IDENTITY (numeric(38,0) = 38 digits + sign + NUL = 40 bytes) and pass the real destination length, mirroring the existing fix in pdo_dblib_stmt_stringify_col().
