### PR TITLE
Fix GH-16217: guard uninitialized SplFileObject in fputcsv() and next()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -24,6 +24,8 @@ PHP                                                                        NEWS
     (jorgsowa)
   . Ignore leading back-slash in class_parents(), class_implements(), and
     class_uses(). (jorgsowa)
+  . Fixed bug GH-16217 (SplFileObject::fputcsv() on an uninitialized object
+    segfaults). (iliaal)
 
 - Standard:
   . Fixed bug GH-22360 (convert.base64-encode corruption on

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -2224,6 +2224,8 @@ PHP_METHOD(SplFileObject, next)
 		RETURN_THROWS();
 	}
 
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED(intern);
+
 	spl_filesystem_file_free_line(intern);
 	if (SPL_HAS_FLAG(intern->flags, SPL_FILE_OBJECT_READ_AHEAD)) {
 		spl_filesystem_file_read_line(ZEND_THIS, intern, true);
@@ -2375,6 +2377,8 @@ PHP_METHOD(SplFileObject, fputcsv)
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "a|ssSS", &fields, &delim, &d_len, &enclo, &e_len, &escape_str, &eol) == FAILURE) {
 		RETURN_THROWS();
 	}
+
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED(intern);
 
 	if (delim) {
 		if (d_len != 1) {

--- a/ext/spl/tests/gh16217.phpt
+++ b/ext/spl/tests/gh16217.phpt
@@ -1,0 +1,35 @@
+--TEST--
+GH-16217 (SplFileObject methods on an uninitialized object segfault)
+--FILE--
+<?php
+function uninitialized(): SplFileObject {
+    return (new ReflectionClass(SplFileObject::class))->newInstanceWithoutConstructor();
+}
+
+try {
+    (new ReflectionMethod(SplFileObject::class, "fputcsv"))->invoke(uninitialized(), []);
+} catch (Error $e) {
+    echo "fputcsv: ", $e->getMessage(), "\n";
+}
+
+try {
+    (new ReflectionMethod(SplFileObject::class, "next"))->invoke(uninitialized());
+} catch (Error $e) {
+    echo "next: ", $e->getMessage(), "\n";
+}
+
+$obj = uninitialized();
+(new ReflectionMethod(SplFileObject::class, "setFlags"))->invoke($obj, SplFileObject::READ_AHEAD);
+try {
+    (new ReflectionMethod(SplFileObject::class, "next"))->invoke($obj);
+} catch (Error $e) {
+    echo "next (READ_AHEAD): ", $e->getMessage(), "\n";
+}
+
+echo "Done\n";
+?>
+--EXPECT--
+fputcsv: Object not initialized
+next: Object not initialized
+next (READ_AHEAD): Object not initialized
+Done


### PR DESCRIPTION
SplFileObject::fputcsv() and ::next() were the only two SplFileObject methods reaching the file stream without the CHECK_SPL_FILE_OBJECT_IS_INITIALIZED backstop the others carry. On an object built via newInstanceWithoutConstructor() the constructor never runs and the stream stays NULL; calling either through reflection (which bypasses the get_method init check) segfaults. next() only reaches the stream when READ_AHEAD is set, itself reachable via the unguarded setFlags(). Both now throw Error: "Object not initialized".

Fixes #16217