### PR TITLE
Fix GH-22516: widen zend_mm srun free counter to cover bin 0

### DIFF
--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -197,7 +197,7 @@ typedef zend_mm_bitset zend_mm_page_map[ZEND_MM_PAGE_MAP_LEN];     /* 64B */
 #define ZEND_MM_SRUN_BIN_NUM_MASK        0x0000001f
 #define ZEND_MM_SRUN_BIN_NUM_OFFSET      0
 
-#define ZEND_MM_SRUN_FREE_COUNTER_MASK   0x01ff0000
+#define ZEND_MM_SRUN_FREE_COUNTER_MASK   0x03ff0000
 #define ZEND_MM_SRUN_FREE_COUNTER_OFFSET 16
 
 #define ZEND_MM_NRUN_OFFSET_MASK         0x01ff0000


### PR DESCRIPTION
Fix is trivial, but given it is only 32bit... not 100% sure if needed

zend_mm_gc()'s per-page free-slot counter is stored in a 9-bit field (ZEND_MM_SRUN_FREE_COUNTER_MASK, max 511), but bin 0 has 512 slots, so a fully-free bin-0 page drives the counter to 512, overflows the field, and reads back as 0. The fully-free-page checks (counter == bin_elements) then never fire and the page is never reclaimed. Widening the field to 10 bits (0x03ff0000) fixes it: bit 25 was unused, and the change is a no-op for every other bin since they all hold at most 256 slots.

Reachable only where ZEND_MM_MIN_USEABLE_BIN_SIZE == 8, i.e. 32-bit or heap-protection-disabled builds. On 64-bit with heap protection, zend_mm_alloc_heap() rounds every sub-16-byte request up to bin 1, so bin 0 is never used and the change is inert there.

Fixes #22516
