### PR TITLE
ir/aarch64: emit cbz/cbnz instead of cmp + b.ne

### DIFF
--- a/ext/opcache/jit/ir/ir_aarch64.dasc
+++ b/ext/opcache/jit/ir/ir_aarch64.dasc
@@ -3469,8 +3469,7 @@ static void ir_emit_if_int(ir_ctx *ctx, uint32_t b, ir_ref def, ir_insn *insn, u
 		op2_reg = IR_REG_NUM(op2_reg);
 		ir_emit_load(ctx, type, op2_reg, insn->op2);
 	}
-	|	ASM_REG_IMM_OP cmp, type, op2_reg, 0
-	ir_emit_jcc(ctx, b, def, insn, next_block, IR_NE, 1);
+	ir_emit_jz(ctx, b, next_block, IR_NE, type, op2_reg);
 }
 
 static void ir_emit_cond(ir_ctx *ctx, ir_ref def, ir_insn *insn)


### PR DESCRIPTION
ir_emit_if_int used to emit 
```asm
cmp   w1, #0
b.ne  >refcount_path
```

and now emits 
```asm
cbnz  w1, >refcount_path
```

for 

```php
function f($x) {
    $s = "s" . $x;   // $s is a refcounted string
    unset($s);       // FREE: DELREF + maybe destroy, only if refcounted
}
```

LLM disclosure: this was fully found and done by Fable, all I did was verify correctness. ~ +1% in jit on phpbench for both Clang and GCC. No non-jit impact for obvious reasons.