### PR TITLE
zend_portability: Consistently allow using `ZEND_ASSUME()` as an expression

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -98,9 +98,7 @@
 # pragma clang diagnostic ignored "-Wassume"
 # define ZEND_ASSUME(c)	__builtin_assume(c)
 #elif defined(PHP_HAVE_BUILTIN_UNREACHABLE) && defined(PHP_HAVE_BUILTIN_EXPECT)
-# define ZEND_ASSUME(c)	do { \
-		if (__builtin_expect(!(c), 0)) __builtin_unreachable(); \
-	} while (0)
+# define ZEND_ASSUME(c)	((void)(__builtin_expect(!(c), 0) ? __builtin_unreachable() : (void)false))
 #else
 # define ZEND_ASSUME(c)
 #endif


### PR DESCRIPTION
Specifically this is intended to be used as the first part of a comma expression in function-like macros that cannot be proper functions (due to needing to work with generic types).

Extracted from #22391.