### PR TITLE
ext/iconv/tests/bug48147.phpt:  whitelist iconvs with //IGNORE

### DIFF
--- a/ext/iconv/tests/bug76249.phpt
+++ b/ext/iconv/tests/bug76249.phpt
@@ -4,16 +4,27 @@ Bug #76249 (stream filter convert.iconv leads to infinite loop on invalid sequen
 iconv
 --FILE--
 <?php
+$ignore = "";
+if (ICONV_IMPL == "libiconv" || ICONV_IMPL == "glibc") {
+    // The original bug report uses "//IGNORE", and the bug itself
+    // involves the return value and errno from iconv(), so in the
+    // interest of fidelity we include the suffix on systems like the
+    // one where the bug was reported. On other systems however, the
+    // "//IGNORE" suffix may not be supported, and this is allowed by
+    // POSIX (musl in particular does not support it).
+    $ignore = "//IGNORE";
+}
+
 $fh = fopen('php://memory', 'rw');
 fwrite($fh, "abc");
 rewind($fh);
-if (false === @stream_filter_append($fh, 'convert.iconv.ucs-2/utf8//IGNORE', STREAM_FILTER_READ, [])) {
-    stream_filter_append($fh, 'convert.iconv.ucs-2/utf-8//IGNORE', STREAM_FILTER_READ, []);
+if (false === @stream_filter_append($fh, "convert.iconv.ucs-2/utf8{$ignore}", STREAM_FILTER_READ, [])) {
+    stream_filter_append($fh, "convert.iconv.ucs-2/utf-8{$ignore}", STREAM_FILTER_READ, []);
 }
 var_dump(stream_get_contents($fh));
 ?>
 DONE
---EXPECTF--
-Warning: stream_get_contents(): iconv stream filter ("ucs-2"=>"utf%A8//IGNORE"): invalid multibyte sequence in %sbug76249.php on line %d
-string(0) ""
+--EXPECTREGEX--
+Warning: stream_get_contents\(\): iconv stream filter \("ucs-2"=>"utf-?8(\/\/IGNORE)?"\): invalid multibyte sequence in .*bug76249\.php on line \d+
+string\(0\) ""
 DONE


### PR DESCRIPTION
Fix the last failure in https://github.com/php/php-src/issues/22413

PHP has `ICONV_BROKEN_IGNORE` for implementations (glibc) that return an `EILSEQ` when they `//IGNORE` an invalid sequence, but some implementations (musl) don't support `//IGNORE` at all, and this is allowed by a careful reading of the `iconv_open()` docs.

Whatever libc does ultimately has to be OK. I think this needs better documentation (https://github.com/php/doc-en/issues/5646) rather than more code.