### PR TITLE
Fix GH-22683: Reflection(Class)Constant::__toString() should not warn on NAN conversions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -84,6 +84,8 @@ PHP                                                                        NEWS
     dynamic properties shadowing a private parent property). (iliaal)
   . Fixed bug GH-22658 (ReflectionConstant::__toString() with a string value
     with null bytes truncates output). (DanielEScherzer)
+  . Fixed bug GH-22683 (Reflection(Class)Constant::__toString() should not warn
+    on NAN conversions). (Khaled Alam)
 
 - Session:
   . Fixed bug GH-21314 (Different session garbage collector behavior between

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -617,6 +617,8 @@ static void _const_string(smart_str *str, const char *name, zval *value, const c
 		smart_str_append(str, ZSTR_KNOWN(ZEND_STR_ARRAY_CAPITALIZED));
 	} else if (Z_TYPE_P(value) == IS_STRING) {
 		smart_str_append(str, Z_STR_P(value));
+	} else if (Z_TYPE_P(value) == IS_DOUBLE) {
+		smart_str_append_double(str, Z_DVAL_P(value), (int) EG(precision), false);
 	} else {
 		zend_string *tmp_value_str;
 		zend_string *value_str = zval_get_tmp_string(value, &tmp_value_str);
@@ -649,6 +651,8 @@ static void _class_const_string(smart_str *str, const zend_string *name, zend_cl
 		smart_str_appends(str, "Array");
 	} else if (Z_TYPE(c->value) == IS_OBJECT) {
 		smart_str_appends(str, "Object");
+	} else if (Z_TYPE(c->value) == IS_DOUBLE) {
+		smart_str_append_double(str, Z_DVAL(c->value), (int) EG(precision), false);
 	} else {
 		zend_string *tmp_value_str;
 		zend_string *value_str = zval_get_tmp_string(&c->value, &tmp_value_str);

--- a/ext/reflection/tests/gh22683.phpt
+++ b/ext/reflection/tests/gh22683.phpt
@@ -1,0 +1,28 @@
+--TEST--
+GH-22683 (Reflection(Class)Constant::__toString() should not warn on NAN conversions)
+--FILE--
+<?php
+
+echo new ReflectionConstant('NAN');
+echo new ReflectionConstant('INF');
+
+class Demo {
+    public const MY_NAN = NAN;
+    public const MY_INF = INF;
+    public const MY_FLOAT = 1.5;
+    public const MY_WHOLE = 2.0;
+}
+
+echo new ReflectionClassConstant(Demo::class, 'MY_NAN');
+echo new ReflectionClassConstant(Demo::class, 'MY_INF');
+echo new ReflectionClassConstant(Demo::class, 'MY_FLOAT');
+echo new ReflectionClassConstant(Demo::class, 'MY_WHOLE');
+
+?>
+--EXPECT--
+Constant [ <persistent> float NAN ] { NAN }
+Constant [ <persistent> float INF ] { INF }
+Constant [ public float MY_NAN ] { NAN }
+Constant [ public float MY_INF ] { INF }
+Constant [ public float MY_FLOAT ] { 1.5 }
+Constant [ public float MY_WHOLE ] { 2 }


### PR DESCRIPTION
Fixes GH-22683.

Add an IS_DOUBLE branch that formats the value with smart_str_append_double() instead.

<img width="788" height="797" alt="image" src="https://github.com/user-attachments/assets/6b7a95e6-8c6d-4cf8-82f7-0c4b26f4e0c1" />
