### PR TITLE
ext/curl: remove XFAIL section for tests that are fixed

### DIFF
--- a/ext/curl/tests/bug77535.phpt
+++ b/ext/curl/tests/bug77535.phpt
@@ -2,7 +2,6 @@
 Bug #77535 (Invalid callback, h2 server push)
 --EXTENSIONS--
 curl
---XFAIL--
 --SKIPIF--
 <?php
 include 'skipif-nocaddy.inc';

--- a/ext/curl/tests/curl_pushfunction_trampoline.phpt
+++ b/ext/curl/tests/curl_pushfunction_trampoline.phpt
@@ -2,7 +2,6 @@
 Test trampoline for curl option CURLMOPT_PUSHFUNCTION
 --EXTENSIONS--
 curl
---XFAIL--
 --SKIPIF--
 <?php
 include 'skipif-nocaddy.inc';


### PR DESCRIPTION
Closes GH-16074