### PR TITLE
ext/intl: Reset IntlChar error state on method entry

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,8 @@ PHP                                                                        NEWS
 ?? ??? ????, PHP 8.4.24
 
 - Intl:
+  . Fixed IntlChar methods leaving stale global error state after successful
+    calls. (Xuyang Zhang)
   . Fixed Locale::lookup() and locale_lookup() to return NULL instead of the
     fallback locale when a language tag cannot be canonicalized. (Weilin Du)
   . Fixed memory leaks when calling Collator::__construct() or

--- a/NEWS
+++ b/NEWS
@@ -3,12 +3,12 @@ PHP                                                                        NEWS
 ?? ??? ????, PHP 8.4.24
 
 - Intl:
-  . Fixed IntlChar methods leaving stale global error state after successful
-    calls. (Xuyang Zhang)
   . Fixed Locale::lookup() and locale_lookup() to return NULL instead of the
     fallback locale when a language tag cannot be canonicalized. (Weilin Du)
   . Fixed memory leaks when calling Collator::__construct() or
     Spoofchecker::__construct() twice. (Weilin Du)
+  . Fixed IntlChar methods leaving stale global error state after successful
+    calls. (Xuyang Zhang)
 
 - Phar:
   . Fixed inconsistent handling of the magic ".phar" directory. Paths such as

--- a/ext/intl/tests/intlchar_reset_error.phpt
+++ b/ext/intl/tests/intlchar_reset_error.phpt
@@ -1,0 +1,19 @@
+--TEST--
+IntlChar methods reset intl error on success
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+var_dump(IntlChar::digit('a', 1));
+var_dump(intl_get_error_code() !== U_ZERO_ERROR);
+
+var_dump(IntlChar::forDigit(1) === ord('1'));
+var_dump(intl_get_error_code() === U_ZERO_ERROR);
+var_dump(intl_get_error_message() === 'U_ZERO_ERROR');
+?>
+--EXPECT--
+bool(false)
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/ext/intl/uchar/uchar.c
+++ b/ext/intl/uchar/uchar.c
@@ -54,6 +54,8 @@ IC_METHOD(chr) {
 	char buffer[5];
 	int buffer_len = 0;
 
+	intl_error_reset(NULL);
+
 	if (parse_code_point_param(INTERNAL_FUNCTION_PARAM_PASSTHRU, &cp) == FAILURE) {
 		RETURN_NULL();
 	}
@@ -73,6 +75,8 @@ IC_METHOD(chr) {
 IC_METHOD(ord) {
 	UChar32 cp;
 
+	intl_error_reset(NULL);
+
 	if (parse_code_point_param(INTERNAL_FUNCTION_PARAM_PASSTHRU, &cp) == FAILURE) {
 		RETURN_NULL();
 	}
@@ -87,6 +91,8 @@ IC_METHOD(hasBinaryProperty) {
 	zend_long prop;
 	zend_string *string_codepoint;
 	zend_long int_codepoint = 0;
+
+	intl_error_reset(NULL);
 
 	ZEND_PARSE_PARAMETERS_START(2, 2)
 		Z_PARAM_STR_OR_LONG(string_codepoint, int_codepoint)
@@ -108,6 +114,8 @@ IC_METHOD(getIntPropertyValue) {
 	zend_string *string_codepoint;
 	zend_long int_codepoint = 0;
 
+	intl_error_reset(NULL);
+
 	ZEND_PARSE_PARAMETERS_START(2, 2)
 		Z_PARAM_STR_OR_LONG(string_codepoint, int_codepoint)
 		Z_PARAM_LONG(prop)
@@ -125,6 +133,8 @@ IC_METHOD(getIntPropertyValue) {
 IC_METHOD(getIntPropertyMinValue) {
 	zend_long prop;
 
+	intl_error_reset(NULL);
+
 	ZEND_PARSE_PARAMETERS_START(1, 1)
 		Z_PARAM_LONG(prop)
 	ZEND_PARSE_PARAMETERS_END();
@@ -137,6 +147,8 @@ IC_METHOD(getIntPropertyMinValue) {
 IC_METHOD(getIntPropertyMaxValue) {
 	zend_long prop;
 
+	intl_error_reset(NULL);
+
 	ZEND_PARSE_PARAMETERS_START(1, 1)
 		Z_PARAM_LONG(prop)
 	ZEND_PARSE_PARAMETERS_END();
@@ -148,6 +160,8 @@ IC_METHOD(getIntPropertyMaxValue) {
 /* {{{ */
 IC_METHOD(getNumericValue) {
 	UChar32 cp;
+
+	intl_error_reset(NULL);
 
 	if (parse_code_point_param(INTERNAL_FUNCTION_PARAM_PASSTHRU, &cp) == FAILURE) {
 		RETURN_NULL();
@@ -191,6 +205,8 @@ static UBool enumCharType_callback(enumCharType_data *context,
 IC_METHOD(enumCharTypes) {
 	enumCharType_data context;
 
+	intl_error_reset(NULL);
+
 	ZEND_PARSE_PARAMETERS_START(1, 1)
 		Z_PARAM_FUNC(context.fci, context.fci_cache)
 	ZEND_PARSE_PARAMETERS_END();
@@ -201,6 +217,8 @@ IC_METHOD(enumCharTypes) {
 /* {{{ */
 IC_METHOD(getBlockCode) {
 	UChar32 cp;
+
+	intl_error_reset(NULL);
 
 	if (parse_code_point_param(INTERNAL_FUNCTION_PARAM_PASSTHRU, &cp) == FAILURE) {
 		RETURN_NULL();
@@ -219,6 +237,8 @@ IC_METHOD(charName) {
 	zend_long nameChoice = U_UNICODE_CHAR_NAME;
 	zend_string *buffer = NULL;
 	int32_t buffer_len;
+
+	intl_error_reset(NULL);
 
 	ZEND_PARSE_PARAMETERS_START(1, 2)
 		Z_PARAM_STR_OR_LONG(string_codepoint, int_codepoint)
@@ -249,6 +269,8 @@ IC_METHOD(charFromName) {
 	zend_long nameChoice = U_UNICODE_CHAR_NAME;
 	UChar32 ret;
 	UErrorCode error = U_ZERO_ERROR;
+
+	intl_error_reset(NULL);
 
 	ZEND_PARSE_PARAMETERS_START(1, 2)
 		Z_PARAM_STRING(name, name_len)
@@ -301,6 +323,7 @@ IC_METHOD(enumCharNames) {
 	zend_long nameChoice = U_UNICODE_CHAR_NAME;
 	UErrorCode error = U_ZERO_ERROR;
 
+	intl_error_reset(NULL);
 
 	ZEND_PARSE_PARAMETERS_START(3, 4)
 		Z_PARAM_STR_OR_LONG(string_start, int_start)
@@ -326,6 +349,8 @@ IC_METHOD(getPropertyName) {
 	zend_long nameChoice = U_LONG_PROPERTY_NAME;
 	const char *ret;
 
+	intl_error_reset(NULL);
+
 	ZEND_PARSE_PARAMETERS_START(1, 2)
 		Z_PARAM_LONG(property)
 		Z_PARAM_OPTIONAL
@@ -348,6 +373,8 @@ IC_METHOD(getPropertyEnum) {
 	char *alias;
 	size_t alias_len;
 
+	intl_error_reset(NULL);
+
 	ZEND_PARSE_PARAMETERS_START(1, 1)
 		Z_PARAM_STRING(alias, alias_len)
 	ZEND_PARSE_PARAMETERS_END();
@@ -360,6 +387,8 @@ IC_METHOD(getPropertyEnum) {
 IC_METHOD(getPropertyValueName) {
 	zend_long property, value, nameChoice = U_LONG_PROPERTY_NAME;
 	const char *ret;
+
+	intl_error_reset(NULL);
 
 	ZEND_PARSE_PARAMETERS_START(2, 3)
 		Z_PARAM_LONG(property)
@@ -385,6 +414,8 @@ IC_METHOD(getPropertyValueEnum) {
 	char *name;
 	size_t name_len;
 
+	intl_error_reset(NULL);
+
 	ZEND_PARSE_PARAMETERS_START(2, 2)
 		Z_PARAM_LONG(property)
 		Z_PARAM_STRING(name, name_len)
@@ -400,6 +431,8 @@ IC_METHOD(foldCase) {
 	zend_long options = U_FOLD_CASE_DEFAULT;
 	zend_string *string_codepoint;
 	zend_long int_codepoint = 0;
+
+	intl_error_reset(NULL);
 
 	ZEND_PARSE_PARAMETERS_START(1, 2)
 		Z_PARAM_STR_OR_LONG(string_codepoint, int_codepoint)
@@ -432,6 +465,8 @@ IC_METHOD(digit) {
 	zend_string *string_codepoint;
 	zend_long int_codepoint = 0;
 
+	intl_error_reset(NULL);
+
 	ZEND_PARSE_PARAMETERS_START(1, 2)
 		Z_PARAM_STR_OR_LONG(string_codepoint, int_codepoint)
 		Z_PARAM_OPTIONAL
@@ -456,6 +491,8 @@ IC_METHOD(digit) {
 IC_METHOD(forDigit) {
 	zend_long digit, radix = 10;
 
+	intl_error_reset(NULL);
+
 	ZEND_PARSE_PARAMETERS_START(1, 2)
 		Z_PARAM_LONG(digit)
 		Z_PARAM_OPTIONAL
@@ -471,6 +508,8 @@ IC_METHOD(charAge) {
 	UChar32 cp;
 	UVersionInfo version;
 	int i;
+
+	intl_error_reset(NULL);
 
 	if (parse_code_point_param(INTERNAL_FUNCTION_PARAM_PASSTHRU, &cp) == FAILURE) {
 		RETURN_NULL();
@@ -489,6 +528,8 @@ IC_METHOD(getUnicodeVersion) {
 	UVersionInfo version;
 	int i;
 
+	intl_error_reset(NULL);
+
 	ZEND_PARSE_PARAMETERS_NONE();
 
 	u_getUnicodeVersion(version);
@@ -506,6 +547,8 @@ IC_METHOD(getFC_NFKC_Closure) {
 	zend_string *u8str;
 	int32_t closure_len;
 	UErrorCode error = U_ZERO_ERROR;
+
+	intl_error_reset(NULL);
 
 	if (parse_code_point_param(INTERNAL_FUNCTION_PARAM_PASSTHRU, &cp) == FAILURE) {
 		RETURN_NULL();
@@ -535,6 +578,7 @@ IC_METHOD(getFC_NFKC_Closure) {
 #define IC_BOOL_METHOD_CHAR(name) \
 IC_METHOD(name) { \
 	UChar32 cp; \
+	intl_error_reset(NULL); \
 	if (parse_code_point_param(INTERNAL_FUNCTION_PARAM_PASSTHRU, &cp) == FAILURE) { \
 		RETURN_NULL(); \
 	} \
@@ -575,6 +619,7 @@ IC_BOOL_METHOD_CHAR(isJavaIDPart)
 #define IC_INT_METHOD_CHAR(name) \
 IC_METHOD(name) { \
 	UChar32 cp; \
+	intl_error_reset(NULL); \
 	if (parse_code_point_param(INTERNAL_FUNCTION_PARAM_PASSTHRU, &cp) == FAILURE) { \
 		RETURN_NULL(); \
 	} \
@@ -595,6 +640,7 @@ IC_METHOD(name) { \
 	UChar32 cp, ret; \
 	zend_string *string_codepoint; \
 		zend_long int_codepoint = -1; \
+		intl_error_reset(NULL); \
 		ZEND_PARSE_PARAMETERS_START(1, 1) \
 			Z_PARAM_STR_OR_LONG(string_codepoint, int_codepoint) \
 		ZEND_PARSE_PARAMETERS_END(); \


### PR DESCRIPTION
`IntlChar` methods did not reset the global intl error state on entry.

 Because of that, a successful call could still leave `intl_get_error_code()` and
 `intl_get_error_message()` reporting an error from a previous failed `IntlChar`
 call.

 This adds the reset at method entry and a PHPT covering a failed
 `IntlChar::digit()` call followed by a successful `IntlChar::forDigit()` call.