### PR TITLE
Install the SQLite ODBC driver in CI

### DIFF
--- a/.github/actions/apt-x64/action.yml
+++ b/.github/actions/apt-x64/action.yml
@@ -63,6 +63,7 @@ runs:
           snmp-mibs-downloader \
           freetds-dev \
           unixodbc-dev \
+          libsqliteodbc \
           llvm \
           clang \
           dovecot-core \


### PR DESCRIPTION
The ext/odbc and pdo_odbc regression tests connect through a real ODBC driver (Driver=SQLite3), which CI never installed, so they skipped on every lane. libsqliteodbc registers the SQLite3 driver and supports Database=:memory:, so the tests run without a database server. Alpine has no such package, so those lanes keep skipping. Follow-up to the driver discussion on #22672.