### PR TITLE
Fix callable invalidation during autoloading

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,9 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 8.4.24
 
+- Core:
+  . Fixed use-after-free when an autoloader modifies a callable. (PuH4ck3rX)
+
 - Calendar:
   . Fixed bug GH-22602 (gregoriantojd() and juliantojd() integer overflow with
     INT_MAX year). (arshidkv12)

--- a/Zend/tests/callable_resolution_autoload_mutation.phpt
+++ b/Zend/tests/callable_resolution_autoload_mutation.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Autoloading must not invalidate callables during callable resolution
+--FILE--
+<?php
+spl_autoload_register(function (string $class): void {
+    if ($class === 'IsCallableAutoloadTest') {
+        $GLOBALS['method1'] = 'missing';
+        eval('class IsCallableAutoloadTest {
+            public static function original(): void {}
+        }');
+    } elseif ($class === 'CallUserFuncAutoloadTest') {
+        $GLOBALS['method2'] = 'changed';
+        eval('class CallUserFuncAutoloadTest {
+            public static function original(): void { echo "original\\n"; }
+            public static function changed(): void { echo "changed\\n"; }
+        }');
+    } elseif ($class === 'CallUserFuncStringAutoloadTest') {
+        $GLOBALS['callable3'][strlen($GLOBALS['callable3']) - 1] = 'o';
+        eval('class CallUserFuncStringAutoloadTest {
+            public static function mOne(): void { echo "mOne\\n"; }
+            public static function mOno(): void { echo "mOno\\n"; }
+        }');
+    }
+});
+
+$method1 = 'original';
+$callable1 = ['IsCallableAutoloadTest', &$method1];
+var_dump(is_callable($callable1));
+
+$method2 = 'original';
+$callable2 = ['CallUserFuncAutoloadTest', &$method2];
+call_user_func($callable2);
+
+$callable3 = strrev('enOm::tseTdaolotuAgnirtScnuFresUllaC');
+$alias3 = &$callable3;
+call_user_func($alias3);
+?>
+--EXPECT--
+bool(true)
+original
+mOne

--- a/Zend/tests/dynamic_call_array_autoload_mutation.phpt
+++ b/Zend/tests/dynamic_call_array_autoload_mutation.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Autoloading must not invalidate an array callable during a dynamic call
+--FILE--
+<?php
+spl_autoload_register(function (string $class): void {
+    $GLOBALS['method'] = 'changed';
+    eval('class DynamicArrayCallableTest {
+        public static function original(): void { echo "original\\n"; }
+        public static function changed(): void { echo "changed\\n"; }
+    }');
+});
+
+$method = 'original';
+$callable = ['DynamicArrayCallableTest', &$method];
+$callable();
+?>
+--EXPECT--
+original

--- a/Zend/tests/dynamic_call_string_autoload_mutation.phpt
+++ b/Zend/tests/dynamic_call_string_autoload_mutation.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Autoloading must not invalidate a string callable during a dynamic call
+--FILE--
+<?php
+spl_autoload_register(function (string $class): void {
+    $GLOBALS['callable'][strlen($GLOBALS['callable']) - 1] = 'o';
+    eval('class DynamicStringCallableTest {
+        public static function mOne(): void { echo "mOne\\n"; }
+        public static function mOno(): void { echo "mOno\\n"; }
+    }');
+});
+
+// Keep this non-interned and uniquely owned so the offset write is in-place.
+$callable = strrev('enOm::tseTelballaCgnirtScimanyD');
+$callable();
+?>
+--EXPECT--
+mOne

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -4179,6 +4179,7 @@ ZEND_API bool zend_is_callable_at_frame(
 	bool ret;
 	zend_fcall_info_cache fcc_local;
 	bool strict_class = 0;
+	zval callable_copy;
 
 	if (fcc == NULL) {
 		fcc = &fcc_local;
@@ -4205,9 +4206,11 @@ again:
 				fcc->called_scope = fcc->calling_scope;
 				return 1;
 			}
+			ZVAL_STR_COPY(&callable_copy, Z_STR_P(callable));
 
 check_func:
-			ret = zend_is_callable_check_func(callable, frame, fcc, strict_class, error, check_flags & IS_CALLABLE_SUPPRESS_DEPRECATIONS);
+			ret = zend_is_callable_check_func(&callable_copy, frame, fcc, strict_class, error, check_flags & IS_CALLABLE_SUPPRESS_DEPRECATIONS);
+			zval_ptr_dtor(&callable_copy);
 			if (fcc == &fcc_local) {
 				zend_release_fcall_info_cache(fcc);
 			}
@@ -4244,7 +4247,12 @@ check_func:
 						return 1;
 					}
 
-					if (!zend_is_callable_check_class(Z_STR_P(obj), get_scope(frame), frame, fcc, &strict_class, error, check_flags & IS_CALLABLE_SUPPRESS_DEPRECATIONS)) {
+					ZVAL_STR_COPY(&callable_copy, Z_STR_P(method));
+					zend_string *class_name = zend_string_copy(Z_STR_P(obj));
+					ret = zend_is_callable_check_class(class_name, get_scope(frame), frame, fcc, &strict_class, error, check_flags & IS_CALLABLE_SUPPRESS_DEPRECATIONS);
+					zend_string_release(class_name);
+					if (!ret) {
+						zval_ptr_dtor(&callable_copy);
 						return 0;
 					}
 				} else {
@@ -4256,9 +4264,9 @@ check_func:
 						fcc->called_scope = fcc->calling_scope;
 						return 1;
 					}
+					ZVAL_STR_COPY(&callable_copy, Z_STR_P(method));
 				}
 
-				callable = method;
 				goto check_func;
 			}
 			return 0;

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -4871,14 +4871,14 @@ static zend_never_inline zend_execute_data *zend_init_dynamic_call_string(zend_s
 		size_t mname_length = ZSTR_LEN(function) - cname_length - (sizeof("::") - 1);
 
 		lcname = zend_string_init(ZSTR_VAL(function), cname_length, 0);
+		mname = zend_string_init(ZSTR_VAL(function) + (cname_length + sizeof("::") - 1), mname_length, 0);
 
 		called_scope = zend_fetch_class_by_name(lcname, NULL, ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 		if (UNEXPECTED(called_scope == NULL)) {
 			zend_string_release_ex(lcname, 0);
+			zend_string_release_ex(mname, 0);
 			return NULL;
 		}
-
-		mname = zend_string_init(ZSTR_VAL(function) + (cname_length + sizeof("::") - 1), mname_length, 0);
 
 		if (called_scope->get_static_method) {
 			fbc = called_scope->get_static_method(called_scope, mname);
@@ -5008,23 +5008,29 @@ static zend_never_inline zend_execute_data *zend_init_dynamic_call_array(zend_ar
 		}
 
 		if (Z_TYPE_P(obj) == IS_STRING) {
-			zend_class_entry *called_scope = zend_fetch_class_by_name(Z_STR_P(obj), NULL, ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
+			zend_string *class_name = zend_string_copy(Z_STR_P(obj));
+			zend_string *method_name = zend_string_copy(Z_STR_P(method));
+			zend_class_entry *called_scope = zend_fetch_class_by_name(class_name, NULL, ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
+			zend_string_release(class_name);
 
 			if (UNEXPECTED(called_scope == NULL)) {
+				zend_string_release(method_name);
 				return NULL;
 			}
 
 			if (called_scope->get_static_method) {
-				fbc = called_scope->get_static_method(called_scope, Z_STR_P(method));
+				fbc = called_scope->get_static_method(called_scope, method_name);
 			} else {
-				fbc = zend_std_get_static_method(called_scope, Z_STR_P(method), NULL);
+				fbc = zend_std_get_static_method(called_scope, method_name, NULL);
 			}
 			if (UNEXPECTED(fbc == NULL)) {
 				if (EXPECTED(!EG(exception))) {
-					zend_undefined_method(called_scope, Z_STR_P(method));
+					zend_undefined_method(called_scope, method_name);
 				}
+				zend_string_release(method_name);
 				return NULL;
 			}
+			zend_string_release(method_name);
 			if (!(fbc->common.fn_flags & ZEND_ACC_STATIC)) {
 				zend_non_static_method_call(fbc);
 				if (fbc->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE) {


### PR DESCRIPTION
Autoloading can execute user code while a callable is being resolved. The dynamic-call helpers and the common callable resolver kept borrowed pointers into the original callable across that boundary. If the autoloader modified or released the callable, the subsequent method lookup could read freed or retyped values.

This change snapshots the relevant class and method strings before class lookup can invoke autoloading. For direct Class::method dynamic calls, the method name is also extracted before entering the autoloader. The same lifetime rule is applied to zend_is_callable_at_frame(), covering both array and string callables used by APIs such as is_callable() and call_user_func().

The regression tests use deterministic callable mutation during autoloading and verify that the callable value captured at the start of resolution is used for the current call.

Checks performed:

- Built PHP 8.4 with ASan and UBSan, with opcache JIT disabled.
- 3 new PHPT tests passed.
- 33 related dynamic-call, callable, is_callable(), and call_user_func() tests passed.
- 5 reduced reproducer scripts completed without sanitizer findings.