### PR TITLE
Fix session save-handler argv leak on recursive rejection

### DIFF
--- a/ext/session/mod_user.c
+++ b/ext/session/mod_user.c
@@ -30,16 +30,16 @@ static void ps_call_handler(zval *func, int argc, zval *argv, zval *retval)
 		PS(in_save_handler) = 0;
 		ZVAL_UNDEF(retval);
 		php_error_docref(NULL, E_WARNING, "Cannot call session save handler in a recursive manner");
-		return;
+	} else {
+		PS(in_save_handler) = 1;
+		if (call_user_function(NULL, NULL, func, retval, argc, argv) == FAILURE) {
+			zval_ptr_dtor(retval);
+			ZVAL_UNDEF(retval);
+		} else if (Z_ISUNDEF_P(retval)) {
+			ZVAL_NULL(retval);
+		}
+		PS(in_save_handler) = 0;
 	}
-	PS(in_save_handler) = 1;
-	if (call_user_function(NULL, NULL, func, retval, argc, argv) == FAILURE) {
-		zval_ptr_dtor(retval);
-		ZVAL_UNDEF(retval);
-	} else if (Z_ISUNDEF_P(retval)) {
-		ZVAL_NULL(retval);
-	}
-	PS(in_save_handler) = 0;
 	for (i = 0; i < argc; i++) {
 		zval_ptr_dtor(&argv[i]);
 	}

--- a/ext/session/tests/user_session_module/recursive_handler_argv_leak.phpt
+++ b/ext/session/tests/user_session_module/recursive_handler_argv_leak.phpt
@@ -1,0 +1,31 @@
+--TEST--
+ps_call_handler() releases argv when a recursive save-handler call is rejected
+--INI--
+session.save_path=
+session.name=PHPSESSID
+--EXTENSIONS--
+session
+--FILE--
+<?php
+class H extends SessionHandler {
+    public bool $tripped = false;
+    public function write($id, $data): bool {
+        if (!$this->tripped) {
+            $this->tripped = true;
+            session_destroy();
+        }
+        return true;
+    }
+}
+
+session_set_save_handler(new H, true);
+session_start();
+$_SESSION['x'] = 1;
+session_write_close();
+echo "done\n";
+?>
+--EXPECTF--
+Warning: session_destroy(): Cannot call session save handler in a recursive manner in %s on line %d
+
+Warning: session_destroy(): Session object destruction failed in %s on line %d
+done


### PR DESCRIPTION
ps_call_handler() returned on the recursive-call rejection branch before the argv cleanup loop, leaking one ref per owned argument. The read/write/destroy callers copy the session id and data into argv and rely on the function to release them, so a handler that re-enters session machinery (for example calling session_destroy() from within a write handler) leaks those strings. Folding the call into an else branch runs the cleanup unconditionally. Confirmed under USE_ZEND_ALLOC=0 valgrind: 64 bytes definitely lost, gone after the fix.