### PR TITLE
ext/Intl: Fix IntlDateFormatter offset type validation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -97,6 +97,9 @@ PHP                                                                        NEWS
     locale_get_display_keyword_value() respectively. (Weilin Du)
   . Fix incorrect argument positions for invalid start/end arguments in
     transliterator_transliterate(). (Weilin Du)
+  . IntlDateFormatter::parse()/datefmt_parse() and
+    IntlDateFormatter::localtime()/datefmt_localtime() now raise TypeError
+    when the offset argument is not of type int. (Weilin Du)
   . Fixed IntlTimeZone::getDisplayName() to synchronize object error state
     for invalid display types. (Weilin Du)
   . Fixed Locale::lookup() and locale_lookup() to return NULL instead of the

--- a/UPGRADING
+++ b/UPGRADING
@@ -38,6 +38,10 @@ PHP 8.6 UPGRADE NOTES
     types / values and raise a TypeError / ValueError accordingly.
 
 - Intl:
+  . IntlDateFormatter::parse()/datefmt_parse() and
+    IntlDateFormatter::localtime()/datefmt_localtime() now raise a TypeError
+    when the offset argument is not of type int instead of silently converting
+    the value.
   . Passing a non-stringable object as a time zone to Intl APIs that accept
     time zone objects or strings now raises a TypeError instead of an Error.
   . IntlBreakIterator::getLocale() now raises a ValueError when the type is

--- a/UPGRADING
+++ b/UPGRADING
@@ -38,10 +38,6 @@ PHP 8.6 UPGRADE NOTES
     types / values and raise a TypeError / ValueError accordingly.
 
 - Intl:
-  . IntlDateFormatter::parse()/datefmt_parse() and
-    IntlDateFormatter::localtime()/datefmt_localtime() now raise a TypeError
-    when the offset argument is not of type int instead of silently converting
-    the value.
   . Passing a non-stringable object as a time zone to Intl APIs that accept
     time zone objects or strings now raises a TypeError instead of an Error.
   . IntlBreakIterator::getLocale() now raises a ValueError when the type is
@@ -57,6 +53,10 @@ PHP 8.6 UPGRADE NOTES
   . ResourceBundle::get() and resourcebundle_get() now report fallback-disabled
     resource lookups with "without fallback to <locale>" instead of the
     malformed "without fallback from to <locale>".
+  . IntlDateFormatter::parse()/datefmt_parse() and
+    IntlDateFormatter::localtime()/datefmt_localtime() now raise a TypeError
+    when the offset argument is not of type int instead of silently converting
+    the value.
 
 - PCNTL:
   . pcntl_alarm() now raises a ValueError if the seconds argument is

--- a/ext/intl/dateformat/dateformat_parse.cpp
+++ b/ext/intl/dateformat/dateformat_parse.cpp
@@ -147,9 +147,12 @@ U_CFUNC PHP_FUNCTION(datefmt_parse)
 	DATE_FORMAT_METHOD_FETCH_OBJECT;
 
 	if (z_parse_pos) {
-		zval *z_parse_pos_tmp = z_parse_pos;
-		ZVAL_DEREF(z_parse_pos_tmp);
-		const zend_long long_parse_pos = zval_get_long(z_parse_pos_tmp);
+		bool failed;
+		const zend_long long_parse_pos = zval_try_get_long(z_parse_pos, &failed);
+		if (failed) {
+			zend_argument_type_error(hasThis() ? 2 : 3, "must be of type int, %s given", zend_zval_value_name(z_parse_pos));
+			RETURN_THROWS();
+		}
 		if (ZEND_LONG_INT_OVFL(long_parse_pos)) {
 			intl_error_set_code(NULL, U_ILLEGAL_ARGUMENT_ERROR);
 			intl_error_set_custom_msg(NULL, "String index is out of valid range.");
@@ -229,9 +232,12 @@ U_CFUNC PHP_FUNCTION(datefmt_localtime)
 	DATE_FORMAT_METHOD_FETCH_OBJECT;
 
 	if (z_parse_pos) {
-		zval *z_parse_pos_tmp = z_parse_pos;
-		ZVAL_DEREF(z_parse_pos_tmp);
-		const zend_long long_parse_pos = zval_get_long(z_parse_pos_tmp);
+		bool failed;
+		const zend_long long_parse_pos = zval_try_get_long(z_parse_pos, &failed);
+		if (failed) {
+			zend_argument_type_error(hasThis() ? 2 : 3, "must be of type int, %s given", zend_zval_value_name(z_parse_pos));
+			RETURN_THROWS();
+		}
 		if (ZEND_LONG_INT_OVFL(long_parse_pos)) {
 			intl_error_set_code(NULL, U_ILLEGAL_ARGUMENT_ERROR);
 			intl_error_set_custom_msg(NULL, "String index is out of valid range.");

--- a/ext/intl/dateformat/dateformat_parse.cpp
+++ b/ext/intl/dateformat/dateformat_parse.cpp
@@ -133,26 +133,25 @@ U_CFUNC PHP_FUNCTION(datefmt_parse)
 	char*           text_to_parse = NULL;
 	size_t          text_len =0;
 	zval*         	z_parse_pos = NULL;
+	zend_long       long_parse_pos = 0;
+	bool            parse_pos_is_null = 1;
 	int32_t		parse_pos = -1;
 
 	DATE_FORMAT_METHOD_INIT_VARS;
 
 	/* Parse parameters. */
-	if( zend_parse_method_parameters( ZEND_NUM_ARGS(), getThis(), "Os|z!",
-		&object, IntlDateFormatter_ce_ptr, &text_to_parse, &text_len, &z_parse_pos ) == FAILURE ){
+	if( zend_parse_method_parameters( ZEND_NUM_ARGS(), getThis(), "Os|l!",
+		&object, IntlDateFormatter_ce_ptr, &text_to_parse, &text_len, &long_parse_pos, &parse_pos_is_null ) == FAILURE ){
 		RETURN_THROWS();
+	}
+	if (ZEND_NUM_ARGS() >= (hasThis() ? 2 : 3)) {
+		z_parse_pos = ZEND_CALL_ARG(execute_data, hasThis() ? 2 : 3);
 	}
 
 	/* Fetch the object. */
 	DATE_FORMAT_METHOD_FETCH_OBJECT;
 
-	if (z_parse_pos) {
-		bool failed;
-		const zend_long long_parse_pos = zval_try_get_long(z_parse_pos, &failed);
-		if (failed) {
-			zend_argument_type_error(hasThis() ? 2 : 3, "must be of type int, %s given", zend_zval_value_name(z_parse_pos));
-			RETURN_THROWS();
-		}
+	if (!parse_pos_is_null) {
 		if (ZEND_LONG_INT_OVFL(long_parse_pos)) {
 			intl_error_set_code(NULL, U_ILLEGAL_ARGUMENT_ERROR);
 			intl_error_set_custom_msg(NULL, "String index is out of valid range.");
@@ -174,6 +173,8 @@ U_CFUNC PHP_METHOD(IntlDateFormatter, parseToCalendar)
 {
 	zend_string *text_to_parse = NULL;
 	zval* z_parse_pos = NULL;
+	zend_long long_parse_pos = 0;
+	bool parse_pos_is_null = 1;
 	int32_t parse_pos = -1;
 
 	DATE_FORMAT_METHOD_INIT_VARS;
@@ -181,21 +182,18 @@ U_CFUNC PHP_METHOD(IntlDateFormatter, parseToCalendar)
 	ZEND_PARSE_PARAMETERS_START(1, 2)
 		Z_PARAM_STR(text_to_parse)
 		Z_PARAM_OPTIONAL
-		Z_PARAM_ZVAL(z_parse_pos)
+		Z_PARAM_LONG_EX(long_parse_pos, parse_pos_is_null, 1, 1)
 	ZEND_PARSE_PARAMETERS_END();
+	if (ZEND_NUM_ARGS() >= 2) {
+		z_parse_pos = ZEND_CALL_ARG(execute_data, 2);
+	}
 
 	object = ZEND_THIS;
 
 	/* Fetch the object. */
 	DATE_FORMAT_METHOD_FETCH_OBJECT;
 
-	if (z_parse_pos) {
-		bool failed;
-		const zend_long long_parse_pos = zval_try_get_long(z_parse_pos, &failed);
-		if (failed) {
-			zend_argument_type_error(2, "must be of type int, %s given", zend_zval_value_name(z_parse_pos));
-			RETURN_THROWS();
-		}
+	if (!parse_pos_is_null) {
 		if (ZEND_LONG_INT_OVFL(long_parse_pos)) {
 			intl_error_set_code(NULL, U_ILLEGAL_ARGUMENT_ERROR);
 			intl_error_set_custom_msg(NULL, "String index is out of valid range.");
@@ -218,26 +216,25 @@ U_CFUNC PHP_FUNCTION(datefmt_localtime)
 	char*           text_to_parse = NULL;
 	size_t          text_len =0;
 	zval*         	z_parse_pos = NULL;
+	zend_long       long_parse_pos = 0;
+	bool            parse_pos_is_null = 1;
 	int32_t		parse_pos = -1;
 
 	DATE_FORMAT_METHOD_INIT_VARS;
 
 	/* Parse parameters. */
-	if( zend_parse_method_parameters( ZEND_NUM_ARGS(), getThis(), "Os|z!",
-		&object, IntlDateFormatter_ce_ptr, &text_to_parse, &text_len, &z_parse_pos ) == FAILURE ){
+	if( zend_parse_method_parameters( ZEND_NUM_ARGS(), getThis(), "Os|l!",
+		&object, IntlDateFormatter_ce_ptr, &text_to_parse, &text_len, &long_parse_pos, &parse_pos_is_null ) == FAILURE ){
 		RETURN_THROWS();
+	}
+	if (ZEND_NUM_ARGS() >= (hasThis() ? 2 : 3)) {
+		z_parse_pos = ZEND_CALL_ARG(execute_data, hasThis() ? 2 : 3);
 	}
 
     /* Fetch the object. */
 	DATE_FORMAT_METHOD_FETCH_OBJECT;
 
-	if (z_parse_pos) {
-		bool failed;
-		const zend_long long_parse_pos = zval_try_get_long(z_parse_pos, &failed);
-		if (failed) {
-			zend_argument_type_error(hasThis() ? 2 : 3, "must be of type int, %s given", zend_zval_value_name(z_parse_pos));
-			RETURN_THROWS();
-		}
+	if (!parse_pos_is_null) {
 		if (ZEND_LONG_INT_OVFL(long_parse_pos)) {
 			intl_error_set_code(NULL, U_ILLEGAL_ARGUMENT_ERROR);
 			intl_error_set_custom_msg(NULL, "String index is out of valid range.");

--- a/ext/intl/dateformat/dateformat_parse.cpp
+++ b/ext/intl/dateformat/dateformat_parse.cpp
@@ -133,25 +133,26 @@ U_CFUNC PHP_FUNCTION(datefmt_parse)
 	char*           text_to_parse = NULL;
 	size_t          text_len =0;
 	zval*         	z_parse_pos = NULL;
-	zend_long       long_parse_pos = 0;
-	bool            parse_pos_is_null = 1;
 	int32_t		parse_pos = -1;
 
 	DATE_FORMAT_METHOD_INIT_VARS;
 
 	/* Parse parameters. */
-	if( zend_parse_method_parameters( ZEND_NUM_ARGS(), getThis(), "Os|l!",
-		&object, IntlDateFormatter_ce_ptr, &text_to_parse, &text_len, &long_parse_pos, &parse_pos_is_null ) == FAILURE ){
+	if( zend_parse_method_parameters( ZEND_NUM_ARGS(), getThis(), "Os|z!",
+		&object, IntlDateFormatter_ce_ptr, &text_to_parse, &text_len, &z_parse_pos ) == FAILURE ){
 		RETURN_THROWS();
-	}
-	if (ZEND_NUM_ARGS() >= (hasThis() ? 2 : 3)) {
-		z_parse_pos = ZEND_CALL_ARG(execute_data, hasThis() ? 2 : 3);
 	}
 
 	/* Fetch the object. */
 	DATE_FORMAT_METHOD_FETCH_OBJECT;
 
-	if (!parse_pos_is_null) {
+	if (z_parse_pos) {
+		bool failed;
+		const zend_long long_parse_pos = zval_try_get_long(z_parse_pos, &failed);
+		if (failed) {
+			zend_argument_type_error(hasThis() ? 2 : 3, "must be of type int, %s given", zend_zval_value_name(z_parse_pos));
+			RETURN_THROWS();
+		}
 		if (ZEND_LONG_INT_OVFL(long_parse_pos)) {
 			intl_error_set_code(NULL, U_ILLEGAL_ARGUMENT_ERROR);
 			intl_error_set_custom_msg(NULL, "String index is out of valid range.");
@@ -173,8 +174,6 @@ U_CFUNC PHP_METHOD(IntlDateFormatter, parseToCalendar)
 {
 	zend_string *text_to_parse = NULL;
 	zval* z_parse_pos = NULL;
-	zend_long long_parse_pos = 0;
-	bool parse_pos_is_null = 1;
 	int32_t parse_pos = -1;
 
 	DATE_FORMAT_METHOD_INIT_VARS;
@@ -182,18 +181,21 @@ U_CFUNC PHP_METHOD(IntlDateFormatter, parseToCalendar)
 	ZEND_PARSE_PARAMETERS_START(1, 2)
 		Z_PARAM_STR(text_to_parse)
 		Z_PARAM_OPTIONAL
-		Z_PARAM_LONG_EX(long_parse_pos, parse_pos_is_null, 1, 1)
+		Z_PARAM_ZVAL(z_parse_pos)
 	ZEND_PARSE_PARAMETERS_END();
-	if (ZEND_NUM_ARGS() >= 2) {
-		z_parse_pos = ZEND_CALL_ARG(execute_data, 2);
-	}
 
 	object = ZEND_THIS;
 
 	/* Fetch the object. */
 	DATE_FORMAT_METHOD_FETCH_OBJECT;
 
-	if (!parse_pos_is_null) {
+	if (z_parse_pos) {
+		bool failed;
+		const zend_long long_parse_pos = zval_try_get_long(z_parse_pos, &failed);
+		if (failed) {
+			zend_argument_type_error(2, "must be of type int, %s given", zend_zval_value_name(z_parse_pos));
+			RETURN_THROWS();
+		}
 		if (ZEND_LONG_INT_OVFL(long_parse_pos)) {
 			intl_error_set_code(NULL, U_ILLEGAL_ARGUMENT_ERROR);
 			intl_error_set_custom_msg(NULL, "String index is out of valid range.");
@@ -216,25 +218,26 @@ U_CFUNC PHP_FUNCTION(datefmt_localtime)
 	char*           text_to_parse = NULL;
 	size_t          text_len =0;
 	zval*         	z_parse_pos = NULL;
-	zend_long       long_parse_pos = 0;
-	bool            parse_pos_is_null = 1;
 	int32_t		parse_pos = -1;
 
 	DATE_FORMAT_METHOD_INIT_VARS;
 
 	/* Parse parameters. */
-	if( zend_parse_method_parameters( ZEND_NUM_ARGS(), getThis(), "Os|l!",
-		&object, IntlDateFormatter_ce_ptr, &text_to_parse, &text_len, &long_parse_pos, &parse_pos_is_null ) == FAILURE ){
+	if( zend_parse_method_parameters( ZEND_NUM_ARGS(), getThis(), "Os|z!",
+		&object, IntlDateFormatter_ce_ptr, &text_to_parse, &text_len, &z_parse_pos ) == FAILURE ){
 		RETURN_THROWS();
-	}
-	if (ZEND_NUM_ARGS() >= (hasThis() ? 2 : 3)) {
-		z_parse_pos = ZEND_CALL_ARG(execute_data, hasThis() ? 2 : 3);
 	}
 
     /* Fetch the object. */
 	DATE_FORMAT_METHOD_FETCH_OBJECT;
 
-	if (!parse_pos_is_null) {
+	if (z_parse_pos) {
+		bool failed;
+		const zend_long long_parse_pos = zval_try_get_long(z_parse_pos, &failed);
+		if (failed) {
+			zend_argument_type_error(hasThis() ? 2 : 3, "must be of type int, %s given", zend_zval_value_name(z_parse_pos));
+			RETURN_THROWS();
+		}
 		if (ZEND_LONG_INT_OVFL(long_parse_pos)) {
 			intl_error_set_code(NULL, U_ILLEGAL_ARGUMENT_ERROR);
 			intl_error_set_custom_msg(NULL, "String index is out of valid range.");

--- a/ext/intl/tests/datefmt_parse_localtime_offset_type_error.phpt
+++ b/ext/intl/tests/datefmt_parse_localtime_offset_type_error.phpt
@@ -1,0 +1,44 @@
+--TEST--
+datefmt_parse() and datefmt_localtime() validate offset type
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+
+$fmt = new IntlDateFormatter('en_GB');
+$fmt->setPattern('VV');
+
+$offset = 'offset';
+try {
+    $fmt->parse('America/Los_Angeles', $offset);
+} catch (TypeError $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+$offset = 'offset';
+try {
+    datefmt_parse($fmt, 'America/Los_Angeles', $offset);
+} catch (TypeError $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+$offset = 'offset';
+try {
+    $fmt->localtime('America/Los_Angeles', $offset);
+} catch (TypeError $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+$offset = 'offset';
+try {
+    datefmt_localtime($fmt, 'America/Los_Angeles', $offset);
+} catch (TypeError $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+IntlDateFormatter::parse(): Argument #2 ($offset) must be of type int, string given
+datefmt_parse(): Argument #3 ($offset) must be of type int, string given
+IntlDateFormatter::localtime(): Argument #2 ($offset) must be of type int, string given
+datefmt_localtime(): Argument #3 ($offset) must be of type int, string given


### PR DESCRIPTION
Now in `IntlDateFormatter::parseToCalendar` we verify if the offset is a int
```
 <?php
  $fmt = new IntlDateFormatter('en_GB');
  $fmt->setPattern('VV');

  $offset = 'offset';

  try {
      $fmt->parseToCalendar('America/Los_Angeles', $offset);
  } catch (TypeError $e) {
      echo $e->getMessage(), PHP_EOL;
  }
```
```
IntlDateFormatter::parseToCalendar(): Argument #2 ($offset) must be of type int, string given
```
reproduce [here](https://onlinephp.io?s=RY3dCoJAEIXvg95hLoRdQekBKsPKfsDIC_FWFhs10F3ZHQiJ3r1Vk-bqMN_hO7DZdXW3XAA4ZUuwBYkvuEpqjoLwpHQriFBzhjI_75m7npt-YJCSEUrOsmxEI1RlaZE1sSmxHyDdw3sIw02KTmiDqTqIBuVD2JWwRf0sxCpWJg9lhQ0a5s3KafwDhaCiBp72HUZaKw0Oun8zFrWyHz-okG5ojKiQux4klySP7vGk-AI%2C&v=8.5.6)
However, in `IntlDateFormatter::parse()` and `IntlDateFormatter::localtime()` we silently accept offset that is not a int and turns it into 0
```
<?php
  $fmt = new IntlDateFormatter('en_GB');
  $fmt->setPattern('VV');

  $offset = 'offset';
  $fmt->parse('America/Los_Angeles', $offset);
  $fmt->localtime('America/Los_Angeles', $offset);
```
This will not throws an error, reproduce [here](https://onlinephp.io?s=s7EvyCjg5VJQUEnLLVGwVchLLVfwzCvJcUksSXXLL8pNLClJLdJQT82Ld3dS17SGqdS1K04tCQBL5mmoh4WBpcCS-WlpQCmgSeoQljqSnoLEouJUDXXH3NSizOREfZ_84njHvPTUnNRidR2YTmQ7cvKTE3NKMnMJ6wEA&v=8.5.6)

At least for consistence's sake, we should reject non-int `offset` in these functions (This also aligns with previous fixes about avoiding silently casting).