### PR TITLE
Fix stream filter flush corrupting a partially-read buffer

### DIFF
--- a/ext/standard/tests/streams/stream_filter_flush_partial_read.phpt
+++ b/ext/standard/tests/streams/stream_filter_flush_partial_read.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Flushing a read filter on a partially-read stream must not duplicate buffered bytes
+--FILE--
+<?php
+class FlushEmitFilter extends php_user_filter
+{
+    public function filter($in, $out, &$consumed, $closing): int
+    {
+        while ($bucket = stream_bucket_make_writeable($in)) {
+            $consumed += $bucket->datalen;
+            stream_bucket_append($out, $bucket);
+        }
+        if ($closing) {
+            stream_bucket_append($out, stream_bucket_new($this->stream, "<FLUSH>"));
+        }
+        return PSFS_PASS_ON;
+    }
+}
+
+stream_filter_register("flushemit", "FlushEmitFilter");
+
+$fp = fopen("php://memory", "r+");
+fwrite($fp, "ABCDEFGHIJKLMNOP");
+rewind($fp);
+
+$filter = stream_filter_append($fp, "flushemit", STREAM_FILTER_READ);
+var_dump(fread($fp, 5));
+stream_filter_remove($filter);
+var_dump(fread($fp, 100));
+?>
+--EXPECT--
+string(5) "ABCDE"
+string(18) "FGHIJKLMNOP<FLUSH>"

--- a/main/streams/filter.c
+++ b/main/streams/filter.c
@@ -459,9 +459,9 @@ PHPAPI int _php_stream_filter_flush(php_stream_filter *filter, int finish)
 		/* Dump any newly flushed data to the read buffer */
 		if (stream->readpos > 0) {
 			/* Back the buffer up */
-			memcpy(stream->readbuf, stream->readbuf + stream->readpos, stream->writepos - stream->readpos);
-			stream->readpos = 0;
+			memmove(stream->readbuf, stream->readbuf + stream->readpos, stream->writepos - stream->readpos);
 			stream->writepos -= stream->readpos;
+			stream->readpos = 0;
 		}
 		if (flushed_size > (stream->readbuflen - stream->writepos)) {
 			/* Grow the buffer */


### PR DESCRIPTION
When a read filter is flushed (for example via stream_filter_remove()) while the stream has already been partially read, _php_stream_filter_flush() backs the unconsumed tail of the read buffer up to offset 0. Two defects in that block diverged from the equivalent code in streams.c. The copy used memcpy() on source/destination ranges that overlap whenever writepos - readpos exceeds readpos, which is undefined behavior (ASAN reports memcpy-param-overlap). And writepos was shrunk with writepos -= readpos after readpos had already been zeroed, making the subtraction a no-op, so writepos stayed inflated by readpos bytes: the stale tail was kept live and later flushed buckets were appended past the real end, duplicating bytes and risking an out-of-bounds write. Use memmove() and subtract before zeroing, matching streams.c. The block dates to the original stream_filter_remove() commit (34550382d8) in 2004.
