### PR TITLE
Show curl option name in error message

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -70,7 +70,8 @@ ZEND_DECLARE_MODULE_GLOBALS(curl)
 static zend_result php_curl_option_str(php_curl *ch, zend_long option, const char *str, const size_t len)
 {
 	if (zend_char_has_nul_byte(str, len)) {
-		zend_value_error("%s(): cURL option must not contain any null bytes", get_active_function_name());
+		const struct curl_easyoption *option_info = curl_easy_option_by_id(option);
+		zend_value_error("%s(): cURL option CURLOPT_%s must not contain any null bytes", get_active_function_name(), option_info->name);
 		return FAILURE;
 	}
 
@@ -2030,43 +2031,10 @@ static zend_result _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue
 			HashTable *ph;
 			zend_string *val, *tmp_val;
 			struct curl_slist *slist = NULL;
-			const char *name = NULL;
-
-			switch (option) {
-				case CURLOPT_HTTPHEADER:
-					name = "CURLOPT_HTTPHEADER";
-					break;
-				case CURLOPT_QUOTE:
-					name = "CURLOPT_QUOTE";
-					break;
-				case CURLOPT_HTTP200ALIASES:
-					name = "CURLOPT_HTTP200ALIASES";
-					break;
-				case CURLOPT_POSTQUOTE:
-					name = "CURLOPT_POSTQUOTE";
-					break;
-				case CURLOPT_PREQUOTE:
-					name = "CURLOPT_PREQUOTE";
-					break;
-				case CURLOPT_TELNETOPTIONS:
-					name = "CURLOPT_TELNETOPTIONS";
-					break;
-				case CURLOPT_MAIL_RCPT:
-					name = "CURLOPT_MAIL_RCPT";
-					break;
-				case CURLOPT_RESOLVE:
-					name = "CURLOPT_RESOLVE";
-					break;
-				case CURLOPT_PROXYHEADER:
-					name = "CURLOPT_PROXYHEADER";
-					break;
-				case CURLOPT_CONNECT_TO:
-					name = "CURLOPT_CONNECT_TO";
-					break;
-			}
 
 			if (Z_TYPE_P(zvalue) != IS_ARRAY) {
-				zend_type_error("%s(): The %s option must have an array value", get_active_function_name(), name);
+				const struct curl_easyoption *option_info = curl_easy_option_by_id(option);
+				zend_type_error("%s(): The CURLOPT_%s option must have an array value", get_active_function_name(), option_info->name);
 				return FAILURE;
 			}
 
@@ -2078,7 +2046,8 @@ static zend_result _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue
 				if (zend_str_has_nul_byte(val)) {
 					curl_slist_free_all(slist);
 					zend_tmp_string_release(tmp_val);
-					zend_value_error("%s(): cURL option %s must not contain any null bytes", get_active_function_name(), name);
+					const struct curl_easyoption *option_info = curl_easy_option_by_id(option);
+					zend_value_error("%s(): cURL option CURLOPT_%s must not contain any null bytes", get_active_function_name(), option_info->name);
 					return FAILURE;
 				}
 

--- a/ext/curl/sync-constants.php
+++ b/ext/curl/sync-constants.php
@@ -12,7 +12,7 @@ const CURL_DOC_FILE = 'https://curl.se/libcurl/c/symbols-in-versions.html';
 
 const SOURCE_FILE = __DIR__ . '/curl_arginfo.h';
 
-const MIN_SUPPORTED_CURL_VERSION = '7.61.0';
+const MIN_SUPPORTED_CURL_VERSION = '7.73.0';
 
 const IGNORED_CURL_CONSTANTS = [
     'CURLOPT_PROGRESSDATA',

--- a/ext/curl/tests/bug68089.phpt
+++ b/ext/curl/tests/bug68089.phpt
@@ -16,5 +16,5 @@ try {
 ?>
 Done
 --EXPECT--
-curl_setopt(): cURL option must not contain any null bytes
+curl_setopt(): cURL option CURLOPT_URL must not contain any null bytes
 Done


### PR DESCRIPTION
Use curl_easy_option_by_id to retrieve the name of the option, and also show the name of the option in the case where strings contain a null byte.

curl_easy_option_by_id simplifies the code, but was introduced in curl 7.73.0, so this also bumps the minimum version of curl. 7.73.0 was released in 2020, so I think that's acceptable.

Showing the option name is especially useful when using curl_setopt_array. A user may specify many options, and this change makes it clear which option is wrong exactly.