### PR TITLE
sapi/cli: support HTTP QUERY method in built-in server

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -297,6 +297,10 @@ PHP 8.6 UPGRADE NOTES
 3. Changes in SAPI modules
 ========================================
 
+- CLI:
+  . The built-in development server now accepts requests using the QUERY HTTP
+    method instead of returning 501 Not Implemented.
+
 ========================================
 4. Deprecated Functionality
 ========================================

--- a/sapi/cli/php_http_parser.c
+++ b/sapi/cli/php_http_parser.c
@@ -82,6 +82,7 @@ static const char *method_strings[] =
   , "POST"
   , "PUT"
   , "PATCH"
+  , "QUERY"
   , "CONNECT"
   , "OPTIONS"
   , "TRACE"
@@ -521,6 +522,7 @@ size_t php_http_parser_execute (php_http_parser *parser,
           case 'N': parser->method = PHP_HTTP_NOTIFY; break;
           case 'O': parser->method = PHP_HTTP_OPTIONS; break;
           case 'P': parser->method = PHP_HTTP_POST; /* or PROPFIND or PROPPATCH or PUT */ break;
+          case 'Q': parser->method = PHP_HTTP_QUERY; break;
           case 'R': parser->method = PHP_HTTP_REPORT; break;
           case 'S': parser->method = PHP_HTTP_SUBSCRIBE; /* or SEARCH */ break;
           case 'T': parser->method = PHP_HTTP_TRACE; break;

--- a/sapi/cli/php_http_parser.h
+++ b/sapi/cli/php_http_parser.h
@@ -79,6 +79,7 @@ enum php_http_method
   , PHP_HTTP_POST
   , PHP_HTTP_PUT
   , PHP_HTTP_PATCH
+  , PHP_HTTP_QUERY
   /* pathological */
   , PHP_HTTP_CONNECT
   , PHP_HTTP_OPTIONS

--- a/sapi/cli/tests/php_cli_server_query_method.phpt
+++ b/sapi/cli/tests/php_cli_server_query_method.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Support HTTP QUERY method
+--SKIPIF--
+<?php
+include "skipif.inc";
+?>
+--FILE--
+<?php
+include "php_cli_server.inc";
+php_cli_server_start(<<<'PHP'
+var_dump($_SERVER['REQUEST_METHOD']);
+PHP
+);
+
+$host = PHP_CLI_SERVER_HOSTNAME;
+$fp = php_cli_server_connect();
+
+if (fwrite($fp, <<<HEADER
+QUERY / HTTP/1.1
+Host: {$host}
+
+
+HEADER
+)) {
+    while (!feof($fp)) {
+        echo fgets($fp);
+    }
+}
+
+fclose($fp);
+?>
+--EXPECTF--
+HTTP/1.1 200 OK
+Host: %s
+Date: %s
+Connection: close
+X-Powered-By: %s
+Content-type: text/html; charset=UTF-8
+
+string(5) "QUERY"


### PR DESCRIPTION
PHP’s built-in development server currently rejects requests using the `QUERY`
HTTP method with a `501 Not Implemented` response before they reach the router
script.

`QUERY` is now standardized by RFC 10008. This adds it to the CLI server HTTP
parser so requests are accepted and passed through like other recognized HTTP
methods.

A regression test is included to verify that `QUERY` reaches the router and is
exposed through `$_SERVER['REQUEST_METHOD']`.