### PR TITLE
Revert the order of keys in ldap_explode_dn to documented behavior

### DIFF
--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -2209,6 +2209,7 @@ PHP_FUNCTION(ldap_explode_dn)
 	zend_long with_attrib;
 	char *dn, **ldap_value;
 	size_t dn_len;
+	int i, count;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "pl", &dn, &dn_len, &with_attrib) != SUCCESS) {
 		RETURN_THROWS();
@@ -2220,11 +2221,16 @@ PHP_FUNCTION(ldap_explode_dn)
 	}
 
 	array_init(return_value);
-	int i;
-	for (i = 0; ldap_value[i] != NULL; i++) {
+	
+	i = 0;
+	while (ldap_value[i] != NULL) i++;
+	count = i;
+
+	add_assoc_long(return_value, "count", count);
+	
+	for (i = 0; i < count; i++) {
 		add_index_string(return_value, i, ldap_value[i]);
 	}
-	add_assoc_long(return_value, "count", i);
 
 	ldap_memvfree((void **)ldap_value);
 }

--- a/ext/ldap/tests/ldap_explode_dn.phpt
+++ b/ext/ldap/tests/ldap_explode_dn.phpt
@@ -34,16 +34,18 @@ echo "Done\n";
 ?>
 --EXPECT--
 array(4) {
+  ["count"]=>
+  int(3)
   [0]=>
   string(6) "cn=bob"
   [1]=>
   string(10) "dc=example"
   [2]=>
   string(6) "dc=com"
-  ["count"]=>
-  int(3)
 }
 array(5) {
+  ["count"]=>
+  int(4)
   [0]=>
   string(6) "cn=bob"
   [1]=>
@@ -52,20 +54,20 @@ array(5) {
   string(10) "dc=example"
   [3]=>
   string(6) "dc=com"
-  ["count"]=>
-  int(4)
 }
 array(4) {
+  ["count"]=>
+  int(3)
   [0]=>
   string(3) "bob"
   [1]=>
   string(7) "example"
   [2]=>
   string(3) "com"
-  ["count"]=>
-  int(3)
 }
 array(5) {
+  ["count"]=>
+  int(4)
   [0]=>
   string(3) "bob"
   [1]=>
@@ -74,8 +76,6 @@ array(5) {
   string(7) "example"
   [3]=>
   string(3) "com"
-  ["count"]=>
-  int(4)
 }
 bool(false)
 bool(false)


### PR DESCRIPTION
- Fixes https://github.com/php/php-src/issues/22511
- Commits cherry-picked from https://github.com/php/php-src/pull/22550