### PR TITLE
ext/sockets: bound interface name copy in from_zval_write_ifindex()

### DIFF
--- a/ext/sockets/conversions.c
+++ b/ext/sockets/conversions.c
@@ -1270,11 +1270,10 @@ static void from_zval_write_ifindex(const zval *zv, char *uinteger, ser_context 
 #elif defined(SIOCGIFINDEX)
 		{
 			struct ifreq ifr;
-			if (ZSTR_LEN(str) >= sizeof(ifr.ifr_name)) {
+			if (strlcpy(ifr.ifr_name, ZSTR_VAL(str), sizeof(ifr.ifr_name))
+					>= sizeof(ifr.ifr_name)) {
 				do_from_zval_err(ctx, "the interface name \"%s\" is too large ", ZSTR_VAL(str));
-			}
-			memcpy(ifr.ifr_name, ZSTR_VAL(str), ZSTR_LEN(str) + 1);
-			if (ioctl(ctx->sock->bsd_socket, SIOCGIFINDEX, &ifr) < 0) {
+			} else if (ioctl(ctx->sock->bsd_socket, SIOCGIFINDEX, &ifr) < 0) {
 				if (errno == ENODEV) {
 					do_from_zval_err(ctx, "no interface with name \"%s\" could be "
 							"found", ZSTR_VAL(str));


### PR DESCRIPTION
3e9b530 replaced the bounded strlcpy in from_zval_write_ifindex() with a memcpy of ZSTR_LEN+1 bytes that runs even when the name overflows ifr_name: the length check sets an error but falls through instead of returning, overrunning the stack. PHP-8.5 and master both carry the regression; 8.4 still has the strlcpy and is unaffected. Restore the strlcpy plus else-if guard.