### PR TITLE
Fix unsigned wrap in bzdecompress() output realloc at source_len UINT_MAX

### DIFF
--- a/ext/bz2/bz2.c
+++ b/ext/bz2/bz2.c
@@ -544,7 +544,7 @@ PHP_FUNCTION(bzdecompress)
 			/* no reason to continue if we're going to drop it anyway */
 			break;
 		}
-		dest = zend_string_safe_realloc(dest, 1, bzs.avail_out+1, (size_t) size, 0);
+		dest = zend_string_safe_realloc(dest, 1, (size_t) bzs.avail_out + 1, (size_t) size, 0);
 		bzs.next_out = ZSTR_VAL(dest) + size;
 	}
 


### PR DESCRIPTION
The input guard rejects only source_len > UINT_MAX, so source_len == UINT_MAX is permitted and assigned to bzs.avail_out (unsigned int). The per-iteration realloc then computed bzs.avail_out+1 in unsigned int arithmetic, which wraps to 0 at UINT_MAX, allocating no headroom while bz2 still believes avail_out bytes are available at next_out, so the next decompress round writes past the buffer. Compute the term as (size_t)bzs.avail_out + 1 so the increment is done in size_t and cannot wrap, matching the (size_t) casts already on the same call. Triggering needs a ~4GB crafted input, so there is no portable red/green test. Follow-up to the input guard added in #22242.
