### PR TITLE
Remove various useless `#include`

### DIFF
--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -34,11 +34,9 @@
 
 #ifdef HAVE_LIBDL
 #ifdef PHP_WIN32
-#include "win32/param.h"
 #include "win32/winutil.h"
 #define GET_DL_ERROR()  php_win_err()
 #else
-#include <sys/param.h>
 #define GET_DL_ERROR()  DL_ERROR()
 #endif
 #endif

--- a/ext/standard/ftp_fopen_wrapper.c
+++ b/ext/standard/ftp_fopen_wrapper.c
@@ -30,10 +30,6 @@
 
 #ifdef PHP_WIN32
 #include <winsock2.h>
-#define O_RDONLY _O_RDONLY
-#include "win32/param.h"
-#else
-#include <sys/param.h>
 #endif
 
 #include "php_standard.h"

--- a/ext/standard/http_fopen_wrapper.c
+++ b/ext/standard/http_fopen_wrapper.c
@@ -33,13 +33,6 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
-#ifdef PHP_WIN32
-#define O_RDONLY _O_RDONLY
-#include "win32/param.h"
-#else
-#include <sys/param.h>
-#endif
-
 #include "php_standard.h"
 
 #ifdef HAVE_SYS_SOCKET_H

--- a/main/network.c
+++ b/main/network.c
@@ -24,10 +24,6 @@
 #ifdef PHP_WIN32
 # include <Ws2tcpip.h>
 # include "win32/winutil.h"
-# define O_RDONLY _O_RDONLY
-# include "win32/param.h"
-#else
-#include <sys/param.h>
 #endif
 
 #include <sys/types.h>

--- a/main/php_scandir.c
+++ b/main/php_scandir.c
@@ -27,7 +27,6 @@
 #ifndef HAVE_SCANDIR
 
 #ifdef PHP_WIN32
-#include "win32/param.h"
 #include "win32/readdir.h"
 #endif
 

--- a/sapi/phpdbg/phpdbg_prompt.c
+++ b/sapi/phpdbg/phpdbg_prompt.c
@@ -48,11 +48,9 @@ extern int phpdbg_startup_run;
 
 #ifdef HAVE_LIBDL
 #ifdef PHP_WIN32
-#include "win32/param.h"
 #include "win32/winutil.h"
 #define GET_DL_ERROR()  php_win_err()
 #else
-#include <sys/param.h>
 #define GET_DL_ERROR()  DL_ERROR()
 #endif
 #endif


### PR DESCRIPTION
This removes leftover win32/param.h / <sys/param.h> includes from files that do not use any of the macros provided by those headers (MAXPATHLEN, MAXHOSTNAMELEN, howmany, roundup).

It also removes local Windows O_RDONLY -> _O_RDONLY aliases from files where O_RDONLY is not used.