### PR TITLE
ext/sockets/tests/gh21161.phpt: skip if no ipv6

### DIFF
--- a/ext/sockets/tests/gh21161.phpt
+++ b/ext/sockets/tests/gh21161.phpt
@@ -7,6 +7,7 @@ sockets
 if (substr(PHP_OS, 0, 3) == 'WIN') {
     die('skip.. Not valid for Windows');
 }
+require 'ipv6_skipif.inc';
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
If `AF_INET6` is not defined, we get

> Fatal error: Uncaught Error: Undefined constant "AF_INET6" ...

before the _expected_ error.