### PR TITLE
Fix GH-22395: Avoid truncating base_convert() output at 64 characters

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,8 @@ PHP                                                                        NEWS
 - Standard:
   . Fixed bug GH-22360 (convert.base64-encode corruption on
     incremental flush). (David Carlier)
+  . Fixed bug GH-22395 (base_convert() outputs at most 64 characters).
+    (Weilin Du)
 
 02 Jul 2026, PHP 8.4.23
 

--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -24,6 +24,7 @@
 #include "zend_exceptions.h"
 #include "zend_multiply.h"
 #include "zend_portability.h"
+#include "zend_strtod.h"
 
 #include <float.h>
 #include <math.h>
@@ -949,7 +950,7 @@ PHPAPI zend_string * _php_math_zvaltobase(zval *arg, int base)
 	if (Z_TYPE_P(arg) == IS_DOUBLE) {
 		double fvalue = floor(Z_DVAL_P(arg)); /* floor it just in case */
 		char *ptr, *end;
-		char buf[(sizeof(double) << 3) + 1];
+		char buf[ZEND_DOUBLE_MAX_LENGTH];
 
 		/* Don't try to convert +/- infinity */
 		if (fvalue == ZEND_INFINITY || fvalue == -ZEND_INFINITY) {

--- a/ext/standard/tests/math/gh22395.phpt
+++ b/ext/standard/tests/math/gh22395.phpt
@@ -1,0 +1,11 @@
+--TEST--
+GH-22395 (base_convert outputs at most 64 characters)
+--FILE--
+<?php
+$result = base_convert(str_repeat("1", 61), 36, 16);
+var_dump(strlen($result));
+var_dump(substr($result, 0, 13));
+?>
+--EXPECT--
+int(78)
+string(13) "4b61b5e0639ff"


### PR DESCRIPTION
By using `ZEND_DOUBLE_MAX_LENGTH` instead of `(sizeof(double) << 3) + 1` should painfully solve the bug. Sigh, I don't find any better solutions.

Fixes #22395.