### PR TITLE
re-enable JIT for ZTS builds on Apple Silicon

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -345,7 +345,6 @@ jobs:
         if: ${{ inputs.all_variations }}
         uses: ./.github/actions/test-macos
       - name: Test Tracing JIT
-        if: ${{ matrix.arch == 'X64' || !matrix.zts }}
         uses: ./.github/actions/test-macos
         with:
           enableOpcache: true
@@ -356,7 +355,7 @@ jobs:
         with:
           enableOpcache: true
       - name: Test Function JIT
-        if: ${{ inputs.all_variations && (matrix.arch == 'X64' || !matrix.zts) }}
+        if: ${{ inputs.all_variations }}
         uses: ./.github/actions/test-macos
         with:
           enableOpcache: true

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -345,6 +345,7 @@ jobs:
         if: ${{ inputs.all_variations }}
         uses: ./.github/actions/test-macos
       - name: Test Tracing JIT
+        if: ${{ matrix.arch == 'X64' || !matrix.zts }}
         uses: ./.github/actions/test-macos
         with:
           enableOpcache: true
@@ -355,7 +356,7 @@ jobs:
         with:
           enableOpcache: true
       - name: Test Function JIT
-        if: ${{ inputs.all_variations }}
+        if: ${{ inputs.all_variations && (matrix.arch == 'X64' || !matrix.zts) }}
         uses: ./.github/actions/test-macos
         with:
           enableOpcache: true

--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,9 @@ PHP                                                                        NEWS
   . Fixed bug GH-22668 (Heap buffer over-read when a column value exceeds the
     driver-reported display size). (iliaal)
 
+- Opcache:
+  . Re-enable JIT for ZTS builds on Apple Silicon. (realFlowControl)
+
 - PDO_ODBC:
   . Fixed bug GH-22667 (Heap buffer over-read when a column value exceeds the
     driver-reported display size). (iliaal)

--- a/UPGRADING
+++ b/UPGRADING
@@ -486,6 +486,9 @@ PHP 8.6 UPGRADE NOTES
 - mysqli
   . Added new constant MYSQLI_OPT_COMPRESS.
 
+- Opcache
+  . JIT is now supported for ZTS builds on Apple Silicon.
+
 ========================================
 10. New Global Constants
 ========================================

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -3259,8 +3259,9 @@ static zend_result accel_post_startup(void)
 	file_cache_only = ZCG(accel_directives).file_cache_only;
 	if (!file_cache_only) {
 		size_t shm_size = ZCG(accel_directives).memory_consumption;
-#ifdef HAVE_JIT
 		size_t jit_size = 0;
+#ifdef HAVE_JIT
+		size_t jit_buffer_size = 0;
 		bool reattached = false;
 
 		if (JIT_G(enabled) && JIT_G(buffer_size)
@@ -3272,21 +3273,16 @@ static zend_result accel_post_startup(void)
 				zend_accel_error_noreturn(ACCEL_LOG_FATAL, "Failure to initialize shared memory structures - can't get page size.");
 				abort();
 			}
-			jit_size = JIT_G(buffer_size);
-			jit_size = ZEND_MM_ALIGNED_SIZE_EX(jit_size, page_size);
-#ifndef ZEND_JIT_USE_APPLE_MAP_JIT
+			jit_buffer_size = JIT_G(buffer_size);
+			jit_buffer_size = ZEND_MM_ALIGNED_SIZE_EX(jit_buffer_size, page_size);
+# ifndef ZEND_JIT_USE_APPLE_MAP_JIT
+			jit_size = jit_buffer_size;
 			shm_size += jit_size;
-#endif
+# endif
 		}
+#endif
 
-#ifdef ZEND_JIT_USE_APPLE_MAP_JIT
-		switch (zend_shared_alloc_startup(shm_size, 0)) {
-#else
 		switch (zend_shared_alloc_startup(shm_size, jit_size)) {
-#endif
-#else
-		switch (zend_shared_alloc_startup(shm_size, 0)) {
-#endif
 			case ALLOC_SUCCESS:
 				if (zend_accel_init_shm() == FAILURE) {
 					accel_startup_ok = false;
@@ -3341,14 +3337,14 @@ static zend_result accel_post_startup(void)
 				JIT_G(enabled) = false;
 				JIT_G(on) = false;
 			} else {
-#ifdef ZEND_JIT_USE_APPLE_MAP_JIT
-				zend_jit_startup(NULL, jit_size, reattached);
-#else
+# ifdef ZEND_JIT_USE_APPLE_MAP_JIT
+				zend_jit_startup(NULL, jit_buffer_size, reattached);
+# else
 				if (!ZSMMG(reserved)) {
 					zend_accel_error_noreturn(ACCEL_LOG_FATAL, "Could not enable JIT: could not use reserved buffer!");
 				}
-				zend_jit_startup(ZSMMG(reserved), jit_size, reattached);
-#endif
+				zend_jit_startup(ZSMMG(reserved), jit_buffer_size, reattached);
+# endif
 				zend_jit_startup_ok = true;
 			}
 		}

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -3274,10 +3274,16 @@ static zend_result accel_post_startup(void)
 			}
 			jit_size = JIT_G(buffer_size);
 			jit_size = ZEND_MM_ALIGNED_SIZE_EX(jit_size, page_size);
+#ifndef ZEND_JIT_USE_APPLE_MAP_JIT
 			shm_size += jit_size;
+#endif
 		}
 
+#ifdef ZEND_JIT_USE_APPLE_MAP_JIT
+		switch (zend_shared_alloc_startup(shm_size, 0)) {
+#else
 		switch (zend_shared_alloc_startup(shm_size, jit_size)) {
+#endif
 #else
 		switch (zend_shared_alloc_startup(shm_size, 0)) {
 #endif
@@ -3334,10 +3340,15 @@ static zend_result accel_post_startup(void)
 			if (JIT_G(buffer_size) == 0) {
 				JIT_G(enabled) = false;
 				JIT_G(on) = false;
-			} else if (!ZSMMG(reserved)) {
-				zend_accel_error_noreturn(ACCEL_LOG_FATAL, "Could not enable JIT: could not use reserved buffer!");
 			} else {
+#ifdef ZEND_JIT_USE_APPLE_MAP_JIT
+				zend_jit_startup(NULL, jit_size, reattached);
+#else
+				if (!ZSMMG(reserved)) {
+					zend_accel_error_noreturn(ACCEL_LOG_FATAL, "Could not enable JIT: could not use reserved buffer!");
+				}
 				zend_jit_startup(ZSMMG(reserved), jit_size, reattached);
+#endif
 				zend_jit_startup_ok = true;
 			}
 		}

--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -31,10 +31,6 @@ AS_VAR_IF([PHP_OPCACHE_JIT], [yes], [
       PHP_OPCACHE_JIT=no
     ])
 
-  if test "$host_vendor" = "apple" && test "$host_cpu" = "aarch64" && test "$PHP_THREAD_SAFETY" = "yes"; then
-    AC_MSG_WARN([JIT not supported on Apple Silicon with ZTS])
-    PHP_OPCACHE_JIT=no
-  fi
 ])
 
 AS_VAR_IF([PHP_OPCACHE_JIT], [yes], [

--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -32,7 +32,7 @@ AS_VAR_IF([PHP_OPCACHE_JIT], [yes], [
     ])
 
   AS_IF([test "$host_vendor" = "apple" && test "$host_cpu" = "aarch64" && test "$PHP_THREAD_SAFETY" = "yes"],
-    [AS_VAR_IF([ac_cv_func_pthread_jit_write_protect_np], [yes], [],
+    [AC_CHECK_FUNC([pthread_jit_write_protect_np], [],
       [AC_MSG_ERROR([OPcache JIT on Apple Silicon with ZTS requires pthread_jit_write_protect_np()])])])
 ])
 

--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -31,6 +31,9 @@ AS_VAR_IF([PHP_OPCACHE_JIT], [yes], [
       PHP_OPCACHE_JIT=no
     ])
 
+  AS_IF([test "$host_vendor" = "apple" && test "$host_cpu" = "aarch64" && test "$PHP_THREAD_SAFETY" = "yes"],
+    [AS_VAR_IF([ac_cv_func_pthread_jit_write_protect_np], [yes], [],
+      [AC_MSG_ERROR([OPcache JIT on Apple Silicon with ZTS requires pthread_jit_write_protect_np()])])])
 ])
 
 AS_VAR_IF([PHP_OPCACHE_JIT], [yes], [

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -43,6 +43,10 @@
 #ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
 #include <pthread.h>
 #endif
+#ifdef ZEND_JIT_USE_APPLE_MAP_JIT
+#include <mach/vm_inherit.h>
+#include <sys/mman.h>
+#endif
 
 #ifdef ZTS
 int jit_globals_id;
@@ -831,7 +835,11 @@ ZEND_EXT_API void zend_jit_status(zval *ret)
 	add_assoc_long(&stats, "opt_level", JIT_G(opt_level));
 	add_assoc_long(&stats, "opt_flags", JIT_G(opt_flags));
 	if (dasm_buf) {
+#ifdef ZEND_JIT_USE_APPLE_MAP_JIT
+		add_assoc_long(&stats, "buffer_size", dasm_size);
+#else
 		add_assoc_long(&stats, "buffer_size", (char*)dasm_end - (char*)dasm_buf);
+#endif
 		add_assoc_long(&stats, "buffer_free", (char*)dasm_end - (char*)*dasm_ptr);
 	} else {
 		add_assoc_long(&stats, "buffer_size", 0);
@@ -3517,7 +3525,11 @@ jit_failure:
 
 void zend_jit_unprotect(void)
 {
-#ifdef HAVE_MPROTECT
+#ifdef ZEND_JIT_USE_APPLE_MAP_JIT
+#ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
+	pthread_jit_write_protect_np(0);
+#endif
+#elif defined(HAVE_MPROTECT)
 	if (!(JIT_G(debug) & (ZEND_JIT_DEBUG_GDB|ZEND_JIT_DEBUG_PERF_DUMP))) {
 		int opts = PROT_READ | PROT_WRITE;
 #ifdef ZTS
@@ -3552,7 +3564,11 @@ void zend_jit_unprotect(void)
 
 void zend_jit_protect(void)
 {
-#ifdef HAVE_MPROTECT
+#ifdef ZEND_JIT_USE_APPLE_MAP_JIT
+#ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
+	pthread_jit_write_protect_np(1);
+#endif
+#elif defined(HAVE_MPROTECT)
 	if (!(JIT_G(debug) & (ZEND_JIT_DEBUG_GDB|ZEND_JIT_DEBUG_PERF_DUMP))) {
 #ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
 		if (zend_write_protect) {
@@ -3780,7 +3796,35 @@ void zend_jit_startup(void *buf, size_t size, bool reattached)
 	zend_jit_interrupt_op = zend_get_interrupt_op();
 	zend_jit_profile_counter_rid = zend_get_op_array_extension_handle(ACCELERATOR_PRODUCT_NAME);
 
-#ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
+#ifdef ZEND_JIT_USE_APPLE_MAP_JIT
+	buf = mmap(NULL, size, PROT_READ | PROT_WRITE | PROT_EXEC,
+		MAP_PRIVATE | MAP_ANON | MAP_JIT, -1, 0);
+	if (buf == MAP_FAILED) {
+		int error = errno;
+		zend_accel_error_noreturn(ACCEL_LOG_FATAL,
+			"Unable to allocate %zu bytes for JIT buffer using MAP_JIT: %s (%d)",
+			size, strerror(error), error);
+	}
+	if (minherit(buf, size, VM_INHERIT_SHARE) != 0) {
+		int error = errno;
+		munmap(buf, size);
+		zend_accel_error_noreturn(ACCEL_LOG_FATAL,
+			"Unable to share JIT buffer across fork using minherit(): %s (%d)",
+			strerror(error), error);
+	}
+#ifndef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
+	munmap(buf, size);
+	zend_accel_error_noreturn(ACCEL_LOG_FATAL,
+		"Apple Silicon ZTS JIT requires pthread_jit_write_protect_np() support");
+#else
+	zend_write_protect = pthread_jit_write_protect_supported_np();
+	if (!zend_write_protect) {
+		munmap(buf, size);
+		zend_accel_error_noreturn(ACCEL_LOG_FATAL,
+			"Apple Silicon ZTS JIT requires pthread_jit_write_protect_np() support");
+	}
+#endif
+#elif defined(HAVE_PTHREAD_JIT_WRITE_PROTECT_NP)
 	zend_write_protect = pthread_jit_write_protect_supported_np();
 #endif
 
@@ -3788,7 +3832,11 @@ void zend_jit_startup(void *buf, size_t size, bool reattached)
 	dasm_size = size;
 	dasm_ptr = dasm_end = (void*)(((char*)dasm_buf) + size - sizeof(*dasm_ptr) * 2);
 
-#ifdef HAVE_MPROTECT
+#ifdef ZEND_JIT_USE_APPLE_MAP_JIT
+#ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
+	pthread_jit_write_protect_np(1);
+#endif
+#elif defined(HAVE_MPROTECT)
 #ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
 	if (zend_write_protect) {
 		pthread_jit_write_protect_np(1);
@@ -3872,6 +3920,12 @@ void zend_jit_shutdown(void)
 	ts_free_id(jit_globals_id);
 #else
 	zend_jit_trace_free_caches(&jit_globals);
+#endif
+
+#ifdef ZEND_JIT_USE_APPLE_MAP_JIT
+	if (dasm_buf != NULL) {
+		munmap(dasm_buf, dasm_size);
+	}
 #endif
 
 	/* Reset global pointers to prevent use-after-free in `zend_jit_status()`

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -3526,20 +3526,20 @@ jit_failure:
 void zend_jit_unprotect(void)
 {
 #ifdef ZEND_JIT_USE_APPLE_MAP_JIT
-#ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
+# ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
 	pthread_jit_write_protect_np(0);
-#endif
+# endif
 #elif defined(HAVE_MPROTECT)
 	if (!(JIT_G(debug) & (ZEND_JIT_DEBUG_GDB|ZEND_JIT_DEBUG_PERF_DUMP))) {
 		int opts = PROT_READ | PROT_WRITE;
-#ifdef ZTS
-#ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
+# ifdef ZTS
+#  ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
 		if (zend_write_protect) {
 			pthread_jit_write_protect_np(0);
 		}
-#endif
+#  endif
 		opts |= PROT_EXEC;
-#endif
+# endif
 		if (mprotect(dasm_buf, dasm_size, opts) != 0) {
 			fprintf(stderr, "mprotect() failed [%d] %s\n", errno, strerror(errno));
 		}
@@ -3547,11 +3547,11 @@ void zend_jit_unprotect(void)
 #elif defined(_WIN32)
 	if (!(JIT_G(debug) & (ZEND_JIT_DEBUG_GDB|ZEND_JIT_DEBUG_PERF_DUMP))) {
 		DWORD old, new;
-#ifdef ZTS
+# ifdef ZTS
 		new = PAGE_EXECUTE_READWRITE;
-#else
+# else
 		new = PAGE_READWRITE;
-#endif
+# endif
 		if (!VirtualProtect(dasm_buf, dasm_size, new, &old)) {
 			DWORD err = GetLastError();
 			char *msg = php_win32_error_to_msg(err);
@@ -3565,16 +3565,16 @@ void zend_jit_unprotect(void)
 void zend_jit_protect(void)
 {
 #ifdef ZEND_JIT_USE_APPLE_MAP_JIT
-#ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
+# ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
 	pthread_jit_write_protect_np(1);
-#endif
+# endif
 #elif defined(HAVE_MPROTECT)
 	if (!(JIT_G(debug) & (ZEND_JIT_DEBUG_GDB|ZEND_JIT_DEBUG_PERF_DUMP))) {
-#ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
+# ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
 		if (zend_write_protect) {
 			pthread_jit_write_protect_np(1);
 		}
-#endif
+# endif
 		if (mprotect(dasm_buf, dasm_size, PROT_READ | PROT_EXEC) != 0) {
 			fprintf(stderr, "mprotect() failed [%d] %s\n", errno, strerror(errno));
 		}
@@ -3812,18 +3812,18 @@ void zend_jit_startup(void *buf, size_t size, bool reattached)
 			"Unable to share JIT buffer across fork using minherit(): %s (%d)",
 			strerror(error), error);
 	}
-#ifndef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
+# ifndef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
 	munmap(buf, size);
 	zend_accel_error_noreturn(ACCEL_LOG_FATAL,
 		"Apple Silicon ZTS JIT requires pthread_jit_write_protect_np() support");
-#else
+# else
 	zend_write_protect = pthread_jit_write_protect_supported_np();
 	if (!zend_write_protect) {
 		munmap(buf, size);
 		zend_accel_error_noreturn(ACCEL_LOG_FATAL,
 			"Apple Silicon ZTS JIT requires pthread_jit_write_protect_np() support");
 	}
-#endif
+# endif
 #elif defined(HAVE_PTHREAD_JIT_WRITE_PROTECT_NP)
 	zend_write_protect = pthread_jit_write_protect_supported_np();
 #endif
@@ -3833,15 +3833,15 @@ void zend_jit_startup(void *buf, size_t size, bool reattached)
 	dasm_ptr = dasm_end = (void*)(((char*)dasm_buf) + size - sizeof(*dasm_ptr) * 2);
 
 #ifdef ZEND_JIT_USE_APPLE_MAP_JIT
-#ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
+# ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
 	pthread_jit_write_protect_np(1);
-#endif
+# endif
 #elif defined(HAVE_MPROTECT)
-#ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
+# ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
 	if (zend_write_protect) {
 		pthread_jit_write_protect_np(1);
 	}
-#endif
+# endif
 	if (JIT_G(debug) & (ZEND_JIT_DEBUG_GDB|ZEND_JIT_DEBUG_PERF_DUMP)) {
 		if (mprotect(dasm_buf, dasm_size, PROT_READ | PROT_WRITE | PROT_EXEC) != 0) {
 			fprintf(stderr, "mprotect() failed [%d] %s\n", errno, strerror(errno));

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -3526,9 +3526,7 @@ jit_failure:
 void zend_jit_unprotect(void)
 {
 #ifdef ZEND_JIT_USE_APPLE_MAP_JIT
-# ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
 	pthread_jit_write_protect_np(0);
-# endif
 #elif defined(HAVE_MPROTECT)
 	if (!(JIT_G(debug) & (ZEND_JIT_DEBUG_GDB|ZEND_JIT_DEBUG_PERF_DUMP))) {
 		int opts = PROT_READ | PROT_WRITE;
@@ -3565,9 +3563,7 @@ void zend_jit_unprotect(void)
 void zend_jit_protect(void)
 {
 #ifdef ZEND_JIT_USE_APPLE_MAP_JIT
-# ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
 	pthread_jit_write_protect_np(1);
-# endif
 #elif defined(HAVE_MPROTECT)
 	if (!(JIT_G(debug) & (ZEND_JIT_DEBUG_GDB|ZEND_JIT_DEBUG_PERF_DUMP))) {
 # ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
@@ -3812,18 +3808,12 @@ void zend_jit_startup(void *buf, size_t size, bool reattached)
 			"Unable to share JIT buffer across fork using minherit(): %s (%d)",
 			strerror(error), error);
 	}
-# ifndef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
-	munmap(buf, size);
-	zend_accel_error_noreturn(ACCEL_LOG_FATAL,
-		"Apple Silicon ZTS JIT requires pthread_jit_write_protect_np() support");
-# else
 	zend_write_protect = pthread_jit_write_protect_supported_np();
 	if (!zend_write_protect) {
 		munmap(buf, size);
 		zend_accel_error_noreturn(ACCEL_LOG_FATAL,
 			"Apple Silicon ZTS JIT requires pthread_jit_write_protect_np() support");
 	}
-# endif
 #elif defined(HAVE_PTHREAD_JIT_WRITE_PROTECT_NP)
 	zend_write_protect = pthread_jit_write_protect_supported_np();
 #endif
@@ -3833,9 +3823,7 @@ void zend_jit_startup(void *buf, size_t size, bool reattached)
 	dasm_ptr = dasm_end = (void*)(((char*)dasm_buf) + size - sizeof(*dasm_ptr) * 2);
 
 #ifdef ZEND_JIT_USE_APPLE_MAP_JIT
-# ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
 	pthread_jit_write_protect_np(1);
-# endif
 #elif defined(HAVE_MPROTECT)
 # ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
 	if (zend_write_protect) {

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -40,11 +40,9 @@
 
 #include "jit/zend_jit_internal.h"
 
-#ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
-#include <pthread.h>
-#endif
 #ifdef ZEND_JIT_USE_APPLE_MAP_JIT
 #include <mach/vm_inherit.h>
+#include <pthread.h>
 #include <sys/mman.h>
 #endif
 
@@ -81,9 +79,6 @@ int16_t zend_jit_hot_counters[ZEND_HOT_COUNTERS_COUNT];
 
 const zend_op *zend_jit_halt_op = NULL;
 const zend_op *zend_jit_interrupt_op = NULL;
-#ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
-static int zend_write_protect = 1;
-#endif
 
 static void *dasm_buf = NULL;
 static void *dasm_end = NULL;
@@ -3531,11 +3526,6 @@ void zend_jit_unprotect(void)
 	if (!(JIT_G(debug) & (ZEND_JIT_DEBUG_GDB|ZEND_JIT_DEBUG_PERF_DUMP))) {
 		int opts = PROT_READ | PROT_WRITE;
 # ifdef ZTS
-#  ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
-		if (zend_write_protect) {
-			pthread_jit_write_protect_np(0);
-		}
-#  endif
 		opts |= PROT_EXEC;
 # endif
 		if (mprotect(dasm_buf, dasm_size, opts) != 0) {
@@ -3566,11 +3556,6 @@ void zend_jit_protect(void)
 	pthread_jit_write_protect_np(1);
 #elif defined(HAVE_MPROTECT)
 	if (!(JIT_G(debug) & (ZEND_JIT_DEBUG_GDB|ZEND_JIT_DEBUG_PERF_DUMP))) {
-# ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
-		if (zend_write_protect) {
-			pthread_jit_write_protect_np(1);
-		}
-# endif
 		if (mprotect(dasm_buf, dasm_size, PROT_READ | PROT_EXEC) != 0) {
 			fprintf(stderr, "mprotect() failed [%d] %s\n", errno, strerror(errno));
 		}
@@ -3808,14 +3793,11 @@ void zend_jit_startup(void *buf, size_t size, bool reattached)
 			"Unable to share JIT buffer across fork using minherit(): %s (%d)",
 			strerror(error), error);
 	}
-	zend_write_protect = pthread_jit_write_protect_supported_np();
-	if (!zend_write_protect) {
+	if (!pthread_jit_write_protect_supported_np()) {
 		munmap(buf, size);
 		zend_accel_error_noreturn(ACCEL_LOG_FATAL,
 			"Apple Silicon ZTS JIT requires pthread_jit_write_protect_np() support");
 	}
-#elif defined(HAVE_PTHREAD_JIT_WRITE_PROTECT_NP)
-	zend_write_protect = pthread_jit_write_protect_supported_np();
 #endif
 
 	dasm_buf = buf;
@@ -3825,11 +3807,6 @@ void zend_jit_startup(void *buf, size_t size, bool reattached)
 #ifdef ZEND_JIT_USE_APPLE_MAP_JIT
 	pthread_jit_write_protect_np(1);
 #elif defined(HAVE_MPROTECT)
-# ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
-	if (zend_write_protect) {
-		pthread_jit_write_protect_np(1);
-	}
-# endif
 	if (JIT_G(debug) & (ZEND_JIT_DEBUG_GDB|ZEND_JIT_DEBUG_PERF_DUMP)) {
 		if (mprotect(dasm_buf, dasm_size, PROT_READ | PROT_WRITE | PROT_EXEC) != 0) {
 			fprintf(stderr, "mprotect() failed [%d] %s\n", errno, strerror(errno));

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -830,11 +830,7 @@ ZEND_EXT_API void zend_jit_status(zval *ret)
 	add_assoc_long(&stats, "opt_level", JIT_G(opt_level));
 	add_assoc_long(&stats, "opt_flags", JIT_G(opt_flags));
 	if (dasm_buf) {
-#ifdef ZEND_JIT_USE_APPLE_MAP_JIT
-		add_assoc_long(&stats, "buffer_size", dasm_size);
-#else
 		add_assoc_long(&stats, "buffer_size", (char*)dasm_end - (char*)dasm_buf);
-#endif
 		add_assoc_long(&stats, "buffer_free", (char*)dasm_end - (char*)*dasm_ptr);
 	} else {
 		add_assoc_long(&stats, "buffer_size", 0);

--- a/ext/opcache/jit/zend_jit.h
+++ b/ext/opcache/jit/zend_jit.h
@@ -17,6 +17,10 @@
 #ifndef HAVE_JIT_H
 #define HAVE_JIT_H
 
+#if defined(__APPLE__) && defined(__aarch64__) && defined(ZTS)
+# define ZEND_JIT_USE_APPLE_MAP_JIT 1
+#endif
+
 #if defined(__x86_64__) || defined(i386) || defined(ZEND_WIN32)
 # define ZEND_JIT_TARGET_X86   1
 # define ZEND_JIT_TARGET_ARM64 0

--- a/ext/opcache/jit/zend_jit.h
+++ b/ext/opcache/jit/zend_jit.h
@@ -18,6 +18,9 @@
 #define HAVE_JIT_H
 
 #if defined(__APPLE__) && defined(__aarch64__) && defined(ZTS)
+# ifndef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
+#  error "Apple Silicon ZTS JIT requires pthread_jit_write_protect_np()"
+# endif
 # define ZEND_JIT_USE_APPLE_MAP_JIT 1
 #endif
 

--- a/ext/opcache/tests/jit/gh13400.phpt
+++ b/ext/opcache/tests/jit/gh13400.phpt
@@ -1,0 +1,55 @@
+--TEST--
+GH-13400: JIT code generated after fork is visible to the parent
+--DESCRIPTION--
+OPcache metadata and generated JIT code are shared by forked workers, so the
+JIT mapping and its allocation pointer must remain shared after fork. This test
+records the available JIT space before forking and makes only the child call a
+function often enough to generate code. The parent then verifies that it sees
+the reduced free space and can execute the generated function.
+
+Without shared inheritance, a private JIT mapping becomes copy-on-write in the
+child. The parent's free-space check would print bool(false), while shared
+OPcache metadata could point the parent at code bytes that exist only in the
+child and cause a crash instead of printing int(42). A startup-only test would
+not detect this failure in fork-based SAPIs such as FPM or Apache.
+--EXTENSIONS--
+opcache
+pcntl
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.file_update_protection=0
+opcache.jit=tracing
+opcache.jit_buffer_size=16M
+opcache.jit_hot_func=1
+--SKIPIF--
+<?php
+if (!function_exists('pcntl_fork')) die('skip pcntl_fork() not available');
+if (!(opcache_get_status()['jit']['on'] ?? false)) die('skip JIT is not available');
+?>
+--FILE--
+<?php
+function value(): int {
+    return 42;
+}
+
+$bufferFree = opcache_get_status()['jit']['buffer_free'];
+$pid = pcntl_fork();
+if ($pid === 0) {
+    for ($i = 0; $i < 100; $i++) {
+        value();
+    }
+    exit(0);
+}
+if ($pid === -1) {
+    echo "pcntl_fork() failed\n";
+    exit(1);
+}
+
+pcntl_waitpid($pid, $status);
+var_dump(opcache_get_status()['jit']['buffer_free'] < $bufferFree);
+var_dump(value());
+?>
+--EXPECT--
+bool(true)
+int(42)


### PR DESCRIPTION
Fixes #13400

For `__APPLE__ && __aarch64__ && ZTS`, this PR moves the JIT buffer out of the OPcache shared memory and creates a dedicated mapping.

### Background

OPcache JIT is currently disabled for ZTS builds on Apple Silicon. The JIT buffer normally lives at the end of OPcache's `MAP_SHARED | MAP_ANON` allocation. In ZTS, one thread may generate code while another executes existing code, so the buffer must remain executable while it is writable.

Apple Silicon rejects RWX anonymous mappings with `EPERM`. Apple's supported solution is `MAP_JIT` with `pthread_jit_write_protect_np()`, which provides per-thread write protection, but macOS rejects `MAP_JIT | MAP_SHARED` with `EINVAL`. The existing combined OPcache/JIT mapping won't work on Apple Silicon.

