### PR TITLE
Fix session memory leak on failed user save handler close

### DIFF
--- a/ext/session/mod_user.c
+++ b/ext/session/mod_user.c
@@ -124,15 +124,25 @@ PS_CLOSE_FUNC(user)
 
 	PS(mod_user_implemented) = false;
 
+	if (!bailout) {
+		ret = verify_bool_return_type_userland_calls(&retval);
+	}
+	if (!Z_ISUNDEF(retval)) {
+		zval_ptr_dtor(&retval);
+	}
+
+	/* User close() may return false without calling parent::close(). */
+	if (PS(default_mod) && PS(mod_data)) {
+		zend_try {
+			PS(default_mod)->s_close(&PS(mod_data));
+		} zend_end_try();
+	}
+	PS(mod_user_is_open) = false;
+
 	if (bailout) {
-		if (!Z_ISUNDEF(retval)) {
-			zval_ptr_dtor(&retval);
-		}
 		zend_bailout();
 	}
 
-	ret = verify_bool_return_type_userland_calls(&retval);
-	zval_ptr_dtor(&retval);
 	return ret;
 }
 

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -1767,8 +1767,19 @@ static bool php_session_abort(void)
 {
 	if (PS(session_status) == php_session_active) {
 		if (PS(mod_data) || PS(mod_user_implemented)) {
-			PS(mod)->s_close(&PS(mod_data));
+			zend_try {
+				PS(mod)->s_close(&PS(mod_data));
+			} zend_end_try();
 		}
+		if (PS(id)) {
+			zend_string_release_ex(PS(id), false);
+			PS(id) = NULL;
+		}
+		if (PS(session_vars)) {
+			zend_string_release_ex(PS(session_vars), false);
+			PS(session_vars) = NULL;
+		}
+		php_session_cleanup_filename();
 		PS(session_status) = php_session_none;
 		return true;
 	}

--- a/ext/session/tests/session_abort_validateid_leak.phpt
+++ b/ext/session/tests/session_abort_validateid_leak.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Session abort does not leak when validateId() returns wrong type
+--INI--
+session.use_strict_mode=1
+session.gc_probability=0
+--EXTENSIONS--
+session
+--FILE--
+<?php
+class MySession extends SessionHandler {
+    public function validateId($key): bool {
+        return null;
+    }
+}
+
+$handler = new MySession();
+
+try {
+    session_set_save_handler($handler);
+    session_start();
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+session_write_close();
+
+try {
+    session_start();
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECTF--
+Session id must be a string

--- a/ext/session/tests/session_close_false_leak.phpt
+++ b/ext/session/tests/session_close_false_leak.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Session close handler returning false does not leak memory
+--INI--
+session.gc_probability=0
+--EXTENSIONS--
+session
+--FILE--
+<?php
+class MySession extends SessionHandler {
+    public function close(): bool {
+        return false;
+    }
+}
+
+$handler = new MySession();
+session_set_save_handler($handler);
+session_start();
+session_write_close();
+?>
+--EXPECT--


### PR DESCRIPTION
Fixes the memory leak reported in #21200 after #21200 was reverted in 3073948885.

The reverted patch saved/restored `EG(exception)` around `s_close()` in
`php_session_abort()`. That changed exception behaviour and did not fix
leaks when a `SessionHandler` subclass `close()` returned false without
calling `parent::close()`.

Changes:
- `php_session_abort()` tears down session state like `php_rshutdown_session_globals()`
- `ps_close_user()` closes the default save handler when `mod_data` is still set

Tests (debug build leak detection):
- `ext/session/tests/session_abort_validateid_leak.phpt`
- `ext/session/tests/session_close_false_leak.phpt`