### PR TITLE
Fix use-after-free serializing an array grown by an element's hook

### DIFF
--- a/ext/standard/tests/serialize/serialize_array_ref_reentrancy.phpt
+++ b/ext/standard/tests/serialize/serialize_array_ref_reentrancy.phpt
@@ -1,0 +1,21 @@
+--TEST--
+serialize(): a by-reference __serialize() that grows the array being walked must not free it
+--FILE--
+<?php
+class G {
+    public $ref;
+    public function __serialize(): array {
+        for ($i = 0; $i < 128; $i++) {
+            $this->ref[] = 'x' . $i;
+        }
+        return ['d' => 1];
+    }
+}
+$g = new G();
+$inner = [$g, 'tail'];
+$g->ref = &$inner;
+$top = [&$inner];
+var_dump(serialize($top));
+?>
+--EXPECT--
+string(59) "a:1:{i:0;a:2:{i:0;O:1:"G":1:{s:1:"d";i:1;}i:1;s:4:"tail";}}"

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -1303,13 +1303,17 @@ again:
 				zend_release_properties(myht);
 				return;
 			}
-		case IS_ARRAY:
+		case IS_ARRAY: {
 			smart_str_appendl(buf, "a:", 2);
 			myht = Z_ARRVAL_P(struc);
+			bool rcn = !is_root && (in_rcn_array || GC_REFCOUNT(myht) > 1);
+			GC_TRY_ADDREF(myht);
 			php_var_serialize_nested_data(
 				buf, struc, myht, zend_array_count(myht), /* incomplete_class */ false, var_hash,
-				!is_root && (in_rcn_array || GC_REFCOUNT(myht) > 1));
+				rcn);
+			GC_TRY_DTOR_NO_REF(myht);
 			return;
+		}
 		case IS_REFERENCE:
 			struc = Z_REFVAL_P(struc);
 			goto again;


### PR DESCRIPTION
The IS_ARRAY case of php_var_serialize_intern() walks the array's HashTable without holding a reference while php_var_serialize_nested_data() recurses into user hooks, so a __serialize() that grows the same array through a by-reference alias reallocs the backing store mid-walk and the iterator reads freed memory. The object case, var_dump, and var_export already hold a ref across the walk; this adds the same GC_ADDREF/GC_DTOR_NO_REF for arrays, so the append separates a copy instead of reallocating in place. __sleep() and Serializable::serialize() reach the same walk, so one test covers all three.

Reproducer (invalid read in php_var_serialize_nested_data under ASan/valgrind; a normal build usually reads the freed memory and passes, so the test is an ASan canary):

```php
<?php
class G {
    public $ref;
    public function __serialize(): array {
        for ($i = 0; $i < 128; $i++) $this->ref[] = 'x' . $i;
        return ['d' => 1];
    }
}
$g = new G();
$inner = [$g, 'tail'];
$g->ref = &$inner;
$top = [&$inner];
serialize($top);
```
