### PR TITLE
phpdbg: fix leaked lowercased lookup keys in phpdbg_resolve_opline_break

### DIFF
--- a/sapi/phpdbg/phpdbg_bp.c
+++ b/sapi/phpdbg/phpdbg_bp.c
@@ -604,13 +604,13 @@ PHPDBG_API int phpdbg_resolve_opline_break(phpdbg_breakopline_t *new_break) /* {
 
 	if (new_break->class_name != NULL) {
 		zend_class_entry *ce;
-		if (!(ce = zend_hash_str_find_ptr(EG(class_table), zend_str_tolower_dup(new_break->class_name, new_break->class_len), new_break->class_len))) {
+		if (!(ce = zend_hash_str_find_ptr_lc(EG(class_table), new_break->class_name, new_break->class_len))) {
 			return FAILURE;
 		}
 		func_table = &ce->function_table;
 	}
 
-	if (!(func = zend_hash_str_find_ptr(func_table, zend_str_tolower_dup(new_break->func_name, new_break->func_len), new_break->func_len))) {
+	if (!(func = zend_hash_str_find_ptr_lc(func_table, new_break->func_name, new_break->func_len))) {
 		if (new_break->class_name != NULL && new_break->func_name != NULL) {
 			phpdbg_error("Method %s doesn't exist in class %s", new_break->func_name, new_break->class_name);
 			return 2;

--- a/sapi/phpdbg/tests/phpdbg_resolve_opline_break_leak.phpt
+++ b/sapi/phpdbg/tests/phpdbg_resolve_opline_break_leak.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Resolving method/function opline breakpoints must not leak the lookup keys
+--PHPDBG--
+b Foo::bar#0
+b baz#0
+b Foo::nope#0
+b Nope::bar#0
+q
+--EXPECTF--
+[Successful compilation of %s]
+prompt> [Breakpoint #0 added at Foo::bar#0]
+prompt> [Breakpoint #1 added at baz#0]
+prompt> [Method nope doesn't exist in class Foo]
+prompt> [Pending breakpoint #3 at Nope::bar#0]
+prompt>
+--FILE--
+<?php
+class Foo {
+    public function bar($x) {
+        return $x + 1;
+    }
+}
+
+function baz($y) {
+    return $y * 2;
+}


### PR DESCRIPTION
Use zend_hash_str_find_ptr_lc(), which lowercases into a temporary and frees it internally, instead of duplicating the key by hand and leaking it.