### PR TITLE
perf: use trunc(dval(&u)) instead of (Long)(dval(&u)) 

### DIFF
--- a/Zend/zend_strtod.c
+++ b/Zend/zend_strtod.c
@@ -3700,6 +3700,15 @@ zend_freedtoa(char *s)
  *	   calculation.
  */
 
+/* trunc(dval(&u)) keeps the per-digit remainder chain in the FP unit instead of a
+ * FP->int->FP round-trip, cutting the digit loop's critical-path latency and
+ * speeding up fixed-precision float->string ((string)/echo/printf/number_format).
+ * Only a win where trunc() lowers to one instruction (aarch64 frintz, x86
+ * roundsd), elsewhere it's a call, so keep (Long)(dval(&u)). */
+#if defined(__SSE4_1__) || defined(__aarch64__)
+# define FAST_TRUNC
+#endif
+
 ZEND_API char *zend_dtoa(double dd, int mode, int ndigits, int *decpt, bool *sign, char **rve)
 {
  /*	Arguments ndigits, decpt, sign are similar to those
@@ -3747,6 +3756,9 @@ ZEND_API char *zend_dtoa(double dd, int mode, int ndigits, int *decpt, bool *sig
 	Bigint *b, *b1, *delta, *mlo, *mhi, *S;
 	U d2, eps, u;
 	double ds;
+#ifdef FAST_TRUNC
+	double tr;
+#endif
 	char *s, *s0;
 #ifndef No_leftright
 #ifdef IEEE_Arith
@@ -4047,9 +4059,16 @@ ZEND_API char *zend_dtoa(double dd, int mode, int ndigits, int *decpt, bool *sig
 			/* Generate ilim digits, then fix them up. */
 			dval(&eps) *= tens[ilim-1];
 			for(i = 1;; i++, dval(&u) *= 10.) {
+#ifdef FAST_TRUNC
+				tr = trunc(dval(&u));
+				L = (Long)tr;
+				if (!(dval(&u) -= tr))
+					ilim = i;
+#else
 				L = (Long)(dval(&u));
 				if (!(dval(&u) -= L))
 					ilim = i;
+#endif
 				*s++ = '0' + (int)L;
 				if (i == ilim) {
 					if (dval(&u) > 0.5 + dval(&eps))
@@ -4084,8 +4103,14 @@ ZEND_API char *zend_dtoa(double dd, int mode, int ndigits, int *decpt, bool *sig
 			goto one_digit;
 			}
 		for(i = 1;; i++, dval(&u) *= 10.) {
+#ifdef FAST_TRUNC
+			tr = trunc(dval(&u) / ds);
+			L = (Long)tr;
+			dval(&u) -= tr*ds;
+#else
 			L = (Long)(dval(&u) / ds);
 			dval(&u) -= L*ds;
+#endif
 #ifdef Check_FLT_ROUNDS
 			/* If FLT_ROUNDS == 2, L will usually be high by 1 */
 			if (dval(&u) < 0) {


### PR DESCRIPTION
… to keep per-digit dependency chain in float register

```php
<?php
// Micro-benchmark of the float->string paths
const N = 4000;
const R = 8;

$vals = [];
for ($i = 1; $i <= N; $i++) {
    $vals[] = M_PI * $i / 7.0 + 1.0 / $i;
}

function bench(string $name, callable $fn, array $vals): void {
    $fn($vals); $fn($vals);
    $best = PHP_INT_MAX;
    for ($r = 0; $r < R; $r++) {
        $t = hrtime(true);
        $sink = $fn($vals);
        $dt = hrtime(true) - $t;
        if ($dt < $best) $best = $dt;
    }
    $ops = count($vals);
    printf("%-26s %8.1f ns/op   (min block %6.2f ms)\n", $name, $best / $ops, $best / 1e6);
}

bench('(string) cast', function($vals){ $s=0; foreach($vals as $v){ $x=(string)$v; $s+=strlen($x); } return $s; }, $vals);
bench('string interpolation', function($vals){ $s=0; foreach($vals as $v){ $x="$v"; $s+=strlen($x); } return $s; }, $vals);
bench('concatenation', function($vals){ $s=''; foreach($vals as $v){ $s = $v . '|'; } return strlen($s); }, $vals);
bench('number_format', function($vals){ $s=0; foreach($vals as $v){ $s+=strlen(number_format($v, 6, '.', ',')); } return $s; }, $vals);
bench("sprintf('%g')", function($vals){ $s=0; foreach($vals as $v){ $s+=strlen(sprintf('%g',$v)); } return $s; }, $vals);
bench("sprintf('%.10f')", function($vals){ $s=0; foreach($vals as $v){ $s+=strlen(sprintf('%.10f',$v)); } return $s; }, $vals);
bench('json_encode (array)', function($vals){ return strlen(json_encode($vals)); }, $vals);
bench('serialize (array)', function($vals){ return strlen(serialize($vals)); }, $vals);
bench('var_export (array)', function($vals){ return strlen(var_export($vals, true)); }, $vals);
bench('implode floats', function($vals){ return strlen(implode(',', $vals)); }, $vals);
```

aarch64:
<table><thead><tr><th>Path (ns/op)</th><th>base</th><th>dtoa</th><th>change</th></tr></thead><tbody><tr><td>(string) cast</td><td>182.6</td><td>146.4</td><td>&minus;19.8%</td></tr><tr><td>string interpolation</td><td>182.8</td><td>146.3</td><td>&minus;20.0%</td></tr><tr><td>concatenation</td><td>196.2</td><td>159.5</td><td>&minus;18.7%</td></tr><tr><td>number_format</td><td>309.8</td><td>286.4</td><td>&minus;7.6%</td></tr><tr><td>sprintf('%g')</td><td>153.0</td><td>137.6</td><td>&minus;10.1%</td></tr><tr><td>sprintf('%.10f')</td><td>258.8</td><td>226.4</td><td>&minus;12.5%</td></tr><tr><td>json_encode (array)</td><td>568.1</td><td>567.8</td><td>&minus;0.1%</td></tr><tr><td>serialize (array)</td><td>580.9</td><td>579.7</td><td>&minus;0.2%</td></tr><tr><td>var_export (array)</td><td>637.5</td><td>635.9</td><td>&minus;0.3%</td></tr><tr><td>implode floats</td><td>164.9</td><td>129.3</td><td>&minus;21.6%</td></tr></tbody></table>

x86_64 (sse4.1):
 <table><thead><tr><th>Path (ns/op)</th><th>base</th><th>dtoa</th><th>change</th></tr></thead><tbody><tr><td>(string) cast</td><td>105.9</td><td>100.1</td><td>&minus;5.5%</td></tr><tr><td>string interpolation</td><td>105.6</td><td>100.3</td><td>&minus;5.0%</td></tr><tr><td>concatenation</td><td>111.5</td><td>106.1</td><td>&minus;4.8%</td></tr><tr><td>number_format</td><td>162.4</td><td>158.8</td><td>&minus;2.2%</td></tr><tr><td>sprintf('%g')</td><td>82.2</td><td>79.8</td><td>&minus;2.9%</td></tr><tr><td>sprintf('%.10f')</td><td>136.9</td><td>130.7</td><td>&minus;4.5%</td></tr><tr><td>json_encode (array)</td><td>261.1</td><td>259.7</td><td>&minus;0.5%</td></tr><tr><td>serialize (array)</td><td>268.2</td><td>266.8</td><td>&minus;0.5%</td></tr><tr><td>var_export (array)</td><td>287.5</td><td>290.1</td><td>&plus;0.9%</td></tr><tr><td>implode floats</td><td>103.1</td><td>97.6</td><td>&minus;5.3%</td></tr></tbody></table>
 
 LLM disclosure: optimisation found entirely by Fable, I verified, wrote the comment and benchmarked.