### PR TITLE
Add 'strace' sub command for generated test reproduction scripts

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -2769,6 +2769,9 @@ case "$1" in
 "valgrind")
     USE_ZEND_ALLOC=0 valgrind $2 {$orig_cmd}
     ;;
+"strace")
+    strace -o /tmp/strace -tt -ff $2 {$orig_cmd}
+    ;;
 "rr")
     rr record $2 {$orig_cmd}
     ;;


### PR DESCRIPTION
This adds `strace` to the options for running the reproducing `.sh` files that the test runner creates when a test fails. This is useful in case the test itself starts other scripts, and/or does IO between them or at all.

I have had this in Xdebug's variant for some time now, and it would be nice not to maintain my patch for this specific item.