### PR TITLE
ext/session: reject null bytes in save_path and referer_check

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -647,12 +647,15 @@ static PHP_INI_MH(OnUpdateSaveDir)
 	SESSION_CHECK_ACTIVE_STATE;
 	SESSION_CHECK_OUTPUT_STATE;
 
+	if (zend_str_has_nul_byte(new_value)) {
+		if (stage != ZEND_INI_STAGE_DEACTIVATE) {
+			php_error_docref(NULL, E_WARNING, "\"%s\" must not contain null bytes", ZSTR_VAL(entry->name));
+		}
+		return FAILURE;
+	}
+
 	/* Only do the open_basedir check at runtime */
 	if (stage == PHP_INI_STAGE_RUNTIME || stage == PHP_INI_STAGE_HTACCESS) {
-		if (zend_str_has_nul_byte(new_value)) {
-			return FAILURE;
-		}
-
 		/* we do not use zend_memrchr() since path can contain ; itself */
 		const char *p = strchr(ZSTR_VAL(new_value), ';');
 		if (p) {
@@ -918,6 +921,13 @@ static PHP_INI_MH(OnUpdateRefererCheck)
 {
 	SESSION_CHECK_ACTIVE_STATE;
 	SESSION_CHECK_OUTPUT_STATE;
+
+	if (zend_str_has_nul_byte(new_value)) {
+		if (stage != ZEND_INI_STAGE_DEACTIVATE) {
+			php_error_docref(NULL, E_WARNING, "\"%s\" must not contain null bytes", ZSTR_VAL(entry->name));
+		}
+		return FAILURE;
+	}
 
 	if (ZSTR_LEN(new_value) != 0) {
 		php_error_docref("session.configuration", E_DEPRECATED, "Usage of session.referer_check INI setting is deprecated");

--- a/ext/session/tests/session_save_path_referer_check_null_byte.phpt
+++ b/ext/session/tests/session_save_path_referer_check_null_byte.phpt
@@ -1,0 +1,24 @@
+--TEST--
+session.save_path and session.referer_check must not contain null bytes
+--EXTENSIONS--
+session
+--SKIPIF--
+<?php include('skipif.inc'); ?>
+--FILE--
+<?php
+
+ob_start();
+
+var_dump(ini_set('session.save_path', "/tmp\0evil"));
+var_dump(ini_set('session.referer_check', "example.com\0evil"));
+
+ob_end_flush();
+echo "Done";
+?>
+--EXPECTF--
+Warning: ini_set(): "session.save_path" must not contain null bytes in %s on line %d
+bool(false)
+
+Warning: ini_set(): "session.referer_check" must not contain null bytes in %s on line %d
+bool(false)
+Done


### PR DESCRIPTION
`session.cookie_path`/`cookie_domain`/`cache_limiter` reject null bytes with a warning (OnUpdateSessionStr), but `session.save_path` silently failed with no diagnostic and `session.referer_check` didn't check at all. Align both with the existing OnUpdateSessionStr behavior.