### PR TITLE
Properly propagate failure of X509_STORE_CTX_new()

### DIFF
--- a/ext/openssl/openssl_backend_common.c
+++ b/ext/openssl/openssl_backend_common.c
@@ -750,7 +750,7 @@ int php_openssl_check_cert(X509_STORE *ctx, X509 *x, STACK_OF(X509) *untrustedch
 	csc = X509_STORE_CTX_new();
 	if (csc == NULL) {
 		php_openssl_store_errors();
-		php_error_docref(NULL, E_ERROR, "Memory allocation failure");
+		php_error_docref(NULL, E_WARNING, "Memory allocation failure");
 		return 0;
 	}
 	if (!X509_STORE_CTX_init(csc, ctx, x, untrustedchain)) {


### PR DESCRIPTION
Propagating is consistent with other "new" failures, and avoids bailing out, which is inherently problematic anyway as it can cause persistent leaks on its own.

Originally reported as a part of https://github.com/php/php-src/issues/21643, but the other issues there are all semantic whereas this is specific to ASAN.