### PR TITLE
Fix use-after-free in json_encode() of a JsonSerializable object

### DIFF
--- a/ext/json/json_encoder.c
+++ b/ext/json/json_encoder.c
@@ -598,6 +598,8 @@ static zend_result php_json_encode_serializable_object(smart_str *buf, zval *val
 
 	ZEND_GUARD_PROTECT_RECURSION(guard, JSON);
 
+	GC_ADDREF(obj);
+
 	ZVAL_STRING(&fname, "jsonSerialize");
 
 	if (FAILURE == call_user_function(NULL, val, &fname, &retval, 0, NULL) || Z_TYPE(retval) == IS_UNDEF) {
@@ -610,6 +612,7 @@ static zend_result php_json_encode_serializable_object(smart_str *buf, zval *val
 			smart_str_appendl(buf, "null", 4);
 		}
 		ZEND_GUARD_UNPROTECT_RECURSION(guard, JSON);
+		OBJ_RELEASE(obj);
 		return FAILURE;
 	}
 
@@ -622,6 +625,7 @@ static zend_result php_json_encode_serializable_object(smart_str *buf, zval *val
 			smart_str_appendl(buf, "null", 4);
 		}
 		ZEND_GUARD_UNPROTECT_RECURSION(guard, JSON);
+		OBJ_RELEASE(obj);
 		return FAILURE;
 	}
 
@@ -638,6 +642,7 @@ static zend_result php_json_encode_serializable_object(smart_str *buf, zval *val
 
 	zval_ptr_dtor(&retval);
 	zval_ptr_dtor(&fname);
+	OBJ_RELEASE(obj);
 
 	return return_code;
 }

--- a/ext/json/tests/gh21024.phpt
+++ b/ext/json/tests/gh21024.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-21024 (UAF in json_encode() when jsonSerialize()'s error handler frees the object)
+--EXTENSIONS--
+json
+--FILE--
+<?php
+class Bar implements JsonSerializable {
+    public function jsonSerialize(): mixed {
+        trigger_error("free me");
+        return ['k' => 1];
+    }
+}
+$arr = [new Bar];
+$ref = &$arr[0];
+set_error_handler(function () use (&$ref) { $ref = null; });
+var_dump(json_encode($arr));
+echo "survived\n";
+?>
+--EXPECT--
+string(9) "[{"k":1}]"
+survived


### PR DESCRIPTION
php_json_encode_serializable_object() keeps the object pointer and its recursion guard live across the jsonSerialize() call. An error handler invoked during that call can drop the object's last reference through an aliased array element, leaving the post-call recursion-guard clear and the return-value identity check reading freed memory. Pin the object across the call. The 8.5 and master encoder dispatches through zend_call_known_function() and gets the same fix in php-src#22469.
