### PR TITLE
zend_ast: Escape control bytes in exported string literals

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,8 @@ PHP                                                                        NEWS
 - Core:
   . Fixed bug GH-22280 (Incorrect compile error for goto to label preceding
     try/finally block). (Pratik Bhujel)
+  . Fixed bug GH-22290 (AST pretty printing does not correctly handle strings
+    containing NUL). (iliaal)
 
 - BCMath:
   . Fixed issues with oversized allocations and signed overflow in bcround()

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -1328,6 +1328,23 @@ static ZEND_COLD void zend_ast_export_qstr(smart_str *str, char quote, zend_stri
 	}
 }
 
+static ZEND_COLD void zend_ast_export_quoted_str(smart_str *str, zend_string *s)
+{
+	size_t i;
+
+	for (i = 0; i < ZSTR_LEN(s); i++) {
+		if ((unsigned char) ZSTR_VAL(s)[i] < ' ') {
+			smart_str_appendc(str, '"');
+			zend_ast_export_qstr(str, '"', s);
+			smart_str_appendc(str, '"');
+			return;
+		}
+	}
+	smart_str_appendc(str, '\'');
+	zend_ast_export_str(str, s);
+	smart_str_appendc(str, '\'');
+}
+
 static ZEND_COLD void zend_ast_export_indent(smart_str *str, int indent)
 {
 	while (indent > 0) {
@@ -1612,9 +1629,7 @@ static ZEND_COLD void zend_ast_export_zval(smart_str *str, zval *zv, int priorit
 				str, Z_DVAL_P(zv), (int) EG(precision), /* zero_fraction */ true);
 			break;
 		case IS_STRING:
-			smart_str_appendc(str, '\'');
-			zend_ast_export_str(str, Z_STR_P(zv));
-			smart_str_appendc(str, '\'');
+			zend_ast_export_quoted_str(str, Z_STR_P(zv));
 			break;
 		case IS_ARRAY: {
 			zend_long idx;
@@ -1629,9 +1644,8 @@ static ZEND_COLD void zend_ast_export_zval(smart_str *str, zval *zv, int priorit
 					smart_str_appends(str, ", ");
 				}
 				if (key) {
-					smart_str_appendc(str, '\'');
-					zend_ast_export_str(str, key);
-					smart_str_appends(str, "' => ");
+					zend_ast_export_quoted_str(str, key);
+					smart_str_appends(str, " => ");
 				} else {
 					smart_str_append_long(str, idx);
 					smart_str_appends(str, " => ");

--- a/ext/standard/tests/assert/gh22290.phpt
+++ b/ext/standard/tests/assert/gh22290.phpt
@@ -1,0 +1,39 @@
+--TEST--
+GH-22290: AST pretty printing does not correctly handle strings containing NUL
+--INI--
+zend.assertions=1
+assert.exception=1
+--FILE--
+<?php
+
+try {
+	$string = "Foo\x00bar";
+	assert(!str_contains($string, "\x00"));
+} catch (AssertionError $e) {
+	echo $e->getMessage(), PHP_EOL;
+}
+
+try {
+	assert(["a\x00b" => 1] === []);
+} catch (AssertionError $e) {
+	echo $e->getMessage(), PHP_EOL;
+}
+
+try {
+	assert("tab\there" === "");
+} catch (AssertionError $e) {
+	echo $e->getMessage(), PHP_EOL;
+}
+
+try {
+	assert(str_contains("plain", "zzz"));
+} catch (AssertionError $e) {
+	echo $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+assert(!str_contains($string, "\000"))
+assert(["a\000b" => 1] === [])
+assert("tab\there" === '')
+assert(str_contains('plain', 'zzz'))


### PR DESCRIPTION
The AST pretty-printer rendered string literals single-quoted with raw bytes. A literal containing a NUL kept the byte in the resulting zend_string, but assert() passes that string to zend_throw_exception() as a const char*, so the failure message was truncated at the first NUL (the rest of the expression was lost).

Render literals that contain a control byte double-quoted via zend_ast_export_qstr(), which escapes those bytes as octal, so no embedded NUL survives and the message is complete. Strings without control bytes are unchanged.

Fixes GH-22290
