### PR TITLE
Fix GH-22360: convert.base64-encode corruption on incremental flush.

### DIFF
--- a/ext/standard/filters.c
+++ b/ext/standard/filters.c
@@ -1519,7 +1519,7 @@ static php_stream_filter_status_t strfilter_convert_filter(
 		php_stream_bucket_delref(bucket);
 	}
 
-	if (flags != PSFS_FLAG_NORMAL) {
+	if (flags & PSFS_FLAG_FLUSH_CLOSE) {
 		if (strfilter_convert_append_bucket(inst, stream, thisfilter,
 				buckets_out, NULL, 0, &consumed,
 				php_stream_is_persistent(stream)) != SUCCESS) {

--- a/ext/standard/tests/filters/gh22360.phpt
+++ b/ext/standard/tests/filters/gh22360.phpt
@@ -1,0 +1,24 @@
+--TEST--
+GH-22360 (convert.base64-encode emits padding on incremental flush)
+--FILE--
+<?php
+$file = __DIR__ . '/gh22360.tmp';
+$fp = fopen($file, 'w');
+stream_filter_append($fp, 'convert.base64-encode', STREAM_FILTER_WRITE);
+
+fwrite($fp, "ab");
+fflush($fp);
+fwrite($fp, "c");
+fflush($fp);
+fclose($fp);
+
+var_dump(file_get_contents($file));
+echo base64_encode("abc"), PHP_EOL;
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/gh22360.tmp');
+?>
+--EXPECT--
+string(4) "YWJj"
+YWJj


### PR DESCRIPTION
Fix #22360