### PR TITLE
session: ensure expected ini directives are set

### DIFF
--- a/ext/session/tests/bug80774.phpt
+++ b/ext/session/tests/bug80774.phpt
@@ -4,6 +4,8 @@ Bug #80774 (session_name() problem with backslash)
 session
 --INI--
 session.use_strict_mode=0
+session.cookie_samesite=Lax
+session.cookie_httponly=1
 --FILE--
 <?php
 session_name("foo\\bar");

--- a/ext/session/tests/gh9200.phpt
+++ b/ext/session/tests/gh9200.phpt
@@ -3,6 +3,8 @@ GH-9200: setcookie has an obsolete expires date format
 --INI--
 session.cookie_lifetime=3600
 session.use_strict_mode=0
+session.cookie_samesite=Lax
+session.cookie_httponly=1
 --EXTENSIONS--
 session
 --CGI--

--- a/ext/session/tests/session_regenerate_id_cookie.phpt
+++ b/ext/session/tests/session_regenerate_id_cookie.phpt
@@ -4,6 +4,8 @@ Test session_regenerate_id() function : basic functionality
 session
 --INI--
 session.sid_length = 32
+session.cookie_samesite=Lax
+session.cookie_httponly=1
 --SKIPIF--
 <?php
 

--- a/ext/session/tests/session_start_partitioned_headers.phpt
+++ b/ext/session/tests/session_start_partitioned_headers.phpt
@@ -4,6 +4,8 @@ session_start() with partitioned cookies - header test
 session
 --INI--
 session.use_strict_mode=0
+session.cookie_samesite=Lax
+session.cookie_httponly=1
 --FILE--
 <?php
 session_id('12345');


### PR DESCRIPTION
Test failing when installed php.ini contains bad values