### PR TITLE
ext/standard: Reject NUL bytes in `openlog()`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -257,6 +257,8 @@ PHP                                                                        NEWS
     contains null bytes. (Weilin Du)
   . dl() now raises a ValueError when the $extension_filename argument
     contains null bytes. (Weilin Du)
+  . openlog() now raises a ValueError when the $prefix argument contains
+    null bytes. (Weilin Du)
   . parse_str() now raises a ValueError when the $string argument contains
     null bytes. (Weilin Du)
   . proc_open() now raises a ValueError when the $cwd argument contains

--- a/UPGRADING
+++ b/UPGRADING
@@ -153,6 +153,8 @@ PHP 8.6 UPGRADE NOTES
     contains null bytes.
   . dl() now raises a ValueError when the $extension_filename argument
     contains null bytes.
+  . openlog() now raises a ValueError when the $prefix argument contains
+    null bytes.
   . parse_str() now raises a ValueError when the $string argument contains
     null bytes.
   . linkinfo() now raises a ValueError when the $path argument is empty.

--- a/ext/standard/syslog.c
+++ b/ext/standard/syslog.c
@@ -61,7 +61,7 @@ PHP_FUNCTION(openlog)
 	size_t ident_len;
 
 	ZEND_PARSE_PARAMETERS_START(3, 3)
-		Z_PARAM_STRING(ident, ident_len)
+		Z_PARAM_PATH(ident, ident_len)
 		Z_PARAM_LONG(option)
 		Z_PARAM_LONG(facility)
 	ZEND_PARSE_PARAMETERS_END();

--- a/ext/standard/tests/network/openlog_null_bytes.phpt
+++ b/ext/standard/tests/network/openlog_null_bytes.phpt
@@ -1,0 +1,16 @@
+--TEST--
+openlog() rejects null bytes in prefix
+--SKIPIF--
+<?php
+if (!function_exists("openlog")) die("skip openlog() is not available");
+?>
+--FILE--
+<?php
+try {
+    openlog("foo\0bar", LOG_NDELAY, LOG_USER);
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+openlog(): Argument #1 ($prefix) must not contain any null bytes


### PR DESCRIPTION
Ah I overlook the `openlog` function in the standard extension with the same problem of #22358 while I am auditing these functions in this extension yesterday. See [here](https://wandbox.org/permlink/yFvKLnzt1nAy883o)

Now with this patch I could say every function in the std extension of php no longer has the NUL bytes issue anymore (except for #21675) :-) Good to see those aged shitty risks being fixed.

@Girgias Can you please have a quick look on this? Thanks! 