### PR TITLE
ext/iconv/tests/bug76249.phpt: fallback for non-GNU iconv()

### DIFF
--- a/ext/iconv/tests/bug76249.phpt
+++ b/ext/iconv/tests/bug76249.phpt
@@ -4,16 +4,30 @@ Bug #76249 (stream filter convert.iconv leads to infinite loop on invalid sequen
 iconv
 --FILE--
 <?php
+$ignore = "";
+if (ICONV_IMPL == "libiconv" || ICONV_IMPL == "glibc") {
+    // The original bug report used "//IGNORE", and the bug itself
+    // involves the return value and errno from iconv(), so in the
+    // interest of fidelity we include the suffix on systems like the
+    // one where the bug was reported. On other systems however,
+    // despite being mentioned in POSIX 2024, the "//IGNORE" suffix is
+    // not supported consistently. Musl in particular does not support
+    // it at all, so we must omit it to avoid triggering other
+    // (unexpected) errors. In any case, it is nice to check that
+    // iconv and invalid streams do not interact badly.
+    $ignore = "//IGNORE";
+}
+
 $fh = fopen('php://memory', 'rw');
 fwrite($fh, "abc");
 rewind($fh);
-if (false === @stream_filter_append($fh, 'convert.iconv.ucs-2/utf8//IGNORE', STREAM_FILTER_READ, [])) {
-    stream_filter_append($fh, 'convert.iconv.ucs-2/utf-8//IGNORE', STREAM_FILTER_READ, []);
+if (false === @stream_filter_append($fh, "convert.iconv.ucs-2/utf8{$ignore}", STREAM_FILTER_READ, [])) {
+    stream_filter_append($fh, "convert.iconv.ucs-2/utf-8{$ignore}", STREAM_FILTER_READ, []);
 }
 var_dump(stream_get_contents($fh));
 ?>
 DONE
---EXPECTF--
-Warning: stream_get_contents(): iconv stream filter ("ucs-2"=>"utf%A8//IGNORE"): invalid multibyte sequence in %sbug76249.php on line %d
-string(0) ""
+--EXPECTREGEX--
+Warning: stream_get_contents\(\): iconv stream filter \("ucs-2"=>"utf-?8(\/\/IGNORE)?"\): invalid multibyte sequence in .*bug76249\.php on line \d+
+string\(0\) ""
 DONE


### PR DESCRIPTION
Fixes one failure in https://github.com/php/php-src/issues/22413. The commit message and comment explain the rationale, but here are some references.

1. The [libiconv docs](https://www.gnu.org/savannah-checkouts/gnu/libiconv/documentation/libiconv-1.19/iconv.3.html) say that `//IGNORE` will ignore only untranslatable sequences; invalid sequences are an error instead.
2. The [libiconv docs](https://www.gnu.org/savannah-checkouts/gnu/libiconv/documentation/libiconv-1.19/iconv_open.3.html) **also** say that both invalid and untranslatable sequences will be ignored. Whether or not this should be an error is unclear.
3. The [glibc docs](https://sourceware.org/git/?p=glibc.git;a=blob;f=manual/charset.texi) ambiguously say "characters that cannot be converted" will be ignored, and do not mention the error status. I would interpret "characters" to mean valid characters, but I am reaching.
4. The [man-pages page for iconv_open](https://www.man7.org/linux/man-pages/man3/iconv_open.3.html) says that only untranslatable sequences are ignored.
5. [POSIX says](https://pubs.opengroup.org/onlinepubs/9799919799/functions/iconv.html) that `//IGNORE` should ignore both invalid and untranslatable sequences. Invalid sequences are _not_ an error in this case.
6. The [musl implementation of iconv](https://git.musl-libc.org/cgit/musl/tree/src/locale/iconv.c) does not support `//IGNORE` at all.
7. FreeBSD apparently uses [some other ignore mechanism](https://man.freebsd.org/cgi/man.cgi?query=iconv&sektion=3&apropos=0&manpath=FreeBSD+15.1-RELEASE+and+Ports.quarterly).