### PR TITLE
sapi/cli/tests/php_cli_server_ipv6_error_message.phpt: use TEST_PHP vars

### DIFF
--- a/sapi/cli/tests/php_cli_server_ipv6_error_message.phpt
+++ b/sapi/cli/tests/php_cli_server_ipv6_error_message.phpt
@@ -14,8 +14,12 @@ $descriptorspec = array(
     2 => array("pipe", "w")
 );
 
+$php = getenv('TEST_PHP_EXECUTABLE');
+$args = getenv('TEST_PHP_EXTRA_ARGS');
+$cmd = "$php $args" . ' -S "[2001:db8::]:8080"';
+
 $process = proc_open(
-    PHP_BINARY . ' -S "[2001:db8::]:8080"',
+    $cmd,
     $descriptorspec,
     $pipes
 );

--- a/sapi/cli/tests/php_cli_server_ipv6_error_message.phpt
+++ b/sapi/cli/tests/php_cli_server_ipv6_error_message.phpt
@@ -14,8 +14,12 @@ $descriptorspec = array(
     2 => array("pipe", "w")
 );
 
+$php = getenv('TEST_PHP_EXECUTABLE_ESCAPED');
+$args = getenv('TEST_PHP_EXTRA_ARGS');
+$cmd = "$php $args" . ' -S "[2001:db8::]:8080"';
+
 $process = proc_open(
-    PHP_BINARY . ' -S "[2001:db8::]:8080"',
+    $cmd,
     $descriptorspec,
     $pipes
 );


### PR DESCRIPTION
When invoking the PHP in a subprocess, `TEST_PHP_EXECUTABLE` is preferable to `PHP_BINARY`, because the former can be set to ensure that the just-built (often development) php gets used rather than a system install. In addition, `TEST_PHP_EXTRA_ARGS` should be passed to this interpreter.