### PR TITLE
ext/standard: Fix #undef directive after cache_request_parse_body_options

### DIFF
--- a/ext/standard/http.c
+++ b/ext/standard/http.c
@@ -317,7 +317,7 @@ static zend_result cache_request_parse_body_options(HashTable *options)
 		return FAILURE;
 	} ZEND_HASH_FOREACH_END();
 
-#undef CACHE_OPTION
+#undef CHECK_OPTION
 
 	return SUCCESS;
 }


### PR DESCRIPTION
`CACHE_OPTION` should be typo ( no idea what it is otherwise I can't find this macro anywhere ) and it should instead be `CHECK_OPTION`.