### PR TITLE
ext/phar: add upper-bound check on LongLink entry size

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,10 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 8.6.0alpha2
 
+- Phar:
+  . Fixed bug GH-22556 (OOM DoS via oversized ././@LongLink entry in TAR phar).
+    (crystarm)
+
 - DBA:
   . Fixed OOB read on malformed length field in dba flatfile handler. (alhudz)
 

--- a/NEWS
+++ b/NEWS
@@ -81,6 +81,8 @@ PHP                                                                        NEWS
     PDOStatement::setFetchMode). (SakiTakamachi)
 
 - Phar:
+  . Fixed bug GH-22556 (OOM DoS via oversized ././@LongLink entry in TAR phar).
+    (crystarm)
   . Fixed bug GH-23418 (Use-after-free when looking up mounted directories).
     (Weilin Du)
   . Fixed bug GH-23477 (Memory leak on duplicate native Phar manifest entries).

--- a/ext/phar/tar.c
+++ b/ext/phar/tar.c
@@ -371,8 +371,9 @@ bail:
 			last_was_longlink = true;
 			/* support the ././@LongLink system for storing long filenames */
 
-			/* Check for overflow - bug 61065 */
-			if (entry.uncompressed_filesize == UINT_MAX || entry.uncompressed_filesize == 0) {
+			/* Check for empty or excessively large ././@LongLink filename entries - bug 61065 */
+			if (entry.uncompressed_filesize == 0
+					|| entry.uncompressed_filesize > UINT16_MAX) {
 				if (error) {
 					spprintf(error, 4096, "phar error: \"%s\" is a corrupted tar file (invalid entry size)", fname);
 				}

--- a/ext/phar/tar.c
+++ b/ext/phar/tar.c
@@ -365,8 +365,9 @@ bail:
 			/* support the ././@LongLink system for storing long filenames */
 			entry.filename_len = entry.uncompressed_filesize;
 
-			/* Check for overflow - bug 61065 */
-			if (entry.filename_len == UINT_MAX || entry.filename_len == 0) {
+			/* Check for empty or excessively large ././@LongLink filename entries - bug 61065 */
+			if (entry.filename_len == 0
+					|| entry.filename_len > UINT16_MAX) {
 				if (error) {
 					spprintf(error, 4096, "phar error: \"%s\" is a corrupted tar file (invalid entry size)", fname);
 				}


### PR DESCRIPTION
Fixes #22556.