### PR TITLE
ext/ldap: Remove unused HAVE_LDAP_EXTENDED_OPERATION

### DIFF
--- a/ext/ldap/config.m4
+++ b/ext/ldap/config.m4
@@ -134,7 +134,6 @@ if test "$PHP_LDAP" != "no"; then
   dnl nor ldap_start_tls_s()
   AC_CHECK_FUNCS(m4_normalize([
     ldap_control_find
-    ldap_extended_operation
     ldap_extended_operation_s
     ldap_parse_extended_result
     ldap_parse_reference

--- a/ext/ldap/config.w32
+++ b/ext/ldap/config.w32
@@ -23,7 +23,6 @@ if (PHP_LDAP != "no") {
 		AC_DEFINE('HAVE_LDAP_PASSWD', 1);
 		AC_DEFINE('HAVE_LDAP_WHOAMI_S', 1);
 		AC_DEFINE('HAVE_LDAP_REFRESH_S', 1);
-		AC_DEFINE('HAVE_LDAP_EXTENDED_OPERATION', 1);
 		AC_DEFINE('HAVE_3ARG_SETREBINDPROC', 1);
 	} else {
 		WARNING("ldap not enabled; libraries and headers not found");


### PR DESCRIPTION
Current code assumes having ldap_extended_operation_s() also means having ldap_extended_operation().