### PR TITLE
Fix int truncation of read length in shmop_read()

### DIFF
--- a/ext/shmop/shmop.c
+++ b/ext/shmop/shmop.c
@@ -224,7 +224,6 @@ PHP_FUNCTION(shmop_read)
 	zend_long start, count;
 	php_shmop *shmop;
 	char *startaddr;
-	int bytes;
 	zend_string *return_string;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Oll", &shmid, shmop_ce, &start, &count) == FAILURE) {
@@ -244,7 +243,7 @@ PHP_FUNCTION(shmop_read)
 	}
 
 	startaddr = shmop->addr + start;
-	bytes = count ? count : shmop->size - start;
+	zend_long bytes = count ? count : shmop->size - start;
 
 	return_string = zend_string_init(startaddr, bytes, 0);
 


### PR DESCRIPTION
shmop_read() held the read length in an int while count and shmop->size are zend_long and the bounds checks validate against the full 64-bit size. On a shared-memory segment larger than INT_MAX, a length that sets the int sign bit was sign-extended into the size_t argument of zend_string_init(), requesting a near-SIZE_MAX allocation; other truncated lengths returned a wrong-sized string. Hold the length in a zend_long, matching the zend_long writesize already used in shmop_write(). Triggering needs a >2GB segment, so there is no portable red/green test; the fix is a type correction with no behavioral change below INT_MAX.
