### PR TITLE
ext/soap/tests/bugs/bug62900.phpt: make use of TEST_PHP_ vars

### DIFF
--- a/ext/soap/tests/bugs/bug62900.phpt
+++ b/ext/soap/tests/bugs/bug62900.phpt
@@ -46,18 +46,15 @@ $combinations = [
 
 chdir(__DIR__);
 
-$args = ["-d", "display_startup_errors=0", "-d", "extension_dir=" . ini_get("extension_dir"), "-d", "extension=" . (substr(PHP_OS, 0, 3) == "WIN" ? "php_" : "") . "soap." . PHP_SHLIB_SUFFIX];
-if (php_ini_loaded_file()) {
-    // Necessary such that it works from a development directory in which case extension_dir might not be the real extension dir
-    $args[] = "-c";
-    $args[] = php_ini_loaded_file();
-}
+$php = getenv('TEST_PHP_EXECUTABLE');
+$args = getenv('TEST_PHP_EXTRA_ARGS');
+$cmd = "$php $args " . __DIR__ . '/bug62900_run';
 
 foreach ($combinations as list($wsdl, $xsd)) {
     file_put_contents(__DIR__."/bug62900.wsdl", $wsdl);
     file_put_contents(__DIR__."/bug62900.xsd", $xsd);
 
-    $proc = proc_open([PHP_BINARY, ...$args, __DIR__.'/bug62900_run'], [1 => ["pipe", "w"], 2 => ["pipe", "w"]], $pipes);
+    $proc = proc_open($cmd, [1 => ["pipe", "w"], 2 => ["pipe", "w"]], $pipes);
     echo stream_get_contents($pipes[1]);
     fclose($pipes[1]);
     proc_close($proc);


### PR DESCRIPTION
I just opened https://github.com/php/php-src/issues/22404 thinking that it was unrelated to my test failure, but after making those changes, the test failure has disappeared. So let's fix it I guess!