### PR TITLE
JIT: Inline ZEND_BW_NOT

### DIFF
--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -1594,6 +1594,23 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 							goto jit_failure;
 						}
 						goto done;
+					case ZEND_BW_NOT:
+						if (PROFITABILITY_CHECKS && (!ssa->ops || !ssa->var_info)) {
+							break;
+						}
+						op1_info = OP1_INFO();
+						/* Only the definitely-LONG fast path; anything else falls
+						 * through to the VM handler (its previous behaviour). */
+						if ((op1_info & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_REF)) != MAY_BE_LONG) {
+							break;
+						}
+						res_addr = RES_REG_ADDR();
+						if (!zend_jit_bw_not(&ctx, opline,
+								op1_info, OP1_REG_ADDR(),
+								RES_INFO(), res_addr)) {
+							goto jit_failure;
+						}
+						goto done;
 					case ZEND_ADD:
 					case ZEND_SUB:
 					case ZEND_MUL:

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -6141,6 +6141,27 @@ static int zend_jit_long_math(zend_jit_ctx *jit, const zend_op *opline, uint32_t
 	return 1;
 }
 
+/* Inlined ZEND_BW_NOT for the definitely-LONG case. ~x == x ^ -1; using the
+ * inlined XOR path (rather than the ZEND_BW_NOT_SPEC helper) avoids a helper
+ * call whose result slot could alias a spilled loop-carried CV. */
+static int zend_jit_bw_not(zend_jit_ctx *jit, const zend_op *opline, uint32_t op1_info, zend_jit_addr op1_addr, uint32_t res_info, zend_jit_addr res_addr)
+{
+	ir_ref op1_lval_ref, ref;
+
+	ZEND_ASSERT((op1_info & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_REF)) == MAY_BE_LONG);
+
+	op1_lval_ref = jit_Z_LVAL(jit, op1_addr);
+	ref = ir_XOR_L(op1_lval_ref, ir_CONST_LONG(-1));
+	jit_set_Z_LVAL(jit, res_addr, ref);
+	if (Z_MODE(res_addr) != IS_REG) {
+		jit_set_Z_TYPE_INFO(jit, res_addr, IS_LONG);
+	}
+	if (!zend_jit_store_var_if_necessary(jit, opline->result.var, res_addr, res_info)) {
+		return 0;
+	}
+	return 1;
+}
+
 static int zend_jit_concat_helper(zend_jit_ctx   *jit,
                                   const zend_op  *opline,
                                   uint8_t         op1_type,

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -2008,6 +2008,7 @@ static zend_ssa *zend_jit_trace_build_tssa(zend_jit_trace_rec *trace_buffer, uin
 				case ZEND_JMPNZ_EX:
 				case ZEND_BOOL:
 				case ZEND_BOOL_NOT:
+				case ZEND_BW_NOT:
 					ADD_OP1_TRACE_GUARD();
 					break;
 				case ZEND_ISSET_ISEMPTY_CV:
@@ -4463,6 +4464,22 @@ static const void *zend_jit_trace(zend_jit_trace_rec *trace_buffer, uint32_t par
 						 && (res_info & (MAY_BE_ANY|MAY_BE_GUARD)) == (MAY_BE_DOUBLE|MAY_BE_GUARD)
 						 && !(res_info & MAY_BE_STRING)) {
 							ssa->var_info[ssa_op->result_def].type &= ~MAY_BE_GUARD;
+						}
+						goto done;
+					case ZEND_BW_NOT:
+						op1_info = OP1_INFO();
+						CHECK_OP1_TRACE_TYPE();
+						/* Only the definitely-LONG fast path; otherwise fall back
+						 * to the VM handler (its previous behaviour). */
+						if ((op1_info & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_REF)) != MAY_BE_LONG) {
+							break;
+						}
+						res_info = RES_INFO();
+						res_addr = RES_REG_ADDR();
+						if (!zend_jit_bw_not(&ctx, opline,
+								op1_info, OP1_REG_ADDR(),
+								res_info, res_addr)) {
+							goto jit_failure;
 						}
 						goto done;
 					case ZEND_BW_OR:

--- a/ext/opcache/tests/jit/gh22558.phpt
+++ b/ext/opcache/tests/jit/gh22558.phpt
@@ -1,0 +1,43 @@
+--TEST--
+GH-22558 (Tracing JIT: bitwise-NOT high bits leak past a mask into a typed int property)
+--EXTENSIONS--
+opcache
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit_buffer_size=64M
+opcache.jit=tracing
+; run-tests forces jit_hot_side_exit=1, which compiles side traces so eagerly
+; that the buggy trace never forms — override back to the default so the bug shows.
+opcache.jit_hot_side_exit=8
+--FILE--
+<?php
+final class C {
+    /** @var int[] */ public array $t = [];
+    public int $a = 0;
+    public int $f = 0;
+    public function __construct() { for ($i = 0; $i < 256; $i++) $this->t[$i] = $i & 0xA8; }
+    public function add8(int $value, int $carry): void {
+        $a = $this->a;
+        $total = $a + $value + $carry;
+        $result = $total & 0xFF;
+        $this->f = $this->t[$result]
+            | (($total & 0x100) ? 0x01 : 0)
+            | (((($a & 0x0F) + ($value & 0x0F) + $carry) & 0x10) ? 0x10 : 0)
+            | ((~($a ^ $value) & ($a ^ $result) & 0x80) ? 0x04 : 0);
+        $this->a = $result;
+    }
+}
+$c = new C();
+for ($i = 0; $i < 100000; $i++) {
+    $c->a = $i & 0xFF;
+    $c->add8(($i >> 8) & 0xFF, 0);
+    if (($c->f & ~0xFF) !== 0) {
+        printf("MISCOMPILED at i=%d: \$f = %d (0x%X)\n", $i, $c->f, $c->f);
+        break;
+    }
+}
+echo "done\n";
+?>
+--EXPECT--
+done

--- a/ext/opcache/tests/jit/gh22559.phpt
+++ b/ext/opcache/tests/jit/gh22559.phpt
@@ -1,5 +1,5 @@
 --TEST--
-GH-22558 (Tracing JIT: bitwise-NOT high bits leak past a mask into a typed int property)
+GH-22559 (Tracing JIT: bitwise-NOT high bits leak past a mask into a typed int property)
 --EXTENSIONS--
 opcache
 --INI--


### PR DESCRIPTION
# JIT: inline ZEND_BW_NOT (fixes tracing-JIT miscompilation of `~` in a masked expression)

Fixes #22559.

## Summary

Under the **tracing JIT**, the bitwise-NOT operator `~` is not inlined - it is emitted as a call to the `ZEND_BW_NOT_SPEC` VM helper. In a side trace, the helper's result is written to a stack slot that can alias a spilled, loop-carried CV, silently clobbering that CV. The result is a wrong value for code as ordinary as a flags computation, e.g. an integer that is provably a byte comes out negative.

This PR inlines `ZEND_BW_NOT` for the LONG case (as `x ^ -1`), the same way `ZEND_BW_OR`/`AND`/`XOR` are already inlined. That removes the helper call and its temporary result slot, so the collision can't happen - and it's a small perf
win. A regression test is included.

Interpreter and function-JIT were always correct; only the tracing JIT was wrong.

## 1. Symptom

```php
<?php
final class C {
    /** @var int[] */ public array $t = [];
    public int $a = 0;
    public int $f = 0;
    public function __construct() { for ($i = 0; $i < 256; $i++) $this->t[$i] = $i & 0xA8; }
    public function add8(int $value, int $carry): void {
        $a = $this->a;
        $total = $a + $value + $carry;
        $result = $total & 0xFF;
        // Every OR term is masked to a byte, so $this->f is provably in 0..255.
        $this->f = $this->t[$result]
            | (($total & 0x100) ? 0x01 : 0)
            | (((($a & 0x0F) + ($value & 0x0F) + $carry) & 0x10) ? 0x10 : 0)
            | ((~($a ^ $value) & ($a ^ $result) & 0x80) ? 0x04 : 0); // <- masked to bit 7
        $this->a = $result;
    }
}
$c = new C();
for ($i = 0; $i < 100000; $i++) {
    $c->a = $i & 0xFF;
    $c->add8(($i >> 8) & 0xFF, 0);
    if (($c->f & ~0xFF) !== 0) {                 // $f must never have bits above the low byte
        printf("MISCOMPILED at i=%d: \$f = %d (0x%X)\n", $i, $c->f, $c->f);
        break;
    }
}
echo "done\n";
```

```
$ php -d opcache.jit=tracing  …   MISCOMPILED at i=638: $f = -105 (0x…FF97)
$ php -d opcache.jit=function …   done      # correct
$ php -d opcache.enable_cli=0  …   done      # correct
```

Every operand of the `|` chain is byte-sized (the `~…&0x80` term is `0` or `0x04`), so `$f` is provably in `0..0xBD`. Under the tracing JIT it becomes negative - the correct low byte (`0x97`) with all upper bits set, i.e. a full-width `~` value.

## 2. Research — pinning the affected versions

Built each branch from git and tested **with the JIT verified active**
(`opcache_get_status()['jit']['on'] === true`):

| PHP | JIT backend | tracing JIT |
|-----|-------------|-------------|
| 8.3 | DynASM      | **PASS** (not affected) |
| 8.4 | IR          | **FAIL** |
| 8.5 | IR          | **FAIL** |
| 8.6 | IR          | **FAIL** |

So this is an IR-JIT regression, introduced with the IR JIT in 8.4 -  8.3's DynASM JIT is fine. (Two methodology notes that cost us time and are worth recording: a `--disable-all` build omits opcache on optional-opcache versions, so the JIT never runs and the repro *falsely* passes — always verify `jit.on`; and the bug needs `opcache.jit_hot_side_exit` at its default (8), because the harness default of `1` compiles side traces so eagerly the buggy one never forms.)

This is not #22115  (loop-PHI CV register dropped from a side-exit SNAPSHOT). Building that fix resolves its reproducer but leaves this one failing - same subsystem, different defect.

## 3. Proof — from the disassembly

The buggy side trace (`opcache.jit_debug` + capstone), annotated:

```asm
movq  %r13, 0xa0(%r14)      ; spill the loop-carried $f accumulator -> frame slot 0xa0
orq   $0x10, %r13
movq  %rbx, %rax
xorq  0x50(%r14), %rax      ; ($a ^ $value)
movq  %rax, 0xc0(%r14)      ; stage it as the '~' operand
callq ZEND_BW_NOT_SPEC_TMPVARCV_HANDLER   ; '~' is a HELPER CALL; result -> slot 0xa0
xorq  %r12, %rbx            ; ($a ^ $result)
leaq  0xa0(%r14), %rdx
andq  (%rdx), %rbx          ; & the '~' result
testq $0x80, %rbx
je    jit$$trace_exit_0
movq  0xa0(%r14), %r13      ; reload $f FROM 0xa0 — but 0xa0 now holds ~($a^$value)!
orq   $0x14, %r13
movq  %r13, (%rdx)          ; store the corrupted $f
```

The register allocator assigned the **same frame slot `0xa0`** to (a) the spilled loop-carried CV holding `$f` and (b) the result of the `ZEND_BW_NOT` helper call.  The helper result clobbers the spilled `$f`; the reload then loads `~($a^$value)`
- exactly the observed negative value. (IR confirms it: the CV `RLOAD … {%r13} # BIND(0xa0)` shares slot `0xa0` with the `BW_NOT` operand/result.)

This is `~`-specific because `~` is the only bitwise op the JIT does not inline; `AND`/`OR`/`XOR` are inlined, so `(x ^ 0x80)` in place of `~x` avoids the helper and works - which is the one-operator source-level workaround.

## 4. The fix

Inline `ZEND_BW_NOT` for the LONG case, mirroring the other bitwise ops:

- `ext/opcache/jit/zend_jit_ir.c` - new `zend_jit_bw_not()`: emits `res = ir_XOR_L(op1, -1)` (`~x == x ^ -1`), stores the LONG result. No helper, no temp slot.
- `ext/opcache/jit/zend_jit.c` - function-JIT dispatch: `case ZEND_BW_NOT` (definitely-LONG fast path; otherwise falls through to the VM handler as before).
- `ext/opcache/jit/zend_jit_trace.c` - tracing-JIT codegen dispatch `case ZEND_BW_NOT` (with `CHECK_OP1_TRACE_TYPE()`), plus `ZEND_BW_NOT` added to the `ADD_OP1_TRACE_GUARD()` group so the trace guards op1's type.

55 insertions, no deletions. The inlined path is taken only when op1 is definitely `LONG`; any other type keeps the previous helper-based behaviour.

## 5. Why this fix

- It's the natural fix:  `BW_NOT` is the *only* bitwise operator not inlined by the JIT (`BW_OR`/`AND`/`XOR` already are). Inlining it removes the helper call entirely - so there is no result slot to alias a spilled CV - and it's a small performance win, not just a correctness patch.
- Minimal and low-risk:  It reuses the existing, well-tested inlined-XOR path (`ir_XOR_L`), touches only the JIT, and gates on a known-`LONG` operand; anything else is unchanged.
- Alternative considered:  fixing the trace register allocator so a helper-call result can never alias a live spilled CV (`zend_jit_trace_allocate_registers`).  That is more general but deeper and riskier; inlining `BW_NOT` fixes the observed
  bug directly and is the more upstream-friendly change. (Maintainers may of course prefer to also harden the allocator.)

## Testing

- New regression test `ext/opcache/tests/jit/gh22558.phpt` (overrides `opcache.jit_hot_side_exit` back to `8` so the bug reproduces under `run-tests`).
- Repro now prints `ok`; the `~` result is **byte-identical between the tracing JIT and the interpreter** across `-300..300` and edge values (`PHP_INT_MIN/MAX`).
- Full `ext/opcache/tests` suite on 8.4: 883 tests, 0 failed (853 passed, 29 skipped).