### PR TITLE
.github/actions/apk/action.yml: don't install gnu-libiconv-dev

### DIFF
--- a/.github/actions/apk/action.yml
+++ b/.github/actions/apk/action.yml
@@ -28,7 +28,6 @@ runs:
             curl-dev \
             freetype-dev \
             gettext-dev \
-            gnu-libiconv-dev \
             gmp-dev \
             icu-dev \
             icu-data-full \

--- a/.github/actions/configure-alpine/action.yml
+++ b/.github/actions/configure-alpine/action.yml
@@ -43,7 +43,7 @@ runs:
           --enable-pcntl \
           --with-readline \
           --enable-mbstring \
-          --with-iconv=/usr \
+          --with-iconv \
           --with-curl \
           --with-gettext \
           --enable-sockets \

--- a/ext/iconv/tests/bug48147.phpt
+++ b/ext/iconv/tests/bug48147.phpt
@@ -2,17 +2,41 @@
 Bug #48147 (iconv with //IGNORE cuts the string)
 --EXTENSIONS--
 iconv
+--SKIPIF--
+<?php
+/*
+ * POSIX 2024 specifies how the "//IGNORE" suffix should behave, but
+ * falls short of requiring implementations to support it (iconv_open
+ * is allowed to return EINVAL for a suffix it does not recognize).
+ *
+ * Many implementations still do not support it, which is OK. We
+ * whitelist the ones that are known to.
+ */
+if (ICONV_IMPL != "glibc" && ICONV_IMPL != "libiconv") {
+    die("skip iconv implementation may not support //IGNORE");
+}
+?>
 --FILE--
 <?php
+/*
+ * POSIX says that when //IGNORE is specified, invalid bytes followed
+ * by valid bytes "shall not be treated as an error." GNU iconv does
+ * not follow this convention, but PHP does the right thing. In the
+ * examples below, invalid bytes in the middle of the string get
+ * dropped, and a string is returned. The two examples where the
+ * problem is at the end do not qualify for the "shall not" exception
+ * because there are no VALID bytes after the error. So PHP is morally
+ * correct in those cases to return an error (false).
+ */
 $text = "aa\xC3\xC3\xC3\xB8aa";
 var_dump(iconv("UTF-8", "UTF-8", $text));
 var_dump(urlencode(iconv("UTF-8", "UTF-8//IGNORE", $text)));
 // only invalid
-var_dump(urlencode(iconv("UTF-8", "UTF-8//IGNORE", "\xC3")));
+var_dump(iconv("UTF-8", "UTF-8//IGNORE", "\xC3"));
 // start invalid
 var_dump(urlencode(iconv("UTF-8", "UTF-8//IGNORE", "\xC3\xC3\xC3\xB8aa")));
 // finish invalid
-var_dump(urlencode(iconv("UTF-8", "UTF-8//IGNORE", "aa\xC3\xC3\xC3")));
+var_dump(iconv("UTF-8", "UTF-8//IGNORE", "aa\xC3\xC3\xC3"));
 ?>
 --EXPECTF--
 Notice: iconv(): Detected an illegal character in input string in %s on line %d
@@ -20,8 +44,8 @@ bool(false)
 string(10) "aa%C3%B8aa"
 
 Notice: iconv(): Detected an incomplete multibyte character in input string in %s on line %d
-string(0) ""
+bool(false)
 string(8) "%C3%B8aa"
 
 Notice: iconv(): Detected an incomplete multibyte character in input string in %s on line %d
-string(0) ""
+bool(false)


### PR DESCRIPTION
If we do not install GNU libiconv, the musl libc `iconv()` implementation should take over, allowing it to be tested on the CI.

It now passes: https://github.com/php/php-src/actions/runs/28979661263/job/85995230557?pr=22645

This includes the intended fix from https://github.com/php/php-src/pull/22552 that I lost somehow. In the end, all commits with the correct messages are present.

Closes https://github.com/php/php-src/issues/22413