### PR TITLE
ext/intl: Fix locale singleton separator bounds check

### DIFF
--- a/ext/intl/locale/locale_methods.cpp
+++ b/ext/intl/locale/locale_methods.cpp
@@ -281,7 +281,7 @@ static zend_off_t getSingletonPos(const char* str)
 					break;
 				} else {
 					/* delimiter found; check for singleton */
-					if( isIDSeparator(*(str+i+2)) ){
+					if( (size_t)i + 2 < len && isIDSeparator(*(str+i+2)) ){
 						/* a singleton; so send the position of separator before singleton */
 						result = i+1;
 						break;

--- a/ext/intl/tests/locale_parse_trailing_singleton.phpt
+++ b/ext/intl/tests/locale_parse_trailing_singleton.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Locale::parseLocale() handles trailing singleton separators
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+$locales = [
+    'en-',
+    'en-a-',
+    'de-CH-x-',
+    'x-',
+];
+
+foreach ($locales as $locale) {
+    echo $locale, ': ';
+    var_export(Locale::parseLocale($locale));
+    echo "\n";
+}
+?>
+--EXPECT--
+en-: array (
+  'language' => 'en',
+)
+en-a-: array (
+  'language' => 'en',
+)
+de-CH-x-: array (
+  'language' => 'de',
+  'region' => 'CH',
+)
+x-: array (
+)


### PR DESCRIPTION
`getSingletonPos()` checks whether the character two bytes after a locale
separator is another separator, in order to detect singleton subtags.

For locale strings ending with a separator, this can read past the end of the
string. Guard the `i + 2` access with the already computed string length before
calling `isIDSeparator()`.

This keeps the existing parsing behavior while avoiding the out-of-bounds read.
