### PR TITLE
Reduce gh22570 test nesting depth to fix macOS ZTS timeout

### DIFF
--- a/ext/dom/tests/modern/xml/gh22570.phpt
+++ b/ext/dom/tests/modern/xml/gh22570.phpt
@@ -18,7 +18,7 @@ zend.max_allowed_stack_size=512K
 // Build bottom-up so the insertion cycle-check stays O(1); top-down is O(n^2).
 $doc = Dom\XMLDocument::createEmpty();
 $node = $doc->createElement('a');
-for ($i = 0; $i < 100000; $i++) {
+for ($i = 0; $i < 10000; $i++) {
     $parent = $doc->createElement('a');
     $parent->appendChild($node);
     $node = $parent;


### PR DESCRIPTION
Follow-up to #22576. The gh22570 test builds a 100000-node tree, which timed out (120s) on the macOS ZTS nightly runner. At `zend.max_allowed_stack_size=512K` the serializer overflows well below 10000 nested nodes, so reducing the depth keeps the test fast while still tripping the stack guard it verifies.
