### PR TITLE
Use PHP version for zip extension

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -3184,7 +3184,6 @@ static PHP_MINFO_FUNCTION(zip)
 	php_info_print_table_start();
 
 	php_info_print_table_row(2, "Zip", "enabled");
-	php_info_print_table_row(2, "Zip version", PHP_ZIP_VERSION);
 #ifdef HAVE_LIBZIP_VERSION
 	if (strcmp(LIBZIP_VERSION, zip_libzip_version())) {
 		php_info_print_table_row(2, "Libzip headers version", LIBZIP_VERSION);

--- a/ext/zip/php_zip.h
+++ b/ext/zip/php_zip.h
@@ -37,7 +37,8 @@ extern zend_module_entry zip_module_entry;
 /* Additional flags not from libzip */
 #define ZIP_FL_OPEN_FILE_NOW (1u<<30)
 
-#define PHP_ZIP_VERSION "1.22.8"
+#include "php_version.h"
+#define PHP_ZIP_VERSION PHP_VERSION
 
 #ifdef HAVE_LIBZIP_VERSION
 #define LIBZIP_VERSION_STR zip_libzip_version()


### PR DESCRIPTION
I plan to stop maintaining the PECL extension https://github.com/pierrejoye/php_zip

So, use the PHP version for the zip extension (as for other extensions)


Reason: lack of time, lack of energy, lack of respect (nobody cares)
