### PR TITLE
iconv: Fix memory management in autoconf test for `//IGNORE`

### DIFF
--- a/ext/iconv/config.m4
+++ b/ext/iconv/config.m4
@@ -112,6 +112,8 @@ int main(void) {
   char *out = malloc(out_left);
   char *out_p = out;
   size_t result = iconv(cd, (char **) &in_p, &in_left, (char **) &out_p, &out_left);
+  free(out);
+  iconv_close(cd);
   if(result == (size_t)-1) {
     return 1;
   }


### PR DESCRIPTION
Sometimes running `./configure` for ASAN hangs on my machine. This is reproducible when compiling and running the program manually using

    clang-16 -g -fsanitize=undefined,address test.c

It seems this is related to the LLVM symbolizer getting stuck, and the symbolizer is likely required to report the memory leak. After adding the memory management functions it seems to work (or rather fail) reliably.