### PR TITLE
Fix invalid Firebird isolation level proceeding with the connection

### DIFF
--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -1410,6 +1410,10 @@ static int pdo_firebird_handle_factory(pdo_dbh_t *dbh, zval *driver_options) /* 
 		char const *dpb_values[] = { dbh->username, dbh->password, vars[1].optval, vars[2].optval };
 		char dpb_buffer[256] = { isc_dpb_version1 }, *dpb;
 
+		if (EG(exception)) {
+			break;
+		}
+
 		dpb = dpb_buffer + 1;
 
 		/* loop through all the provided arguments and set dpb fields accordingly */
@@ -1446,7 +1450,7 @@ static int pdo_firebird_handle_factory(pdo_dbh_t *dbh, zval *driver_options) /* 
 		}
 	}
 
-	if (!dbh->methods) {
+	if (!dbh->methods && !EG(exception)) {
 		char errmsg[512];
 		const ISC_STATUS *s = H->isc_status;
 		fb_interpret(errmsg, sizeof(errmsg),&s);


### PR DESCRIPTION
pdo_firebird_handle_factory() raised a ValueError for an out-of-range TRANSACTION_ISOLATION_LEVEL but only set ret = 0; zend_value_error() queues the exception without aborting, so control fell through into the isc_attach_database() block, opened the connection and overwrote ret with 1. The constructor then returned success with a pending ValueError and a live handle whose isolation level was never selected. Break out of the attach block when an exception is pending and skip the trailing fb_interpret() throw so the ValueError is the sole result; the existing !ret path runs firebird_handle_closer(), which is NULL-guarded on every field and safely frees the unused handle. Note: built against FreeBSD/Firebird is unavailable locally, so this was not compiled here; the change is two EG(exception) guards.
