### PR TITLE
Check whether stream correctly ends in dechunk

### DIFF
--- a/ext/standard/filters.c
+++ b/ext/standard/filters.c
@@ -1949,6 +1949,11 @@ static php_stream_filter_status_t php_chunked_filter(
 		*bytes_consumed = consumed;
 	}
 
+	if ((flags & PSFS_FLAG_FLUSH_CLOSE) && data->state != CHUNK_TRAILER) {
+		php_error_docref(NULL, E_WARNING, "Stream filter (dechunk): unexpected end of stream");
+		return PSFS_ERR_FATAL;
+	}
+
 	return PSFS_PASS_ON;
 }
 

--- a/ext/standard/tests/filters/chunked_002.phpt
+++ b/ext/standard/tests/filters/chunked_002.phpt
@@ -39,7 +39,7 @@ fclose($buffer);
 $buffer = fopen('php://temp', 'w+');
 stream_filter_append($buffer, 'dechunk', STREAM_FILTER_WRITE);
 
-fwrite($buffer, "5\r\nHello\r\n");
+fwrite($buffer, "5\r\nHello\r\n0\r\n");
 $data = stream_get_contents($buffer, -1, 0);
 var_dump($data);
 

--- a/ext/standard/tests/filters/chunked_invalid.phpt
+++ b/ext/standard/tests/filters/chunked_invalid.phpt
@@ -1,0 +1,53 @@
+--TEST--
+Chunked encoding with invalid values
+--SKIPIF--
+<?php
+$filters = stream_get_filters();
+if(! in_array( "dechunk", $filters )) die( "skip Chunked filter not available." );
+?>
+--INI--
+allow_url_fopen=1
+--FILE--
+<?php
+$streams = array(
+    "data://text/plain,1\r\n",
+    "data://text/plain,1\r\n0\r\n",
+    "data://text/plain,1\r\nab\r\n0\r\n",
+    "data://text/plain,a\r\n",
+    "data://text/plain,z\r\n",
+    "data://text/plain,z\r\n0\r\n",
+    "data://text/plain,a string that starts with a valid hex character\r\n0\r\n",
+    "data://text/plain,some string that does not start with a hex character\r\n0\r\n",
+);
+foreach ($streams as $name) {
+    $fp = fopen($name, "r");
+    stream_filter_append($fp, "dechunk", STREAM_FILTER_READ);
+    var_dump(stream_get_contents($fp));
+    fclose($fp);
+}
+?>
+--EXPECTF--
+
+Warning: stream_get_contents(): Stream filter (dechunk): unexpected end of stream in %s on line %d
+string(0) ""
+
+Warning: stream_get_contents(): Stream filter (dechunk): unexpected end of stream in %s on line %d
+string(0) ""
+
+Warning: stream_get_contents(): Stream filter (dechunk): unexpected end of stream in %s on line %d
+string(0) ""
+
+Warning: stream_get_contents(): Stream filter (dechunk): unexpected end of stream in %s on line %d
+string(0) ""
+
+Warning: stream_get_contents(): Stream filter (dechunk): unexpected end of stream in %s on line %d
+string(0) ""
+
+Warning: stream_get_contents(): Stream filter (dechunk): unexpected end of stream in %s on line %d
+string(0) ""
+
+Warning: stream_get_contents(): Stream filter (dechunk): unexpected end of stream in %s on line %d
+string(0) ""
+
+Warning: stream_get_contents(): Stream filter (dechunk): unexpected end of stream in %s on line %d
+string(0) ""


### PR DESCRIPTION
At the end of the stream, we expect to have read the trailer. Check whether the chunked encoding is at the end of the encoded data when the stream ends.

This makes it more difficult to abuse the dechunk filter for abuse.

Related to #21983