### PR TITLE
Throw exception for invalid characters for number base

### DIFF
--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -908,7 +908,7 @@ PHPAPI zend_result _php_math_basetozval(zend_string *str, int base, zval *ret)
 	}
 
 	if (invalidchars > 0) {
-		zend_value_error("Invalid characters passed for attempted conversion");
+		zend_argument_value_error(1, "has invalid characters for attempted conversion");
 		return FAILURE;
 	}
 

--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -845,7 +845,7 @@ PHPAPI zend_long _php_math_basetolong(zval *arg, int base)
 /*
  * Convert a string representation of a base(2-36) number to a zval.
  */
-PHPAPI void _php_math_basetozval(zend_string *str, int base, zval *ret)
+PHPAPI zend_result _php_math_basetozval(zend_string *str, int base, zval *ret)
 {
 	zend_long num = 0;
 	double fnum = 0;
@@ -908,7 +908,8 @@ PHPAPI void _php_math_basetozval(zend_string *str, int base, zval *ret)
 	}
 
 	if (invalidchars > 0) {
-		zend_error(E_DEPRECATED, "Invalid characters passed for attempted conversion, these have been ignored");
+		zend_value_error("Invalid characters passed for attempted conversion");
+		return FAILURE;
 	}
 
 	if (mode == 1) {
@@ -916,6 +917,7 @@ PHPAPI void _php_math_basetozval(zend_string *str, int base, zval *ret)
 	} else {
 		ZVAL_LONG(ret, num);
 	}
+	return SUCCESS;
 }
 /* }}} */
 
@@ -1033,7 +1035,9 @@ PHP_FUNCTION(bindec)
 		Z_PARAM_STR(arg)
 	ZEND_PARSE_PARAMETERS_END();
 
-	_php_math_basetozval(arg, 2, return_value);
+	if (SUCCESS != _php_math_basetozval(arg, 2, return_value)) {
+		RETURN_THROWS();
+	}
 }
 /* }}} */
 
@@ -1046,7 +1050,9 @@ PHP_FUNCTION(hexdec)
 		Z_PARAM_STR(arg)
 	ZEND_PARSE_PARAMETERS_END();
 
-	_php_math_basetozval(arg, 16, return_value);
+	if (SUCCESS != _php_math_basetozval(arg, 16, return_value)) {
+		RETURN_THROWS();
+	}
 }
 /* }}} */
 
@@ -1059,7 +1065,9 @@ PHP_FUNCTION(octdec)
 		Z_PARAM_STR(arg)
 	ZEND_PARSE_PARAMETERS_END();
 
-	_php_math_basetozval(arg, 8, return_value);
+	if (SUCCESS != _php_math_basetozval(arg, 8, return_value)) {
+		RETURN_THROWS();
+	}
 }
 /* }}} */
 
@@ -1136,7 +1144,10 @@ PHP_FUNCTION(base_convert)
 		RETURN_THROWS();
 	}
 
-	_php_math_basetozval(number, (int)frombase, &temp);
+	if (SUCCESS != _php_math_basetozval(number, (int)frombase, &temp)) {
+		RETURN_THROWS();
+	}
+
 	result = _php_math_zvaltobase(&temp, (int)tobase);
 	if (!result) {
 		RETURN_THROWS();

--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -908,7 +908,7 @@ PHPAPI zend_result _php_math_basetozval(zend_string *str, int base, zval *ret)
 	}
 
 	if (invalidchars > 0) {
-		zend_argument_value_error(1, "has invalid characters for attempted conversion");
+		zend_throw_exception_ex(NULL, 0, "Invalid characters passed for attempted conversion");
 		return FAILURE;
 	}
 

--- a/ext/standard/php_math.h
+++ b/ext/standard/php_math.h
@@ -22,7 +22,7 @@ PHPAPI zend_string *_php_math_number_format_ex(double d, int dec, const char *de
 PHPAPI zend_string *_php_math_number_format_long(zend_long num, zend_long dec, const char *dec_point, size_t dec_point_len, const char *thousand_sep, size_t thousand_sep_len);
 PHPAPI zend_string * _php_math_longtobase(zend_long arg, int base);
 PHPAPI zend_long _php_math_basetolong(zval *arg, int base);
-PHPAPI void _php_math_basetozval(zend_string *str, int base, zval *ret);
+PHPAPI zend_result _php_math_basetozval(zend_string *str, int base, zval *ret);
 PHPAPI zend_string * _php_math_zvaltobase(zval *arg, int base);
 
 #include <math.h>

--- a/ext/standard/tests/math/base_convert_basic.phpt
+++ b/ext/standard/tests/math/base_convert_basic.phpt
@@ -22,256 +22,130 @@ for ($f= 0; $f < count($frombase); $f++) {
     for ($t= 0; $t < count($tobase); $t++) {
         echo "......to base is ", $tobase[$t], "\n";
         for ($i =0; $i < count($values); $i++){
-            $res = base_convert($values[$i],$frombase[$f],$tobase[$t]);
-            echo ".........value= ", $values[$i], " res = ", $res, "\n";
+            try {
+                $res = base_convert($values[$i],$frombase[$f],$tobase[$t]);
+                echo ".........value= ", $values[$i], " res = ", $res, "\n";
+            } catch (ValueError $e) {
+                echo "E........exc= ", $e->getMessage(), "\n";
+            }
         }
     }
 }
 ?>
---EXPECTF--
+--EXPECT--
 ...from base is 2
 ......to base is 2
 .........value= 10 res = 10
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 27 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 95 res = 0
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
 .........value= 10 res = 10
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 27 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 0
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
 ......to base is 8
 .........value= 10 res = 2
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 27 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 95 res = 0
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
 .........value= 10 res = 2
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 27 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 0
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
 ......to base is 10
 .........value= 10 res = 2
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 27 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 95 res = 0
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
 .........value= 10 res = 2
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 27 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 0
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
 ......to base is 16
 .........value= 10 res = 2
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 27 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 95 res = 0
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
 .........value= 10 res = 2
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 27 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 0
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
 ......to base is 36
 .........value= 10 res = 2
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 27 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 95 res = 0
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
 .........value= 10 res = 2
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 27 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 0
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
 
 ...from base is 8
 ......to base is 2
 .........value= 10 res = 1000
 .........value= 27 res = 10111
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 11
+E........exc= Invalid characters passed for attempted conversion
 .........value= 3 res = 11
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 95 res = 101
+E........exc= Invalid characters passed for attempted conversion
 .........value= 10 res = 1000
 .........value= 27 res = 10111
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 11
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 101
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 11
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
 ......to base is 8
 .........value= 10 res = 10
 .........value= 27 res = 27
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 3
+E........exc= Invalid characters passed for attempted conversion
 .........value= 3 res = 3
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 95 res = 5
+E........exc= Invalid characters passed for attempted conversion
 .........value= 10 res = 10
 .........value= 27 res = 27
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 3
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 5
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 3
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
 ......to base is 10
 .........value= 10 res = 8
 .........value= 27 res = 23
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 3
+E........exc= Invalid characters passed for attempted conversion
 .........value= 3 res = 3
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 95 res = 5
+E........exc= Invalid characters passed for attempted conversion
 .........value= 10 res = 8
 .........value= 27 res = 23
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 3
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 5
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 3
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
 ......to base is 16
 .........value= 10 res = 8
 .........value= 27 res = 17
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 3
+E........exc= Invalid characters passed for attempted conversion
 .........value= 3 res = 3
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 95 res = 5
+E........exc= Invalid characters passed for attempted conversion
 .........value= 10 res = 8
 .........value= 27 res = 17
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 3
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 5
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 3
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
 ......to base is 36
 .........value= 10 res = 8
 .........value= 27 res = n
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 3
+E........exc= Invalid characters passed for attempted conversion
 .........value= 3 res = 3
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 95 res = 5
+E........exc= Invalid characters passed for attempted conversion
 .........value= 10 res = 8
 .........value= 27 res = n
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 3
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 5
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 3
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
 
 ...from base is 10
 ......to base is 2
@@ -283,12 +157,8 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 10 res = 1010
 .........value= 27 res = 11011
 .........value= 39 res = 100111
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 101
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 11
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
 ......to base is 8
 .........value= 10 res = 12
 .........value= 27 res = 33
@@ -298,12 +168,8 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 10 res = 12
 .........value= 27 res = 33
 .........value= 39 res = 47
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 5
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 3
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
 ......to base is 10
 .........value= 10 res = 10
 .........value= 27 res = 27
@@ -313,12 +179,8 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 10 res = 10
 .........value= 27 res = 27
 .........value= 39 res = 39
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 5
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 3
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
 ......to base is 16
 .........value= 10 res = a
 .........value= 27 res = 1b
@@ -328,12 +190,8 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 10 res = a
 .........value= 27 res = 1b
 .........value= 39 res = 27
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 5
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 3
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
 ......to base is 36
 .........value= 10 res = a
 .........value= 27 res = r
@@ -343,12 +201,8 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 10 res = a
 .........value= 27 res = r
 .........value= 39 res = 13
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 5
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 3
+E........exc= Invalid characters passed for attempted conversion
+E........exc= Invalid characters passed for attempted conversion
 
 ...from base is 16
 ......to base is 2
@@ -361,9 +215,7 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 27 res = 100111
 .........value= 39 res = 111001
 .........value= 5F res = 1011111
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 11
+E........exc= Invalid characters passed for attempted conversion
 ......to base is 8
 .........value= 10 res = 20
 .........value= 27 res = 47
@@ -374,9 +226,7 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 27 res = 47
 .........value= 39 res = 71
 .........value= 5F res = 137
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 3
+E........exc= Invalid characters passed for attempted conversion
 ......to base is 10
 .........value= 10 res = 16
 .........value= 27 res = 39
@@ -387,9 +237,7 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 27 res = 39
 .........value= 39 res = 57
 .........value= 5F res = 95
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 3
+E........exc= Invalid characters passed for attempted conversion
 ......to base is 16
 .........value= 10 res = 10
 .........value= 27 res = 27
@@ -400,9 +248,7 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 27 res = 27
 .........value= 39 res = 39
 .........value= 5F res = 5f
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 3
+E........exc= Invalid characters passed for attempted conversion
 ......to base is 36
 .........value= 10 res = g
 .........value= 27 res = 13
@@ -413,9 +259,7 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 27 res = 13
 .........value= 39 res = 1l
 .........value= 5F res = 2n
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 3
+E........exc= Invalid characters passed for attempted conversion
 
 ...from base is 36
 ......to base is 2

--- a/ext/standard/tests/math/base_convert_basic.phpt
+++ b/ext/standard/tests/math/base_convert_basic.phpt
@@ -36,116 +36,116 @@ for ($f= 0; $f < count($frombase); $f++) {
 ...from base is 2
 ......to base is 2
 .........value= 10 res = 10
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 .........value= 10 res = 10
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 ......to base is 8
 .........value= 10 res = 2
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 .........value= 10 res = 2
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 ......to base is 10
 .........value= 10 res = 2
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 .........value= 10 res = 2
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 ......to base is 16
 .........value= 10 res = 2
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 .........value= 10 res = 2
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 ......to base is 36
 .........value= 10 res = 2
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 .........value= 10 res = 2
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 
 ...from base is 8
 ......to base is 2
 .........value= 10 res = 1000
 .........value= 27 res = 10111
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 .........value= 3 res = 11
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 .........value= 10 res = 1000
 .........value= 27 res = 10111
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 ......to base is 8
 .........value= 10 res = 10
 .........value= 27 res = 27
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 .........value= 3 res = 3
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 .........value= 10 res = 10
 .........value= 27 res = 27
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 ......to base is 10
 .........value= 10 res = 8
 .........value= 27 res = 23
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 .........value= 3 res = 3
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 .........value= 10 res = 8
 .........value= 27 res = 23
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 ......to base is 16
 .........value= 10 res = 8
 .........value= 27 res = 17
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 .........value= 3 res = 3
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 .........value= 10 res = 8
 .........value= 27 res = 17
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 ......to base is 36
 .........value= 10 res = 8
 .........value= 27 res = n
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 .........value= 3 res = 3
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 .........value= 10 res = 8
 .........value= 27 res = n
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 
 ...from base is 10
 ......to base is 2
@@ -157,8 +157,8 @@ E........exc= Invalid characters passed for attempted conversion
 .........value= 10 res = 1010
 .........value= 27 res = 11011
 .........value= 39 res = 100111
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 ......to base is 8
 .........value= 10 res = 12
 .........value= 27 res = 33
@@ -168,8 +168,8 @@ E........exc= Invalid characters passed for attempted conversion
 .........value= 10 res = 12
 .........value= 27 res = 33
 .........value= 39 res = 47
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 ......to base is 10
 .........value= 10 res = 10
 .........value= 27 res = 27
@@ -179,8 +179,8 @@ E........exc= Invalid characters passed for attempted conversion
 .........value= 10 res = 10
 .........value= 27 res = 27
 .........value= 39 res = 39
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 ......to base is 16
 .........value= 10 res = a
 .........value= 27 res = 1b
@@ -190,8 +190,8 @@ E........exc= Invalid characters passed for attempted conversion
 .........value= 10 res = a
 .........value= 27 res = 1b
 .........value= 39 res = 27
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 ......to base is 36
 .........value= 10 res = a
 .........value= 27 res = r
@@ -201,8 +201,8 @@ E........exc= Invalid characters passed for attempted conversion
 .........value= 10 res = a
 .........value= 27 res = r
 .........value= 39 res = 13
-E........exc= Invalid characters passed for attempted conversion
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 
 ...from base is 16
 ......to base is 2
@@ -215,7 +215,7 @@ E........exc= Invalid characters passed for attempted conversion
 .........value= 27 res = 100111
 .........value= 39 res = 111001
 .........value= 5F res = 1011111
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 ......to base is 8
 .........value= 10 res = 20
 .........value= 27 res = 47
@@ -226,7 +226,7 @@ E........exc= Invalid characters passed for attempted conversion
 .........value= 27 res = 47
 .........value= 39 res = 71
 .........value= 5F res = 137
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 ......to base is 10
 .........value= 10 res = 16
 .........value= 27 res = 39
@@ -237,7 +237,7 @@ E........exc= Invalid characters passed for attempted conversion
 .........value= 27 res = 39
 .........value= 39 res = 57
 .........value= 5F res = 95
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 ......to base is 16
 .........value= 10 res = 10
 .........value= 27 res = 27
@@ -248,7 +248,7 @@ E........exc= Invalid characters passed for attempted conversion
 .........value= 27 res = 27
 .........value= 39 res = 39
 .........value= 5F res = 5f
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 ......to base is 36
 .........value= 10 res = g
 .........value= 27 res = 13
@@ -259,7 +259,7 @@ E........exc= Invalid characters passed for attempted conversion
 .........value= 27 res = 13
 .........value= 39 res = 1l
 .........value= 5F res = 2n
-E........exc= Invalid characters passed for attempted conversion
+E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 
 ...from base is 36
 ......to base is 2

--- a/ext/standard/tests/math/base_convert_basic.phpt
+++ b/ext/standard/tests/math/base_convert_basic.phpt
@@ -25,8 +25,8 @@ for ($f= 0; $f < count($frombase); $f++) {
             try {
                 $res = base_convert($values[$i],$frombase[$f],$tobase[$t]);
                 echo ".........value= ", $values[$i], " res = ", $res, "\n";
-            } catch (ValueError $e) {
-                echo "E........exc= ", $e->getMessage(), "\n";
+            } catch (Exception $e) {
+                echo "E........exc= ", $e::class, ': ', $e->getMessage(), "\n";
             }
         }
     }
@@ -36,116 +36,116 @@ for ($f= 0; $f < count($frombase); $f++) {
 ...from base is 2
 ......to base is 2
 .........value= 10 res = 10
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 .........value= 10 res = 10
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 ......to base is 8
 .........value= 10 res = 2
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 .........value= 10 res = 2
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 ......to base is 10
 .........value= 10 res = 2
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 .........value= 10 res = 2
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 ......to base is 16
 .........value= 10 res = 2
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 .........value= 10 res = 2
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 ......to base is 36
 .........value= 10 res = 2
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 .........value= 10 res = 2
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 
 ...from base is 8
 ......to base is 2
 .........value= 10 res = 1000
 .........value= 27 res = 10111
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 .........value= 3 res = 11
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 .........value= 10 res = 1000
 .........value= 27 res = 10111
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 ......to base is 8
 .........value= 10 res = 10
 .........value= 27 res = 27
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 .........value= 3 res = 3
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 .........value= 10 res = 10
 .........value= 27 res = 27
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 ......to base is 10
 .........value= 10 res = 8
 .........value= 27 res = 23
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 .........value= 3 res = 3
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 .........value= 10 res = 8
 .........value= 27 res = 23
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 ......to base is 16
 .........value= 10 res = 8
 .........value= 27 res = 17
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 .........value= 3 res = 3
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 .........value= 10 res = 8
 .........value= 27 res = 17
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 ......to base is 36
 .........value= 10 res = 8
 .........value= 27 res = n
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 .........value= 3 res = 3
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 .........value= 10 res = 8
 .........value= 27 res = n
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 
 ...from base is 10
 ......to base is 2
@@ -157,8 +157,8 @@ E........exc= base_convert(): Argument #1 ($num) has invalid characters for atte
 .........value= 10 res = 1010
 .........value= 27 res = 11011
 .........value= 39 res = 100111
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 ......to base is 8
 .........value= 10 res = 12
 .........value= 27 res = 33
@@ -168,8 +168,8 @@ E........exc= base_convert(): Argument #1 ($num) has invalid characters for atte
 .........value= 10 res = 12
 .........value= 27 res = 33
 .........value= 39 res = 47
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 ......to base is 10
 .........value= 10 res = 10
 .........value= 27 res = 27
@@ -179,8 +179,8 @@ E........exc= base_convert(): Argument #1 ($num) has invalid characters for atte
 .........value= 10 res = 10
 .........value= 27 res = 27
 .........value= 39 res = 39
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 ......to base is 16
 .........value= 10 res = a
 .........value= 27 res = 1b
@@ -190,8 +190,8 @@ E........exc= base_convert(): Argument #1 ($num) has invalid characters for atte
 .........value= 10 res = a
 .........value= 27 res = 1b
 .........value= 39 res = 27
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 ......to base is 36
 .........value= 10 res = a
 .........value= 27 res = r
@@ -201,8 +201,8 @@ E........exc= base_convert(): Argument #1 ($num) has invalid characters for atte
 .........value= 10 res = a
 .........value= 27 res = r
 .........value= 39 res = 13
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 
 ...from base is 16
 ......to base is 2
@@ -215,7 +215,7 @@ E........exc= base_convert(): Argument #1 ($num) has invalid characters for atte
 .........value= 27 res = 100111
 .........value= 39 res = 111001
 .........value= 5F res = 1011111
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 ......to base is 8
 .........value= 10 res = 20
 .........value= 27 res = 47
@@ -226,7 +226,7 @@ E........exc= base_convert(): Argument #1 ($num) has invalid characters for atte
 .........value= 27 res = 47
 .........value= 39 res = 71
 .........value= 5F res = 137
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 ......to base is 10
 .........value= 10 res = 16
 .........value= 27 res = 39
@@ -237,7 +237,7 @@ E........exc= base_convert(): Argument #1 ($num) has invalid characters for atte
 .........value= 27 res = 39
 .........value= 39 res = 57
 .........value= 5F res = 95
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 ......to base is 16
 .........value= 10 res = 10
 .........value= 27 res = 27
@@ -248,7 +248,7 @@ E........exc= base_convert(): Argument #1 ($num) has invalid characters for atte
 .........value= 27 res = 27
 .........value= 39 res = 39
 .........value= 5F res = 5f
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 ......to base is 36
 .........value= 10 res = g
 .........value= 27 res = 13
@@ -259,7 +259,7 @@ E........exc= base_convert(): Argument #1 ($num) has invalid characters for atte
 .........value= 27 res = 13
 .........value= 39 res = 1l
 .........value= 5F res = 2n
-E........exc= base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+E........exc= Exception: Invalid characters passed for attempted conversion
 
 ...from base is 36
 ......to base is 2

--- a/ext/standard/tests/math/base_convert_improvements.phpt
+++ b/ext/standard/tests/math/base_convert_improvements.phpt
@@ -62,9 +62,9 @@ try {
 7
 10
 =======================================
-Invalid characters passed for attempted conversion
-Invalid characters passed for attempted conversion
-Invalid characters passed for attempted conversion
-Invalid characters passed for attempted conversion
-Invalid characters passed for attempted conversion
-Invalid characters passed for attempted conversion
+base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+base_convert(): Argument #1 ($num) has invalid characters for attempted conversion

--- a/ext/standard/tests/math/base_convert_improvements.phpt
+++ b/ext/standard/tests/math/base_convert_improvements.phpt
@@ -12,17 +12,46 @@ echo base_convert("\r\nFF\t\n" , 16, 10) . "\n";
 echo base_convert("0o7" , 8, 10) . "\n";
 echo base_convert("0b1010" , 2, 10) . "\n";
 
-echo "=======================================";
+echo "=======================================\n";
 
 // These should fail
-echo base_convert('fg', 16, 10);
-echo base_convert('f 0xff ', 16, 10);
-echo base_convert('1xff ', 16, 10);
-echo base_convert(chr(0), 16, 10);
-echo base_convert("0o7" , 9, 10);
-echo base_convert("0 0" , 9, 10) . "\n";
+try {
+    echo base_convert('fg', 16, 10);
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    echo base_convert('f 0xff ', 16, 10);
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    echo base_convert('1xff ', 16, 10);
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    echo base_convert(chr(0), 16, 10);
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    echo base_convert("0o7" , 9, 10);
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    echo base_convert("0 0" , 9, 10) . "\n";
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
 ?>
---EXPECTF--
+--EXPECT--
 255
 16
 255
@@ -33,15 +62,9 @@ echo base_convert("0 0" , 9, 10) . "\n";
 7
 10
 =======================================
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-15
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-61695
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-511
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-0
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-7
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-0
+Invalid characters passed for attempted conversion
+Invalid characters passed for attempted conversion
+Invalid characters passed for attempted conversion
+Invalid characters passed for attempted conversion
+Invalid characters passed for attempted conversion
+Invalid characters passed for attempted conversion

--- a/ext/standard/tests/math/base_convert_improvements.phpt
+++ b/ext/standard/tests/math/base_convert_improvements.phpt
@@ -17,38 +17,38 @@ echo "=======================================\n";
 // These should fail
 try {
     echo base_convert('fg', 16, 10);
-} catch (ValueError $e) {
-    echo $e->getMessage(), "\n";
+} catch (Exception $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
 }
 
 try {
     echo base_convert('f 0xff ', 16, 10);
-} catch (ValueError $e) {
-    echo $e->getMessage(), "\n";
+} catch (Exception $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
 }
 
 try {
     echo base_convert('1xff ', 16, 10);
-} catch (ValueError $e) {
-    echo $e->getMessage(), "\n";
+} catch (Exception $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
 }
 
 try {
     echo base_convert(chr(0), 16, 10);
-} catch (ValueError $e) {
-    echo $e->getMessage(), "\n";
+} catch (Exception $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
 }
 
 try {
     echo base_convert("0o7" , 9, 10);
-} catch (ValueError $e) {
-    echo $e->getMessage(), "\n";
+} catch (Exception $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
 }
 
 try {
     echo base_convert("0 0" , 9, 10) . "\n";
-} catch (ValueError $e) {
-    echo $e->getMessage(), "\n";
+} catch (Exception $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
@@ -62,9 +62,9 @@ try {
 7
 10
 =======================================
-base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
-base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion

--- a/ext/standard/tests/math/base_convert_variation1.phpt
+++ b/ext/standard/tests/math/base_convert_variation1.phpt
@@ -76,25 +76,25 @@ string(1) "1"
 string(2) "14"
 
 -- Iteration 4 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 
 -- Iteration 5 --
 string(11) "17777777777"
 
 -- Iteration 6 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 
 -- Iteration 7 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 
 -- Iteration 8 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 
 -- Iteration 9 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 
 -- Iteration 10 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 
 -- Iteration 11 --
 string(1) "1"
@@ -118,13 +118,13 @@ string(1) "0"
 TypeError: base_convert(): Argument #1 ($num) must be of type string, array given
 
 -- Iteration 18 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 
 -- Iteration 19 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 
 -- Iteration 20 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
 
 -- Iteration 21 --
 TypeError: base_convert(): Argument #1 ($num) must be of type string, resource given

--- a/ext/standard/tests/math/base_convert_variation1.phpt
+++ b/ext/standard/tests/math/base_convert_variation1.phpt
@@ -55,13 +55,15 @@ foreach($inputs as $input) {
     try {
         var_dump(base_convert($input, 10, 8));
     } catch (TypeError $exception) {
-        echo $exception->getMessage() . "\n";
+        echo 'TypeError: ', $exception->getMessage() . "\n";
+    } catch (ValueError $exception) {
+        echo 'ValueError: ', $exception->getMessage() . "\n";
     }
     $iterator++;
 }
 fclose($fp);
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing base_convert() : usage variations ***
 
 -- Iteration 1 --
@@ -74,37 +76,25 @@ string(1) "1"
 string(2) "14"
 
 -- Iteration 4 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-string(2) "14"
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 5 --
 string(11) "17777777777"
 
 -- Iteration 6 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-string(3) "151"
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 7 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-string(3) "151"
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 8 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-string(7) "4553207"
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 9 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-string(7) "4553207"
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 10 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-string(1) "5"
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 11 --
 string(1) "1"
@@ -125,22 +115,16 @@ string(1) "0"
 string(1) "0"
 
 -- Iteration 17 --
-base_convert(): Argument #1 ($num) must be of type string, array given
+TypeError: base_convert(): Argument #1 ($num) must be of type string, array given
 
 -- Iteration 18 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-string(1) "0"
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 19 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-string(1) "0"
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 20 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-string(1) "0"
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 21 --
-base_convert(): Argument #1 ($num) must be of type string, resource given
+TypeError: base_convert(): Argument #1 ($num) must be of type string, resource given

--- a/ext/standard/tests/math/base_convert_variation1.phpt
+++ b/ext/standard/tests/math/base_convert_variation1.phpt
@@ -54,10 +54,8 @@ foreach($inputs as $input) {
     echo "\n-- Iteration $iterator --\n";
     try {
         var_dump(base_convert($input, 10, 8));
-    } catch (TypeError $exception) {
-        echo 'TypeError: ', $exception->getMessage() . "\n";
-    } catch (ValueError $exception) {
-        echo 'ValueError: ', $exception->getMessage() . "\n";
+    } catch (Throwable $e) {
+        echo $e::class, ': ', $e->getMessage() . "\n";
     }
     $iterator++;
 }
@@ -76,25 +74,25 @@ string(1) "1"
 string(2) "14"
 
 -- Iteration 4 --
-ValueError: base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 5 --
 string(11) "17777777777"
 
 -- Iteration 6 --
-ValueError: base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 7 --
-ValueError: base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 8 --
-ValueError: base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 9 --
-ValueError: base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 10 --
-ValueError: base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 11 --
 string(1) "1"
@@ -118,13 +116,13 @@ string(1) "0"
 TypeError: base_convert(): Argument #1 ($num) must be of type string, array given
 
 -- Iteration 18 --
-ValueError: base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 19 --
-ValueError: base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 20 --
-ValueError: base_convert(): Argument #1 ($num) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 21 --
 TypeError: base_convert(): Argument #1 ($num) must be of type string, resource given

--- a/ext/standard/tests/math/bindec_basic.phpt
+++ b/ext/standard/tests/math/bindec_basic.phpt
@@ -39,20 +39,20 @@ for ($i = 0; $i < count($values); $i++) {
 ?>
 --EXPECT--
 int(455)
-ValueError: Invalid characters passed for attempted conversion
-ValueError: Invalid characters passed for attempted conversion
-ValueError: Invalid characters passed for attempted conversion
-ValueError: Invalid characters passed for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
 int(455)
 int(224)
 int(2147483647)
 float(2147483648)
-ValueError: Invalid characters passed for attempted conversion
-ValueError: Invalid characters passed for attempted conversion
-ValueError: Invalid characters passed for attempted conversion
-ValueError: Invalid characters passed for attempted conversion
-ValueError: Invalid characters passed for attempted conversion
-ValueError: Invalid characters passed for attempted conversion
-ValueError: Invalid characters passed for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
 int(1)
 int(0)

--- a/ext/standard/tests/math/bindec_basic.phpt
+++ b/ext/standard/tests/math/bindec_basic.phpt
@@ -29,48 +29,30 @@ $values = array(111000111,
                 );
 
 for ($i = 0; $i < count($values); $i++) {
-    $res = bindec($values[$i]);
-    var_dump($res);
+    try {
+        $res = bindec($values[$i]);
+        var_dump($res);
+    } catch (ValueError $e) {
+        echo 'ValueError: ', $e->getMessage(), "\n";
+    }
 }
 ?>
---EXPECTF--
+--EXPECT--
 int(455)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(32766)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(5)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(129)
+ValueError: Invalid characters passed for attempted conversion
+ValueError: Invalid characters passed for attempted conversion
+ValueError: Invalid characters passed for attempted conversion
+ValueError: Invalid characters passed for attempted conversion
 int(455)
 int(224)
 int(2147483647)
 float(2147483648)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(129)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(13)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(13)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(26)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(6)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
+ValueError: Invalid characters passed for attempted conversion
+ValueError: Invalid characters passed for attempted conversion
+ValueError: Invalid characters passed for attempted conversion
+ValueError: Invalid characters passed for attempted conversion
+ValueError: Invalid characters passed for attempted conversion
+ValueError: Invalid characters passed for attempted conversion
+ValueError: Invalid characters passed for attempted conversion
 int(1)
 int(0)

--- a/ext/standard/tests/math/bindec_basic.phpt
+++ b/ext/standard/tests/math/bindec_basic.phpt
@@ -32,27 +32,27 @@ for ($i = 0; $i < count($values); $i++) {
     try {
         $res = bindec($values[$i]);
         var_dump($res);
-    } catch (ValueError $e) {
-        echo 'ValueError: ', $e->getMessage(), "\n";
+    } catch (Throwable $e) {
+        echo $e::class, ': ', $e->getMessage() . "\n";
     }
 }
 ?>
 --EXPECT--
 int(455)
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 int(455)
 int(224)
 int(2147483647)
 float(2147483648)
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 int(1)
 int(0)

--- a/ext/standard/tests/math/bindec_basic_64bit.phpt
+++ b/ext/standard/tests/math/bindec_basic_64bit.phpt
@@ -29,48 +29,30 @@ $values = array(111000111,
                 );
 
 for ($i = 0; $i < count($values); $i++) {
-    $res = bindec($values[$i]);
-    var_dump($res);
+    try {
+        $res = bindec($values[$i]);
+        var_dump($res);
+    } catch (ValueError $e) {
+        echo 'ValueError: ', $e->getMessage(), "\n";
+    }
 }
 ?>
---EXPECTF--
+--EXPECT--
 int(455)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(32766)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(5)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(129)
+ValueError: Invalid characters passed for attempted conversion
+ValueError: Invalid characters passed for attempted conversion
+ValueError: Invalid characters passed for attempted conversion
+ValueError: Invalid characters passed for attempted conversion
 int(455)
 int(224)
 int(2147483647)
 int(2147483648)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(129)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(13)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(13)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(26)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(6)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
+ValueError: Invalid characters passed for attempted conversion
+ValueError: Invalid characters passed for attempted conversion
+ValueError: Invalid characters passed for attempted conversion
+ValueError: Invalid characters passed for attempted conversion
+ValueError: Invalid characters passed for attempted conversion
+ValueError: Invalid characters passed for attempted conversion
+ValueError: Invalid characters passed for attempted conversion
 int(1)
 int(0)

--- a/ext/standard/tests/math/bindec_basic_64bit.phpt
+++ b/ext/standard/tests/math/bindec_basic_64bit.phpt
@@ -39,20 +39,20 @@ for ($i = 0; $i < count($values); $i++) {
 ?>
 --EXPECT--
 int(455)
-ValueError: Invalid characters passed for attempted conversion
-ValueError: Invalid characters passed for attempted conversion
-ValueError: Invalid characters passed for attempted conversion
-ValueError: Invalid characters passed for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
 int(455)
 int(224)
 int(2147483647)
 int(2147483648)
-ValueError: Invalid characters passed for attempted conversion
-ValueError: Invalid characters passed for attempted conversion
-ValueError: Invalid characters passed for attempted conversion
-ValueError: Invalid characters passed for attempted conversion
-ValueError: Invalid characters passed for attempted conversion
-ValueError: Invalid characters passed for attempted conversion
-ValueError: Invalid characters passed for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
 int(1)
 int(0)

--- a/ext/standard/tests/math/bindec_basic_64bit.phpt
+++ b/ext/standard/tests/math/bindec_basic_64bit.phpt
@@ -32,27 +32,27 @@ for ($i = 0; $i < count($values); $i++) {
     try {
         $res = bindec($values[$i]);
         var_dump($res);
-    } catch (ValueError $e) {
-        echo 'ValueError: ', $e->getMessage(), "\n";
+    } catch (Throwable $e) {
+        echo $e::class, ': ', $e->getMessage() . "\n";
     }
 }
 ?>
 --EXPECT--
 int(455)
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 int(455)
 int(224)
 int(2147483647)
 int(2147483648)
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 int(1)
 int(0)

--- a/ext/standard/tests/math/bindec_variation1.phpt
+++ b/ext/standard/tests/math/bindec_variation1.phpt
@@ -76,25 +76,25 @@ int(0)
 int(1)
 
 -- Iteration 3 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
 
 -- Iteration 4 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
 
 -- Iteration 5 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
 
 -- Iteration 6 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
 
 -- Iteration 7 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
 
 -- Iteration 8 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
 
 -- Iteration 9 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
 
 -- Iteration 10 --
 int(1)
@@ -118,13 +118,13 @@ int(0)
 TypeError: bindec(): Argument #1 ($binary_string) must be of type string, array given
 
 -- Iteration 17 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
 
 -- Iteration 18 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
 
 -- Iteration 19 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
 
 -- Iteration 20 --
 TypeError: bindec(): Argument #1 ($binary_string) must be of type string, resource given

--- a/ext/standard/tests/math/bindec_variation1.phpt
+++ b/ext/standard/tests/math/bindec_variation1.phpt
@@ -58,13 +58,15 @@ foreach($inputs as $input) {
     try {
         var_dump(bindec($input));
     } catch (TypeError $e) {
-        echo $e->getMessage(), "\n";
+        echo 'TypeError: ', $e->getMessage(), "\n";
+    } catch (ValueError $e) {
+        echo 'ValueError: ', $e->getMessage(), "\n";
     }
     $iterator++;
 };
 fclose($fp);
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing bindec() : usage variations ***
 
 -- Iteration 1 --
@@ -74,39 +76,25 @@ int(0)
 int(1)
 
 -- Iteration 3 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(1)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 4 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 5 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(2)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 6 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(2)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 7 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(8)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 8 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(1)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 9 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 10 --
 int(1)
@@ -130,19 +118,13 @@ int(0)
 bindec(): Argument #1 ($binary_string) must be of type string, array given
 
 -- Iteration 17 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 18 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 19 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 20 --
 bindec(): Argument #1 ($binary_string) must be of type string, resource given

--- a/ext/standard/tests/math/bindec_variation1.phpt
+++ b/ext/standard/tests/math/bindec_variation1.phpt
@@ -115,7 +115,7 @@ int(0)
 int(0)
 
 -- Iteration 16 --
-bindec(): Argument #1 ($binary_string) must be of type string, array given
+TypeError: bindec(): Argument #1 ($binary_string) must be of type string, array given
 
 -- Iteration 17 --
 ValueError: Invalid characters passed for attempted conversion
@@ -127,4 +127,4 @@ ValueError: Invalid characters passed for attempted conversion
 ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 20 --
-bindec(): Argument #1 ($binary_string) must be of type string, resource given
+TypeError: bindec(): Argument #1 ($binary_string) must be of type string, resource given

--- a/ext/standard/tests/math/bindec_variation1.phpt
+++ b/ext/standard/tests/math/bindec_variation1.phpt
@@ -57,10 +57,8 @@ foreach($inputs as $input) {
     echo "\n-- Iteration $iterator --\n";
     try {
         var_dump(bindec($input));
-    } catch (TypeError $e) {
-        echo 'TypeError: ', $e->getMessage(), "\n";
-    } catch (ValueError $e) {
-        echo 'ValueError: ', $e->getMessage(), "\n";
+    } catch (Throwable $e) {
+        echo $e::class, ': ', $e->getMessage() . "\n";
     }
     $iterator++;
 };
@@ -76,25 +74,25 @@ int(0)
 int(1)
 
 -- Iteration 3 --
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 4 --
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 5 --
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 6 --
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 7 --
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 8 --
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 9 --
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 10 --
 int(1)
@@ -118,13 +116,13 @@ int(0)
 TypeError: bindec(): Argument #1 ($binary_string) must be of type string, array given
 
 -- Iteration 17 --
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 18 --
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 19 --
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 20 --
 TypeError: bindec(): Argument #1 ($binary_string) must be of type string, resource given

--- a/ext/standard/tests/math/bindec_variation1_64bit.phpt
+++ b/ext/standard/tests/math/bindec_variation1_64bit.phpt
@@ -76,25 +76,25 @@ int(0)
 int(1)
 
 -- Iteration 3 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
 
 -- Iteration 4 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
 
 -- Iteration 5 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
 
 -- Iteration 6 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
 
 -- Iteration 7 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
 
 -- Iteration 8 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
 
 -- Iteration 9 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
 
 -- Iteration 10 --
 int(1)
@@ -118,13 +118,13 @@ int(0)
 TypeError: bindec(): Argument #1 ($binary_string) must be of type string, array given
 
 -- Iteration 17 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
 
 -- Iteration 18 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
 
 -- Iteration 19 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
 
 -- Iteration 20 --
 TypeError: bindec(): Argument #1 ($binary_string) must be of type string, resource given

--- a/ext/standard/tests/math/bindec_variation1_64bit.phpt
+++ b/ext/standard/tests/math/bindec_variation1_64bit.phpt
@@ -58,13 +58,15 @@ foreach($inputs as $input) {
     try {
         var_dump(bindec($input));
     } catch (TypeError $e) {
-        echo $e->getMessage(), "\n";
+        echo 'TypeError: ', $e->getMessage(), "\n";
+    } catch (ValueError $e) {
+        echo 'ValueError: ', $e->getMessage(), "\n";
     }
     $iterator++;
 };
 fclose($fp);
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing bindec() : usage variations ***
 
 -- Iteration 1 --
@@ -74,39 +76,25 @@ int(0)
 int(1)
 
 -- Iteration 3 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(1)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 4 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 5 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(2)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 6 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(2)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 7 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(8)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 8 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(1)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 9 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 10 --
 int(1)
@@ -127,22 +115,16 @@ int(0)
 int(0)
 
 -- Iteration 16 --
-bindec(): Argument #1 ($binary_string) must be of type string, array given
+TypeError: bindec(): Argument #1 ($binary_string) must be of type string, array given
 
 -- Iteration 17 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 18 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 19 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 20 --
-bindec(): Argument #1 ($binary_string) must be of type string, resource given
+TypeError: bindec(): Argument #1 ($binary_string) must be of type string, resource given

--- a/ext/standard/tests/math/bindec_variation1_64bit.phpt
+++ b/ext/standard/tests/math/bindec_variation1_64bit.phpt
@@ -57,10 +57,8 @@ foreach($inputs as $input) {
     echo "\n-- Iteration $iterator --\n";
     try {
         var_dump(bindec($input));
-    } catch (TypeError $e) {
-        echo 'TypeError: ', $e->getMessage(), "\n";
-    } catch (ValueError $e) {
-        echo 'ValueError: ', $e->getMessage(), "\n";
+    } catch (Throwable $e) {
+        echo $e::class, ': ', $e->getMessage() . "\n";
     }
     $iterator++;
 };
@@ -76,25 +74,25 @@ int(0)
 int(1)
 
 -- Iteration 3 --
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 4 --
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 5 --
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 6 --
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 7 --
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 8 --
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 9 --
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 10 --
 int(1)
@@ -118,13 +116,13 @@ int(0)
 TypeError: bindec(): Argument #1 ($binary_string) must be of type string, array given
 
 -- Iteration 17 --
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 18 --
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 19 --
-ValueError: bindec(): Argument #1 ($binary_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 20 --
 TypeError: bindec(): Argument #1 ($binary_string) must be of type string, resource given

--- a/ext/standard/tests/math/hexdec.phpt
+++ b/ext/standard/tests/math/hexdec.phpt
@@ -33,8 +33,8 @@ var_dump((float)hexdec("17fffffff"));
 --EXPECT--
 int(74565)
 int(74565)
-ValueError: Invalid characters passed for attempted conversion
-ValueError: Invalid characters passed for attempted conversion
-ValueError: Invalid characters passed for attempted conversion
+ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
+ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
+ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
 float(78187069441)
 float(6442450943)

--- a/ext/standard/tests/math/hexdec.phpt
+++ b/ext/standard/tests/math/hexdec.phpt
@@ -7,24 +7,34 @@ precision=14
 
 var_dump(hexdec("012345"));
 var_dump(hexdec("12345"));
-var_dump(hexdec("q12345"));
-var_dump(hexdec("12345+?!"));
-var_dump(hexdec("12345q"));
+
+try {
+    var_dump(hexdec("q12345"));
+} catch (ValueError $e) {
+    echo 'ValueError: ', $e->getMessage(), "\n";
+}
+
+try {
+    var_dump(hexdec("12345+?!"));
+} catch (ValueError $e) {
+    echo 'ValueError: ', $e->getMessage(), "\n";
+}
+
+try {
+    var_dump(hexdec("12345q"));
+} catch (ValueError $e) {
+    echo 'ValueError: ', $e->getMessage(), "\n";
+}
+
 var_dump((float)hexdec("1234500001"));
 var_dump((float)hexdec("17fffffff"));
 
 ?>
---EXPECTF--
+--EXPECT--
 int(74565)
 int(74565)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(74565)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(74565)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(74565)
+ValueError: Invalid characters passed for attempted conversion
+ValueError: Invalid characters passed for attempted conversion
+ValueError: Invalid characters passed for attempted conversion
 float(78187069441)
 float(6442450943)

--- a/ext/standard/tests/math/hexdec.phpt
+++ b/ext/standard/tests/math/hexdec.phpt
@@ -10,20 +10,20 @@ var_dump(hexdec("12345"));
 
 try {
     var_dump(hexdec("q12345"));
-} catch (ValueError $e) {
-    echo 'ValueError: ', $e->getMessage(), "\n";
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage() . "\n";
 }
 
 try {
     var_dump(hexdec("12345+?!"));
-} catch (ValueError $e) {
-    echo 'ValueError: ', $e->getMessage(), "\n";
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage() . "\n";
 }
 
 try {
     var_dump(hexdec("12345q"));
-} catch (ValueError $e) {
-    echo 'ValueError: ', $e->getMessage(), "\n";
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage() . "\n";
 }
 
 var_dump((float)hexdec("1234500001"));
@@ -33,8 +33,8 @@ var_dump((float)hexdec("17fffffff"));
 --EXPECT--
 int(74565)
 int(74565)
-ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
-ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
-ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 float(78187069441)
 float(6442450943)

--- a/ext/standard/tests/math/hexdec_basic.phpt
+++ b/ext/standard/tests/math/hexdec_basic.phpt
@@ -42,10 +42,10 @@ int(1194684)
 int(7904751)
 int(2147483647)
 float(2147483648)
-ValueError: Invalid characters passed for attempted conversion
+ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
 int(3215381)
 int(3215381)
-ValueError: Invalid characters passed for attempted conversion
+ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
 int(51446064)
 int(18279)
 int(70199)

--- a/ext/standard/tests/math/hexdec_basic.phpt
+++ b/ext/standard/tests/math/hexdec_basic.phpt
@@ -29,7 +29,7 @@ for ($i = 0; $i < count($values); $i++) {
     var_dump($res);
 }
 ?>
---EXPECTF--
+--EXPECT--
 int(18433668)
 int(126895953)
 float(142929835591)
@@ -38,14 +38,10 @@ int(1194684)
 int(7904751)
 int(2147483647)
 float(2147483648)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(1194684)
+ValueError: Invalid characters passed for attempted conversion
 int(3215381)
 int(3215381)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(3215379)
+ValueError: Invalid characters passed for attempted conversion
 int(51446064)
 int(18279)
 int(70199)

--- a/ext/standard/tests/math/hexdec_basic.phpt
+++ b/ext/standard/tests/math/hexdec_basic.phpt
@@ -25,8 +25,12 @@ $values = array(0x123abc,
                 false,
                 );
 for ($i = 0; $i < count($values); $i++) {
-    $res = hexdec($values[$i]);
-    var_dump($res);
+    try {
+        $res = hexdec($values[$i]);
+        var_dump($res);
+    } catch (ValueError $e) {
+        echo 'ValueError: ', $e->getMessage(), "\n";
+    }
 }
 ?>
 --EXPECT--

--- a/ext/standard/tests/math/hexdec_basic.phpt
+++ b/ext/standard/tests/math/hexdec_basic.phpt
@@ -28,8 +28,8 @@ for ($i = 0; $i < count($values); $i++) {
     try {
         $res = hexdec($values[$i]);
         var_dump($res);
-    } catch (ValueError $e) {
-        echo 'ValueError: ', $e->getMessage(), "\n";
+    } catch (Throwable $e) {
+        echo $e::class, ': ', $e->getMessage() . "\n";
     }
 }
 ?>
@@ -42,10 +42,10 @@ int(1194684)
 int(7904751)
 int(2147483647)
 float(2147483648)
-ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 int(3215381)
 int(3215381)
-ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 int(51446064)
 int(18279)
 int(70199)

--- a/ext/standard/tests/math/hexdec_basic_64bit.phpt
+++ b/ext/standard/tests/math/hexdec_basic_64bit.phpt
@@ -29,11 +29,15 @@ $values = array(0x123abc,
 
 foreach($values as $value) {
     echo "\n-- hexdec $value --\n";
-    var_dump(hexdec($value));
+    try {
+        var_dump(hexdec($value));
+    } catch (ValueError $e) {
+        echo 'ValueError: ', $e->getMessage(), "\n";
+    }
 };
 
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing hexdec() : basic functionality ***
 
 -- hexdec 1194684 --
@@ -61,9 +65,7 @@ int(2147483647)
 int(2147483648)
 
 -- hexdec 0x123XYZABC --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(1194684)
+ValueError: Invalid characters passed for attempted conversion
 
 -- hexdec 311015 --
 int(3215381)
@@ -72,9 +74,7 @@ int(3215381)
 int(3215381)
 
 -- hexdec 31101.3 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(3215379)
+ValueError: Invalid characters passed for attempted conversion
 
 -- hexdec 3110130 --
 int(51446064)

--- a/ext/standard/tests/math/hexdec_basic_64bit.phpt
+++ b/ext/standard/tests/math/hexdec_basic_64bit.phpt
@@ -65,7 +65,7 @@ int(2147483647)
 int(2147483648)
 
 -- hexdec 0x123XYZABC --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
 
 -- hexdec 311015 --
 int(3215381)
@@ -74,7 +74,7 @@ int(3215381)
 int(3215381)
 
 -- hexdec 31101.3 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
 
 -- hexdec 3110130 --
 int(51446064)

--- a/ext/standard/tests/math/hexdec_basic_64bit.phpt
+++ b/ext/standard/tests/math/hexdec_basic_64bit.phpt
@@ -31,8 +31,8 @@ foreach($values as $value) {
     echo "\n-- hexdec $value --\n";
     try {
         var_dump(hexdec($value));
-    } catch (ValueError $e) {
-        echo 'ValueError: ', $e->getMessage(), "\n";
+    } catch (Throwable $e) {
+        echo $e::class, ': ', $e->getMessage() . "\n";
     }
 };
 
@@ -65,7 +65,7 @@ int(2147483647)
 int(2147483648)
 
 -- hexdec 0x123XYZABC --
-ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- hexdec 311015 --
 int(3215381)
@@ -74,7 +74,7 @@ int(3215381)
 int(3215381)
 
 -- hexdec 31101.3 --
-ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- hexdec 3110130 --
 int(51446064)

--- a/ext/standard/tests/math/hexdec_variation1.phpt
+++ b/ext/standard/tests/math/hexdec_variation1.phpt
@@ -62,7 +62,9 @@ foreach($inputs as $input) {
     try {
         var_dump(hexdec($input));
     } catch (TypeError $e) {
-        echo $e->getMessage(), "\n";
+        echo 'TypeError: ', $e->getMessage(), "\n";
+    } catch (ValueError $e) {
+        echo 'ValueError: ', $e->getMessage(), "\n";
     }
     $iterator++;
 };
@@ -123,7 +125,7 @@ int(0)
 int(0)
 
 -- Iteration 18 --
-hexdec(): Argument #1 ($hex_string) must be of type string, array given
+TypeError: hexdec(): Argument #1 ($hex_string) must be of type string, array given
 
 -- Iteration 19 --
 ValueError: Invalid characters passed for attempted conversion
@@ -135,4 +137,4 @@ ValueError: Invalid characters passed for attempted conversion
 ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 22 --
-hexdec(): Argument #1 ($hex_string) must be of type string, resource given
+TypeError: hexdec(): Argument #1 ($hex_string) must be of type string, resource given

--- a/ext/standard/tests/math/hexdec_variation1.phpt
+++ b/ext/standard/tests/math/hexdec_variation1.phpt
@@ -83,7 +83,7 @@ int(1)
 int(74565)
 
 -- Iteration 4 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
 
 -- Iteration 5 --
 float(285960729237)
@@ -92,19 +92,19 @@ float(285960729237)
 float(285960729238)
 
 -- Iteration 7 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
 
 -- Iteration 8 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
 
 -- Iteration 9 --
 float(20015998341120)
 
 -- Iteration 10 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
 
 -- Iteration 11 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
 
 -- Iteration 12 --
 int(1)
@@ -128,13 +128,13 @@ int(0)
 TypeError: hexdec(): Argument #1 ($hex_string) must be of type string, array given
 
 -- Iteration 19 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
 
 -- Iteration 20 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
 
 -- Iteration 21 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
 
 -- Iteration 22 --
 TypeError: hexdec(): Argument #1 ($hex_string) must be of type string, resource given

--- a/ext/standard/tests/math/hexdec_variation1.phpt
+++ b/ext/standard/tests/math/hexdec_variation1.phpt
@@ -68,7 +68,7 @@ foreach($inputs as $input) {
 };
 fclose($fp);
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing hexdec() : usage variations ***
 
 -- Iteration 1 --
@@ -81,9 +81,7 @@ int(1)
 int(74565)
 
 -- Iteration 4 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(9029)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 5 --
 float(285960729237)
@@ -92,27 +90,19 @@ float(285960729237)
 float(285960729238)
 
 -- Iteration 7 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(261)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 8 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(261)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 9 --
 float(20015998341120)
 
 -- Iteration 10 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-float(1250999896553)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 11 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(5)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 12 --
 int(1)
@@ -136,19 +126,13 @@ int(0)
 hexdec(): Argument #1 ($hex_string) must be of type string, array given
 
 -- Iteration 19 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(2748)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 20 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(2748)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 21 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(2748)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 22 --
 hexdec(): Argument #1 ($hex_string) must be of type string, resource given

--- a/ext/standard/tests/math/hexdec_variation1.phpt
+++ b/ext/standard/tests/math/hexdec_variation1.phpt
@@ -61,10 +61,8 @@ foreach($inputs as $input) {
     echo "\n-- Iteration $iterator --\n";
     try {
         var_dump(hexdec($input));
-    } catch (TypeError $e) {
-        echo 'TypeError: ', $e->getMessage(), "\n";
-    } catch (ValueError $e) {
-        echo 'ValueError: ', $e->getMessage(), "\n";
+    } catch (Throwable $e) {
+        echo $e::class, ': ', $e->getMessage() . "\n";
     }
     $iterator++;
 };
@@ -83,7 +81,7 @@ int(1)
 int(74565)
 
 -- Iteration 4 --
-ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 5 --
 float(285960729237)
@@ -92,19 +90,19 @@ float(285960729237)
 float(285960729238)
 
 -- Iteration 7 --
-ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 8 --
-ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 9 --
 float(20015998341120)
 
 -- Iteration 10 --
-ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 11 --
-ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 12 --
 int(1)
@@ -128,13 +126,13 @@ int(0)
 TypeError: hexdec(): Argument #1 ($hex_string) must be of type string, array given
 
 -- Iteration 19 --
-ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 20 --
-ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 21 --
-ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 22 --
 TypeError: hexdec(): Argument #1 ($hex_string) must be of type string, resource given

--- a/ext/standard/tests/math/hexdec_variation1_64bit.phpt
+++ b/ext/standard/tests/math/hexdec_variation1_64bit.phpt
@@ -62,13 +62,15 @@ foreach($inputs as $input) {
     try {
         var_dump(hexdec($input));
     } catch (TypeError $e) {
-        echo $e->getMessage(), "\n";
+        echo 'TypeError: ', $e->getMessage(), "\n";
+    } catch (ValueError $e) {
+        echo 'ValueError: ', $e->getMessage(), "\n";
     }
     $iterator++;
 };
 fclose($fp);
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing hexdec() : usage variations ***
 
 -- Iteration 1 --
@@ -81,9 +83,7 @@ int(1)
 int(74565)
 
 -- Iteration 4 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(9029)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 5 --
 int(285960729237)
@@ -92,27 +92,19 @@ int(285960729237)
 int(285960729238)
 
 -- Iteration 7 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(261)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 8 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(261)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 9 --
 int(20015998341120)
 
 -- Iteration 10 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(1250999896553)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 11 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(5)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 12 --
 int(1)
@@ -133,22 +125,16 @@ int(0)
 int(0)
 
 -- Iteration 18 --
-hexdec(): Argument #1 ($hex_string) must be of type string, array given
+TypeError: hexdec(): Argument #1 ($hex_string) must be of type string, array given
 
 -- Iteration 19 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(2748)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 20 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(2748)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 21 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(2748)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 22 --
-hexdec(): Argument #1 ($hex_string) must be of type string, resource given
+TypeError: hexdec(): Argument #1 ($hex_string) must be of type string, resource given

--- a/ext/standard/tests/math/hexdec_variation1_64bit.phpt
+++ b/ext/standard/tests/math/hexdec_variation1_64bit.phpt
@@ -83,7 +83,7 @@ int(1)
 int(74565)
 
 -- Iteration 4 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
 
 -- Iteration 5 --
 int(285960729237)
@@ -92,19 +92,19 @@ int(285960729237)
 int(285960729238)
 
 -- Iteration 7 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
 
 -- Iteration 8 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
 
 -- Iteration 9 --
 int(20015998341120)
 
 -- Iteration 10 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
 
 -- Iteration 11 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
 
 -- Iteration 12 --
 int(1)
@@ -128,13 +128,13 @@ int(0)
 TypeError: hexdec(): Argument #1 ($hex_string) must be of type string, array given
 
 -- Iteration 19 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
 
 -- Iteration 20 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
 
 -- Iteration 21 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
 
 -- Iteration 22 --
 TypeError: hexdec(): Argument #1 ($hex_string) must be of type string, resource given

--- a/ext/standard/tests/math/hexdec_variation1_64bit.phpt
+++ b/ext/standard/tests/math/hexdec_variation1_64bit.phpt
@@ -61,10 +61,8 @@ foreach($inputs as $input) {
     echo "\n-- Iteration $iterator --\n";
     try {
         var_dump(hexdec($input));
-    } catch (TypeError $e) {
-        echo 'TypeError: ', $e->getMessage(), "\n";
-    } catch (ValueError $e) {
-        echo 'ValueError: ', $e->getMessage(), "\n";
+    } catch (Throwable $e) {
+        echo $e::class, ': ', $e->getMessage() . "\n";
     }
     $iterator++;
 };
@@ -83,7 +81,7 @@ int(1)
 int(74565)
 
 -- Iteration 4 --
-ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 5 --
 int(285960729237)
@@ -92,19 +90,19 @@ int(285960729237)
 int(285960729238)
 
 -- Iteration 7 --
-ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 8 --
-ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 9 --
 int(20015998341120)
 
 -- Iteration 10 --
-ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 11 --
-ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 12 --
 int(1)
@@ -128,13 +126,13 @@ int(0)
 TypeError: hexdec(): Argument #1 ($hex_string) must be of type string, array given
 
 -- Iteration 19 --
-ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 20 --
-ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 21 --
-ValueError: hexdec(): Argument #1 ($hex_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 22 --
 TypeError: hexdec(): Argument #1 ($hex_string) must be of type string, resource given

--- a/ext/standard/tests/math/octdec_basic.phpt
+++ b/ext/standard/tests/math/octdec_basic.phpt
@@ -29,31 +29,20 @@ for ($i = 0; $i < count($values); $i++) {
     var_dump($res);
 }
 ?>
---EXPECTF--
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(14489)
+--EXPECT--
+ValueError: Invalid characters passed for attempted conversion
 int(253)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(36947879)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(4618484)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(4104)
+ValueError: Invalid characters passed for attempted conversion
+ValueError: Invalid characters passed for attempted conversion
+ValueError: Invalid characters passed for attempted conversion
 int(5349)
 int(342391)
 int(375)
 int(2147483647)
 float(2147483648)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(668)
+ValueError: Invalid characters passed for attempted conversion
 int(5349)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(102923)
+ValueError: Invalid characters passed for attempted conversion
 int(823384)
 int(1)
 int(0)

--- a/ext/standard/tests/math/octdec_basic.phpt
+++ b/ext/standard/tests/math/octdec_basic.phpt
@@ -25,8 +25,12 @@ $values = array(01234567,
                 );
 
 for ($i = 0; $i < count($values); $i++) {
-    $res = octdec($values[$i]);
-    var_dump($res);
+    try {
+        $res = octdec($values[$i]);
+        var_dump($res);
+    } catch (ValueError $e) {
+        echo 'ValueError: ', $e->getMessage(), "\n";
+    }
 }
 ?>
 --EXPECT--

--- a/ext/standard/tests/math/octdec_basic.phpt
+++ b/ext/standard/tests/math/octdec_basic.phpt
@@ -34,19 +34,19 @@ for ($i = 0; $i < count($values); $i++) {
 }
 ?>
 --EXPECT--
-ValueError: Invalid characters passed for attempted conversion
+ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
 int(253)
-ValueError: Invalid characters passed for attempted conversion
-ValueError: Invalid characters passed for attempted conversion
-ValueError: Invalid characters passed for attempted conversion
+ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
+ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
+ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
 int(5349)
 int(342391)
 int(375)
 int(2147483647)
 float(2147483648)
-ValueError: Invalid characters passed for attempted conversion
+ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
 int(5349)
-ValueError: Invalid characters passed for attempted conversion
+ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
 int(823384)
 int(1)
 int(0)

--- a/ext/standard/tests/math/octdec_basic.phpt
+++ b/ext/standard/tests/math/octdec_basic.phpt
@@ -28,25 +28,25 @@ for ($i = 0; $i < count($values); $i++) {
     try {
         $res = octdec($values[$i]);
         var_dump($res);
-    } catch (ValueError $e) {
-        echo 'ValueError: ', $e->getMessage(), "\n";
+    } catch (Throwable $e) {
+        echo $e::class, ': ', $e->getMessage() . "\n";
     }
 }
 ?>
 --EXPECT--
-ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 int(253)
-ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
-ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
-ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 int(5349)
 int(342391)
 int(375)
 int(2147483647)
 float(2147483648)
-ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 int(5349)
-ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 int(823384)
 int(1)
 int(0)

--- a/ext/standard/tests/math/octdec_basic_64bit.phpt
+++ b/ext/standard/tests/math/octdec_basic_64bit.phpt
@@ -38,19 +38,19 @@ for ($i = 0; $i < count($values); $i++) {
 ?>
 --EXPECT--
 *** Testing octdec() : basic functionality ***
-ValueError: Invalid characters passed for attempted conversion
+ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
 int(253)
-ValueError: Invalid characters passed for attempted conversion
-ValueError: Invalid characters passed for attempted conversion
-ValueError: Invalid characters passed for attempted conversion
+ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
+ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
+ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
 int(5349)
 int(342391)
 int(375)
 int(2147483647)
 int(2147483648)
-ValueError: Invalid characters passed for attempted conversion
+ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
 int(5349)
-ValueError: Invalid characters passed for attempted conversion
+ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
 int(823384)
 int(1)
 int(0)

--- a/ext/standard/tests/math/octdec_basic_64bit.phpt
+++ b/ext/standard/tests/math/octdec_basic_64bit.phpt
@@ -28,37 +28,29 @@ $values = array(01234567,
                 );
 
 for ($i = 0; $i < count($values); $i++) {
-    $res = octdec($values[$i]);
-    var_dump($res);
+    try {
+        $res = octdec($values[$i]);
+        var_dump($res);
+    } catch (ValueError $e) {
+        echo 'ValueError: ', $e->getMessage(), "\n";
+    }
 }
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing octdec() : basic functionality ***
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(14489)
+ValueError: Invalid characters passed for attempted conversion
 int(253)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(36947879)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(4618484)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(4104)
+ValueError: Invalid characters passed for attempted conversion
+ValueError: Invalid characters passed for attempted conversion
+ValueError: Invalid characters passed for attempted conversion
 int(5349)
 int(342391)
 int(375)
 int(2147483647)
 int(2147483648)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(668)
+ValueError: Invalid characters passed for attempted conversion
 int(5349)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(102923)
+ValueError: Invalid characters passed for attempted conversion
 int(823384)
 int(1)
 int(0)

--- a/ext/standard/tests/math/octdec_basic_64bit.phpt
+++ b/ext/standard/tests/math/octdec_basic_64bit.phpt
@@ -31,26 +31,26 @@ for ($i = 0; $i < count($values); $i++) {
     try {
         $res = octdec($values[$i]);
         var_dump($res);
-    } catch (ValueError $e) {
-        echo 'ValueError: ', $e->getMessage(), "\n";
+    } catch (Throwable $e) {
+        echo $e::class, ': ', $e->getMessage() . "\n";
     }
 }
 ?>
 --EXPECT--
 *** Testing octdec() : basic functionality ***
-ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 int(253)
-ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
-ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
-ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 int(5349)
 int(342391)
 int(375)
 int(2147483647)
 int(2147483648)
-ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 int(5349)
-ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 int(823384)
 int(1)
 int(0)

--- a/ext/standard/tests/math/octdec_variation1.phpt
+++ b/ext/standard/tests/math/octdec_variation1.phpt
@@ -80,28 +80,28 @@ int(1)
 int(5349)
 
 -- Iteration 4 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
 
 -- Iteration 5 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
 
 -- Iteration 6 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
 
 -- Iteration 7 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
 
 -- Iteration 8 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
 
 -- Iteration 9 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
 
 -- Iteration 10 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
 
 -- Iteration 11 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
 
 -- Iteration 12 --
 int(1)
@@ -125,13 +125,13 @@ int(0)
 TypeError: octdec(): Argument #1 ($octal_string) must be of type string, array given
 
 -- Iteration 19 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
 
 -- Iteration 20 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
 
 -- Iteration 21 --
-ValueError: Invalid characters passed for attempted conversion
+ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
 
 -- Iteration 22 --
 TypeError: octdec(): Argument #1 ($octal_string) must be of type string, resource given

--- a/ext/standard/tests/math/octdec_variation1.phpt
+++ b/ext/standard/tests/math/octdec_variation1.phpt
@@ -58,14 +58,16 @@ foreach($inputs as $input) {
     try {
         var_dump(octdec($input));
     } catch (TypeError $e) {
-        echo $e->getMessage(), "\n";
+        echo 'TypeError: ', $e->getMessage(), "\n";
+    } catch (ValueError $e) {
+        echo 'ValueError: ', $e->getMessage(), "\n";
     }
     $iterator++;
 };
 fclose($fp);
 ?>
 ---Done---
---EXPECTF--
+--EXPECT--
 *** Testing octdec() : usage variations ***
 
 -- Iteration 1 --
@@ -78,44 +80,28 @@ int(1)
 int(5349)
 
 -- Iteration 4 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(1253)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 5 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(1134037)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 6 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(1134038)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 7 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(69)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 8 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(69)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 9 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(175304192)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 10 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(342391)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 11 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(5)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 12 --
 int(1)
@@ -136,23 +122,17 @@ int(0)
 int(0)
 
 -- Iteration 18 --
-octdec(): Argument #1 ($octal_string) must be of type string, array given
+TypeError: octdec(): Argument #1 ($octal_string) must be of type string, array given
 
 -- Iteration 19 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 20 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 21 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
+ValueError: Invalid characters passed for attempted conversion
 
 -- Iteration 22 --
-octdec(): Argument #1 ($octal_string) must be of type string, resource given
+TypeError: octdec(): Argument #1 ($octal_string) must be of type string, resource given
 ---Done---

--- a/ext/standard/tests/math/octdec_variation1.phpt
+++ b/ext/standard/tests/math/octdec_variation1.phpt
@@ -57,10 +57,8 @@ foreach($inputs as $input) {
     echo "\n-- Iteration $iterator --\n";
     try {
         var_dump(octdec($input));
-    } catch (TypeError $e) {
-        echo 'TypeError: ', $e->getMessage(), "\n";
-    } catch (ValueError $e) {
-        echo 'ValueError: ', $e->getMessage(), "\n";
+    } catch (Throwable $e) {
+        echo $e::class, ': ', $e->getMessage() . "\n";
     }
     $iterator++;
 };
@@ -80,28 +78,28 @@ int(1)
 int(5349)
 
 -- Iteration 4 --
-ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 5 --
-ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 6 --
-ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 7 --
-ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 8 --
-ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 9 --
-ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 10 --
-ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 11 --
-ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 12 --
 int(1)
@@ -125,13 +123,13 @@ int(0)
 TypeError: octdec(): Argument #1 ($octal_string) must be of type string, array given
 
 -- Iteration 19 --
-ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 20 --
-ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 21 --
-ValueError: octdec(): Argument #1 ($octal_string) has invalid characters for attempted conversion
+Exception: Invalid characters passed for attempted conversion
 
 -- Iteration 22 --
 TypeError: octdec(): Argument #1 ($octal_string) must be of type string, resource given


### PR DESCRIPTION
This is about the situation where a character is not within the specified number base. E.g. only 0-9, a-f are allowed for hexadecimal, so what should `hexdec('z')` do?

In the past, such characters were silently ignored. Since PHP 7.4 a deprecation notice would be generated. This PR changes that to a ~~ValueError~~ Exception.

Earlier RFC:
https://wiki.php.net/rfc/base_convert_improvements