### PR TITLE
Fix GH-22422: define ZEND_TRACK_ARENA_ALLOC in php_config.h

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -30,6 +30,8 @@ PHP                                                                        NEWS
     string interpolation). (timwolla)
   . Fixed bug GH-22373 (AST pretty-printing drops meaningful parentheses
     surrounding property access). (timwolla)
+  . Fixed GH-22422 (zend_arena layout mismatch leaked memory in separately
+    built extensions under AddressSanitizer). (iliaal)
 
 - BCMath:
   . Added NUL-byte validation to BCMath functions. (jorgsowa)

--- a/configure.ac
+++ b/configure.ac
@@ -1539,8 +1539,10 @@ AS_VAR_IF([PHP_ADDRESS_SANITIZER], [yes],
   ]))])
 
   AX_CHECK_COMPILE_FLAG([-fsanitize=address], [
-    CFLAGS="$CFLAGS -fsanitize=address -DZEND_TRACK_ARENA_ALLOC"
-    CXXFLAGS="$CXXFLAGS -fsanitize=address -DZEND_TRACK_ARENA_ALLOC"
+    CFLAGS="$CFLAGS -fsanitize=address"
+    CXXFLAGS="$CXXFLAGS -fsanitize=address"
+    AC_DEFINE([ZEND_TRACK_ARENA_ALLOC], [1],
+      [Whether to track arena allocations individually for AddressSanitizer.])
   ], [AC_MSG_ERROR([AddressSanitizer is not available])])
 ])
 


### PR DESCRIPTION
ZEND_TRACK_ARENA_ALLOC switches the zend_arena struct layout under AddressSanitizer but was only added to the core CFLAGS, so it never reached php_config.h. A phpize-built extension inherits php_config.h, not the core CFLAGS, and therefore compiled the untracked layout while core used the tracked one; calling zend_arena_destroy on a core-created arena from such an extension leaked every tracked allocation (78 leaks reproduced via zend_test_compile_to_ast). AC_DEFINE it so the layout stays consistent across core and separately built extensions.

Fixes #22422
