### PR TITLE
ext/gd: pack imageloadfont short-read test in native byte order

### DIFF
--- a/ext/gd/tests/imageloadfont_short_read.phpt
+++ b/ext/gd/tests/imageloadfont_short_read.phpt
@@ -7,7 +7,9 @@ gd
 /* A user-space wrapper returns one byte per read, so php_stream_read() hands
  * imageloadfont()'s header loop a short read on every iteration. The header
  * (4 ints) plus a single 1x1 glyph byte form a valid font, which only loads
- * when each short read lands at the correct byte offset. */
+ * when each short read lands at the correct byte offset. imageloadfont() reads
+ * the header as native-endian ints, so pack the fields with 'i' (not 'V') to
+ * keep the font valid on big-endian hosts too. */
 class drip
 {
     public $context;
@@ -16,7 +18,7 @@ class drip
 
     public function stream_open($path, $mode, $options, &$opened): bool
     {
-        $this->data = pack('V4', 1, 32, 1, 1) . "\x00";
+        $this->data = pack('i4', 1, 32, 1, 1) . "\x00";
         return true;
     }
 


### PR DESCRIPTION
The imageloadfont_short_read test packed the font header with `pack('V4', ...)` (little-endian), but `imageloadfont()` reads it as native-endian ints, so on big-endian hosts the byte-swapped values trip the INT_MAX overflow guard before the FLIPWORD fallback and the font is rejected. Packing with `pack('i4', ...)` keeps the header valid on both, fixing the PPC64 nightly failure.