### PR TITLE
ext/com_dotnet: release the held IUnknown in com_get_active_object()

### DIFF
--- a/ext/com_dotnet/com_com.c
+++ b/ext/com_dotnet/com_com.c
@@ -321,7 +321,7 @@ PHP_FUNCTION(com_get_active_object)
 		IDispatch_Release(obj);
 	}
 	if (unk) {
-		IUnknown_Release(obj);
+		IUnknown_Release(unk);
 	}
 	efree(module);
 }


### PR DESCRIPTION
The cleanup block guards on `unk` but releases `obj`, so a successful GetActiveObject() releases the IDispatch proxy twice and never releases the IUnknown it returned, leaking it. Release `unk` so each interface pointer is released exactly once. Windows-only; no test, since it needs a live Running Object Table entry.