### PR TITLE
Fix use-after-free in extract() EXTR_REFS collision modes

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -1764,8 +1764,10 @@ static zend_long php_extract_ref_if_exists(const zend_array *arr, const zend_arr
 			} else {
 				ZVAL_MAKE_REF_EX(entry, 2);
 			}
-			zval_ptr_dtor(orig_var);
+			zval garbage;
+			ZVAL_COPY_VALUE(&garbage, orig_var);
 			ZVAL_REF(orig_var, Z_REF_P(entry));
+			zval_ptr_dtor(&garbage);
 			count++;
 		}
 	} ZEND_HASH_FOREACH_END();
@@ -1957,8 +1959,10 @@ static zend_long php_extract_ref_prefix_if_exists(const zend_array *arr, zend_ar
 					if (Z_TYPE_P(orig_var) == IS_INDIRECT) {
 						orig_var = Z_INDIRECT_P(orig_var);
 					}
-					zval_ptr_dtor(orig_var);
+					zval garbage;
+					ZVAL_COPY_VALUE(&garbage, orig_var);
 					ZVAL_REF(orig_var, Z_REF_P(entry));
+					zval_ptr_dtor(&garbage);
 				} else {
 					zend_hash_add_new(symbol_table, final_name, entry);
 				}
@@ -2070,8 +2074,10 @@ prefix:;
 					if (Z_TYPE_P(orig_var) == IS_INDIRECT) {
 						orig_var = Z_INDIRECT_P(orig_var);
 					}
-					zval_ptr_dtor(orig_var);
+					zval garbage;
+					ZVAL_COPY_VALUE(&garbage, orig_var);
 					ZVAL_REF(orig_var, Z_REF_P(entry));
+					zval_ptr_dtor(&garbage);
 				} else {
 					zend_hash_add_new(symbol_table, final_name, entry);
 				}
@@ -2198,8 +2204,10 @@ static zend_long php_extract_ref_prefix_all(const zend_array *arr, zend_array *s
 				if (Z_TYPE_P(orig_var) == IS_INDIRECT) {
 					orig_var = Z_INDIRECT_P(orig_var);
 				}
-				zval_ptr_dtor(orig_var);
+				zval garbage;
+				ZVAL_COPY_VALUE(&garbage, orig_var);
 				ZVAL_REF(orig_var, Z_REF_P(entry));
+				zval_ptr_dtor(&garbage);
 			} else {
 				zend_hash_add_new(symbol_table, final_name, entry);
 			}
@@ -2300,8 +2308,10 @@ static zend_long php_extract_ref_prefix_invalid(const zend_array *arr, zend_arra
 			if (Z_TYPE_P(orig_var) == IS_INDIRECT) {
 				orig_var = Z_INDIRECT_P(orig_var);
 			}
-			zval_ptr_dtor(orig_var);
+			zval garbage;
+			ZVAL_COPY_VALUE(&garbage, orig_var);
 			ZVAL_REF(orig_var, Z_REF_P(entry));
+			zval_ptr_dtor(&garbage);
 		} else {
 			zend_hash_add_new(symbol_table, final_name, entry);
 		}

--- a/ext/standard/tests/array/extract_refs_reentrant_dtor.phpt
+++ b/ext/standard/tests/array/extract_refs_reentrant_dtor.phpt
@@ -1,0 +1,32 @@
+--TEST--
+extract() EXTR_REFS: destructor freeing the target symbol during the ref write (GH-18209 siblings)
+--FILE--
+<?php
+// EXTR_IF_EXISTS path: php_extract_ref_if_exists
+class A {
+    public function __destruct() {
+        unset($GLOBALS['b']);
+    }
+}
+$b = new A();
+$r1 = 'r1';
+extract(['b' => &$r1], EXTR_REFS | EXTR_IF_EXISTS);
+var_dump($b ?? 'b-unset');
+
+// EXTR_PREFIX_ALL path: php_extract_ref_prefix_all
+class B {
+    public function __destruct() {
+        unset($GLOBALS['p_c']);
+    }
+}
+$p_c = new B();
+$r2 = 'r2';
+extract(['c' => &$r2], EXTR_REFS | EXTR_PREFIX_ALL, 'p');
+var_dump($p_c ?? 'p_c-unset');
+
+echo "done\n";
+?>
+--EXPECT--
+string(7) "b-unset"
+string(9) "p_c-unset"
+done


### PR DESCRIPTION
The GH-18209 fix guarded `php_extract_ref_overwrite` against a destructor freeing the extract target during the reference write, but the five sibling EXTR_REFS collision paths still drop the old value before writing the reference. The added test crashes on master through the EXTR_IF_EXISTS and EXTR_PREFIX_ALL paths; the fix copies the old value aside and drops it after the write, matching `php_extract_ref_overwrite`.

Fixes GH-18209
