### PR TITLE
Possible way to deprecate dechunk filter

### DIFF
--- a/ext/standard/filters.c
+++ b/ext/standard/filters.c
@@ -1983,7 +1983,7 @@ static const php_stream_filter_ops chunked_filter_ops = {
 	"dechunk"
 };
 
-static php_stream_filter *chunked_filter_create(const char *filtername, zval *filterparams, bool persistent)
+PHPAPI php_stream_filter *chunked_filter_create(const char *filtername, zval *filterparams, bool persistent)
 {
 	const php_stream_filter_ops *fops = NULL;
 	php_chunked_filter_data *data;
@@ -2002,8 +2002,18 @@ static php_stream_filter *chunked_filter_create(const char *filtername, zval *fi
 	return php_stream_filter_alloc(fops, data, persistent, PSFS_SEEKABLE_START, PSFS_SEEKABLE_ALWAYS);
 }
 
+static php_stream_filter *chunked_filter_create_deprecated(const char *filtername, zval *filterparams, bool persistent)
+{
+	if (strcasecmp(filtername, "dechunk")) {
+		return NULL;
+	}
+
+	php_error_docref(NULL, E_DEPRECATED, "The \"dechunk\" stream filter is deprecated");
+	return chunked_filter_create(filtername, filterparams, persistent);
+}
+
 static const php_stream_filter_factory chunked_filter_factory = {
-	chunked_filter_create
+	chunked_filter_create_deprecated
 };
 /* }}} */
 

--- a/ext/standard/http_fopen_wrapper.c
+++ b/ext/standard/http_fopen_wrapper.c
@@ -330,7 +330,7 @@ static zend_string *php_stream_http_response_headers_parse(php_stream_wrapper *w
 					/* Prevent a memory leak in case there are more transfer-encoding headers. */
 					php_stream_filter_free(header_info->transfer_encoding);
 				}
-				header_info->transfer_encoding = php_stream_filter_create(
+				header_info->transfer_encoding = chunked_filter_create(
 						"dechunk", NULL, php_stream_is_persistent(stream));
 				if (header_info->transfer_encoding != NULL) {
 					/* Do not store transfer-encoding header. */

--- a/ext/standard/php_standard.h
+++ b/ext/standard/php_standard.h
@@ -47,3 +47,5 @@
 #define phpext_standard_ptr basic_functions_module_ptr
 PHP_MINIT_FUNCTION(standard_filters);
 PHP_MSHUTDOWN_FUNCTION(standard_filters);
+
+PHPAPI php_stream_filter *chunked_filter_create(const char *filtername, zval *filterparams, bool persistent);


### PR DESCRIPTION
Calls through the dechunk factory show the deprecation warning, but we expose chunked_filter_create and that is called directly in http_fopen_wrapper.c, so that it doesn't show the deprecation warning.

Related to #21983.