### PR TITLE
Fix GH-22671: assert.bail must not unwind with a pending exception

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -80,6 +80,8 @@ PHP                                                                        NEWS
 - Standard:
   . Fixed sleep() and usleep() to reject values that overflow the underlying
     unsigned int timeout. (Weilin Du)
+  . Fixed bug GH-22671 (assert.bail aborts the process when the assert callback
+    throws an exception whose reporting re-throws). (iliaal)
 
 - Streams:
   . Fixed bug GH-21468 (Segfault in file_get_contents w/ a https URL

--- a/ext/standard/assert.c
+++ b/ext/standard/assert.c
@@ -245,7 +245,9 @@ PHP_FUNCTION(assert)
 			 * exception so we can avoid bailout and use unwind_exit. */
 			zend_exception_error(EG(exception), E_WARNING);
 		}
-		zend_throw_unwind_exit();
+		if (!EG(exception)) {
+			zend_throw_unwind_exit();
+		}
 		RETURN_THROWS();
 	} else {
 		RETURN_FALSE;

--- a/ext/standard/tests/assert/gh22671.phpt
+++ b/ext/standard/tests/assert/gh22671.phpt
@@ -1,0 +1,40 @@
+--TEST--
+GH-22671 (assert.bail must not call zend_throw_unwind_exit with a pending exception)
+--INI--
+zend.assertions=1
+assert.bail=1
+assert.exception=0
+assert.callback=cb
+error_reporting=0
+--FILE--
+<?php
+register_shutdown_function(function () {
+    echo "shutdown reached\n";
+});
+
+class Inner extends Exception {
+    public function __destruct() {
+        throw new Exception("thrown from __destruct");
+    }
+}
+
+class Boom extends Exception {
+    public function __toString(): string {
+        throw new Inner("inner");
+    }
+}
+
+function cb() {
+    throw new Boom("boom");
+}
+
+// The callback throws Boom; the bail path prints it, which re-throws from
+// Boom::__toString(), and releasing that exception re-throws again from
+// Inner::__destruct(). The bail path must not reach zend_throw_unwind_exit()
+// while an exception is pending, otherwise the process aborts.
+assert(false);
+
+echo "not reached\n";
+?>
+--EXPECT--
+shutdown reached


### PR DESCRIPTION
assert.bail called zend_throw_unwind_exit() (which requires no pending exception) right after printing the callback's exception, but that printing can itself re-throw (a throwing __toString or __destruct, or the stack guard re-tripping). Now it only unwinds when nothing is pending, otherwise the exception propagates, matching exit() and phar. The regression test re-throws from both __toString and __destruct, so it is deterministic and compiler-independent (unlike the reporter's stack-layout-sensitive recursion). Fixes #22671