### PR TITLE
zend_ast: Surround function by parens when exporting calls to function stored in property

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -28,6 +28,8 @@ PHP                                                                        NEWS
     invalid variable names). (timwolla)
   . Fixed bug GH-22291 (AST pretty printing does not correctly handle braces
     in string interpolation). (timwolla)
+  . Fixed bug GH-22373 (AST pretty-printing drops meaningful parentheses
+    surrounding property access). (timwolla)
 
 - BCMath:
   . Added NUL-byte validation to BCMath functions. (jorgsowa)

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -2544,7 +2544,7 @@ simple_list:
 					break;
 				default:
 					smart_str_appendc(str, '(');
-					zend_ast_export_ns_name(str, left, 0, indent);
+					zend_ast_export_ex(str, left, 0, indent);
 					smart_str_appendc(str, ')');
 					break;
 			}

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -2535,12 +2535,18 @@ simple_list:
 			break;
 		case ZEND_AST_CALL: {
 			zend_ast *left = ast->child[0];
-			if (left->kind == ZEND_AST_ARROW_FUNC || left->kind == ZEND_AST_CLOSURE) {
-				smart_str_appendc(str, '(');
-				zend_ast_export_ns_name(str, left, 0, indent);
-				smart_str_appendc(str, ')');
-			} else {
-				zend_ast_export_ns_name(str, left, 0, indent);
+			switch (left->kind) {
+				/* ZEND_AST_ZVAL is a regular function call. */
+				case ZEND_AST_ZVAL:
+				/* ZEND_AST_VAR ($foo()) is unambiguous without parens. */
+				case ZEND_AST_VAR:
+					zend_ast_export_ns_name(str, left, 0, indent);
+					break;
+				default:
+					smart_str_appendc(str, '(');
+					zend_ast_export_ns_name(str, left, 0, indent);
+					smart_str_appendc(str, ')');
+					break;
 			}
 			smart_str_appendc(str, '(');
 			zend_ast_export_ex(str, ast->child[1], 0, indent);

--- a/ext/standard/tests/assert/gh22373.phpt
+++ b/ext/standard/tests/assert/gh22373.phpt
@@ -1,0 +1,36 @@
+--TEST--
+GH-22373: AST pretty-printing drops meaningful parentheses surrounding property access
+--FILE--
+<?php
+
+class Foo {
+	public static Closure $sf = strrev(...);
+
+	public function __construct(
+		public Closure $f = strrev(...),
+	) {
+		try {
+			assert(($this->f)('abc') !== 'cba');
+		} catch (Error $e) {
+			echo $e->getMessage(), PHP_EOL;
+		}
+		try {
+			assert(($this?->f)('abc') !== 'cba');
+		} catch (Error $e) {
+			echo $e->getMessage(), PHP_EOL;
+		}
+		try {
+			assert((self::$sf)('abc') !== 'cba');
+		} catch (Error $e) {
+			echo $e->getMessage(), PHP_EOL;
+		}
+	}
+}
+
+new Foo();
+
+?>
+--EXPECT--
+assert(($this->f)('abc') !== 'cba')
+assert(($this?->f)('abc') !== 'cba')
+assert((self::$sf)('abc') !== 'cba')


### PR DESCRIPTION
The extra parentheses are needed to disambiguate method calls from calls to a function stored in a property.

Fixes php/php-src#22373.