### PR TITLE
ext/zlib: honor preset dictionary for raw inflate with non-default window

### DIFF
--- a/ext/zlib/tests/inflate_raw_dictionary_window.phpt
+++ b/ext/zlib/tests/inflate_raw_dictionary_window.phpt
@@ -1,0 +1,20 @@
+--TEST--
+inflate_init(): preset dictionary is honored for raw encoding with a non-default window
+--EXTENSIONS--
+zlib
+--FILE--
+<?php
+$dict = "the quick brown fox jumps over the lazy dog";
+$data = str_repeat($dict . " ", 8);
+$opts = ['window' => 10, 'dictionary' => $dict];
+
+$def = deflate_init(ZLIB_ENCODING_RAW, $opts);
+$comp = deflate_add($def, $data, ZLIB_FINISH);
+
+$inf = inflate_init(ZLIB_ENCODING_RAW, $opts);
+$out = inflate_add($inf, $comp, ZLIB_FINISH);
+
+var_dump($out === $data);
+?>
+--EXPECT--
+bool(true)

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -901,6 +901,7 @@ PHP_FUNCTION(inflate_init)
 	ctx->inflateDictlen = dictlen;
 	ctx->status = Z_OK;
 
+	zend_long orig_encoding = encoding;
 	if (encoding < 0) {
 		encoding += 15 - window;
 	} else {
@@ -914,7 +915,7 @@ PHP_FUNCTION(inflate_init)
 		RETURN_FALSE;
 	}
 
-	if (encoding == PHP_ZLIB_ENCODING_RAW && dictlen > 0) {
+	if (orig_encoding == PHP_ZLIB_ENCODING_RAW && dictlen > 0) {
 		switch (inflateSetDictionary(&ctx->Z, (Bytef *) ctx->inflateDict, ctx->inflateDictlen)) {
 			case Z_OK:
 				efree(ctx->inflateDict);


### PR DESCRIPTION
inflate_init() applies a preset dictionary eagerly for raw streams, gated on encoding == PHP_ZLIB_ENCODING_RAW, but encoding is first adjusted by the window size (encoding += 15 - window), so a raw stream with a non-default window no longer matches and the dictionary is silently dropped. Raw streams carry no header and never emit Z_NEED_DICT, so the deferred application in inflate_add() never runs either. Gate on the pre-adjustment encoding; the deflate side already applies the dictionary unconditionally, so the roundtrip was broken for this case.