### PR TITLE
Fix GH-15836: don't expose a freed stream resource to user filters

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -35,6 +35,10 @@ PHP                                                                        NEWS
   . Fixed bug GH-22395 (base_convert() outputs at most 64 characters).
     (Weilin Du)
 
+- Streams:
+  . Fixed bug GH-15836 (Use-after-free when a user stream filter accesses
+    $this->stream during the close flush). (iliaal)
+
 02 Jul 2026, PHP 8.4.23
 
 - Core:

--- a/ext/standard/tests/filters/bug54350.phpt
+++ b/ext/standard/tests/filters/bug54350.phpt
@@ -23,4 +23,4 @@ fwrite($fd, "foo");
 ?>
 --EXPECTF--
 Warning: fclose(): 5 is not a valid stream resource in %s on line %d
-fclose(): supplied resource is not a valid stream resource
+fclose(): Argument #1 ($stream) must be of type resource, null given

--- a/ext/standard/tests/filters/gh15836.phpt
+++ b/ext/standard/tests/filters/gh15836.phpt
@@ -1,0 +1,34 @@
+--TEST--
+GH-15836 (use-after-free when a user filter reads $this->stream during the close flush)
+--FILE--
+<?php
+class my_filter extends php_user_filter {
+    public static ?Throwable $e = null;
+    function filter($in, $out, &$consumed, $closing): int {
+        if ($closing) {
+            try {
+                stream_bucket_new($this->stream, "x");
+            } catch (TypeError $e) {
+                self::$e = $e;
+            }
+        }
+        return PSFS_PASS_ON;
+    }
+}
+var_dump(stream_filter_register("my_filter", "my_filter"));
+
+function run() {
+    $s = fopen("php://memory", "wb+");
+    stream_filter_append($s, "my_filter", STREAM_FILTER_WRITE);
+}
+run();
+
+echo my_filter::$e->getTraceAsString(), "\n";
+echo "done\n";
+?>
+--EXPECTF--
+bool(true)
+#0 %s(%d): stream_bucket_new(NULL, 'x')
+#1 %s(%d): my_filter->filter(Resource id #%d, Resource id #%d, 0, true)
+#2 {main}
+done

--- a/ext/standard/user_filters.c
+++ b/ext/standard/user_filters.c
@@ -156,7 +156,11 @@ static php_stream_filter_status_t userfilter_filter(
 	bool stream_property_exists = Z_OBJ_HT_P(obj)->has_property(Z_OBJ_P(obj), stream_name, ZEND_PROPERTY_EXISTS, NULL);
 	if (stream_property_exists) {
 		zval stream_zval;
-		php_stream_to_zval(stream, &stream_zval);
+		if (EXPECTED(stream->res && stream->res->type >= 0)) {
+			php_stream_to_zval(stream, &stream_zval);
+		} else {
+			ZVAL_NULL(&stream_zval);
+		}
 		zend_update_property_ex(Z_OBJCE_P(obj), Z_OBJ_P(obj), stream_name, &stream_zval);
 		/* If property update threw an exception, skip filter execution */
 		if (EG(exception)) {


### PR DESCRIPTION
A user stream filter that reads `$this->stream` during the close flush could capture an already-freed stream resource in an exception backtrace, a use-after-free that corrupts the heap (the reporter's php://memory reproducer aborts with "zend_mm_heap corrupted").

When `_php_stream_free()` runs the write-filter close flush from the resource destructor, the resource is already dtor'd (`type == -1`) and about to be `efree`'d, but `userfilter_filter()` still handed it to userland via `$this->stream`. The guard exposes the resource only while it is still live and assigns null otherwise. The explicit `fclose()` path flushes before `zend_list_close()`, so its resource is still live and behavior there is unchanged. The null branch intentionally skips `php_stream_to_zval()`'s `__exposed=1` side effect, since the resource is not actually exposed.

Fixes #15836
