### PR TITLE
Zend: Make `instanceof object` equivalent to `is_object()`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,8 @@ PHP                                                                        NEWS
 ?? ??? ????, PHP 8.6.0alpha1
 
 - Core:
+  . `$x instanceof object` now evaluates like `is_object($x)`, correctly
+    returning true for any object. (Damien Seguy)
   . Added first-class callable cache to share instances for the duration of the
     request. (ilutov)
   . It is now possible to use reference assign on WeakMap without the key

--- a/UPGRADING
+++ b/UPGRADING
@@ -19,6 +19,10 @@ PHP 8.6 UPGRADE NOTES
 1. Backward Incompatible Changes
 ========================================
 
+- Core:
+  . `$x instanceof object` previously always evaluated to false. It now
+    evaluates identically to `is_object($x)`, returning true for any object.
+
 - DOM:
   . Properties previously documented as @readonly (e.g. DOMNode::$nodeType,
     DOMDocument::$xmlEncoding, DOMEntity::$actualEncoding, ::$encoding,
@@ -181,6 +185,8 @@ PHP 8.6 UPGRADE NOTES
 ========================================
 
 - Core:
+  . `$x instanceof object` now evaluates like `is_object($x)`, correctly
+    returning true for any object.
   . It is now possible to use reference assign on WeakMap without the key
     needing to be present beforehand.
   . It is now possible to define the `__debugInfo()` magic method on enums.

--- a/Zend/tests/instanceof_object_fq_error.phpt
+++ b/Zend/tests/instanceof_object_fq_error.phpt
@@ -1,0 +1,9 @@
+--TEST--
+instanceof '\object' must produce a compile error (object must be unqualified)
+--FILE--
+<?php
+$x = new stdClass;
+var_dump($x instanceof \object);
+?>
+--EXPECTF--
+Fatal error: Type declaration 'object' must be unqualified in %s on line %d

--- a/Zend/tests/instanceof_object_pseudo_type.phpt
+++ b/Zend/tests/instanceof_object_pseudo_type.phpt
@@ -1,0 +1,58 @@
+--TEST--
+instanceof with pseudo-type "object" is equivalent to is_object()
+--FILE--
+<?php
+
+// Objects
+$obj = new stdClass;
+var_dump($obj instanceof object);
+
+$anon = new class {};
+var_dump($anon instanceof object);
+
+// Case-insensitive
+var_dump($obj instanceof Object);
+var_dump($obj instanceof OBJECT);
+
+// Non-objects (variables, so they go through ZEND_TYPE_CHECK, not the const early-return)
+$null = null;
+var_dump($null instanceof object);
+
+$int = 42;
+var_dump($int instanceof object);
+
+$str = "string";
+var_dump($str instanceof object);
+
+$arr = [];
+var_dump($arr instanceof object);
+
+// Must be identical to is_object() for any value
+$values = [new stdClass, new class {}, null, 42, "str", [], true, 1.5];
+foreach ($values as $v) {
+    if (($v instanceof object) !== is_object($v)) {
+        echo "MISMATCH for: ";
+        var_dump($v);
+    }
+}
+echo "All match is_object()\n";
+
+// Inside a class scope — class context must not affect the result
+class Foo {}
+$foo = new Foo;
+var_dump($foo instanceof object);
+var_dump($foo instanceof Foo);  // still works normally
+
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+All match is_object()
+bool(true)
+bool(true)

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -11077,6 +11077,15 @@ static void zend_compile_instanceof(znode *result, zend_ast *ast) /* {{{ */
 		return;
 	}
 
+	/* "instanceof object" is equivalent to is_object(): emit a type-check instead of a class lookup */
+	if (class_ast->kind == ZEND_AST_ZVAL
+			&& Z_TYPE_P(zend_ast_get_zval(class_ast)) == IS_STRING
+			&& zend_string_equals_ci(zend_ast_get_str(class_ast), ZSTR_KNOWN(ZEND_STR_OBJECT))) {
+		opline = zend_emit_op_tmp(result, ZEND_TYPE_CHECK, &obj_node, NULL);
+		opline->extended_value = (1 << IS_OBJECT);
+		return;
+	}
+
 	zend_compile_class_ref(&class_node, class_ast,
 		ZEND_FETCH_CLASS_NO_AUTOLOAD | ZEND_FETCH_CLASS_EXCEPTION | ZEND_FETCH_CLASS_SILENT);
 

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -11081,6 +11081,10 @@ static void zend_compile_instanceof(znode *result, zend_ast *ast) /* {{{ */
 	if (class_ast->kind == ZEND_AST_ZVAL
 			&& Z_TYPE_P(zend_ast_get_zval(class_ast)) == IS_STRING
 			&& zend_string_equals_ci(zend_ast_get_str(class_ast), ZSTR_KNOWN(ZEND_STR_OBJECT))) {
+		if ((class_ast->attr & ZEND_NAME_NOT_FQ) != ZEND_NAME_NOT_FQ) {
+			zend_error_noreturn(E_COMPILE_ERROR,
+				"Type declaration 'object' must be unqualified");
+		}
 		opline = zend_emit_op_tmp(result, ZEND_TYPE_CHECK, &obj_node, NULL);
 		opline->extended_value = (1 << IS_OBJECT);
 		return;


### PR DESCRIPTION
`$x instanceof object` was syntactically valid but always returned false because `object` is a pseudo-type with no corresponding class entry in the class table. This made the construct silently unusable.

At compile time, when the right-hand side of `instanceof` is the literal `object` pseudo-type, emit `ZEND_TYPE_CHECK` with `MAY_BE_OBJECT` instead of `ZEND_INSTANCEOF`. This is the same opcode used by `is_object()`, so `$x instanceof object` now behaves identically to `is_object($x)`.

The fix is entirely at compile time; no VM handler changes are required.