### PR TITLE
JIT: Fix run_time_cache offset stored without map_ptr dereference

### DIFF
--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -10221,10 +10221,7 @@ static int zend_jit_do_fcall(zend_jit_ctx *jit, const zend_op *opline, const zen
 			 && ZEND_MAP_PTR_IS_OFFSET(func->op_array.run_time_cache)) {
 				run_time_cache = ir_LOAD_A(ir_ADD_OFFSET(ir_LOAD_A(jit_CG(map_ptr_base)),
 					(uintptr_t)ZEND_MAP_PTR(func->op_array.run_time_cache)));
-			} else if ((func && (func->op_array.fn_flags & ZEND_ACC_CLOSURE)) ||
-					(JIT_G(current_frame) &&
-					 JIT_G(current_frame)->call &&
-					 TRACE_FRAME_IS_CLOSURE_CALL(JIT_G(current_frame)->call))) {
+			} else if (func && (func->op_array.fn_flags & ZEND_ACC_CLOSURE)) {
 				/* Closures always use direct pointers */
 				ir_ref local_func_ref = func_ref ? func_ref : ir_LOAD_A(jit_CALL(rx, func));
 

--- a/ext/opcache/tests/jit/gh22443.phpt
+++ b/ext/opcache/tests/jit/gh22443.phpt
@@ -1,0 +1,57 @@
+--TEST--
+GH-22443 (SIGSEGV in tracing JIT: run_time_cache offset stored without map_ptr dereference)
+--EXTENSIONS--
+opcache
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit=tracing
+opcache.jit_buffer_size=64M
+opcache.jit_max_polymorphic_calls=0
+--FILE--
+<?php
+final class Svc {
+    public function m0(...$a): int { return (int) array_sum($a) + 0; }
+    public function m1(...$a): int { return (int) array_sum($a) + 1; }
+    public function m2(...$a): int { return (int) array_sum($a) + 2; }
+    public function m3(...$a): int { return (int) array_sum($a) + 3; }
+    public function m4(...$a): int { return (int) array_sum($a) + 4; }
+    public function m5(...$a): int { return (int) array_sum($a) + 5; }
+    public function m6(...$a): int { return (int) array_sum($a) + 6; }
+    public function m7(...$a): int { return (int) array_sum($a) + 7; }
+    public function coldMethod(...$a): int { return $this->helper((int) array_sum($a)); }
+    private function helper(int $x): int { return $x + 1; }
+}
+
+function makeListener($listener): Closure {
+    return function ($event, $payload) use ($listener) {
+        return $listener(...array_values($payload));
+    };
+}
+
+function invokeListeners(array $listeners, string $event, array $payload): int {
+    $r = 0;
+    foreach ($listeners as $l) {
+        $r += $l($event, $payload);
+    }
+    return $r;
+}
+
+$svc = new Svc();
+$warm = [];
+for ($k = 0; $k < 8; $k++) {
+    $warm[] = makeListener([$svc, 'm' . $k]);
+}
+$cold = [makeListener([$svc, 'coldMethod'])];
+
+$s = 0;
+for ($i = 0; $i < 4000000; $i++) {
+    $s += invokeListeners($warm, 'e', [$i & 7, ($i >> 2) & 7]);
+}
+for ($j = 0; $j < 5; $j++) {
+    $s += invokeListeners($cold, 'e', [$j, $j + 1]);
+}
+echo "done\n";
+?>
+--EXPECT--
+done


### PR DESCRIPTION
The tracing JIT could store a raw zend_map_ptr offset into EX(run_time_cache) for a polymorphic dynamic call (`$callable(...)`) that resolves to a non-closure function or method, so the interpreter dereferenced a bogus address on the next cached lookup. The codegen took the closure direct-pointer shortcut based on TRACE_FRAME_IS_CLOSURE_CALL, but that flag is set for every ZEND_INIT_DYNAMIC_CALL regardless of the resolved callee.

Restricting the shortcut to statically-known closures is safe: an invoked closure object always carries a resolved direct run_time_cache pointer (zend_closures.c), even when its persistent template is offset-tagged under opcache SHM or file_cache. Regression from 6872432adf1; see GH-22443 for the report and the reproduction.
