### PR TITLE
ext/posix: remove musl pathconf workarounds

### DIFF
--- a/ext/posix/config.m4
+++ b/ext/posix/config.m4
@@ -42,12 +42,7 @@ if test "$PHP_POSIX" = "yes"; then
       #endif
     ])])
 
-dnl Skip pathconf and fpathconf check on musl libc due to limited implementation
-dnl (first argument is not validated and has different error).
-  PHP_C_STANDARD_LIBRARY
-  AS_VAR_IF([php_cv_c_standard_library], [musl],
-    [],
-    [AC_CHECK_FUNCS([pathconf fpathconf])])
+  AC_CHECK_FUNCS([pathconf fpathconf])
 
   AC_CACHE_CHECK([for working ttyname_r() implementation],
     [php_cv_func_ttyname_r],

--- a/ext/posix/tests/posix_pathconf.phpt
+++ b/ext/posix/tests/posix_pathconf.phpt
@@ -13,12 +13,15 @@ try {
 } catch (\ValueError $e) {
 	echo $e->getMessage(). "\n";
 }
-var_dump(posix_pathconf(str_repeat('non_existent', 4096), POSIX_PC_NAME_MAX));
-var_dump(posix_errno() != 0);
+
+/* POSIX specifically allows implementations to ignore the first
+ * argument if it will not affect the result. */
+$result = posix_pathconf(str_repeat('non_existent', 4096),
+                         POSIX_PC_NAME_MAX);
+var_dump( ($result == false && posix_errno() != 0) || is_int($result) );
 var_dump(posix_pathconf(sys_get_temp_dir(), POSIX_PC_PATH_MAX));
 ?>
 --EXPECTF--
 posix_pathconf(): Argument #1 ($path) must not be empty
-bool(false)
 bool(true)
 int(%d)


### PR DESCRIPTION
We have a test in `build/php.m4` for the C library (glibc, musl, etc.) that is used to skip the `pathconf()` and `fpathconf()` checks in `ext/posix/config.m4`. They are skipped on musl because the musl implementations do not validate their first arguments, and in the past that lead to two test failures: one for `posix_pathconf()`, and one for `posix_fpathconf()`.

In php >= 8.5, the `posix_fpathconf()` wrapper now validates the file descriptor itself, so there is no longer any need to exclude musl in that case.

The other failure in `posix_pathconf()` looks for an error when using a non-existent path. POSIX however allows the implementation to ignore the path when it will not affect the result, meaning that musl is fully compliant here. And as we obtain the correct answer in lieu of an error, I think it is fine to accept the musl implementation here as well.

This commit removes the build-time musl exception, and updates the one failing test to expect either a failure (glibc), or an integer response (musl) when given an invalid path.

The relevant POSIX page is https://pubs.opengroup.org/onlinepubs/9799919799/functions/pathconf.html, but you have to read the RATIONALE section for the juicy bit:

> Also note that most of the errors are optional. If one of the variables always has the same value on an implementation, the implementation need not look at path or fildes to return that value and is, therefore, not required to detect any of the errors except the meaning of [EINVAL] that indicates that the value of name is not valid for that variable, and the [EOVERFLOW] error that indicates the value to be returned is larger than {LONG_MAX}.

Targeting PHP-8.5 where `posix_fpathconf()` already works, but the same approach can be used in `posix_fpathconf.phpt` for PHP-8.4.