### PR TITLE
Fix GH-22665: pdo_odbc OOB write on oversized diagnostic length

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -47,6 +47,8 @@ PHP                                                                        NEWS
     carries no credentials). (iliaal)
   . Fixed bug GH-22667 (Heap buffer over-read when a column value exceeds the
     driver-reported display size). (iliaal)
+  . Fixed bug GH-22665 (Out-of-bounds write when the ODBC driver reports a
+    diagnostic message length beyond the error buffer). (iliaal)
 
 - Phar:
   . Fixed inconsistent handling of the magic ".phar" directory. Paths such as

--- a/ext/pdo_odbc/odbc_driver.c
+++ b/ext/pdo_odbc/odbc_driver.c
@@ -90,6 +90,8 @@ void pdo_odbc_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, PDO_ODBC_HSTMT statement, 
 
 	if (rc != SQL_SUCCESS && rc != SQL_SUCCESS_WITH_INFO) {
 		errmsgsize = 0;
+	} else if ((size_t) errmsgsize >= sizeof(einfo->last_err_msg)) {
+		errmsgsize = sizeof(einfo->last_err_msg) - 1;
 	}
 
 	einfo->last_err_msg[errmsgsize] = '\0';

--- a/ext/pdo_odbc/tests/gh22665.phpt
+++ b/ext/pdo_odbc/tests/gh22665.phpt
@@ -1,0 +1,32 @@
+--TEST--
+GH-22665 (OOB write in pdo_odbc_error when the driver reports a long message)
+--EXTENSIONS--
+pdo_odbc
+--SKIPIF--
+<?php
+require __DIR__ . '/config.inc';
+try {
+    $pdo = new PDO(PDO_ODBC_SQLITE_DSN);
+} catch (PDOException $e) {
+    die("skip requires the SQLite3 ODBC driver");
+}
+?>
+--FILE--
+<?php
+require __DIR__ . '/config.inc';
+$pdo = new PDO(PDO_ODBC_SQLITE_DSN, null, null, [
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_SILENT,
+]);
+
+// A failing query with a long identifier makes the driver report a diagnostic
+// message length >= the fixed last_err_msg buffer. The terminator write must
+// stay inside the buffer.
+$pdo->query('SELECT * FROM "' . str_repeat('A', 4096) . '"');
+$info = $pdo->errorInfo();
+
+echo "sqlstate: ", $info[0], "\n";
+echo "done\n";
+?>
+--EXPECT--
+sqlstate: HY000
+done


### PR DESCRIPTION
pdo_odbc_error() NUL-terminates the diagnostic buffer at the length SQLGetDiagRec reports, which on a truncated message is the full untruncated length and can reach or exceed the 512-byte last_err_msg buffer, writing the terminator out of bounds into the adjacent last_error field. Clamps the index to sizeof-1; the size_t cast also covers a negative driver-reported length. Reproduces with the SQLite3 ODBC driver (reports 512) via a failing query whose long identifier lengthens the message; the test skips without that driver.

Fixes #22665