### PR TITLE
ext/dba: prevent reallocation for info function

### DIFF
--- a/ext/dba/dba.c
+++ b/ext/dba/dba.c
@@ -1282,10 +1282,8 @@ PHP_FUNCTION(dba_handlers)
 
 	for (const dba_handler *hptr = handler; hptr->name; hptr++) {
 		if (full_info) {
-			// TODO: avoid reallocation ???
-			char *str = hptr->info(hptr, NULL);
+			const char *str = hptr->info(hptr, NULL);
 			add_assoc_string(return_value, hptr->name, str);
-			efree(str);
 		} else {
 			add_next_index_string(return_value, hptr->name);
 		}

--- a/ext/dba/dba_cdb.c
+++ b/ext/dba/dba_cdb.c
@@ -319,12 +319,12 @@ DBA_INFO_FUNC(cdb)
 {
 #ifdef DBA_CDB_BUILTIN
 	if (!strcmp(hnd->name, "cdb")) {
-		return estrdup(cdb_version());
+		return cdb_version();
 	} else {
-		return estrdup(cdb_make_version());
+		return cdb_make_version();
 	}
 #else
-	return estrdup("External");
+	return "External";
 #endif
 }
 

--- a/ext/dba/dba_db1.c
+++ b/ext/dba/dba_db1.c
@@ -177,7 +177,7 @@ DBA_SYNC_FUNC(db1)
 
 DBA_INFO_FUNC(db1)
 {
-	return estrdup(DB1_VERSION);
+	return DB1_VERSION;
 }
 
 #endif

--- a/ext/dba/dba_db2.c
+++ b/ext/dba/dba_db2.c
@@ -187,7 +187,7 @@ DBA_SYNC_FUNC(db2)
 
 DBA_INFO_FUNC(db2)
 {
-	return estrdup(DB_VERSION_STRING);
+	return DB_VERSION_STRING;
 }
 
 #endif

--- a/ext/dba/dba_db3.c
+++ b/ext/dba/dba_db3.c
@@ -225,7 +225,7 @@ DBA_SYNC_FUNC(db3)
 
 DBA_INFO_FUNC(db3)
 {
-	return estrdup(DB_VERSION_STRING);
+	return DB_VERSION_STRING;
 }
 
 #endif

--- a/ext/dba/dba_db4.c
+++ b/ext/dba/dba_db4.c
@@ -282,7 +282,7 @@ DBA_SYNC_FUNC(db4)
 
 DBA_INFO_FUNC(db4)
 {
-	return estrdup(DB_VERSION_STRING);
+	return DB_VERSION_STRING;
 }
 
 #endif

--- a/ext/dba/dba_dbm.c
+++ b/ext/dba/dba_dbm.c
@@ -192,7 +192,7 @@ DBA_INFO_FUNC(dbm)
 		return dba_info_gdbm(hnd, info);
 	}
 #endif
-	return estrdup(DBM_VERSION);
+	return DBM_VERSION;
 }
 
 #endif

--- a/ext/dba/dba_flatfile.c
+++ b/ext/dba/dba_flatfile.c
@@ -167,7 +167,7 @@ DBA_SYNC_FUNC(flatfile)
 
 DBA_INFO_FUNC(flatfile)
 {
-	return estrdup(flatfile_version());
+	return flatfile_version();
 }
 
 #endif

--- a/ext/dba/dba_gdbm.c
+++ b/ext/dba/dba_gdbm.c
@@ -189,7 +189,7 @@ DBA_SYNC_FUNC(gdbm)
 
 DBA_INFO_FUNC(gdbm)
 {
-	return estrdup(gdbm_version);
+	return gdbm_version;
 }
 
 #endif

--- a/ext/dba/dba_inifile.c
+++ b/ext/dba/dba_inifile.c
@@ -186,7 +186,7 @@ DBA_SYNC_FUNC(inifile)
 
 DBA_INFO_FUNC(inifile)
 {
-	return estrdup(inifile_version());
+	return inifile_version();
 }
 
 #endif

--- a/ext/dba/dba_lmdb.c
+++ b/ext/dba/dba_lmdb.c
@@ -360,7 +360,7 @@ DBA_SYNC_FUNC(lmdb)
 
 DBA_INFO_FUNC(lmdb)
 {
-	return estrdup(MDB_VERSION_STRING);
+	return MDB_VERSION_STRING;
 }
 
 #endif

--- a/ext/dba/dba_ndbm.c
+++ b/ext/dba/dba_ndbm.c
@@ -147,7 +147,7 @@ DBA_SYNC_FUNC(ndbm)
 
 DBA_INFO_FUNC(ndbm)
 {
-	return estrdup("NDBM");
+	return "NDBM";
 }
 
 #endif

--- a/ext/dba/dba_qdbm.c
+++ b/ext/dba/dba_qdbm.c
@@ -173,7 +173,7 @@ DBA_SYNC_FUNC(qdbm)
 
 DBA_INFO_FUNC(qdbm)
 {
-	return estrdup(dpversion);
+	return dpversion;
 }
 
 #endif

--- a/ext/dba/dba_tcadb.c
+++ b/ext/dba/dba_tcadb.c
@@ -193,7 +193,7 @@ DBA_SYNC_FUNC(tcadb)
 
 DBA_INFO_FUNC(tcadb)
 {
-	return estrdup(tcversion);
+	return tcversion;
 }
 
 #endif

--- a/ext/dba/php_dba.h
+++ b/ext/dba/php_dba.h
@@ -89,7 +89,7 @@ typedef struct dba_handler {
 	zend_string* (*nextkey)(dba_info *);
 	zend_result (*optimize)(dba_info *);
 	zend_result (*sync)(dba_info *);
-	char* (*info)(const struct dba_handler *hnd, dba_info *);
+	const char* (*info)(const struct dba_handler *hnd, dba_info *);
 		/* dba_info==NULL: Handler info, dba_info!=NULL: Database info */
 } dba_handler;
 
@@ -116,7 +116,7 @@ typedef struct dba_handler {
 #define DBA_SYNC_FUNC(x) \
 	zend_result dba_sync_##x(dba_info *info)
 #define DBA_INFO_FUNC(x) \
-	char *dba_info_##x(const dba_handler *hnd, dba_info *info)
+	const char *dba_info_##x(const dba_handler *hnd, dba_info *info)
 
 #define DBA_FUNCS(x) \
 	DBA_OPEN_FUNC(x); \


### PR DESCRIPTION
There is no need to duplicate the strings as they are all `const char*` pointers Thus just change the handle to return `const char*`

Supersedes #22229