### PR TITLE
Fix GH-22667: pdo_odbc heap over-read on oversized column value

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -45,6 +45,8 @@ PHP                                                                        NEWS
 - PDO_ODBC:
   . Fixed bug GH-20726 (Crash with ODBC connection pooling when the DSN
     carries no credentials). (iliaal)
+  . Fixed bug GH-22667 (Heap buffer over-read when a column value exceeds the
+    driver-reported display size). (iliaal)
 
 - Phar:
   . Fixed inconsistent handling of the magic ".phar" directory. Paths such as

--- a/ext/pdo_odbc/odbc_stmt.c
+++ b/ext/pdo_odbc/odbc_stmt.c
@@ -744,7 +744,14 @@ in_data:
 		return 1;
 	} else if (C->fetched_len >= 0) {
 		/* it was stored perfectly */
-		ZVAL_STRINGL_FAST(result, C->data, C->fetched_len);
+		SQLLEN data_len = C->fetched_len;
+		if (!C->is_long) {
+			SQLLEN max_len = C->is_unicode ? (SQLLEN)C->datalen + 1 : (SQLLEN)C->datalen;
+			if (data_len > max_len) {
+				data_len = max_len;
+			}
+		}
+		ZVAL_STRINGL_FAST(result, C->data, data_len);
 		if (C->is_unicode) {
 			goto unicode_conv;
 		}

--- a/ext/pdo_odbc/tests/config.inc
+++ b/ext/pdo_odbc/tests/config.inc
@@ -1,0 +1,3 @@
+<?php
+
+const PDO_ODBC_SQLITE_DSN = "odbc:Driver=SQLite3;Database=:memory:";

--- a/ext/pdo_odbc/tests/gh22667.phpt
+++ b/ext/pdo_odbc/tests/gh22667.phpt
@@ -1,0 +1,32 @@
+--TEST--
+GH-22667 (Heap buffer over-read when a column value exceeds the bound buffer)
+--EXTENSIONS--
+pdo_odbc
+--SKIPIF--
+<?php
+require __DIR__ . '/config.inc';
+try {
+    $pdo = new PDO(PDO_ODBC_SQLITE_DSN);
+} catch (PDOException $e) {
+    die("skip requires the SQLite3 ODBC driver");
+}
+?>
+--FILE--
+<?php
+require __DIR__ . '/config.inc';
+$pdo = new PDO(PDO_ODBC_SQLITE_DSN);
+
+// The SQLite3 driver reports a 255 byte display size for a computed column, so
+// the short-bound buffer holds at most 255 bytes while the value is far longer.
+// A conforming driver truncates into the buffer but reports the full length; the
+// returned string must stay within the buffer, not over-read past it.
+$stmt = $pdo->query("SELECT printf('%.*c', 4096, 'A') AS data");
+$row = $stmt->fetch(PDO::FETCH_ASSOC);
+$s = $row['data'];
+
+echo "clamped to buffer: "; var_dump(strlen($s) < 4096);
+echo "only value bytes:  "; var_dump(strlen($s) === substr_count($s, 'A'));
+?>
+--EXPECT--
+clamped to buffer: bool(true)
+only value bytes:  bool(true)


### PR DESCRIPTION
ext/pdo_odbc builds the result string from the driver-reported fetched_len, which on truncation exceeds the bound colsize+1 buffer (SQL_SUCCESS_WITH_INFO), over-reading heap into the returned value. Clamps to the bound capacity for short-bound columns only, so long columns are unaffected. Reproduces with the SQLite3 ODBC driver; the test skips without it. Sibling of GH-22668.

Fixes #22667