### PR TITLE
ext/iconv/tests/bug52211.phpt: use per-iconv charset names

### DIFF
--- a/ext/iconv/tests/bug52211.phpt
+++ b/ext/iconv/tests/bug52211.phpt
@@ -5,8 +5,22 @@ iconv
 --FILE--
 <?php
 
+// According to POSIX 2024, the to/from charset names are
+// implementation-defined. To keep this test true to its original
+// purpose, we retain the charsets used in bug 52211, but only when
+// the implementation is known to support them. Otherwise we default
+// both to ASCII, which should be supported everywhere (in particular
+// on musl) yet still considers the input invalid.
+$from_charset = "ASCII";
+$to_charset = "ASCII";
+
+if (ICONV_IMPL == "libiconv" || ICONV_IMPL == "glibc") {
+    $from_charset = "CP850";
+    $to_charset = "ISO-8859-1";
+}
+
 $str = "PATHOLOGIES MÉDICO-CHIRUR. ADUL. PL";
-$str_iconv = iconv('CP850', 'ISO-8859-1', $str );
+$str_iconv = iconv($from_charset, $to_charset, $str );
 var_dump($str_iconv);
 
 ?>


### PR DESCRIPTION
The charset names used in this test are implementation-specific, and in particular are not known to musl. This causes musl to fall back to utf8, in which the input string is not actually invalid, leading to a failed test. The input string is already invalid in ASCII however, so we solve the general problem by using ASCII as the to/from charset unless the `ICONV_IMPL` is known to support the originals.

Fixes another one of the failures in https://github.com/php/php-src/issues/22413