### PR TITLE
Fix use-after-free during lazy object initialization

### DIFF
--- a/Zend/tests/lazy_objects/gh22399.phpt
+++ b/Zend/tests/lazy_objects/gh22399.phpt
@@ -1,0 +1,39 @@
+--TEST--
+GH-22399 (Lazy object revert init with object destructor can lead to double free)
+--FILE--
+<?php
+
+class A {
+    public $b;
+}
+
+class B {
+    public function __construct(public $a) {}
+    public function __destruct() {
+        unset($this->a->b);
+    }
+}
+
+$reflector = new ReflectionClass(A::class);
+
+$a = $reflector->newLazyGhost(function (A $a) {
+    $a->b = new B($a);
+    throw new Exception('initializer exception');
+});
+
+try {
+    $a->any;
+} catch (Exception $e) {
+    printf("%s\n", $e->getMessage());
+}
+
+var_dump($a);
+printf("Is lazy: %d\n", $reflector->isUninitializedLazyObject($a));
+echo "done\n";
+?>
+--EXPECTF--
+initializer exception
+lazy ghost object(A)#%d (0) {
+}
+Is lazy: 1
+done

--- a/Zend/tests/lazy_objects/gh22399_dynamic_props.phpt
+++ b/Zend/tests/lazy_objects/gh22399_dynamic_props.phpt
@@ -1,0 +1,40 @@
+--TEST--
+GH-22399 (Lazy object revert init double free, dynamic property variant)
+--FILE--
+<?php
+
+#[AllowDynamicProperties]
+class A {
+    public $trigger;
+}
+
+class B {
+    public function __construct(public $a) {}
+    public function __destruct() {
+        unset($this->a->dyn);
+    }
+}
+
+$reflector = new ReflectionClass(A::class);
+
+$a = $reflector->newLazyGhost(function (A $a) {
+    $a->dyn = new B($a);
+    throw new Exception('initializer exception');
+});
+
+try {
+    $a->trigger;
+} catch (Exception $e) {
+    printf("%s\n", $e->getMessage());
+}
+
+var_dump($a);
+printf("Is lazy: %d\n", $reflector->isUninitializedLazyObject($a));
+echo "done\n";
+?>
+--EXPECTF--
+initializer exception
+lazy ghost object(A)#%d (0) {
+}
+Is lazy: 1
+done

--- a/Zend/tests/lazy_objects/gh22399_proxy.phpt
+++ b/Zend/tests/lazy_objects/gh22399_proxy.phpt
@@ -1,0 +1,40 @@
+--TEST--
+GH-22399 (Lazy object double free, proxy cleanup variant)
+--FILE--
+<?php
+
+#[AllowDynamicProperties]
+class A {
+    public $trigger;
+    public $b;
+}
+
+class B {
+    public function __construct(public $proxy) {}
+    public function __destruct() {
+        unset($this->proxy->b);
+    }
+}
+
+class C {
+    public function __construct(public $proxy) {}
+    public function __destruct() {
+        unset($this->proxy->dyn);
+    }
+}
+
+$reflector = new ReflectionClass(A::class);
+
+$a = $reflector->newLazyProxy(function (A $a) {
+    $a->b = new B($a);
+    $a->dyn = new C($a);
+    return new A();
+});
+
+$a->trigger;
+var_dump($reflector->isUninitializedLazyObject($a));
+echo "done\n";
+?>
+--EXPECT--
+bool(false)
+done

--- a/Zend/tests/lazy_objects/gh22399_reset_as_lazy_ghost.phpt
+++ b/Zend/tests/lazy_objects/gh22399_reset_as_lazy_ghost.phpt
@@ -1,0 +1,72 @@
+--TEST--
+GH-22399 (Lazy object double free): zend_object_make_lazy() unset-declared-properties loop (ghost variant)
+--DESCRIPTION--
+zend_object_make_lazy()'s unset-declared-properties loop had the same
+dtor-before-clear bug GH-22401 fixed in zend_lazy_object_revert_init() and
+zend_lazy_object_init_proxy(), but was never patched there. A destructor
+reentering through the property slot being cleared could free the object
+twice. Reproduced under ASAN with USE_ZEND_ALLOC=0.
+--FILE--
+<?php
+
+class A {
+    public $b;
+}
+
+class B {
+    public function __construct(public $a) {}
+    public function __destruct() {
+        // Reentrant: fires while zend_object_make_lazy() is still in the
+        // middle of tearing down $a's "b" slot below. $this->a is that same
+        // $a, and "b" is the very property make_lazy is clearing.
+        unset($this->a->b);
+    }
+}
+
+// $a: object refcount 1 (held by the local variable only).
+$a = new A();
+
+// B::__construct() promotes its $a parameter into $this->a, which bumps A's
+// refcount to 2 (local variable "$a" + B's "a" property). The resulting B
+// instance is then stored into A's "b" property and settles at refcount 1
+// (reachable only via $a->b). A and B now form a reference cycle
+// ($a->b->a === $a); B has no root reference outside that cycle, so it can
+// only go away by dropping A's "b" slot (or via the cycle collector).
+$a->b = new B($a);
+
+$reflector = new ReflectionClass(A::class);
+
+// A has no __destruct of its own, so zend_object_make_lazy() skips the
+// "call the object's own destructor" step entirely and goes straight to the
+// "unset() declared properties" loop (Zend/zend_lazy_objects.c, ~line 328).
+// That loop reaches the slot for "b" and does, in order:
+//
+//   zval garbage;
+//   ZVAL_COPY_VALUE(&garbage, p);   // (1) copy B's zval out to a local
+//   ZVAL_UNDEF(p);                  // (2) clear A's "b" slot FIRST
+//   zval_ptr_dtor(&garbage);        // (3) drop B's refcount 1 -> 0, freeing it
+//
+// Step (3) is what synchronously invokes B::__destruct(). By that point
+// A's "b" slot was already cleared in step (2), so the reentrant
+// unset($this->a->b) below sees an UNDEF slot and is a no-op, instead of
+// freeing B a second time through a stale reference. Before this fix, the
+// dtor ran *before* the slot was cleared, so the reentrant unset() would
+// free B while the outer loop was still using it -- a heap-use-after-free.
+// This is the same bug class GH-22401 fixed in
+// zend_lazy_object_revert_init() and zend_lazy_object_init_proxy(), now
+// also applied here.
+$reflector->resetAsLazyGhost($a, function ($obj) {
+    // Never reached: nothing below triggers initialization of the ghost.
+    echo "initializer called\n";
+});
+
+var_dump($a);
+printf("Is lazy: %d\n", $reflector->isUninitializedLazyObject($a));
+echo "done\n";
+
+?>
+--EXPECTF--
+lazy ghost object(A)#%d (0) {
+}
+Is lazy: 1
+done

--- a/Zend/tests/lazy_objects/gh22399_reset_as_lazy_proxy.phpt
+++ b/Zend/tests/lazy_objects/gh22399_reset_as_lazy_proxy.phpt
@@ -1,0 +1,68 @@
+--TEST--
+GH-22399 (Lazy object double free): zend_object_make_lazy() unset-declared-properties loop (proxy variant)
+--DESCRIPTION--
+Same root cause as gh22399_reset_as_lazy_ghost.phpt, exercised through
+ReflectionClass::resetAsLazyProxy() instead of resetAsLazyGhost().
+--FILE--
+<?php
+
+class A {
+    public $b;
+}
+
+class B {
+    public function __construct(public $a) {}
+    public function __destruct() {
+        // Reentrant: fires while zend_object_make_lazy() is still in the
+        // middle of tearing down $a's "b" slot below.
+        unset($this->a->b);
+    }
+}
+
+// $a: refcount 1 (local variable only).
+$a = new A();
+
+// Same cycle as the ghost variant: B::__construct() promotes $a into
+// $this->a (A's refcount -> 2: local variable + B's "a" property), then the
+// new B settles into $a->b at refcount 1 (reachable only via $a->b). B is
+// kept alive purely by this A<->B cycle.
+$a->b = new B($a);
+
+$reflector = new ReflectionClass(A::class);
+
+// resetAsLazyProxy() also funnels into zend_object_make_lazy() (same
+// function as resetAsLazyGhost(), just with the PROXY strategy flag set).
+// Before that flag matters at all, the function runs the shared "unset()
+// declared properties" loop against $a's existing state:
+//
+//   zval garbage;
+//   ZVAL_COPY_VALUE(&garbage, p);   // (1) copy B's zval out to a local
+//   ZVAL_UNDEF(p);                  // (2) clear A's "b" slot FIRST
+//   zval_ptr_dtor(&garbage);        // (3) drop B's refcount 1 -> 0, freeing it
+//
+// Step (3) synchronously invokes B::__destruct(), but A's "b" slot is
+// already UNDEF (step 2) by then, so the reentrant unset($this->a->b)
+// below is a no-op instead of a second, invalid free of B. See
+// gh22399_reset_as_lazy_ghost.phpt for the full step-by-step of why the
+// ordering matters.
+//
+// Only once this loop finishes does make_lazy get to the proxy-specific
+// setup (OBJ_EXTRA_FLAGS(obj) |= IS_OBJ_LAZY_PROXY, storing the factory
+// closure for later) -- the loop's safety does not depend on which
+// strategy triggered it.
+$reflector->resetAsLazyProxy($a, function ($obj) {
+    // Never reached: nothing below triggers initialization of the proxy.
+    echo "factory called\n";
+    return new A();
+});
+
+var_dump($a);
+printf("Is lazy: %d\n", $reflector->isUninitializedLazyObject($a));
+echo "done\n";
+
+?>
+--EXPECTF--
+lazy proxy object(A)#%d (0) {
+}
+Is lazy: 1
+done

--- a/Zend/zend_lazy_objects.c
+++ b/Zend/zend_lazy_objects.c
@@ -417,7 +417,18 @@ static void zend_lazy_object_revert_init(zend_object *obj, zval *properties_tabl
 			}
 
 			zval *p = &properties_table[OBJ_PROP_TO_NUM(prop_info->offset)];
-			zend_object_dtor_property(obj, p);
+			if (Z_REFCOUNTED_P(p)) {
+				if (UNEXPECTED(Z_ISREF_P(p)) &&
+						(ZEND_DEBUG || ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(p)))) {
+					if (ZEND_TYPE_IS_SET(prop_info->type)) {
+						ZEND_REF_DEL_TYPE_SOURCE(Z_REF_P(p), prop_info);
+					}
+				}
+				zval garbage;
+				ZVAL_COPY_VALUE(&garbage, p);
+				ZVAL_UNDEF(p);
+				zval_ptr_dtor(&garbage);
+			}
 			ZVAL_COPY_VALUE_PROP(p, &properties_table_snapshot[OBJ_PROP_TO_NUM(prop_info->offset)]);
 
 			if (Z_ISREF_P(p) && ZEND_TYPE_IS_SET(prop_info->type)) {
@@ -430,15 +441,17 @@ static void zend_lazy_object_revert_init(zend_object *obj, zval *properties_tabl
 	if (properties_snapshot) {
 		if (obj->properties != properties_snapshot) {
 			ZEND_ASSERT((GC_FLAGS(properties_snapshot) & IS_ARRAY_IMMUTABLE) || GC_REFCOUNT(properties_snapshot) >= 1);
-			zend_release_properties(obj->properties);
+			HashTable *garbage = obj->properties;
 			obj->properties = properties_snapshot;
+			zend_release_properties(garbage);
 		} else {
 			ZEND_ASSERT((GC_FLAGS(properties_snapshot) & IS_ARRAY_IMMUTABLE) || GC_REFCOUNT(properties_snapshot) > 1);
 			zend_release_properties(properties_snapshot);
 		}
 	} else if (obj->properties) {
-		zend_release_properties(obj->properties);
+		HashTable *garbage = obj->properties;
 		obj->properties = NULL;
+		zend_release_properties(garbage);
 	}
 
 	OBJ_EXTRA_FLAGS(obj) |= IS_OBJ_LAZY_UNINITIALIZED;
@@ -529,16 +542,27 @@ static zend_object *zend_lazy_object_init_proxy(zend_object *obj)
 
 	/* unset() properties of the proxy. This ensures that all accesses are be
 	 * delegated to the backing instance from now on. */
-	zend_object_dtor_dynamic_properties(obj);
+	HashTable *garbage_ht = obj->properties;
 	obj->properties = NULL;
+	zend_release_properties(garbage_ht);
 
 	for (int i = 0; i < Z_OBJ(retval)->ce->default_properties_count; i++) {
 		zend_property_info *prop_info = Z_OBJ(retval)->ce->properties_info_table[i];
 		if (EXPECTED(prop_info)) {
 			zval *prop = &obj->properties_table[OBJ_PROP_TO_NUM(prop_info->offset)];
-			zend_object_dtor_property(obj, prop);
+			zval garbage;
+			ZVAL_COPY_VALUE(&garbage, prop);
 			ZVAL_UNDEF(prop);
 			Z_PROP_FLAG_P(prop) = IS_PROP_UNINIT | IS_PROP_LAZY;
+			if (Z_REFCOUNTED(garbage)) {
+				if (UNEXPECTED(Z_ISREF(garbage)) &&
+						(ZEND_DEBUG || ZEND_REF_HAS_TYPE_SOURCES(Z_REF(garbage)))) {
+					if (ZEND_TYPE_IS_SET(prop_info->type)) {
+						ZEND_REF_DEL_TYPE_SOURCE(Z_REF(garbage), prop_info);
+					}
+				}
+				zval_ptr_dtor(&garbage);
+			}
 		}
 	}
 

--- a/Zend/zend_lazy_objects.c
+++ b/Zend/zend_lazy_objects.c
@@ -336,8 +336,18 @@ ZEND_API zend_object *zend_object_make_lazy(zend_object *obj,
 							&& ((obj->ce->ce_flags & ZEND_ACC_FINAL) || (prop_info->flags & ZEND_ACC_FINAL))) {
 						continue;
 					}
-					zend_object_dtor_property(obj, p);
+					zval garbage;
+					ZVAL_COPY_VALUE(&garbage, p);
 					ZVAL_UNDEF(p);
+					if (Z_REFCOUNTED(garbage)) {
+						if (UNEXPECTED(Z_ISREF(garbage)) &&
+								(ZEND_DEBUG || ZEND_REF_HAS_TYPE_SOURCES(Z_REF(garbage)))) {
+							if (ZEND_TYPE_IS_SET(prop_info->type)) {
+								ZEND_REF_DEL_TYPE_SOURCE(Z_REF(garbage), prop_info);
+							}
+						}
+						zval_ptr_dtor(&garbage);
+					}
 				}
 				Z_PROP_FLAG_P(p) = IS_PROP_UNINIT | IS_PROP_LAZY;
 				lazy_properties_count++;


### PR DESCRIPTION
Lazy object initialization destroyed property values while the slot or the dynamic-properties `HashTable` still aliased them, so a value whose `__destruct` reaches back through a reference cycle (`unset($this->obj->prop)`) double-freed it, a UAF in `zend_objects_store_del`. The fix clears the slot and detaches the properties table before dropping the refcount, across all four destruction sites in `zend_lazy_object_revert_init` and `zend_lazy_object_init_proxy` (declared and dynamic properties, ghost revert and proxy cleanup); verified under ASAN.

Fixes GH-22399
