### PR TITLE
Fix GH-17387: crash on unterminated quote in phpdbg lexer

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,9 @@ PHP                                                                        NEWS
     copying, ArrayAccess, stream lookup, directory iteration and extraction.
     (Weilin Du)
 
+- PHPDBG:
+  . Fixed bug GH-17387 (Trivial crash in phpdbg lexer). (iliaal)
+
 - Reflection:
   . Fixed bug GH-22324 (Ignore leading namespace separator in
     ReflectionParameter::__construct()). (jorgsowa)

--- a/sapi/phpdbg/phpdbg_lexer.l
+++ b/sapi/phpdbg/phpdbg_lexer.l
@@ -166,6 +166,13 @@ INPUT       ("\\"[#"']|["]("\\\\"|"\\"["]|[^\n\000"])*["]|[']("\\"[']|"\\\\"|[^\
 	return T_ID;
 }
 
+<NORMAL>["'] {
+	phpdbg_init_param(yylval, STR_PARAM);
+	yylval->str = estrndup(yytext, yyleng);
+	yylval->len = yyleng;
+	return T_ID;
+}
+
 <RAW>{INPUT} {
 	phpdbg_init_param(yylval, STR_PARAM);
 	yylval->str = estrdup(yytext);

--- a/sapi/phpdbg/tests/gh17387.phpt
+++ b/sapi/phpdbg/tests/gh17387.phpt
@@ -1,0 +1,8 @@
+--TEST--
+GH-17387 (Trivial crash in phpdbg lexer)
+--PHPDBG--
+a';
+q
+--EXPECT--
+prompt> [The command "a" could not be found]
+prompt> 


### PR DESCRIPTION
Completes the partial fix from 8.3.17. A lone unterminated quote (e.g. `a';`) matched no rule in the NORMAL lexer condition, so re2c fell back to a zero-length GENERIC_ID accept and `yyleng - unescape_string(yytext)` underflowed `size_t` into a roughly 4GB `estrndup`. An explicit one-character accept for a bare quote advances the cursor and keeps `unescape_string` off malformed tokens. The broader cross-condition default-rule cleanup stays with GH-17523.

Fixes #17387
