### PR TITLE
Add json_encode/json_decode micro-benchmarks and optimize JSON key writing

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -499,6 +499,8 @@ PHP 8.6 UPGRADE NOTES
   . Improve performance of encoding arrays and objects.
   . Improved performance of indentation generation in json_encode()
     when using PHP_JSON_PRETTY_PRINT.
+  . Improved performance of json_encode() for strings without special
+    characters and for objects with declared properties.
 
 - Phar:
   . Reduced temporary allocations when iterating Phar directories.

--- a/Zend/micro_bench.php
+++ b/Zend/micro_bench.php
@@ -231,6 +231,30 @@ function ternary2($n) {
     }
 }
 
+class JsonObj {
+    public function __construct(
+        public int $id,
+        public string $name,
+        public bool $active,
+        public string $category,
+        public int $score
+    ) {}
+}
+
+function json_encode_obj($n) {
+    $obj = new JsonObj(1, 'test', true, 'category', 42);
+    for ($i = 0; $i < $n; $i++) {
+        json_encode($obj);
+    }
+}
+
+function json_encode_arr($n) {
+    $arr = ['id' => 1, 'name' => 'test', 'active' => true, 'category' => 'cat', 'score' => 42];
+    for ($i = 0; $i < $n; $i++) {
+        json_encode($arr);
+    }
+}
+
 /*****/
 
 function empty_loop($n) {
@@ -355,4 +379,8 @@ ternary(N);
 $t = end_test($t, '$x = $f ? $f : $a', $overhead);
 ternary2(N);
 $t = end_test($t, '$x = $f ? $f : tmp', $overhead);
+json_encode_obj(N/50);
+$t = end_test($t, 'json_encode(obj)', $overhead);
+json_encode_arr(N/50);
+$t = end_test($t, 'json_encode(arr)', $overhead);
 total($t0, "Total");

--- a/ext/json/json_encoder.c
+++ b/ext/json/json_encoder.c
@@ -30,16 +30,23 @@
 
 static const char digits[] = "0123456789abcdef";
 
-static const uint32_t charmap[8] = {
-	0xffffffff, 0x500080c4, 0x10000000, 0x00000000,
-	0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff};
-
 static zend_always_inline void php_json_append_quoted(smart_str *buf, const char *s, size_t len)
 {
 	char *dst = smart_str_extend(buf, len + 2);
 	dst[0] = '"';
 	memcpy(dst + 1, s, len);
 	dst[len + 1] = '"';
+}
+
+static zend_always_inline void php_json_append_unicode_escape(smart_str *buf, unsigned int us)
+{
+	char *dst = smart_str_extend(buf, 6);
+	dst[0] = '\\';
+	dst[1] = 'u';
+	dst[2] = digits[(us >> 12) & 0xf];
+	dst[3] = digits[(us >> 8) & 0xf];
+	dst[4] = digits[(us >> 4) & 0xf];
+	dst[5] = digits[us & 0xf];
 }
 
 static zend_always_inline bool php_json_check_stack_limit(void)
@@ -124,23 +131,23 @@ static zend_result php_json_encode_identifier(
 		smart_str *buf, const char *s, size_t len,
 		int options, php_json_encoder *encoder)
 {
+	size_t pos, checkpoint;
+
 	/* fast path: no characters require escaping (PHP identifiers contain no JSON-special ASCII bytes) */
-	{
-		size_t i = 0;
-		while (i < len && (unsigned char)s[i] < 0x80) {
-			i++;
-		}
-		if (EXPECTED(i == len)) {
-			php_json_append_quoted(buf, s, len);
-			return SUCCESS;
-		}
+	pos = 0;
+	while (pos < len && (unsigned char)s[pos] < 0x80) {
+		pos++;
+	}
+	if (EXPECTED(pos == len)) {
+		php_json_append_quoted(buf, s, len);
+		return SUCCESS;
 	}
 
-	size_t checkpoint = buf->s ? ZSTR_LEN(buf->s) : 0;
+	checkpoint = buf->s ? ZSTR_LEN(buf->s) : 0;
 	smart_str_alloc(buf, len + 2, 0);
 	smart_str_appendc(buf, '"');
 
-	size_t pos = 0;
+	pos = 0;
 	do {
 		unsigned int us = (unsigned char)s[pos];
 		if (EXPECTED(us < 0x80)) {
@@ -181,28 +188,15 @@ static zend_result php_json_encode_identifier(
 						|| us < 0x2028 || us > 0x2029)) {
 				smart_str_appendl(buf, s, pos);
 			} else {
-				char *dst;
 				if (us >= 0x10000) {
 					unsigned int next_us;
 					us -= 0x10000;
 					next_us = (unsigned short)((us & 0x3ff) | 0xdc00);
 					us = (unsigned short)((us >> 10) | 0xd800);
-					dst = smart_str_extend(buf, 6);
-					dst[0] = '\\';
-					dst[1] = 'u';
-					dst[2] = digits[(us >> 12) & 0xf];
-					dst[3] = digits[(us >> 8) & 0xf];
-					dst[4] = digits[(us >> 4) & 0xf];
-					dst[5] = digits[us & 0xf];
+					php_json_append_unicode_escape(buf, us);
 					us = next_us;
 				}
-				dst = smart_str_extend(buf, 6);
-				dst[0] = '\\';
-				dst[1] = 'u';
-				dst[2] = digits[(us >> 12) & 0xf];
-				dst[3] = digits[(us >> 8) & 0xf];
-				dst[4] = digits[(us >> 4) & 0xf];
-				dst[5] = digits[us & 0xf];
+				php_json_append_unicode_escape(buf, us);
 			}
 			s += pos;
 			len -= pos;
@@ -459,6 +453,9 @@ zend_result php_json_escape_string(
 		smart_str *buf, const char *s, size_t len,
 		int options, php_json_encoder *encoder) /* {{{ */
 {
+	static const uint32_t charmap[8] = {
+		0xffffffff, 0x500080c4, 0x10000000, 0x00000000,
+		0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff};
 	size_t pos, checkpoint;
 	char *dst;
 
@@ -484,15 +481,13 @@ zend_result php_json_escape_string(
 
 	}
 	/* fast path: no characters in the string require escaping allows us to single alloc and memcpy */
-	{
-		size_t i = 0;
-		while (i < len && !ZEND_BIT_TEST(charmap, (unsigned char)s[i])) {
-			i++;
-		}
-		if (EXPECTED(i == len)) {
-			php_json_append_quoted(buf, s, len);
-			return SUCCESS;
-		}
+	pos = 0;
+	while (pos < len && !ZEND_BIT_TEST(charmap, (unsigned char)s[pos])) {
+		pos++;
+	}
+	if (EXPECTED(pos == len)) {
+		php_json_append_quoted(buf, s, len);
+		return SUCCESS;
 	}
 
 	checkpoint = buf->s ? ZSTR_LEN(buf->s) : 0;
@@ -558,22 +553,10 @@ zend_result php_json_escape_string(
 						us -= 0x10000;
 						next_us = (unsigned short)((us & 0x3ff) | 0xdc00);
 						us = (unsigned short)((us >> 10) | 0xd800);
-						dst = smart_str_extend(buf, 6);
-						dst[0] = '\\';
-						dst[1] = 'u';
-						dst[2] = digits[(us >> 12) & 0xf];
-						dst[3] = digits[(us >> 8) & 0xf];
-						dst[4] = digits[(us >> 4) & 0xf];
-						dst[5] = digits[us & 0xf];
+						php_json_append_unicode_escape(buf, us);
 						us = next_us;
 					}
-					dst = smart_str_extend(buf, 6);
-					dst[0] = '\\';
-					dst[1] = 'u';
-					dst[2] = digits[(us >> 12) & 0xf];
-					dst[3] = digits[(us >> 8) & 0xf];
-					dst[4] = digits[(us >> 4) & 0xf];
-					dst[5] = digits[us & 0xf];
+					php_json_append_unicode_escape(buf, us);
 				}
 				s += pos;
 				len -= pos;

--- a/ext/json/json_encoder.c
+++ b/ext/json/json_encoder.c
@@ -147,6 +147,12 @@ static zend_result php_json_encode_identifier(
 	smart_str_alloc(buf, len + 2, 0);
 	smart_str_appendc(buf, '"');
 
+	/* flush the clean ASCII prefix found by the fast path scan */
+	if (pos) {
+		smart_str_appendl(buf, s, pos);
+		s += pos;
+		len -= pos;
+	}
 	pos = 0;
 	do {
 		unsigned int us = (unsigned char)s[pos];
@@ -496,6 +502,12 @@ zend_result php_json_escape_string(
 	smart_str_alloc(buf, len+2, 0);
 	smart_str_appendc(buf, '"');
 
+	/* flush the clean ASCII prefix found by the fast path scan */
+	if (pos) {
+		smart_str_appendl(buf, s, pos);
+		s += pos;
+		len -= pos;
+	}
 	pos = 0;
 
 	do {

--- a/ext/json/json_encoder.c
+++ b/ext/json/json_encoder.c
@@ -117,6 +117,102 @@ static inline void php_json_encode_double(smart_str *buf, double d, int options)
 		} \
 	} while (0)
 
+/* encode a PHP identifier (property name) as a JSON string key.
+ * PHP identifiers cannot contain ASCII characters that require JSON escaping,
+ * so the fast path only scans for multi-byte UTF-8 sequences (bytes >= 0x80). */
+static zend_result php_json_encode_identifier(
+		smart_str *buf, const char *s, size_t len,
+		int options, php_json_encoder *encoder)
+{
+	/* fast path: no characters require escaping (PHP identifiers contain no JSON-special ASCII bytes) */
+	{
+		size_t i = 0;
+		while (i < len && (unsigned char)s[i] < 0x80) {
+			i++;
+		}
+		if (EXPECTED(i == len)) {
+			php_json_append_quoted(buf, s, len);
+			return SUCCESS;
+		}
+	}
+
+	size_t checkpoint = buf->s ? ZSTR_LEN(buf->s) : 0;
+	smart_str_alloc(buf, len + 2, 0);
+	smart_str_appendc(buf, '"');
+
+	size_t pos = 0;
+	do {
+		unsigned int us = (unsigned char)s[pos];
+		if (EXPECTED(us < 0x80)) {
+			pos++;
+			len--;
+			if (len == 0) {
+				smart_str_appendl(buf, s, pos);
+				break;
+			}
+		} else {
+			if (pos) {
+				smart_str_appendl(buf, s, pos);
+				s += pos;
+				pos = 0;
+			}
+			zend_result status;
+			us = php_next_utf8_char((unsigned char *)s, len, &pos, &status);
+
+			if (UNEXPECTED(status != SUCCESS)) {
+				if (options & PHP_JSON_INVALID_UTF8_IGNORE) {
+					/* ignore invalid UTF-8 byte */
+				} else if (options & PHP_JSON_INVALID_UTF8_SUBSTITUTE) {
+					if (options & PHP_JSON_UNESCAPED_UNICODE) {
+						smart_str_appendl(buf, "\xef\xbf\xbd", 3);
+					} else {
+						smart_str_appendl(buf, "\\ufffd", 6);
+					}
+				} else {
+					ZSTR_LEN(buf->s) = checkpoint;
+					encoder->error_code = PHP_JSON_ERROR_UTF8;
+					if (options & PHP_JSON_PARTIAL_OUTPUT_ON_ERROR) {
+						smart_str_appendl(buf, "null", 4);
+					}
+					return FAILURE;
+				}
+			} else if ((options & PHP_JSON_UNESCAPED_UNICODE)
+					&& ((options & PHP_JSON_UNESCAPED_LINE_TERMINATORS)
+						|| us < 0x2028 || us > 0x2029)) {
+				smart_str_appendl(buf, s, pos);
+			} else {
+				char *dst;
+				if (us >= 0x10000) {
+					unsigned int next_us;
+					us -= 0x10000;
+					next_us = (unsigned short)((us & 0x3ff) | 0xdc00);
+					us = (unsigned short)((us >> 10) | 0xd800);
+					dst = smart_str_extend(buf, 6);
+					dst[0] = '\\';
+					dst[1] = 'u';
+					dst[2] = digits[(us >> 12) & 0xf];
+					dst[3] = digits[(us >> 8) & 0xf];
+					dst[4] = digits[(us >> 4) & 0xf];
+					dst[5] = digits[us & 0xf];
+					us = next_us;
+				}
+				dst = smart_str_extend(buf, 6);
+				dst[0] = '\\';
+				dst[1] = 'u';
+				dst[2] = digits[(us >> 12) & 0xf];
+				dst[3] = digits[(us >> 8) & 0xf];
+				dst[4] = digits[(us >> 4) & 0xf];
+				dst[5] = digits[us & 0xf];
+			}
+			s += pos;
+			len -= pos;
+			pos = 0;
+		}
+	} while (len);
+
+	smart_str_appendc(buf, '"');
+	return SUCCESS;
+}
 
 static zend_result php_json_encode_array(smart_str *buf, zval *val, int options, php_json_encoder *encoder) /* {{{ */
 {
@@ -175,7 +271,7 @@ static zend_result php_json_encode_array(smart_str *buf, zval *val, int options,
 			php_json_pretty_print_char(buf, options, '\n');
 			php_json_pretty_print_indent(buf, options, encoder);
 
-			if (php_json_escape_string(buf, ZSTR_VAL(prop_info->name), ZSTR_LEN(prop_info->name),
+			if (php_json_encode_identifier(buf, ZSTR_VAL(prop_info->name), ZSTR_LEN(prop_info->name),
 					options & ~PHP_JSON_NUMERIC_CHECK, encoder) == FAILURE &&
 					(options & PHP_JSON_PARTIAL_OUTPUT_ON_ERROR) &&
 					buf->s) {

--- a/ext/json/json_encoder.c
+++ b/ext/json/json_encoder.c
@@ -30,6 +30,18 @@
 
 static const char digits[] = "0123456789abcdef";
 
+static const uint32_t charmap[8] = {
+	0xffffffff, 0x500080c4, 0x10000000, 0x00000000,
+	0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff};
+
+static zend_always_inline void php_json_append_quoted(smart_str *buf, const char *s, size_t len)
+{
+	char *dst = smart_str_extend(buf, len + 2);
+	dst[0] = '"';
+	memcpy(dst + 1, s, len);
+	dst[len + 1] = '"';
+}
+
 static zend_always_inline bool php_json_check_stack_limit(void)
 {
 #ifdef ZEND_CHECK_STACK_LIMIT
@@ -104,6 +116,7 @@ static inline void php_json_encode_double(smart_str *buf, double d, int options)
 			GC_TRY_UNPROTECT_RECURSION(_tmp_ht); \
 		} \
 	} while (0)
+
 
 static zend_result php_json_encode_array(smart_str *buf, zval *val, int options, php_json_encoder *encoder) /* {{{ */
 {
@@ -374,6 +387,18 @@ zend_result php_json_escape_string(
 		}
 
 	}
+	/* fast path: no characters in the string require escaping allows us to single alloc and memcpy */
+	{
+		size_t i = 0;
+		while (i < len && !ZEND_BIT_TEST(charmap, (unsigned char)s[i])) {
+			i++;
+		}
+		if (EXPECTED(i == len)) {
+			php_json_append_quoted(buf, s, len);
+			return SUCCESS;
+		}
+	}
+
 	checkpoint = buf->s ? ZSTR_LEN(buf->s) : 0;
 
 	/* pre-allocate for string length plus 2 quotes */
@@ -383,10 +408,6 @@ zend_result php_json_escape_string(
 	pos = 0;
 
 	do {
-		static const uint32_t charmap[8] = {
-			0xffffffff, 0x500080c4, 0x10000000, 0x00000000,
-			0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff};
-
 		unsigned int us = (unsigned char)s[pos];
 		if (EXPECTED(!ZEND_BIT_TEST(charmap, us))) {
 			pos++;


### PR DESCRIPTION
Hi @bukka,

This PR aims to be a first small step to get my feet wet optimizing some of the most used parts of the runtime. JSON encoding/decoding is used in pretty much every web application, and optimized parsing is something I've done lots of for Wonderland Engine in the past, so it feels like a good match.

## In this PR

This PR does the following (each in a small commit):

1. Adds an encode/decode of various data structures to micro_bench.php, to be able to measure impact of this PR and future PRs.
2. Optimizes JSON `"<key>"` output as the most used primitive in JSON output. The idea is fairly simple: most key strings will be trivial identifiers like `"id"`, `"name"`, `"value"`, `"list"` etc. and we don't need to escape the string at all. We detect this case to do a single alloc + simple `memcpy` instead.
3. Another frequent case is PHP identifiers as JSON keys for which we can use a specialized, slim form of string escaping. It is used especially when encoding class objects to JSON.
4. Finally, I realized that even if we fail the fast-path detection, we can reuse the information of where it failed and fast-path the trivial prefix, which avoids pessimizing strings with long trivial ASCII prefixes that contain ASCII characters.

I know the string encoding work looks like it overlaps with https://github.com/php/php-src/pull/17734, which optimizes the encoding itself (especially for long strings), but in the spirit of "the fastest code is that which does not run at all", this optimization cuts past the code that the other PR would optimize.

## Results

From callgrind:

| State                      | json_encoder.c insns | vs baseline |
|----------------------------|---------------------|-------------|
| Baseline                   |         248,600,000 |           |
| + String fast path         |         226,300,000 |       -9.0% |
| + Identifier fast path     |         197,000,000 |      -20.8% |
| + Prefix flush             |         209,600,000 |      -15.7% |

I wanted to run some WordPress/Symfony benchmarks to measure the impact there, but the results were a bit too noisy to be presentable. The "regression" in the prefix flush is because the benchmarks contain only the trivial case strings so far, but it's necessary to avoid pessimization mentioned above.

## LLM usage disclosure

I **did** use coding agents/LLMs for the following tasks:
* Running and "typing out" of the benchmarks
* Implementing optimization ideas
* Writing commit messages
* Search open PRs for existing overlapping work 

More importantly, I did **not** use LLMs for ideas on optimization approaches, those were exclusively generated by myself. Also, reading the code, and the process of optimization and strict reviews of the LLM's generated code as well as critical evaluation of the benchmark results are my own work.. This PR description is hand-written.