### PR TITLE
Fix leak on double DatePeriod::__construct() call

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -5206,6 +5206,23 @@ PHP_METHOD(DatePeriod, createFromISO8601String)
 	}
 }
 
+static void date_period_reset(php_period_obj *period_obj)
+{
+	if (period_obj->start) {
+		timelib_time_dtor(period_obj->start);
+	}
+	if (period_obj->current) {
+		timelib_time_dtor(period_obj->current);
+	}
+	if (period_obj->end) {
+		timelib_time_dtor(period_obj->end);
+	}
+	if (period_obj->interval) {
+		timelib_rel_time_dtor(period_obj->interval);
+	}
+	memset(period_obj, 0, XtOffsetOf(php_period_obj, std));
+}
+
 /* {{{ Creates new DatePeriod object. */
 PHP_METHOD(DatePeriod, __construct)
 {
@@ -5227,7 +5244,7 @@ PHP_METHOD(DatePeriod, __construct)
 	}
 
 	dpobj = Z_PHPPERIOD_P(ZEND_THIS);
-	dpobj->current = NULL;
+	date_period_reset(dpobj);
 
 	if (isostr) {
 		zend_error(E_DEPRECATED, "Calling DatePeriod::__construct(string $isostr, int $options = 0) is deprecated, "
@@ -5245,6 +5262,7 @@ PHP_METHOD(DatePeriod, __construct)
 		if (end) {
 			DATE_CHECK_INITIALIZED(Z_PHPDATE_P(end)->time, date_ce_interface);
 		}
+		DATE_CHECK_INITIALIZED(Z_PHPINTERVAL_P(interval)->initialized, Z_OBJCE_P(interval));
 
 		/* init */
 		php_interval_obj *intobj = Z_PHPINTERVAL_P(interval);

--- a/ext/date/tests/DatePeriod_double_constructor_call.phpt
+++ b/ext/date/tests/DatePeriod_double_constructor_call.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Double DatePeriod::__construct() call
+--FILE--
+<?php
+
+$start = new \DateTime();
+$interval = new \DateInterval('P1D');
+$period = new \DatePeriod($start, $interval, 1);
+$period->__construct($start, $interval, 1);
+
+?>
+===DONE===
+--EXPECT--
+===DONE===


### PR DESCRIPTION
See https://github.com/php/php-src/actions/runs/28911263674/job/85769105449.

Normally we might want to discuss whether such code is even sensible, but it seems carbon is relying on it, as evidenced by the CI failure above. A minimal carbon example that reproduces the error:

```php
<?php

use Carbon\Carbon;

require __DIR__ . '/vendor/autoload.php';

$day = Carbon::now();
$period = Carbon::now()->toPeriod($day);
```

Just remembered, will have to rebase onto 8.2 to keep nightly green.