### PR TITLE
Fix GH-22051: report errors from SQLite3Result reset and finalize

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -230,6 +230,8 @@ PHP                                                                        NEWS
 
 - Sqlite3:
   . Fix NUL byte truncation in sqlite3 TEXT column handling. (ndossche)
+  . Fixed bug GH-22051 (Inconsistent error reporting in SQLite3Result::reset()
+    and SQLite3Result::finalize()). (iliaal)
 
 - Standard:
   . Fixed bug GH-19926 (reset internal pointer earlier while splicing array

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -2125,6 +2125,7 @@ PHP_METHOD(SQLite3Result, reset)
 	sqlite3result_clear_column_names_cache(result_obj);
 
 	if (sqlite3_reset(result_obj->stmt_obj->stmt) != SQLITE_OK) {
+		php_sqlite3_error(result_obj->db_obj, sqlite3_errcode(sqlite3_db_handle(result_obj->stmt_obj->stmt)), "Unable to reset statement: %s", sqlite3_errmsg(sqlite3_db_handle(result_obj->stmt_obj->stmt)));
 		RETURN_FALSE;
 	}
 
@@ -2150,7 +2151,9 @@ PHP_METHOD(SQLite3Result, finalize)
 		zend_llist_del_element(&(result_obj->db_obj->free_list), result_obj->stmt_obj,
 			(int (*)(void *, void *)) php_sqlite3_compare_stmt_free);
 	} else {
-		sqlite3_reset(result_obj->stmt_obj->stmt);
+		if (sqlite3_reset(result_obj->stmt_obj->stmt) != SQLITE_OK) {
+			php_sqlite3_error(result_obj->db_obj, sqlite3_errcode(sqlite3_db_handle(result_obj->stmt_obj->stmt)), "Unable to reset statement: %s", sqlite3_errmsg(sqlite3_db_handle(result_obj->stmt_obj->stmt)));
+		}
 	}
 
 	RETURN_TRUE;

--- a/ext/sqlite3/tests/gh22051.phpt
+++ b/ext/sqlite3/tests/gh22051.phpt
@@ -1,0 +1,43 @@
+--TEST--
+GH-22051 (SQLite3Result::reset()/finalize() report the error on failure)
+--EXTENSIONS--
+sqlite3
+--FILE--
+<?php
+$db = new SQLite3(':memory:');
+
+// A query whose second step overflows leaves the statement in an error state.
+$sql = "SELECT abs(x) FROM (SELECT 1 AS x UNION ALL SELECT -9223372036854775807 - 1)";
+
+echo "--- SQLite3Result::reset() ---\n";
+$result = $db->query($sql);
+var_dump($result->fetchArray(SQLITE3_NUM));
+var_dump(@$result->fetchArray(SQLITE3_NUM));
+var_dump($result->reset());
+
+echo "--- SQLite3Result::finalize() ---\n";
+$stmt = $db->prepare($sql);
+$result = $stmt->execute();
+var_dump($result->fetchArray(SQLITE3_NUM));
+var_dump(@$result->fetchArray(SQLITE3_NUM));
+var_dump($result->finalize());
+?>
+--EXPECTF--
+--- SQLite3Result::reset() ---
+array(1) {
+  [0]=>
+  int(1)
+}
+bool(false)
+
+Warning: SQLite3Result::reset(): Unable to reset statement: integer overflow in %s on line %d
+bool(false)
+--- SQLite3Result::finalize() ---
+array(1) {
+  [0]=>
+  int(1)
+}
+bool(false)
+
+Warning: SQLite3Result::finalize(): Unable to reset statement: integer overflow in %s on line %d
+bool(true)


### PR DESCRIPTION
SQLite3Stmt::reset() reports a failed sqlite3_reset() through php_sqlite3_error(), but SQLite3Result::reset() returned false silently and SQLite3Result::finalize() ignored the result. Both now report the same way; finalize() keeps its : true return type and reports without changing it. The other sqlite3_reset/sqlite3_finalize calls are left unchecked deliberately: resets after a successful step cannot fail, the reset-before-execute for bug #77051 returns the prior run's stale code, the error-path finalize calls would re-report an error already surfaced in the same function, and the destructor calls have no userland frame to report from.

Fixes php/php-src#22051

