### PR TITLE
ext/gd/tests/gh19{666,739}.phpt: skip for external libgd

### DIFF
--- a/ext/gd/tests/gh19666.phpt
+++ b/ext/gd/tests/gh19666.phpt
@@ -2,6 +2,10 @@
 GH-19666 (Unexpected nan value in imageconvolution)
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+    if (!GD_BUNDLED) die("skip requires bundled GD library\n");
+?>
 --FILE--
 <?php
 $image = imagecreatetruecolor(180, 30);

--- a/ext/gd/tests/gh19739.phpt
+++ b/ext/gd/tests/gh19739.phpt
@@ -2,6 +2,10 @@
 GH-19739 (integer overflow in imageellipse / imagefilledellipse)
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+    if (!GD_BUNDLED) die("skip requires bundled GD library\n");
+?>
 --FILE--
 <?php
 $im = imagecreatetruecolor(400, 300);


### PR DESCRIPTION
These two are regression tests for the bundled libgd, we have to skip them if an external libgd is used, at least until the upstream libgd starts making bugfix releases again.