### PR TITLE
Fix unchecked sqlite3_column_text() calls

### DIFF
--- a/ext/pdo_sqlite/sqlite_statement.c
+++ b/ext/pdo_sqlite/sqlite_statement.c
@@ -276,8 +276,13 @@ static int pdo_sqlite_stmt_get_col(
 			int64_t i = sqlite3_column_int64(S->stmt, colno);
 #if SIZEOF_ZEND_LONG < 8
 			if (i > ZEND_LONG_MAX || i < ZEND_LONG_MIN) {
+				const char *text = (const char *) sqlite3_column_text(S->stmt, colno);
+				if (UNEXPECTED(!text)) {
+					pdo_sqlite_error_stmt(stmt);
+					return 0;
+				}
 				ZVAL_STRINGL(result,
-					(char *) sqlite3_column_text(S->stmt, colno),
+					text,
 					sqlite3_column_bytes(S->stmt, colno));
 				return 1;
 			}
@@ -295,10 +300,15 @@ static int pdo_sqlite_stmt_get_col(
 				sqlite3_column_blob(S->stmt, colno), sqlite3_column_bytes(S->stmt, colno));
 			return 1;
 
-		default:
-			ZVAL_STRINGL_FAST(result,
-				(char *) sqlite3_column_text(S->stmt, colno), sqlite3_column_bytes(S->stmt, colno));
+		default: {
+			const char *text = (const char *) sqlite3_column_text(S->stmt, colno);
+			if (UNEXPECTED(!text)) {
+				pdo_sqlite_error_stmt(stmt);
+				return 0;
+			}
+			ZVAL_STRINGL_FAST(result, text, sqlite3_column_bytes(S->stmt, colno));
 			return 1;
+		}
 	}
 }
 


### PR DESCRIPTION
This is the pdo equivalent of GH-22045. Notably it does not include a change for the blob call because ZVAL_STRINGL_FAST already takes care of that implicitly.