### PR TITLE
ext/session: Fix NULL pointer dereference in SessionHandler::create_sid()

### DIFF
--- a/ext/session/mod_user_class.c
+++ b/ext/session/mod_user_class.c
@@ -167,6 +167,12 @@ PHP_METHOD(SessionHandler, create_sid)
 	PS_SANITY_CHECK;
 
 	id = PS(default_mod)->s_create_sid(&PS(mod_data));
+	if (!id) {
+		if (!EG(exception)) {
+			zend_throw_error(NULL, "Failed to create session ID: %s", PS(default_mod)->s_name);
+		}
+		RETURN_THROWS();
+	}
 
 	RETURN_STR(id);
 }


### PR DESCRIPTION
`s_create_sid()` can return NULL when `php_random_bytes_throw()` fails (e.g. CSPRNG exhaustion). Every other internal caller of `s_create_sid()` in session.c ([php_session_initialize](https://github.com/php/php-src/blob/master/ext/session/session.c#L448-L454), [session_regenerate_id](https://github.com/php/php-src/blob/master/ext/session/session.c#L2399-L2405)) already NULL-checks the result.

It's not possible to test it through .phpt test file. Should it be pointed to the PHP8.4 branch? 