### PR TITLE
Fix GH-22490: NULL deref for a pipe on the lhs of ??=

### DIFF
--- a/Zend/tests/pipe_operator/gh22490.phpt
+++ b/Zend/tests/pipe_operator/gh22490.phpt
@@ -1,0 +1,60 @@
+--TEST--
+GH-22490: Null pointer dereference compiling a pipe on the lhs of ??=
+--FILE--
+<?php
+$calls = 0;
+function unset_prop($x) {
+    global $calls;
+    $calls++;
+    return new stdClass;
+}
+function set_prop($x) {
+    global $calls;
+    $calls++;
+    $o = new stdClass;
+    $o->p = 7;
+    return $o;
+}
+
+echo "property unset, assigns and returns default: ";
+var_dump((1 |> unset_prop(...))->p ??= 99);
+echo "pipe evaluated once: ";
+var_dump($calls);
+
+$calls = 0;
+echo "property set, returns existing value: ";
+var_dump((1 |> set_prop(...))->p ??= 99);
+echo "pipe evaluated once: ";
+var_dump($calls);
+
+function new_array($x) {
+    global $calls;
+    $calls++;
+    return [];
+}
+
+$calls = 0;
+echo "dim target on a pipe result: ";
+var_dump((1 |> new_array(...))[0] ??= 42);
+echo "pipe evaluated once: ";
+var_dump($calls);
+
+function identity($x) {
+    return $x;
+}
+
+$calls = 0;
+echo "nested pipe on the lhs: ";
+var_dump((1 |> identity(...) |> unset_prop(...))->p ??= 5);
+echo "pipe evaluated once: ";
+var_dump($calls);
+?>
+--EXPECT--
+property unset, assigns and returns default: int(99)
+pipe evaluated once: int(1)
+property set, returns existing value: int(7)
+pipe evaluated once: int(1)
+dim target on a pipe result: int(42)
+pipe evaluated once: int(1)
+nested pipe on the lhs: int(5)
+pipe evaluated once: int(1)

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -12270,6 +12270,7 @@ static zend_op *zend_compile_var_inner(znode *result, zend_ast *ast, uint32_t ty
 			case ZEND_AST_METHOD_CALL:
 			case ZEND_AST_NULLSAFE_METHOD_CALL:
 			case ZEND_AST_STATIC_CALL:
+			case ZEND_AST_PIPE:
 				zend_compile_memoized_expr(result, ast, BP_VAR_W);
 				/* This might not actually produce an opcode, e.g. for expressions evaluated at comptime. */
 				return NULL;


### PR DESCRIPTION
A pipe expression on the left-hand side of `??=`, e.g. `(1 |> f(...))->g ??= 2`, crashes the compiler with a NULL pointer dereference in `zend_compile_memoized_expr`. The coalesce-assign LHS is compiled twice and call results are memoized by AST-node pointer, but `zend_compile_pipe` desugars the pipe into a freshly allocated call node on each pass, so the fetch pass looks up a pointer the compile pass never stored. Memoizing the whole pipe under its stable original node, consistent with `zend_is_call()`, makes the pipe compile once and the fetch pass reuse the result.

Fixes #22490
