### PR TITLE
Fix int32_t overflow in intl_charFromString() capacity calculation

### DIFF
--- a/ext/intl/intl_convertcpp.cpp
+++ b/ext/intl/intl_convertcpp.cpp
@@ -62,6 +62,10 @@ zend_string* intl_charFromString(const UnicodeString &from, UErrorCode *status)
 
 	//the number of UTF-8 code units is not larger than that of UTF-16 code
 	//units * 3
+	if (UNEXPECTED(from.length() > INT32_MAX / 3)) {
+		*status = U_BUFFER_OVERFLOW_ERROR;
+		return NULL;
+	}
 	int32_t capacity = from.length() * 3;
 
 	if (from.isEmpty()) {


### PR DESCRIPTION
intl_charFromString() computed the UTF-8 output capacity as from.length() * 3 in int32_t arithmetic. For a UnicodeString longer than INT32_MAX/3 UTF-16 code units the multiply overflows: capacity can go negative (zend_string_alloc() then requests a near-SIZE_MAX block) or wrap small, undersizing the buffer that u_strToUTF8WithSub() writes into. Reject the over-long input with U_BUFFER_OVERFLOW_ERROR up front, mirroring the INT32_MAX guard already present in the sibling intl_stringFromChar(). The input is always ICU-produced output, so triggering needs a multi-GB UnicodeString; there is no portable red/green test, and the fix matches the project's symmetric-path convention.
