### PR TITLE
Fix posix_getgrnam()/posix_getgrgid() crash on NULL group name

### DIFF
--- a/ext/posix/posix.c
+++ b/ext/posix/posix.c
@@ -669,7 +669,11 @@ int php_posix_group_to_array(struct group *g, zval *array_group) /* {{{ */
 
 	array_init(&array_members);
 
-	add_assoc_string(array_group, "name", g->gr_name);
+	if (g->gr_name) {
+		add_assoc_string(array_group, "name", g->gr_name);
+	} else {
+		add_assoc_null(array_group, "name");
+	}
 	if (g->gr_passwd) {
 		add_assoc_string(array_group, "passwd", g->gr_passwd);
 	} else {


### PR DESCRIPTION
php_posix_group_to_array() passes gr_name straight to add_assoc_string() with no NULL guard, so a NULL group name segfaults via zend_string_init(). The sibling gr_passwd field right below is already guarded.

glibc's files NSS backend normalizes empty fields to the empty string, but third-party NSS modules (nss-systemd, nss-ldap, sssd and other directory backends) populate struct group directly and may leave gr_name NULL.

The field is now guarded and emits null instead, matching the existing gr_passwd handling. Companion to #22426, which guarded the equivalent fields in the passwd array.