### PR TITLE
ext/session: Add tests for session_regenerate_id() write/destroy failure paths

### DIFF
--- a/ext/session/tests/user_session_module/session_regenerate_id_destroy_fails.phpt
+++ b/ext/session/tests/user_session_module/session_regenerate_id_destroy_fails.phpt
@@ -1,0 +1,50 @@
+--TEST--
+session_regenerate_id(true): warns and returns false when save handler's destroy() fails
+--EXTENSIONS--
+session
+--INI--
+session.save_path=
+--FILE--
+<?php
+
+class FailingDestroyHandler implements SessionHandlerInterface {
+    function open($save_path, $session_name): bool {
+        return true;
+    }
+
+    function close(): bool {
+        return true;
+    }
+
+    function read($id): string|false {
+        return '';
+    }
+
+    function write($id, $session_data): bool {
+        return true;
+    }
+
+    function destroy($id): bool {
+        return false;
+    }
+
+    function gc($maxlifetime): int|false {
+        return 0;
+    }
+}
+
+session_set_save_handler(new FailingDestroyHandler());
+session_start();
+$_SESSION['foo'] = 'bar';
+$old_id = session_id();
+
+var_dump(session_regenerate_id(true));
+var_dump(session_id() === $old_id);
+var_dump(session_status() === PHP_SESSION_NONE);
+
+?>
+--EXPECTF--
+Warning: session_regenerate_id(): Session object destruction failed. ID: user (path: ) in %s on line %d
+bool(false)
+bool(true)
+bool(true)

--- a/ext/session/tests/user_session_module/session_regenerate_id_write_fails.phpt
+++ b/ext/session/tests/user_session_module/session_regenerate_id_write_fails.phpt
@@ -1,0 +1,50 @@
+--TEST--
+session_regenerate_id(false): warns and returns false when save handler's write() fails
+--EXTENSIONS--
+session
+--INI--
+session.save_path=
+--FILE--
+<?php
+
+class FailingWriteHandler implements SessionHandlerInterface {
+    function open($save_path, $session_name): bool {
+        return true;
+    }
+
+    function close(): bool {
+        return true;
+    }
+
+    function read($id): string|false {
+        return '';
+    }
+
+    function write($id, $session_data): bool {
+        return false;
+    }
+
+    function destroy($id): bool {
+        return true;
+    }
+
+    function gc($maxlifetime): int|false {
+        return 0;
+    }
+}
+
+session_set_save_handler(new FailingWriteHandler());
+session_start();
+$_SESSION['foo'] = 'bar';
+$old_id = session_id();
+
+var_dump(session_regenerate_id(false));
+var_dump(session_id() === $old_id);
+var_dump(session_status() === PHP_SESSION_NONE);
+
+?>
+--EXPECTF--
+Warning: session_regenerate_id(): Session write failed. ID: user (path: ) in %s on line %d
+bool(false)
+bool(true)
+bool(true)


### PR DESCRIPTION
Covers `FAILURE` branches where a userland save handler's write() or destroy() returns false during `session_regenerate_id()`, which should warn and return false while leaving the current session ID unchanged.