### PR TITLE
ext/dom: fix UAF when setting an attribute colliding by local name.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -50,6 +50,9 @@ PHP                                                                        NEWS
 - DOM:
   . Fix GH-22219 (Dom\XMLDocument::schemaValidate fails to resolve
     xs:QName with prefix from imported schema). (David Carlier)
+  . Fixed bug GH-22447 (UAF at dom_objects_free_storage when setting an
+    attribute node that collides by local name with a namespaced
+    attribute). (David Carlier)
 
 - Exif:
   . Read correct value for single and double tags. (ndossche)

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -722,6 +722,8 @@ static void dom_element_set_attribute_node_common(INTERNAL_FUNCTION_PARAMETERS, 
 	nsp = attrp->ns;
 	if (use_ns && nsp != NULL) {
 		existattrp = xmlHasNsProp(nodep, attrp->name, nsp->href);
+	} else if (nsp == NULL) {
+		existattrp = xmlHasNsProp(nodep, attrp->name, NULL);
 	} else {
 		existattrp = xmlHasProp(nodep, attrp->name);
 	}

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -965,7 +965,7 @@ static void dom_node_insert_before_legacy(zval *return_value, zval *ref, dom_obj
 			xmlAttrPtr lastattr;
 
 			if (child->ns == NULL)
-				lastattr = xmlHasProp(refp->parent, child->name);
+				lastattr = xmlHasNsProp(refp->parent, child->name, NULL);
 			else
 				lastattr = xmlHasNsProp(refp->parent, child->name, child->ns->href);
 			if (lastattr != NULL && lastattr->type != XML_ATTRIBUTE_DECL) {
@@ -1012,7 +1012,7 @@ static void dom_node_insert_before_legacy(zval *return_value, zval *ref, dom_obj
 			xmlAttrPtr lastattr;
 
 			if (child->ns == NULL)
-				lastattr = xmlHasProp(parentp, child->name);
+				lastattr = xmlHasNsProp(parentp, child->name, NULL);
 			else
 				lastattr = xmlHasNsProp(parentp, child->name, child->ns->href);
 			if (lastattr != NULL && lastattr->type != XML_ATTRIBUTE_DECL) {
@@ -1374,7 +1374,7 @@ static void dom_node_append_child_legacy(zval *return_value, dom_object *intern,
 		xmlAttrPtr lastattr;
 
 		if (child->ns == NULL)
-			lastattr = xmlHasProp(nodep, child->name);
+			lastattr = xmlHasNsProp(nodep, child->name, NULL);
 		else
 			lastattr = xmlHasNsProp(nodep, child->name, child->ns->href);
 		if (lastattr != NULL && lastattr->type != XML_ATTRIBUTE_DECL) {

--- a/ext/dom/tests/gh22447.phpt
+++ b/ext/dom/tests/gh22447.phpt
@@ -1,0 +1,25 @@
+--TEST--
+GH-22447 (UAF at dom_objects_free_storage when setAttributeNode collides with a namespaced attribute of the same local name)
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$dom = Dom\HTMLDocument::createEmpty();
+
+$attribute1 = $dom->createAttribute("my-attribute");
+$container  = $dom->appendChild($dom->createElement("container"));
+$attribute2 = $dom->createAttribute("my-attribute");
+$attribute4 = $dom->createAttributeNS("urn:a", "my-attribute");
+
+$container->setAttributeNode($attribute1);
+$container->setAttributeNode($attribute4);
+
+var_dump($container->setAttributeNode($attribute2) === $attribute1);
+var_dump($container->setAttributeNode($attribute1) === $attribute2);
+
+echo $dom->saveXml($container), PHP_EOL;
+?>
+--EXPECT--
+bool(true)
+bool(true)
+<container xmlns="http://www.w3.org/1999/xhtml" xmlns:ns1="urn:a" ns1:my-attribute="" my-attribute=""></container>


### PR DESCRIPTION
Fix #22447

xmlHasProp() matches an attribute by local name only, ignoring its namespace, whereas xmlAddChild()/xmlAddPrevSibling() dedup an incoming no-namespace attribute via xmlHasNsProp(..., NULL), which matches only attributes with no namespace. When both a no-namespace and a namespaced attribute share a local name, the pre-insertion check unlinked the wrong (namespaced) attribute, leaving libxml to free the still-wrapped no-namespace duplicate and producing a use-after-free at request shutdown.

Use xmlHasNsProp(..., NULL) so the pre-insertion check matches libxml's internal duplicate detection, as advised by @nwellnhof.