### PR TITLE
ext/Intl: Fix memory leaks when calling IntlListFormatter::__construct() twice

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,8 @@ PHP                                                                        NEWS
     fallback locale when a language tag cannot be canonicalized. (Weilin Du)
   . Fixed memory leaks when calling Collator::__construct() or
     Spoofchecker::__construct() twice. (Weilin Du)
+  . Fixed memory leak when calling IntlListFormatter::__construct() twice.
+    (Weilin Du)
 
 - Reflection:
   . Fixed bug GH-22324 (Ignore leading namespace separator in

--- a/ext/intl/listformatter/listformatter_class.c
+++ b/ext/intl/listformatter/listformatter_class.c
@@ -67,6 +67,11 @@ PHP_METHOD(IntlListFormatter, __construct)
         Z_PARAM_LONG(width)
     ZEND_PARSE_PARAMETERS_END();
 
+    if (LISTFORMATTER_OBJECT(obj)) {
+        zend_throw_error(NULL, "IntlListFormatter object is already constructed");
+        RETURN_THROWS();
+    }
+
     if(locale_len == 0) {
         locale = (char *)intl_locale_get_default();
     }

--- a/ext/intl/tests/listformatter/listformatter_double_ctor.phpt
+++ b/ext/intl/tests/listformatter/listformatter_double_ctor.phpt
@@ -1,0 +1,16 @@
+--TEST--
+IntlListFormatter double construction should not be allowed
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+$formatter = new IntlListFormatter('en_US');
+
+try {
+    $formatter->__construct('en_US');
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+IntlListFormatter object is already constructed


### PR DESCRIPTION
Follow up of #22386. 

`IntlListFormatter` stores a `UListFormatter*`. Calling the constructor again on an already initialized object overwrote the existing pointer.