### PR TITLE
GH-22658: avoid truncation on null bytes in `ReflectionConstant::__toString()`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -65,6 +65,8 @@ PHP                                                                        NEWS
     ReflectionParameter::__construct()). (jorgsowa)
   . Fixed bug GH-22441 (ReflectionClass::hasProperty() and getProperty() ignore
     dynamic properties shadowing a private parent property). (iliaal)
+  . Fixed bug GH-22658 (ReflectionConstant::__toString() with a string value
+    with null bytes truncates output). (DanielEScherzer)
 
 - Session:
   . Fixed bug GH-21314 (Different session garbage collector behavior between

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -585,7 +585,7 @@ static void _const_string(smart_str *str, const char *name, zval *value, const c
 	if (Z_TYPE_P(value) == IS_ARRAY) {
 		smart_str_append(str, ZSTR_KNOWN(ZEND_STR_ARRAY_CAPITALIZED));
 	} else if (Z_TYPE_P(value) == IS_STRING) {
-		smart_str_appends(str, Z_STRVAL_P(value));
+		smart_str_append(str, Z_STR_P(value));
 	} else {
 		zend_string *tmp_value_str;
 		zend_string *value_str = zval_get_tmp_string(value, &tmp_value_str);

--- a/ext/reflection/tests/ReflectionConstant_null_byte_value.phpt
+++ b/ext/reflection/tests/ReflectionConstant_null_byte_value.phpt
@@ -10,5 +10,5 @@ var_dump( $r->getValue() );
 
 ?>
 --EXPECTF--
-Constant [ string DEMO ] { f }
+Constant [ string DEMO ] { f%0oo }
 string(4) "f%0oo"

--- a/ext/reflection/tests/ReflectionConstant_null_byte_value.phpt
+++ b/ext/reflection/tests/ReflectionConstant_null_byte_value.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-22658: ReflectionConstant with a string value with a null byte
+--FILE--
+<?php
+
+define('DEMO', "f\0oo");
+$r = new ReflectionConstant('DEMO');
+echo $r;
+var_dump( $r->getValue() );
+
+?>
+--EXPECTF--
+Constant [ string DEMO ] { f }
+string(4) "f%0oo"


### PR DESCRIPTION
Fixes #22658