### PR TITLE
ext/Intl: Fix memory leaks when calling `Collator::__construct()` or `Spoofchecker::__construct()` twice.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -50,6 +50,8 @@ PHP                                                                        NEWS
     and later. (Graham Campbell)
   . Fixed Locale::lookup() and locale_lookup() to return NULL instead of the
     fallback locale when a language tag cannot be canonicalized. (Weilin Du)
+  . Fixed memory leaks when calling Collator::__construct() or
+    Spoofchecker::__construct() twice. (Weilin Du)
 
 - mysqli:
   . Fix stmt->query leak in mysqli_execute_query() validation errors.

--- a/ext/intl/collator/collator_create.c
+++ b/ext/intl/collator/collator_create.c
@@ -42,6 +42,10 @@ static int collator_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling *erro
 
 	INTL_CHECK_LOCALE_LEN_OR_FAILURE(locale_len);
 	COLLATOR_METHOD_FETCH_OBJECT;
+	if (co->ucoll) {
+		zend_throw_error(NULL, "Collator object is already constructed");
+		return FAILURE;
+	}
 
 	if(locale_len == 0) {
 		locale = (char *)intl_locale_get_default();

--- a/ext/intl/spoofchecker/spoofchecker_create.c
+++ b/ext/intl/spoofchecker/spoofchecker_create.c
@@ -31,9 +31,13 @@ PHP_METHOD(Spoofchecker, __construct)
 
 	ZEND_PARSE_PARAMETERS_NONE();
 
-	zend_replace_error_handling(EH_THROW, IntlException_ce_ptr, &error_handling);
-
 	SPOOFCHECKER_METHOD_FETCH_OBJECT_NO_CHECK;
+	if (co->uspoof) {
+		zend_throw_error(NULL, "Spoofchecker object is already constructed");
+		RETURN_THROWS();
+	}
+
+	zend_replace_error_handling(EH_THROW, IntlException_ce_ptr, &error_handling);
 
 	co->uspoof = uspoof_open(SPOOFCHECKER_ERROR_CODE_P(co));
 	INTL_METHOD_CHECK_STATUS(co, "spoofchecker: unable to open ICU Spoof Checker");

--- a/ext/intl/tests/collator_double_ctor.phpt
+++ b/ext/intl/tests/collator_double_ctor.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Collator double construction should not be allowed
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+$collator = new Collator('en_US');
+
+try {
+    $collator->__construct('en_US');
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Collator object is already constructed

--- a/ext/intl/tests/spoofchecker_double_ctor.phpt
+++ b/ext/intl/tests/spoofchecker_double_ctor.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Spoofchecker double construction should not be allowed
+--EXTENSIONS--
+intl
+--SKIPIF--
+<?php if (!class_exists("Spoofchecker")) print "skip"; ?>
+--FILE--
+<?php
+$checker = new Spoofchecker();
+
+try {
+    $checker->__construct();
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Spoofchecker object is already constructed


### PR DESCRIPTION
Both constructors could be called again on an already initialized object and would overwrite the existing ICU handles:

  - `Collator` overwrote the `UCollator *`
  - `Spoofchecker` overwrote the `USpoofChecker *` / `USpoofCheckResult *`
 
The previous handles were not released before being overwritten, so only the newly stored handles could be cleaned up during object destruction.

This aligns these classes with other ext/intl classes by rejecting double construction with an `Error`. The similar bug happens on listformatter but I want to fix it in a separate PR because it need to target a different branch. (i.e. 8.5)