### PR TITLE
Opcache file permission setting

### DIFF
--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -176,6 +176,7 @@ typedef struct _zend_accel_directives {
 	char          *lockfile_path;
 #endif
 	char          *file_cache;
+	mode_t    file_cache_permissions;
 	bool      file_cache_read_only;
 	bool      file_cache_only;
 	bool      file_cache_consistency_checks;

--- a/ext/opcache/tests/file_cache_permissions.phpt
+++ b/ext/opcache/tests/file_cache_permissions.phpt
@@ -1,0 +1,32 @@
+--TEST--
+opcache.file_cache_permissions
+--EXTENSIONS--
+opcache
+--SKIPIF--
+<?php
+$fileCache = sys_get_temp_dir() . '/9664b02e-6f64-42dd-b088-99f3dccc3422';
+@mkdir($fileCache, 0777, true);
+?>
+--INI--
+opcache.enable="1"
+opcache.enable_cli="1"
+opcache.file_cache="{TMP}/9664b02e-6f64-42dd-b088-99f3dccc3422"
+opcache.file_cache_only="1"
+opcache.file_update_protection="0"
+opcache.file_cache_permissions="0660"
+--FILE--
+<?php
+$fileCache = sys_get_temp_dir() . '/9664b02e-6f64-42dd-b088-99f3dccc3422';
+$iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($fileCache, FilesystemIterator::SKIP_DOTS));
+foreach ($iterator as $splFileInfo) {
+    if (!$splFileInfo->isFile()) {
+        continue;
+    }
+    if (str_ends_with($splFileInfo->getPathname(), '.bin')) {
+        var_dump(sprintf('%o', fileperms($splFileInfo->getPathname()) & 0o777));
+        break;
+    }
+}
+?>
+--EXPECT--
+string(3) "660"

--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -320,6 +320,7 @@ ZEND_INI_BEGIN()
 #endif
 
 	STD_PHP_INI_ENTRY("opcache.file_cache"                    , NULL  , PHP_INI_SYSTEM, OnUpdateFileCache, accel_directives.file_cache,                    zend_accel_globals, accel_globals)
+	STD_PHP_INI_ENTRY("opcache.file_cache_permissions", "0600", PHP_INI_SYSTEM, OnUpdateLong, accel_directives.file_cache_permissions, zend_accel_globals, accel_globals)
 	STD_PHP_INI_BOOLEAN("opcache.file_cache_read_only"          , "0"   , PHP_INI_SYSTEM, OnUpdateBool,    accel_directives.file_cache_read_only,          zend_accel_globals, accel_globals)
 	STD_PHP_INI_BOOLEAN("opcache.file_cache_only"               , "0"   , PHP_INI_SYSTEM, OnUpdateBool,	   accel_directives.file_cache_only,               zend_accel_globals, accel_globals)
 	STD_PHP_INI_BOOLEAN("opcache.file_cache_consistency_checks" , "1"   , PHP_INI_SYSTEM, OnUpdateBool,	   accel_directives.file_cache_consistency_checks, zend_accel_globals, accel_globals)
@@ -845,6 +846,7 @@ ZEND_FUNCTION(opcache_get_configuration)
 #endif
 
 	add_assoc_string(&directives, "opcache.file_cache",                    ZCG(accel_directives).file_cache ? ZCG(accel_directives).file_cache : "");
+	add_assoc_long(&directives,   "opcache.file_cache_permissions",        ZCG(accel_directives).file_cache_permissions);
 	add_assoc_bool(&directives,   "opcache.file_cache_read_only",          ZCG(accel_directives).file_cache_read_only);
 	add_assoc_bool(&directives,   "opcache.file_cache_only",               ZCG(accel_directives).file_cache_only);
 	add_assoc_bool(&directives,   "opcache.file_cache_consistency_checks", ZCG(accel_directives).file_cache_consistency_checks);

--- a/ext/opcache/zend_file_cache.c
+++ b/ext/opcache/zend_file_cache.c
@@ -1171,7 +1171,7 @@ int zend_file_cache_script_store(zend_persistent_script *script, bool in_shm)
 		return FAILURE;
 	}
 
-	fd = zend_file_cache_open(filename, O_CREAT | O_EXCL | O_RDWR | O_BINARY, S_IRUSR | S_IWUSR);
+	fd = zend_file_cache_open(filename, O_CREAT | O_EXCL | O_RDWR | O_BINARY, ZCG(accel_directives).file_cache_permissions);
 	if (fd < 0) {
 		if (errno != EEXIST) {
 			zend_accel_error(ACCEL_LOG_WARNING, "opcache cannot create file '%s', %s\n", filename, strerror(errno));
@@ -1179,6 +1179,11 @@ int zend_file_cache_script_store(zend_persistent_script *script, bool in_shm)
 		efree(filename);
 		return FAILURE;
 	}
+#ifndef ZEND_WIN32
+	if (fchmod(fd, ZCG(accel_directives).file_cache_permissions) == -1) {
+		zend_accel_error(ACCEL_LOG_WARNING, "Unable to change opcache file permissions in %s: %s (%d)", filename, strerror(errno), errno);
+	}
+#endif
 
 	if (zend_file_cache_flock(fd, LOCK_EX) != 0) {
 		close(fd);

--- a/php.ini-development
+++ b/php.ini-development
@@ -1777,6 +1777,9 @@ ldap.max_links = -1
 ; SHM reset. The default "" disables file based caching.
 ;opcache.file_cache=
 
+; The permissions of the files cached.
+;opcache.file_cache_permissions=0600
+
 ; Enables or disables read-only mode for the second level cache directory.
 ; It should improve performance for read-only containers,
 ; when the cache is pre-warmed and packaged alongside the application.

--- a/php.ini-production
+++ b/php.ini-production
@@ -1779,6 +1779,9 @@ ldap.max_links = -1
 ; SHM reset. The default "" disables file based caching.
 ;opcache.file_cache=
 
+; The permissions of the files cached.
+;opcache.file_cache_permissions=0600
+
 ; Enables or disables read-only mode for the second level cache directory.
 ; It should improve performance for read-only containers,
 ; when the cache is pre-warmed and packaged alongside the application.


### PR DESCRIPTION
The PR adds a new ini setting to control the file permissions of cached opcache files.

Fixes: https://github.com/php/php-src/issues/22226
Could also fix: https://github.com/php/php-src/issues/22289

My personal use case of this would be:
- www-data will make cache files from the apache context
- cli-user will make cache files from the cli context
- both users can use each others cached files
- the cli-user can clean up old cache files from www-data/cli-user