### PR TITLE
ext/standard: Reject NUL bytes in `dl()`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -254,6 +254,8 @@ PHP                                                                        NEWS
     (Weilin Du)
   . getenv() and putenv() now raises a ValueError when the first argument
     contains null bytes. (Weilin Du)
+  . dl() now raises a ValueError when the $extension_filename argument
+    contains null bytes. (Weilin Du)
   . parse_str() now raises a ValueError when the $string argument contains
     null bytes. (Weilin Du)
   . proc_open() now raises a ValueError when the $cwd argument contains

--- a/UPGRADING
+++ b/UPGRADING
@@ -151,6 +151,8 @@ PHP 8.6 UPGRADE NOTES
     argument value is passed.
   . getenv() and putenv() now raises a ValueError when the first argument
     contains null bytes.
+  . dl() now raises a ValueError when the $extension_filename argument
+    contains null bytes.
   . parse_str() now raises a ValueError when the $string argument contains
     null bytes.
   . linkinfo() now raises a ValueError when the $path argument is empty.

--- a/ext/standard/dl.c
+++ b/ext/standard/dl.c
@@ -43,7 +43,7 @@ PHPAPI PHP_FUNCTION(dl)
 	size_t filename_len;
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_STRING(filename, filename_len)
+		Z_PARAM_PATH(filename, filename_len)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (!PG(enable_dl)) {

--- a/ext/standard/tests/general_functions/dl_null_bytes.phpt
+++ b/ext/standard/tests/general_functions/dl_null_bytes.phpt
@@ -1,0 +1,14 @@
+--TEST--
+dl() rejects null bytes in extension filename
+--FILE--
+<?php
+
+try {
+    dl("foo\0bar");
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+dl(): Argument #1 ($extension_filename) must not contain any null bytes


### PR DESCRIPTION
Similar to #21942 and #21871. The `dl` function in std extension now silently truncates from NUL bytes. That is
```php
 <?php
 $payload = "a\0/bcdefgh";
 set_error_handler(function ($severity, $message) {
      echo "warning: $message\n";
      return true;
  });
 try {
     var_dump(dl($payload));
 } catch (ValueError $e) {
     echo "ValueError: ", $e->getMessage(), "\n";
 }
``` 
Will return:
```
warning: dl(): Unable to load dynamic library 'a'
```
not
```
warning: dl(): Unable to load dynamic library 'a/bcdefgh'
```

Reproduce [here](https://onlinephp.io?s=TY5PC4JAEMXvQd9hWDysUNTZ_p06du0kyLQ7uYKtMu4aEn73dC3rXQbmvXnzg_2pNvVyAVGNXVmhhgMITLebm9J0z43YDV5DLiPmijODVpfE8u6tckVlQUYNtcSF61YQPahpMKcYXsNREClTgXgi28LmyZxIbegNYnKeLTj2FHZ9PA7H3dzSImfaP2qpS_nFjEOqB4VOGZBXLD2dR0SI_v5P739mAmLApPUxJ3eZUGS8AvHh6d8%2C&v=8.5.6)

This PR rejects parameters containing NUL bytes as we always do in other cases.