### PR TITLE
ext/standard: Fix `sleep` and `usleep` unsigned integer overflow

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -51,6 +51,10 @@ PHP                                                                        NEWS
   . Fixed bug GH-22585 (OOM on bailout with uninitialized
     do_request() parameters). (David Carlier)
 
+- Standard:
+  . Fixed sleep() and usleep() to reject values that overflow the underlying
+    unsigned int timeout. (Weilin Du)
+
 - Streams:
   . Fixed bug GH-21468 (Segfault in file_get_contents w/ a https URL
     and a proxy set). (CVE-2026-12184) (ndossche)

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -1133,6 +1133,18 @@ PHP_FUNCTION(sleep)
 		RETURN_THROWS();
 	}
 
+#ifdef PHP_WIN32
+	if (num > (zend_long) (UINT_MAX / 1000)) {
+		zend_argument_value_error(1, "must be less than or equal to %u", UINT_MAX / 1000);
+		RETURN_THROWS();
+	}
+#else
+	if (ZEND_LONG_UINT_OVFL(num)) {
+		zend_argument_value_error(1, "must be less than or equal to %u", UINT_MAX);
+		RETURN_THROWS();
+	}
+#endif
+
 	RETURN_LONG(php_sleep((unsigned int)num));
 }
 /* }}} */
@@ -1148,6 +1160,10 @@ PHP_FUNCTION(usleep)
 
 	if (num < 0) {
 		zend_argument_value_error(1, "must be greater than or equal to 0");
+		RETURN_THROWS();
+	}
+	if (ZEND_LONG_UINT_OVFL(num)) {
+		zend_argument_value_error(1, "must be less than or equal to %u", UINT_MAX);
 		RETURN_THROWS();
 	}
 

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -1123,27 +1123,20 @@ PHP_FUNCTION(flush)
 PHP_FUNCTION(sleep)
 {
 	zend_long num;
+#ifdef PHP_WIN32
+	const unsigned int max = UINT_MAX / 1000;
+#else
+	const unsigned int max = UINT_MAX;
+#endif
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
 		Z_PARAM_LONG(num)
 	ZEND_PARSE_PARAMETERS_END();
 
-	if (num < 0) {
-		zend_argument_value_error(1, "must be greater than or equal to 0");
+	if (num < 0 || (zend_ulong) num > max) {
+		zend_argument_value_error(1, "must be between 0 and %u", max);
 		RETURN_THROWS();
 	}
-
-#ifdef PHP_WIN32
-	if (num > (zend_long) (UINT_MAX / 1000)) {
-		zend_argument_value_error(1, "must be less than or equal to %u", UINT_MAX / 1000);
-		RETURN_THROWS();
-	}
-#else
-	if (ZEND_LONG_UINT_OVFL(num)) {
-		zend_argument_value_error(1, "must be less than or equal to %u", UINT_MAX);
-		RETURN_THROWS();
-	}
-#endif
 
 	RETURN_LONG(php_sleep((unsigned int)num));
 }
@@ -1158,12 +1151,8 @@ PHP_FUNCTION(usleep)
 		Z_PARAM_LONG(num)
 	ZEND_PARSE_PARAMETERS_END();
 
-	if (num < 0) {
-		zend_argument_value_error(1, "must be greater than or equal to 0");
-		RETURN_THROWS();
-	}
-	if (ZEND_LONG_UINT_OVFL(num)) {
-		zend_argument_value_error(1, "must be less than or equal to %u", UINT_MAX);
+	if (num < 0 || (zend_ulong) num > UINT_MAX) {
+		zend_argument_value_error(1, "must be between 0 and %u", UINT_MAX);
 		RETURN_THROWS();
 	}
 

--- a/ext/standard/tests/general_functions/sleep_error.phpt
+++ b/ext/standard/tests/general_functions/sleep_error.phpt
@@ -7,7 +7,7 @@ sleep(-10);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ValueError: sleep(): Argument #1 ($seconds) must be greater than or equal to 0 in %s:%d
+Fatal error: Uncaught ValueError: sleep(): Argument #1 ($seconds) must be between 0 and %d in %s:%d
 Stack trace:
 #0 %s(%d): sleep(-10)
 #1 {main}

--- a/ext/standard/tests/general_functions/sleep_usleep_uint_overflow.phpt
+++ b/ext/standard/tests/general_functions/sleep_usleep_uint_overflow.phpt
@@ -1,0 +1,25 @@
+--TEST--
+sleep() and usleep() reject values above their unsigned int limits
+--SKIPIF--
+<?php
+if (PHP_INT_SIZE < 8) die('skip 64-bit only');
+?>
+--FILE--
+<?php
+var_dump(sleep(0));
+usleep(0);
+echo "usleep(0) ok\n";
+
+foreach (['sleep', 'usleep'] as $function) {
+    try {
+        $function(4294967296);
+    } catch (ValueError $e) {
+        echo $e->getMessage(), "\n";
+    }
+}
+?>
+--EXPECTF--
+int(0)
+usleep(0) ok
+sleep(): Argument #1 ($seconds) must be less than or equal to %d
+usleep(): Argument #1 ($microseconds) must be less than or equal to 4294967295

--- a/ext/standard/tests/general_functions/sleep_usleep_uint_overflow.phpt
+++ b/ext/standard/tests/general_functions/sleep_usleep_uint_overflow.phpt
@@ -21,5 +21,5 @@ foreach (['sleep', 'usleep'] as $function) {
 --EXPECTF--
 int(0)
 usleep(0) ok
-sleep(): Argument #1 ($seconds) must be less than or equal to %d
-usleep(): Argument #1 ($microseconds) must be less than or equal to 4294967295
+sleep(): Argument #1 ($seconds) must be between 0 and %d
+usleep(): Argument #1 ($microseconds) must be between 0 and 4294967295

--- a/ext/standard/tests/general_functions/usleep_error.phpt
+++ b/ext/standard/tests/general_functions/usleep_error.phpt
@@ -7,7 +7,7 @@ usleep(-10);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ValueError: usleep(): Argument #1 ($microseconds) must be greater than or equal to 0 in %s:%d
+Fatal error: Uncaught ValueError: usleep(): Argument #1 ($microseconds) must be between 0 and 4294967295 in %s:%d
 Stack trace:
 #0 %s(%d): usleep(-10)
 #1 {main}


### PR DESCRIPTION
`sleep(4294967296)` actually sleep 0 seconds because of a unsigned int overflow bug, see [here](https://onlinephp.io?s=s7EvyCjg5SrOSU0t0DAxsjSxNDM3sjTTtOblKsUmaG8HAA%2C%2C&v=8.5.6). This is also true in `usleep`

I target this to master as a fix that is classified as a stricter parsing. Now we throw `ValueError` instead.

p.s.: in Windows, the sleep function is implemented with `SleepEx(t * 1000, TRUE)` not php_sleep, phew, so we need to lower the threshold to UINT_MAX / 1000