### PR TITLE
Fix signed dbconvert() return stored into size_t in dblib lastInsertId

### DIFF
--- a/ext/pdo_dblib/dblib_driver.c
+++ b/ext/pdo_dblib/dblib_driver.c
@@ -234,7 +234,7 @@ zend_string *dblib_handle_last_id(pdo_dbh_t *dbh, const zend_string *name)
 
 	RETCODE ret;
 	char *id = NULL;
-	size_t len;
+	DBINT len;
 	zend_string *ret_id;
 
 	/*
@@ -270,6 +270,11 @@ zend_string *dblib_handle_last_id(pdo_dbh_t *dbh, const zend_string *name)
 	id = emalloc(40);
 	len = dbconvert(NULL, (dbcoltype(H->link, 1)) , (dbdata(H->link, 1)) , (dbdatlen(H->link, 1)), SQLCHAR, (BYTE *)id, (DBINT)40);
 	dbcancel(H->link);
+
+	if (len < 0) {
+		efree(id);
+		return NULL;
+	}
 
 	ret_id = zend_string_init(id, len, 0);
 	efree(id);


### PR DESCRIPTION
dblib_handle_last_id() stored the DBINT return of dbconvert() into a size_t len. dbconvert() returns -1 on conversion failure, which sign-extends to SIZE_MAX and is passed as the length to zend_string_init(), reading far past the 40-byte buffer and requesting a SIZE_MAX allocation. Hold the result in a DBINT and bail on a negative return, matching the failure-returns-NULL handling already used for dbresults()/dbnextrow()/dbdatlen() earlier in the function. Triggering needs a live SQL Server returning an unconvertible @@IDENTITY, so there is no portable red/green test; follow-up to the buffer-overflow fix in #22348.
