### PR TITLE
Fix use-after-free when a destructor bails out during zend_hash_clean()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,10 @@ PHP                                                                        NEWS
   . Fixed bug GH-22602 (gregoriantojd() and juliantojd() integer overflow with
     INT_MAX year). (arshidkv12)
 
+- Core:
+  . Fixed use-after-free when a destructor bails out (memory_limit, timeout)
+    during zend_hash_clean(), e.g. from session_unset(). (iliaal)
+
 - Date:
   . Update timelib to 2022.17. (Derick)
   . Fixed bug GH-19803 (Parsing a string with a single white space does create

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -1887,12 +1887,16 @@ ZEND_API void ZEND_FASTCALL zend_hash_clean(HashTable *ht)
 				if (HT_HAS_STATIC_KEYS_ONLY(ht)) {
 					if (HT_IS_WITHOUT_HOLES(ht)) {
 						do {
-							ht->pDestructor(zv);
+							zval val = *zv;
+							ZVAL_UNDEF(zv);
+							ht->pDestructor(&val);
 						} while (++zv != end);
 					} else {
 						do {
 							if (EXPECTED(Z_TYPE_P(zv) != IS_UNDEF)) {
-								ht->pDestructor(zv);
+								zval val = *zv;
+								ZVAL_UNDEF(zv);
+								ht->pDestructor(&val);
 							}
 						} while (++zv != end);
 					}
@@ -1906,29 +1910,37 @@ ZEND_API void ZEND_FASTCALL zend_hash_clean(HashTable *ht)
 				if (HT_HAS_STATIC_KEYS_ONLY(ht)) {
 					if (HT_IS_WITHOUT_HOLES(ht)) {
 						do {
-							ht->pDestructor(&p->val);
+							zval val = p->val;
+							ZVAL_UNDEF(&p->val);
+							ht->pDestructor(&val);
 						} while (++p != end);
 					} else {
 						do {
 							if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF)) {
-								ht->pDestructor(&p->val);
+								zval val = p->val;
+								ZVAL_UNDEF(&p->val);
+								ht->pDestructor(&val);
 							}
 						} while (++p != end);
 					}
 				} else if (HT_IS_WITHOUT_HOLES(ht)) {
 					do {
-						ht->pDestructor(&p->val);
+						zval val = p->val;
+						ZVAL_UNDEF(&p->val);
 						if (EXPECTED(p->key)) {
 							zend_string_release(p->key);
 						}
+						ht->pDestructor(&val);
 					} while (++p != end);
 				} else {
 					do {
 						if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF)) {
-							ht->pDestructor(&p->val);
+							zval val = p->val;
+							ZVAL_UNDEF(&p->val);
 							if (EXPECTED(p->key)) {
 								zend_string_release(p->key);
 							}
+							ht->pDestructor(&val);
 						}
 					} while (++p != end);
 				}

--- a/ext/session/tests/hash_clean_bailout.phpt
+++ b/ext/session/tests/hash_clean_bailout.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Use-after-free when a destructor bails out during zend_hash_clean() via session_unset()
+--EXTENSIONS--
+session
+--XLEAK--
+The intentional E_USER_ERROR bailout abandons the aborted request's op_array.
+--SKIPIF--
+<?php include('skipif.inc'); ?>
+--INI--
+session.save_handler=files
+session.use_cookies=0
+session.cache_limiter=
+--FILE--
+<?php
+error_reporting(E_ALL & ~E_DEPRECATED);
+class Dtor {
+    public function __destruct() {}
+}
+class Killer {
+    public function __destruct() {
+        trigger_error("boom", E_USER_ERROR);
+    }
+}
+session_start();
+$_SESSION['a'] = new Dtor();
+$_SESSION['b'] = new Killer();
+$_SESSION['c'] = new Dtor();
+session_unset();
+?>
+--EXPECTF--
+Fatal error: boom in %s on line %d


### PR DESCRIPTION
zend_hash_clean() runs each element's destructor and resets the table only after the loop, so a zend_bailout from a destructor (memory_limit, timeout, E_USER_ERROR) leaves already-destroyed slots in a still-reachable table and shutdown teardown frees them a second time. session_unset() on a $_SESSION whose value has a bailing destructor reproduces it. The fix moves each element into a local and clears its slot to IS_UNDEF before running the destructor, so a bailed-out clean leaves consumed slots that teardown skips; the buffer and packed/map shape are preserved, so cleaning during iteration is unaffected.