### PR TITLE
Deprecate returning from a finally block

### DIFF
--- a/Zend/tests/exit_finally_3.phpt
+++ b/Zend/tests/exit_finally_3.phpt
@@ -15,5 +15,6 @@ function test() {
 var_dump(test());
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
 Exit

--- a/Zend/tests/gc/gc_050.phpt
+++ b/Zend/tests/gc/gc_050.phpt
@@ -36,5 +36,6 @@ for ($i = 0; $i < 100000; $i++) {
 }
 echo "OK\n";
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
 OK

--- a/Zend/tests/generators/finally/return_return.phpt
+++ b/Zend/tests/generators/finally/return_return.phpt
@@ -27,7 +27,8 @@ $gen = gen();
 $gen->rewind(); // force run
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
 before return
 before return in inner finally
 outer finally run

--- a/Zend/tests/generators/finally/yield_return.phpt
+++ b/Zend/tests/generators/finally/yield_return.phpt
@@ -15,5 +15,6 @@ foreach (foo(1, 5) as $x) {
     echo $x, "\n";
 }
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
 1

--- a/Zend/tests/generators/get_return_and_finally.phpt
+++ b/Zend/tests/generators/get_return_and_finally.phpt
@@ -41,7 +41,8 @@ try {
 }
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
 int(42)
 gen2() throw
 Cannot get return value of a generator that hasn't returned

--- a/Zend/tests/generators/gh11028_1.phpt
+++ b/Zend/tests/generators/gh11028_1.phpt
@@ -24,7 +24,8 @@ test("false", false);
 test("true", true);
 test("object", new stdClass);
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
 yield null
 Keys must be of type int|string during array unpacking
 yield false

--- a/Zend/tests/generators/gh11028_2.phpt
+++ b/Zend/tests/generators/gh11028_2.phpt
@@ -15,6 +15,8 @@ $c = (function () {
 })()[0];
 ?>
 --EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
+
 Warning: Undefined variable $a in %s on line %d
 
 Fatal error: Uncaught Error: Keys must be of type int|string during array unpacking in %s:%d

--- a/Zend/tests/generators/gh11028_3.phpt
+++ b/Zend/tests/generators/gh11028_3.phpt
@@ -17,5 +17,6 @@ try {
     echo $e->getMessage(), "\n";
 }
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
 exception

--- a/Zend/tests/generators/yield_in_finally_cleanup.phpt
+++ b/Zend/tests/generators/yield_in_finally_cleanup.phpt
@@ -47,5 +47,6 @@ gen4()->rewind();
 
 ?>
 ===DONE===
---EXPECT--
+--EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
 ===DONE===

--- a/Zend/tests/oss_fuzz_438780145.phpt
+++ b/Zend/tests/oss_fuzz_438780145.phpt
@@ -20,6 +20,8 @@ test();
 
 ?>
 --EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
+
 Fatal error: Uncaught TypeError: test(): Return value must be of type int, string returned in %s:%d
 Stack trace:
 #0 %s(%d): test()

--- a/Zend/tests/return_types/029.phpt
+++ b/Zend/tests/return_types/029.phpt
@@ -14,6 +14,8 @@ function foo() : array {
 foo();
 ?>
 --EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
+
 Fatal error: Uncaught Exception: xxxx in %s:%d
 Stack trace:
 #0 %s(%d): foo()

--- a/Zend/tests/return_types/never_finally_return.phpt
+++ b/Zend/tests/return_types/never_finally_return.phpt
@@ -14,4 +14,6 @@ function foo() : never {
 // Note the lack of function call: function validated at compile-time
 ?>
 --EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
+
 Fatal error: A never-returning function must not return in %s on line %d

--- a/Zend/tests/try/bug70228.phpt
+++ b/Zend/tests/try/bug70228.phpt
@@ -10,5 +10,6 @@ function foo() {
 
 var_dump(foo());
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
 string(2) "bb"

--- a/Zend/tests/try/bug70228_2.phpt
+++ b/Zend/tests/try/bug70228_2.phpt
@@ -16,5 +16,6 @@ function test() {
 
 var_dump(test());
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
 int(42)

--- a/Zend/tests/try/bug70228_3.phpt
+++ b/Zend/tests/try/bug70228_3.phpt
@@ -26,6 +26,7 @@ try {
     } while ($e);
 }
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
 2
 1

--- a/Zend/tests/try/bug70228_4.phpt
+++ b/Zend/tests/try/bug70228_4.phpt
@@ -28,5 +28,6 @@ try {
     } while ($e);
 }
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
 1

--- a/Zend/tests/try/bug70228_6.phpt
+++ b/Zend/tests/try/bug70228_6.phpt
@@ -14,5 +14,6 @@ function test($x) {
 
 var_dump(test([1]));
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
 int(42)

--- a/Zend/tests/try/catch_finally_003.phpt
+++ b/Zend/tests/try/catch_finally_003.phpt
@@ -32,7 +32,10 @@ function &bar($a) {
 var_dump(foo("para"));
 var_dump(bar("para"));
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
+
+Deprecated: Returning from a finally block is deprecated in %s on line %d
 string(3) "try"
 string(7) "finally"
 string(7) "finally"

--- a/Zend/tests/try/catch_finally_005.phpt
+++ b/Zend/tests/try/catch_finally_005.phpt
@@ -17,5 +17,6 @@ function foo ($a) {
 
 var_dump(foo("para"));
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
 int(3)

--- a/Zend/tests/try/catch_finally_006.phpt
+++ b/Zend/tests/try/catch_finally_006.phpt
@@ -22,7 +22,8 @@ try {
     var_dump($e->getMessage());
 }
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
 string(4) "para"
 string(7) "finally"
 string(6) "return"

--- a/Zend/tests/try/finally_goto_005.phpt
+++ b/Zend/tests/try/finally_goto_005.phpt
@@ -11,5 +11,6 @@ label: try {
 }
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
 success

--- a/Zend/tests/try/finally_return_deprecation.phpt
+++ b/Zend/tests/try/finally_return_deprecation.phpt
@@ -1,0 +1,86 @@
+--TEST--
+Returning from a finally block is deprecated
+--FILE--
+<?php
+
+function withValue() {
+    try {
+    } finally {
+        return 1;
+    }
+}
+
+function withoutValue() {
+    try {
+    } finally {
+        return;
+    }
+}
+
+// Not deprecated: the return belongs to the try block, not the finally.
+function inTry() {
+    try {
+        return 1;
+    } finally {
+    }
+}
+
+// Not deprecated: the return belongs to a catch block.
+function inCatch() {
+    try {
+        throw new Exception();
+    } catch (Exception $e) {
+        return 1;
+    } finally {
+    }
+}
+
+// Not deprecated: the return belongs to a nested closure, not the finally.
+function nestedClosure() {
+    try {
+    } finally {
+        $f = function () {
+            return 1;
+        };
+    }
+}
+
+// Deprecated twice: both returns are lexically inside the outer finally, even
+// though one of them sits in a nested try block.
+function nestedTry() {
+    try {
+    } finally {
+        try {
+            return 1;
+        } finally {
+            return 2;
+        }
+    }
+}
+
+// Deprecated once: only the closure's own finally return is flagged. The outer
+// finally must not leak into the closure, so the closure's try return is left alone.
+function closureWithTry() {
+    try {
+    } finally {
+        $f = function () {
+            try {
+                return 1;
+            } finally {
+                return 2;
+            }
+        };
+    }
+}
+
+?>
+--EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
+
+Deprecated: Returning from a finally block is deprecated in %s on line %d
+
+Deprecated: Returning from a finally block is deprecated in %s on line %d
+
+Deprecated: Returning from a finally block is deprecated in %s on line %d
+
+Deprecated: Returning from a finally block is deprecated in %s on line %d

--- a/Zend/tests/try/try_catch_finally_003.phpt
+++ b/Zend/tests/try/try_catch_finally_003.phpt
@@ -32,5 +32,6 @@ function foo () {
 
 var_dump(foo());
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
 1234int(4)

--- a/Zend/tests/try/try_finally_013.phpt
+++ b/Zend/tests/try/try_finally_013.phpt
@@ -18,6 +18,7 @@ function foo() {
 
 foo();
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
 try
 finally

--- a/Zend/tests/try/try_finally_014.phpt
+++ b/Zend/tests/try/try_finally_014.phpt
@@ -20,6 +20,7 @@ function foo() {
 
 foo();
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
 try
 finally

--- a/Zend/tests/try/try_finally_021.phpt
+++ b/Zend/tests/try/try_finally_021.phpt
@@ -15,6 +15,7 @@ foreach ([0] as $_) {
     }
 }
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
 ok
 ok

--- a/Zend/tests/try/try_finally_023.phpt
+++ b/Zend/tests/try/try_finally_023.phpt
@@ -31,6 +31,7 @@ try {
 
 ?>
 --EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
 Exception: 1 in %s:%d
 Stack trace:
 #0 %s(%d): test()

--- a/Zend/tests/try/try_finally_027.phpt
+++ b/Zend/tests/try/try_finally_027.phpt
@@ -23,6 +23,7 @@ try {
 
 ?>
 --EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
 Exception: 1 in %s:%d
 Stack trace:
 #0 %s(%d): test()

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -343,6 +343,7 @@ void zend_oparray_context_begin(zend_oparray_context *prev_context, zend_op_arra
 	CG(context).brk_cont_array = NULL;
 	CG(context).labels = NULL;
 	CG(context).in_jmp_frameless_branch = false;
+	CG(context).in_finally = false;
 	CG(context).active_property_info_name = NULL;
 	CG(context).active_property_hook_kind = (zend_property_hook_kind)-1;
 }
@@ -5993,6 +5994,10 @@ static void zend_compile_return(const zend_ast *ast) /* {{{ */
 		zend_compile_expr(&expr_node, expr_ast);
 	}
 
+	if (CG(context).in_finally) {
+		zend_error(E_DEPRECATED, "Returning from a finally block is deprecated");
+	}
+
 	if ((CG(active_op_array)->fn_flags & ZEND_ACC_HAS_FINALLY_BLOCK)
 	 && (expr_node.op_type == IS_CV || (by_ref && expr_node.op_type == IS_VAR))
 	 && zend_has_finally()) {
@@ -7163,7 +7168,10 @@ static void zend_compile_try(const zend_ast *ast) /* {{{ */
 
 		zend_emit_op(NULL, ZEND_JMP, NULL, NULL);
 
+		bool orig_in_finally = CG(context).in_finally;
+		CG(context).in_finally = true;
 		zend_compile_stmt(finally_ast);
+		CG(context).in_finally = orig_in_finally;
 
 		CG(active_op_array)->try_catch_array[try_catch_offset].finally_op = opnum_jmp + 1;
 		CG(active_op_array)->try_catch_array[try_catch_offset].finally_end

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -348,6 +348,7 @@ void zend_oparray_context_begin(zend_oparray_context *prev_context, zend_op_arra
 	CG(context).brk_cont_array = NULL;
 	CG(context).labels = NULL;
 	CG(context).in_jmp_frameless_branch = false;
+	CG(context).in_finally = false;
 	CG(context).active_property_info_name = NULL;
 	CG(context).active_property_hook_kind = (zend_property_hook_kind)-1;
 }
@@ -6150,6 +6151,10 @@ static void zend_compile_return(const zend_ast *ast) /* {{{ */
 		}
 	}
 
+	if (CG(context).in_finally) {
+		zend_error(E_DEPRECATED, "Returning from a finally block is deprecated");
+	}
+
 	if ((CG(active_op_array)->fn_flags & ZEND_ACC_HAS_FINALLY_BLOCK)
 	 && (expr_node.op_type == IS_CV || (by_ref && expr_node.op_type == IS_VAR))
 	 && zend_has_finally()) {
@@ -7398,7 +7403,10 @@ static void zend_compile_try(const zend_ast *ast) /* {{{ */
 
 		zend_emit_op(NULL, ZEND_JMP, NULL, NULL);
 
+		bool orig_in_finally = CG(context).in_finally;
+		CG(context).in_finally = true;
 		zend_compile_stmt(finally_ast);
+		CG(context).in_finally = orig_in_finally;
 
 		CG(active_op_array)->try_catch_array[try_catch_offset].finally_op = opnum_jmp + 1;
 		CG(active_op_array)->try_catch_array[try_catch_offset].finally_end

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -207,6 +207,7 @@ typedef struct _zend_oparray_context {
 	zend_string *active_property_info_name;
 	zend_property_hook_kind active_property_hook_kind;
 	bool       in_jmp_frameless_branch;
+	bool       in_finally;
 	bool has_assigned_to_http_response_header;
 } zend_oparray_context;
 

--- a/sapi/phpdbg/tests/exceptions_001.phpt
+++ b/sapi/phpdbg/tests/exceptions_001.phpt
@@ -7,6 +7,7 @@ ev 1 + 2
 c
 q
 --EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
 [Successful compilation of %s]
 prompt> handle first
 [Uncaught Error in %s on line 16: Call to undefined function foo()]
@@ -22,6 +23,8 @@ Stack trace:
 #0 %s(22): {closure:%s:%d}()
 #1 {main}
 [Script ended normally]
+
+Deprecated: Returning from a finally block is deprecated in %s on line %d
 prompt> 
 --FILE--
 <?php

--- a/sapi/phpdbg/tests/exceptions_002.phpt
+++ b/sapi/phpdbg/tests/exceptions_002.phpt
@@ -7,6 +7,7 @@ c
 
 q
 --EXPECTF--
+Deprecated: Returning from a finally block is deprecated in %s on line %d
 [Successful compilation of %s]
 prompt> handle first
 [Uncaught Error in %s on line 16: Call to undefined function foo()]
@@ -26,6 +27,8 @@ Stack trace:
 #0 %s(20): {closure:%s:%d}()
 #1 {main}
 [Script ended normally]
+
+Deprecated: Returning from a finally block is deprecated in %s on line %d
 prompt> [The stack contains nothing !]
 prompt> 
 --FILE--


### PR DESCRIPTION
This PR implements the "return inside finally" deprecation from the PHP 8.6 deprecations RFC.

https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_returning_from_a_finally_block

Returning from a finally block now raises `E_DEPRECATED` at compile time.
The check tracks the return lexically. Returning from the try or catch part is still fine, and a return inside a nested closure stays fine because the closure has its own scope. A return in a nested try that is itself inside the finally does get flagged though.

`Zend/tests/try/finally_return_deprecation.phpt` covers all of that.
The rest of the diff adds the deprecation line to existing tests that already return from a finally.