### PR TITLE
Skip ISO-2022-JP tests on unknown libc

### DIFF
--- a/ext/iconv/tests/eucjp2iso2022jp.phpt
+++ b/ext/iconv/tests/eucjp2iso2022jp.phpt
@@ -2,6 +2,16 @@
 EUC-JP to ISO-2022-JP
 --EXTENSIONS--
 iconv
+--SKIPIF--
+<?php
+// ISO-2022-JP is a stateful encoding, so the right answer is not
+// unique. In particular, musl (type "unknown") is known to have an
+// inefficient encoding for it that does not agree with the expected
+// output below.
+if (ICONV_IMPL == "unknown") {
+    die("skip byte-comparison of stateful encoding with unknown iconv");
+}
+?>
 --INI--
 error_reporting=2039
 --FILE--

--- a/ext/iconv/tests/iconv_mime_encode.phpt
+++ b/ext/iconv/tests/iconv_mime_encode.phpt
@@ -2,6 +2,16 @@
 iconv_mime_encode()
 --EXTENSIONS--
 iconv
+--SKIPIF--
+<?php
+// ISO-2022-JP is a stateful encoding, so the right answer is not
+// unique. In particular, musl (type "unknown") is known to have an
+// inefficient encoding for it that does not agree with the expected
+// output below.
+if (ICONV_IMPL == "unknown") {
+    die("skip byte-comparison of stateful encoding with unknown iconv");
+}
+?>
 --INI--
 iconv.internal_charset=iso-8859-1
 --FILE--


### PR DESCRIPTION
Fixes two failures in https://github.com/php/php-src/issues/22413.

The ISO-2022-JP encoding is stateful, so there is no single "right answer" in these tests. Musl ("unknown") uses a less-efficient encoding that makes the tests fail. To fix it, we can just skip these tests on unknown libc, since in that case we can't expect the expected output.

Cherry-picked from https://github.com/php/php-src/pull/16840