### PR TITLE
Fix GH-20726: crash in pdo_odbc with pooling and no credentials

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,10 @@ PHP                                                                        NEWS
   . Fixed memory leaks when calling Collator::__construct() or
     Spoofchecker::__construct() twice. (Weilin Du)
 
+- PDO_ODBC:
+  . Fixed bug GH-20726 (Crash with ODBC connection pooling when the DSN
+    carries no credentials). (iliaal)
+
 - Phar:
   . Fixed inconsistent handling of the magic ".phar" directory. Paths such as
     "/.phar" remain protected, while non-magic paths that merely start with

--- a/ext/pdo_odbc/odbc_driver.c
+++ b/ext/pdo_odbc/odbc_driver.c
@@ -601,7 +601,11 @@ static int pdo_odbc_handle_factory(pdo_dbh_t *dbh, zval *driver_options) /* {{{ 
 				dsnbuf, sizeof(dsnbuf)-1, &dsnbuflen, SQL_DRIVER_NOPROMPT);
 	}
 	if (!use_direct) {
-		rc = SQLConnect(H->dbc, (SQLCHAR *) dbh->data_source, SQL_NTS, (SQLCHAR *) dbh->username, SQL_NTS, (SQLCHAR *) dbh->password, SQL_NTS);
+		/* unixODBC pooling strcmp()s the credentials when matching a cached
+		 * connection and crashes on a NULL username/password, so pass "". */
+		rc = SQLConnect(H->dbc, (SQLCHAR *) dbh->data_source, SQL_NTS,
+			(SQLCHAR *) (dbh->username ? dbh->username : ""), SQL_NTS,
+			(SQLCHAR *) (dbh->password ? dbh->password : ""), SQL_NTS);
 	}
 
 	if (rc != SQL_SUCCESS && rc != SQL_SUCCESS_WITH_INFO) {


### PR DESCRIPTION
pdo_odbc passed dbh->username and dbh->password straight to SQLConnect, and both are NULL when the DSN carries no credentials. With ODBC connection pooling enabled, the unixODBC driver manager runs strcmp() on the cached and requested credentials while matching a pooled connection, dereferences the NULL, and crashes inside SQLConnect. Passing empty strings avoids it. Reproduced on PHP-8.4 against the MDBTools driver with pooling enabled: a connect/close loop SIGSEGVs unpatched and runs clean patched. This hardens the PHP side only; the residual fault under pooling is an uninitialised-value read inside unixODBC's own pool bookkeeping and belongs upstream. Refs #20726
