### PR TITLE
ext/intl: Fix NumberFormatter parse offset overflow

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,11 @@ PHP                                                                        NEWS
   . Fixed bug GH-11020 (exif_read_data() emits a spurious "Illegal IFD size"
     warning when an IFD is not followed by a next-IFD offset). (Eyüp Can Akman)
 
+- Intl:
+  . Fixed NumberFormatter::parse() and NumberFormatter::parseCurrency() to
+    reject offset values outside the 32-bit range instead of silently
+    truncating them. (Weilin Du)
+
 - Opcache:
   . Fixed bug GH-21770 (Infinite recursion in property hook getter in opcache
     preloaded trait). (iliaal)

--- a/ext/intl/formatter/formatter_parse.cpp
+++ b/ext/intl/formatter/formatter_parse.cpp
@@ -51,7 +51,7 @@ U_CFUNC PHP_FUNCTION( numfmt_parse )
 
 	if (zposition) {
 		zend_long long_position = zval_get_long(zposition);
-		if (ZEND_LONG_EXCEEDS_INT(long_position)) {
+		if (long_position < INT32_MIN || long_position > INT32_MAX) {
 			zend_argument_value_error(hasThis() ? 3 : 4, "must be between %d and %d", INT32_MIN, INT32_MAX);
 			RETURN_THROWS();
 		}
@@ -162,7 +162,7 @@ U_CFUNC PHP_FUNCTION( numfmt_parse_currency )
 
 	if (zposition) {
 		zend_long long_position = zval_get_long(zposition);
-		if (ZEND_LONG_EXCEEDS_INT(long_position)) {
+		if (long_position < INT32_MIN || long_position > INT32_MAX) {
 			zend_argument_value_error(hasThis() ? 3 : 4, "must be between %d and %d", INT32_MIN, INT32_MAX);
 			RETURN_THROWS();
 		}

--- a/ext/intl/formatter/formatter_parse.cpp
+++ b/ext/intl/formatter/formatter_parse.cpp
@@ -50,7 +50,12 @@ U_CFUNC PHP_FUNCTION( numfmt_parse )
 	}
 
 	if (zposition) {
-		position = (int32_t) zval_get_long(zposition);
+		zend_long long_position = zval_get_long(zposition);
+		if (ZEND_LONG_EXCEEDS_INT(long_position)) {
+			zend_argument_value_error(hasThis() ? 3 : 4, "must be between %d and %d", INT32_MIN, INT32_MAX);
+			RETURN_THROWS();
+		}
+		position = (int32_t) long_position;
 	}
 
 	/* Fetch the object. */
@@ -155,8 +160,13 @@ U_CFUNC PHP_FUNCTION( numfmt_parse_currency )
 	intl_stringFromChar(ustr, str, str_len, &INTL_DATA_ERROR_CODE(nfo));
 	INTL_METHOD_CHECK_STATUS( nfo, "String conversion to UTF-16 failed" );
 
-	if(zposition) {
-		position = (int32_t) zval_get_long(zposition);
+	if (zposition) {
+		zend_long long_position = zval_get_long(zposition);
+		if (ZEND_LONG_EXCEEDS_INT(long_position)) {
+			zend_argument_value_error(hasThis() ? 3 : 4, "must be between %d and %d", INT32_MIN, INT32_MAX);
+			RETURN_THROWS();
+		}
+		position = (int32_t) long_position;
 	}
 
 	icu::ParsePosition pp(position);

--- a/ext/intl/tests/formatter_parse_offset_overflow.phpt
+++ b/ext/intl/tests/formatter_parse_offset_overflow.phpt
@@ -1,0 +1,46 @@
+--TEST--
+NumberFormatter parse offset overflow
+--EXTENSIONS--
+intl
+--SKIPIF--
+<?php if (PHP_INT_SIZE != 8) die("skip: 64-bit only"); ?>
+--FILE--
+<?php
+$fmt = new NumberFormatter('en_US', NumberFormatter::DECIMAL);
+$currencyFmt = new NumberFormatter('en_US', NumberFormatter::CURRENCY);
+
+function print_error(callable $callback): void {
+    try {
+        $callback();
+    } catch (Throwable $e) {
+        echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+    }
+}
+
+$offset = PHP_INT_MAX;
+print_error(function () use ($fmt, &$offset) {
+    $fmt->parse('123', NumberFormatter::TYPE_DOUBLE, $offset);
+});
+
+$offset = PHP_INT_MAX;
+print_error(function () use ($fmt, &$offset) {
+    numfmt_parse($fmt, '123', NumberFormatter::TYPE_DOUBLE, $offset);
+});
+
+$currency = '';
+$offset = PHP_INT_MAX;
+print_error(function () use ($currencyFmt, &$currency, &$offset) {
+    $currencyFmt->parseCurrency('$123.00', $currency, $offset);
+});
+
+$currency = '';
+$offset = PHP_INT_MAX;
+print_error(function () use ($currencyFmt, &$currency, &$offset) {
+    numfmt_parse_currency($currencyFmt, '$123.00', $currency, $offset);
+});
+?>
+--EXPECT--
+ValueError: NumberFormatter::parse(): Argument #3 ($offset) must be between -2147483648 and 2147483647
+ValueError: numfmt_parse(): Argument #4 ($offset) must be between -2147483648 and 2147483647
+ValueError: NumberFormatter::parseCurrency(): Argument #3 ($offset) must be between -2147483648 and 2147483647
+ValueError: numfmt_parse_currency(): Argument #4 ($offset) must be between -2147483648 and 2147483647


### PR DESCRIPTION
Same as #22423, NumberFormatter::parse() and NumberFormatter::parseCurrency() accepted the by-reference offset as a zend_long, but then cast it directly to int32_t. So it will cause a silent truncation.

```
<?php
$fmt = new NumberFormatter('en_US', NumberFormatter::DECIMAL);

$offset = PHP_INT_MAX;
var_dump($fmt->parse('123', NumberFormatter::TYPE_DOUBLE, $offset));
var_dump($offset);
```
[returns](https://onlinephp.io?s=s7EvyCjg5VJJyy1RsFXISy1X8CvNTUotcssvyk0sKUkt0lBPzYsPDVbXQZewsnJxdfb0dfTRtOblApqQn5ZWnAoyJMAjIN7TLyTe1zECKFOWWBSfUppboAGyQteuILGoOFVD3dDIGJuJIZEBrvEu_qFOPq46ClATNTVRTIEKWgMA&v=8.5.6)
```
float(0)
int(-1)
```
In order to align with other previous fixes, we throw an error when the number is out of range