### PR TITLE
ext/gmp: Fix GMP operator RHS overflow for GMP values

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -73,6 +73,8 @@ PHP                                                                        NEWS
 - GMP:
   . Fixed bug GH-22549 (Assertion failure / UB on a compound GMP power or shift
     assignment with a negative exponent). (iliaal)
+  . Fixed GMP power and shift operators to reject GMP right operands outside
+    the unsigned long range instead of silently truncating them. (Weilin Du)
 
 - Intl:
   . Fixed NumberFormatter::parse() and NumberFormatter::parseCurrency() to

--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,10 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 8.6.0alpha3
 
+- GMP:
+  . Fixed GMP power and shift operators to reject GMP right operands outside
+    the unsigned long range instead of silently truncating them. (Weilin Du)
+
 - ODBC:
   . Fixed bug GH-22668 (Heap buffer over-read when a column value exceeds the
     driver-reported display size). (iliaal)
@@ -73,8 +77,6 @@ PHP                                                                        NEWS
 - GMP:
   . Fixed bug GH-22549 (Assertion failure / UB on a compound GMP power or shift
     assignment with a negative exponent). (iliaal)
-  . Fixed GMP power and shift operators to reject GMP right operands outside
-    the unsigned long range instead of silently truncating them. (Weilin Du)
 
 - Intl:
   . Fixed NumberFormatter::parse() and NumberFormatter::parseCurrency() to

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -327,8 +327,18 @@ static zend_result binop_operator_helper(gmp_binary_op_t gmp_op, zval *return_va
 
 typedef void (*gmp_binary_ui_op_t)(mpz_ptr, mpz_srcptr, gmp_ulong);
 
+static zend_result gmp_shift_operator_range_error(uint8_t opcode) {
+	zend_throw_error(
+		zend_ce_value_error, "%s must be between 0 and %lu",
+		opcode == ZEND_POW ? "Exponent" : "Shift", ULONG_MAX
+	);
+	return FAILURE;
+}
+
 static zend_result shift_operator_helper(gmp_binary_ui_op_t op, zval *return_value, zval *op1, zval *op2, uint8_t opcode) {
 	zend_long shift = 0;
+	gmp_ulong shift_ui = 0;
+	bool have_shift_ui = false;
 
 	if (UNEXPECTED(Z_TYPE_P(op2) != IS_LONG)) {
 		if (UNEXPECTED(!IS_GMP(op2))) {
@@ -349,20 +359,25 @@ static zend_result shift_operator_helper(gmp_binary_ui_op_t op, zval *return_val
 					goto typeof_op_failure;
 			}
 		} else {
-			// TODO We shouldn't cast the GMP object to int here
-			shift = zval_get_long(op2);
+			mpz_ptr gmpnum_shift = GET_GMP_FROM_ZVAL(op2);
+			if (!mpz_fits_ulong_p(gmpnum_shift)) {
+				return gmp_shift_operator_range_error(opcode);
+			}
+			shift_ui = (gmp_ulong) mpz_get_ui(gmpnum_shift);
+			have_shift_ui = true;
 		}
 	} else {
 		shift = Z_LVAL_P(op2);
 	}
 
-	if (shift < 0 || shift > ULONG_MAX) {
-		zend_throw_error(
-			zend_ce_value_error, "%s must be between 0 and %lu",
-			opcode == ZEND_POW ? "Exponent" : "Shift", ULONG_MAX
-		);
-		return FAILURE;
-	} else {
+	if (!have_shift_ui) {
+		if (shift < 0 || shift > ULONG_MAX) {
+			return gmp_shift_operator_range_error(opcode);
+		}
+		shift_ui = (gmp_ulong) shift;
+	}
+
+	{
 		mpz_ptr gmpnum_op, gmpnum_result;
 
 		if (!gmp_zend_parse_arg_into_mpz_ex(op1, &gmpnum_op, 1, true)) {
@@ -370,7 +385,7 @@ static zend_result shift_operator_helper(gmp_binary_ui_op_t op, zval *return_val
 		}
 
 		INIT_GMP_RETVAL(gmpnum_result);
-		op(gmpnum_result, gmpnum_op, (gmp_ulong) shift);
+		op(gmpnum_result, gmpnum_op, shift_ui);
 		return SUCCESS;
 	}
 

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -327,12 +327,11 @@ static zend_result binop_operator_helper(gmp_binary_op_t gmp_op, zval *return_va
 
 typedef void (*gmp_binary_ui_op_t)(mpz_ptr, mpz_srcptr, gmp_ulong);
 
-static zend_result gmp_shift_operator_range_error(uint8_t opcode) {
+static void gmp_shift_operator_range_error(uint8_t opcode) {
 	zend_throw_error(
 		zend_ce_value_error, "%s must be between 0 and %lu",
 		opcode == ZEND_POW ? "Exponent" : "Shift", ULONG_MAX
 	);
-	return FAILURE;
 }
 
 static zend_result shift_operator_helper(gmp_binary_ui_op_t op, zval *return_value, zval *op1, zval *op2, uint8_t opcode) {
@@ -361,7 +360,8 @@ static zend_result shift_operator_helper(gmp_binary_ui_op_t op, zval *return_val
 		} else {
 			mpz_ptr gmpnum_shift = GET_GMP_FROM_ZVAL(op2);
 			if (!mpz_fits_ulong_p(gmpnum_shift)) {
-				return gmp_shift_operator_range_error(opcode);
+				gmp_shift_operator_range_error(opcode);
+				return FAILURE;
 			}
 			shift_ui = (gmp_ulong) mpz_get_ui(gmpnum_shift);
 			have_shift_ui = true;
@@ -372,22 +372,21 @@ static zend_result shift_operator_helper(gmp_binary_ui_op_t op, zval *return_val
 
 	if (!have_shift_ui) {
 		if (shift < 0 || shift > ULONG_MAX) {
-			return gmp_shift_operator_range_error(opcode);
+			gmp_shift_operator_range_error(opcode);
+			return FAILURE;
 		}
 		shift_ui = (gmp_ulong) shift;
 	}
 
-	{
-		mpz_ptr gmpnum_op, gmpnum_result;
+	mpz_ptr gmpnum_op, gmpnum_result;
 
-		if (!gmp_zend_parse_arg_into_mpz_ex(op1, &gmpnum_op, 1, true)) {
-			goto typeof_op_failure;
-		}
-
-		INIT_GMP_RETVAL(gmpnum_result);
-		op(gmpnum_result, gmpnum_op, shift_ui);
-		return SUCCESS;
+	if (!gmp_zend_parse_arg_into_mpz_ex(op1, &gmpnum_op, 1, true)) {
+		goto typeof_op_failure;
 	}
+
+	INIT_GMP_RETVAL(gmpnum_result);
+	op(gmpnum_result, gmpnum_op, shift_ui);
+	return SUCCESS;
 
 typeof_op_failure: ;
 	/* Returning FAILURE without throwing an exception would emit the

--- a/ext/gmp/tests/gmp_operator_rhs_gmp_overflow.phpt
+++ b/ext/gmp/tests/gmp_operator_rhs_gmp_overflow.phpt
@@ -1,0 +1,26 @@
+--TEST--
+GMP operator right operand rejects values outside the unsigned long range
+--EXTENSIONS--
+gmp
+--FILE--
+<?php
+$too_large = gmp_init("18446744073709551616");
+
+try {
+    var_dump(gmp_init(2) ** $too_large);
+} catch (ValueError $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump(gmp_init(2) << $too_large);
+} catch (ValueError $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+echo "Done\n";
+?>
+--EXPECTF--
+Exponent must be between 0 and %d
+Shift must be between 0 and %d
+Done

--- a/ext/gmp/tests/gmp_operator_rhs_gmp_overflow.phpt
+++ b/ext/gmp/tests/gmp_operator_rhs_gmp_overflow.phpt
@@ -18,9 +18,16 @@ try {
     echo $e->getMessage(), PHP_EOL;
 }
 
+try {
+    var_dump(gmp_init(2) >> $too_large);
+} catch (ValueError $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
 echo "Done\n";
 ?>
 --EXPECTF--
 Exponent must be between 0 and %d
+Shift must be between 0 and %d
 Shift must be between 0 and %d
 Done


### PR DESCRIPTION
```php
<?php
$too_large = gmp_init("18446744073709551616");

var_dump(gmp_init(2) ** $too_large);
var_dump(gmp_init(2) << $too_large);
```
```
object(GMP)#3 (1) {
  ["num"]=>
  string(1) "1"
}
object(GMP)#2 (1) {
  ["num"]=>
  string(1) "2"
}
```
This PR fix the overflow by rejecting large gmp objects in these calculation (throws ValueError)