### PR TITLE
ext/standard: Fix `phpcredits()` QA team heading alignment

### DIFF
--- a/ext/standard/credits.c
+++ b/ext/standard/credits.c
@@ -99,7 +99,7 @@ PHPAPI ZEND_COLD void php_print_credits(int flag) /* {{{ */
 
 	if (flag & PHP_CREDITS_QA) {
 		php_info_print_table_start();
-		php_info_print_table_header(1, "PHP Quality Assurance Team");
+		php_info_print_table_colspan_header(1, "PHP Quality Assurance Team");
 		php_info_print_table_row(1, "Ilia Alshanetsky, Joerg Behrens, Antony Dovgal, Stefan Esser, Moriyoshi Koizumi, Magnus Maatta, Sebastian Nohn, Derick Rethans, Melvyn Sopacua, Pierre-Alain Joye, Dmitry Stogov, Felipe Pena, David Soria Parra, Stanislav Malyshev, Julien Pauli, Stephen Zarkos, Anatol Belski, Remi Collet, Ferenc Kovacs");
 		php_info_print_table_end();
 	}

--- a/ext/standard/credits.c
+++ b/ext/standard/credits.c
@@ -97,13 +97,6 @@ PHPAPI ZEND_COLD void php_print_credits(int flag) /* {{{ */
 		php_info_print_table_end();
 	}
 
-	if (flag & PHP_CREDITS_QA) {
-		php_info_print_table_start();
-		php_info_print_table_colspan_header(1, "PHP Quality Assurance Team");
-		php_info_print_table_row(1, "Ilia Alshanetsky, Joerg Behrens, Antony Dovgal, Stefan Esser, Moriyoshi Koizumi, Magnus Maatta, Sebastian Nohn, Derick Rethans, Melvyn Sopacua, Pierre-Alain Joye, Dmitry Stogov, Felipe Pena, David Soria Parra, Stanislav Malyshev, Julien Pauli, Stephen Zarkos, Anatol Belski, Remi Collet, Ferenc Kovacs");
-		php_info_print_table_end();
-	}
-
 	if (flag & PHP_CREDITS_WEB) {
 		/* Websites and infrastructure */
 

--- a/ext/standard/credits.c
+++ b/ext/standard/credits.c
@@ -97,6 +97,13 @@ PHPAPI ZEND_COLD void php_print_credits(int flag) /* {{{ */
 		php_info_print_table_end();
 	}
 
+	if (flag & PHP_CREDITS_QA) {
+		php_info_print_table_start();
+		php_info_print_table_colspan_header(1, "PHP Quality Assurance Team");
+		php_info_print_table_row(1, "Ilia Alshanetsky, Joerg Behrens, Antony Dovgal, Stefan Esser, Moriyoshi Koizumi, Magnus Maatta, Sebastian Nohn, Derick Rethans, Melvyn Sopacua, Pierre-Alain Joye, Dmitry Stogov, Felipe Pena, David Soria Parra, Stanislav Malyshev, Julien Pauli, Stephen Zarkos, Anatol Belski, Remi Collet, Ferenc Kovacs");
+		php_info_print_table_end();
+	}
+
 	if (flag & PHP_CREDITS_WEB) {
 		/* Websites and infrastructure */
 

--- a/ext/standard/tests/general_functions/phpcredits.phpt
+++ b/ext/standard/tests/general_functions/phpcredits.phpt
@@ -33,7 +33,7 @@ Language Design & Concept
 %wPHP Documentation%w
 %a
 
-PHP Quality Assurance Team
+%wPHP Quality Assurance Team%w
 %a
 
 %wWebsites and Infrastructure team%w

--- a/ext/standard/tests/general_functions/phpcredits.phpt
+++ b/ext/standard/tests/general_functions/phpcredits.phpt
@@ -33,6 +33,9 @@ Language Design & Concept
 %wPHP Documentation%w
 %a
 
+%wPHP Quality Assurance Team%w
+%a
+
 %wWebsites and Infrastructure team%w
 %a
 bool(true)

--- a/ext/standard/tests/general_functions/phpcredits.phpt
+++ b/ext/standard/tests/general_functions/phpcredits.phpt
@@ -33,9 +33,6 @@ Language Design & Concept
 %wPHP Documentation%w
 %a
 
-%wPHP Quality Assurance Team%w
-%a
-
 %wWebsites and Infrastructure team%w
 %a
 bool(true)


### PR DESCRIPTION
```
<?php
phpcredits()
?>
```
in the output, only the QA team isn't centered correctly. It looks like:
```
... hack hack hack ...
                            PHP Documentation
Authors => Mehdi Achour, Friedhelm Betz, Antony Dovgal, Nuno Lopes, Hannes Magnusson, Philip Olson, Georg Richter, Damien Seguy, Jakub Vrana, Adam Harvey
Editor => Peter Cowburn
User Note Maintainers => Daniel P. Brown, Thiago Henrique Pojda
Other Contributors => Previously active authors, editors and other contributors are listed in the manual.

PHP Quality Assurance Team
Ilia Alshanetsky, Joerg Behrens, Antony Dovgal, Stefan Esser, Moriyoshi Koizumi, Magnus Maatta, Sebastian Nohn, Derick Rethans, Melvyn Sopacua, Pierre-Alain Joye, Dmitry Stogov, Felipe Pena, David Soria Parra, Stanislav Malyshev, Julien Pauli, Stephen Zarkos, Anatol Belski, Remi Collet, Ferenc Kovacs

                     Websites and Infrastructure team
PHP Websites Team => Rasmus Lerdorf, Hannes Magnusson, Philip Olson, Lukas Kahwe Smith, Pierre-Alain Joye, Kalle Sommer Nielsen, Peter Cowburn, Adam Harvey, Ferenc Kovacs, Levi Morrison
Event Maintainers => Damien Seguy, Daniel P. Brown
Network Infrastructure => Daniel P. Brown
Windows Infrastructure => Alex Schoenmaker
```
Reproduce at [here](https://onlinephp.io?s=s7EvyCjg5QISyUWpKZklxRrOQa4uniHB8Y4-Ppq8XPZ2AA%2C%2C&v=8.5.6)