### PR TITLE
Readonly properties must be re-locked after clone-with

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,8 @@ PHP                                                                        NEWS
     containing NUL). (iliaal)
   . Fixed bug GH-22206 (missing return in global register detection).
     (P3p111n0)
+  . Lock unmodified readonly properties for modification after clone-with.
+    (NickSdot)
 
 - Calendar:
   . Fixed bug GH-22602 (gregoriantojd() and juliantojd() integer overflow with

--- a/Zend/tests/clone/clone_with_014.phpt
+++ b/Zend/tests/clone/clone_with_014.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Properties are still readonly after clone-with
+--FILE--
+<?php
+
+readonly class Test {
+    public public(set) int $a;
+    public public(set) int $b;
+
+    public function __construct() {
+        $this->a = 1;
+        $this->b = 2;
+    }
+}
+
+$test = clone(new Test(), ['a' => 3]);
+var_dump($test);
+
+try {
+    $test->b = 4;
+} catch (Error $e) {
+    echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+}
+
+var_dump($test);
+
+?>
+--EXPECT--
+object(Test)#2 (2) {
+  ["a"]=>
+  int(3)
+  ["b"]=>
+  int(2)
+}
+Error: Cannot modify readonly property Test::$b
+object(Test)#2 (2) {
+  ["a"]=>
+  int(3)
+  ["b"]=>
+  int(2)
+}

--- a/Zend/zend_objects.c
+++ b/Zend/zend_objects.c
@@ -322,6 +322,14 @@ ZEND_API zend_object *zend_objects_clone_obj_with(zend_object *old_object, const
 		} ZEND_HASH_FOREACH_END();
 
 		EG(fake_scope) = old_scope;
+
+		/* Lock readonly properties once more. */
+		if (ZEND_CLASS_HAS_READONLY_PROPS(new_object->ce)) {
+			for (uint32_t i = 0; i < new_object->ce->default_properties_count; i++) {
+				zval* prop = OBJ_PROP_NUM(new_object, i);
+				Z_PROP_FLAG_P(prop) &= ~IS_PROP_REINITABLE;
+			}
+		}
 	}
 
 	return new_object;


### PR DESCRIPTION
Found this while stealing code for #22588. The following code:

```php
readonly class Test {
    public public(set) int $a;
    public public(set) int $b;

    public function __construct() {
        $this->a = 1;
        $this->b = 2;
    }
}

$cloneWith = clone(new Test(), ['a' => 3]); // only a
$cloneWith->b = 4; // why legal?
var_dump($cloneWith);
}
```

Resulted in this output:
```
object(Foo)#2 (2) {
  ["a"]=>
  int(3)
  ["b"]=>
  int(4)
```

But I expected this output instead:
```
Error: Cannot modify readonly property Test::$b
```

cc @TimWolla

---

Edit: I just realise this probably should rather target PHP-8.4?