### PR TITLE
ext/soap: fix use of uninitialized params in do_request() on OOM bail…

### DIFF
--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -2273,6 +2273,10 @@ static bool do_request(zval *this_ptr, xmlDoc *request, const char *location, co
 		return false;
 	}
 
+	ZVAL_UNDEF(&params[0]);
+	ZVAL_UNDEF(&params[1]);
+	ZVAL_UNDEF(&params[2]);
+
 	zend_try {
 		ZVAL_STRINGL(&params[0], buf, buf_size);
 		ZVAL_STRING(&params[1], location);

--- a/ext/soap/tests/gh22585.phpt
+++ b/ext/soap/tests/gh22585.phpt
@@ -1,0 +1,39 @@
+--TEST--
+GH-22585 (Use of uninitialized params in do_request() on out-of-memory bailout)
+--EXTENSIONS--
+soap
+--INI--
+soap.wsdl_cache_enabled=0
+memory_limit=64M
+--FILE--
+<?php
+/* Deep recursion that keeps issuing SOAP calls until memory is exhausted while
+ * do_request() is only part-way through initializing its params array. The
+ * cleanup path must not touch the uninitialized slots. Depending on the
+ * environment the run ends either by the recursion limit (reaching "Done") or
+ * by the memory-exhaustion fatal; both are fine, a crash/UB abort is not. */
+try {
+    class MySoapClient extends SoapClient {
+        public function __doRequest($request, $location, $action, $version, $one_way = false, ?string $uriParserClass = null): string {
+            return '';
+        }
+    }
+
+    function main() {
+        for (;;) {
+            $soap = new MySoapClient(
+                null,
+                ['location' => "http://localhost/soap.php", 'uri' => "http://localhost/"]
+            );
+            $soap->call(1.1);
+            main();
+        }
+    }
+
+    main();
+} catch (\Throwable $e) {
+}
+echo "Done" . PHP_EOL;
+?>
+--EXPECTREGEX--
+(?s)(Done|.*Allowed memory size of \d+ bytes exhausted.*)


### PR DESCRIPTION
…out.

Fix #22585