### PR TITLE
Check the stack limit when calling internal functions

### DIFF
--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -861,6 +861,14 @@ zend_result zend_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_
 		}
 	}
 
+#ifdef ZEND_CHECK_STACK_LIMIT
+	if (UNEXPECTED(zend_call_stack_overflowed(EG(stack_limit)))) {
+		zend_call_stack_size_error();
+		zend_release_fcall_info_cache(fci_cache);
+		return SUCCESS;
+	}
+#endif
+
 	call = zend_vm_stack_push_call_frame(call_info,
 		func, fci->param_count, object_or_called_scope);
 	uint32_t consumed_args = fci->param_count ? fci->consumed_args : 0;

--- a/ext/spl/tests/gh15672.phpt
+++ b/ext/spl/tests/gh15672.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-15672 (MultipleIterator attached to itself overflows the C stack)
+--SKIPIF--
+<?php
+if (!function_exists('zend_test_zend_call_stack_get')) die("skip zend_test_zend_call_stack_get() is not available");
+if (getenv("SKIP_SLOW_TESTS")) die('skip slow test');
+?>
+--EXTENSIONS--
+zend_test
+--INI--
+memory_limit=2G
+zend.max_allowed_stack_size=512K
+--FILE--
+<?php
+$m = new MultipleIterator();
+$m->attachIterator(new ArrayIterator([1, 2, 3]), "1");
+$m->attachIterator($m, 3);
+foreach ($m as $key => $value) {
+}
+?>
+--EXPECTREGEX--
+.*Maximum call stack size of \d+ bytes.*Infinite recursion\?.*thrown in .* on line \d+

--- a/ext/spl/tests/gh15911.phpt
+++ b/ext/spl/tests/gh15911.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-15911 (AppendIterator appended to itself overflows the C stack)
+--SKIPIF--
+<?php
+if (!function_exists('zend_test_zend_call_stack_get')) die("skip zend_test_zend_call_stack_get() is not available");
+if (getenv("SKIP_SLOW_TESTS")) die('skip slow test');
+?>
+--EXTENSIONS--
+zend_test
+--INI--
+memory_limit=2G
+zend.max_allowed_stack_size=512K
+--FILE--
+<?php
+$it = new AppendIterator();
+$it->append($it);
+foreach ($it as $v) {
+}
+?>
+--EXPECTREGEX--
+.*Maximum call stack size of \d+ bytes.*Infinite recursion\?.*thrown in .* on line \d+


### PR DESCRIPTION
GH-16492 fixes GH-15911 by guarding AppendIterator against appending to itself; this is the general form. An internal function that recurses through zend_call_function (which invokes internal handlers directly, with no VM frame and no stack-limit check) never yields back to the VM, so the C stack overflows into a SEGV. This adds the interpreter's stack-limit check to that path, behind ZEND_CHECK_STACK_LIMIT, raising the usual "Maximum call stack size reached" error instead. It covers a MultipleIterator (GH-15672) or AppendIterator (GH-15911) attached to itself and a mutual cycle between two such iterators that a per-iterator guard cannot see. For a pure internal-to-internal cycle the error is uncatchable, since there is no user frame in the recursion to unwind into. Fixes php/php-src#15672 and php/php-src#15911.
