### PR TITLE
perf: ZTS: remove obsolete realpath access check

### DIFF
--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -2190,11 +2190,6 @@ PHP_FUNCTION(realpath)
 			RETURN_FALSE;
 		}
 
-#ifdef ZTS
-		if (VCWD_ACCESS(resolved_path_buff, F_OK)) {
-			RETURN_FALSE;
-		}
-#endif
 		RETURN_STRING(resolved_path_buff);
 	} else {
 		RETURN_FALSE;


### PR DESCRIPTION
Was benchmarking Symfony demo and figured out that ZTS builds had a much larger performance penalty in dev mode than in prod mode, with a lot of time spent in AssetMapper calling `realpath()`. Traced it down to this.

@iliaal https://github.com/php/php-src/commit/29e829fdcf8 was the commit introducing it. I don't think it's required anymore, the `virtual_realpath` resolver itself fails for non-existent paths nowadays, just like NTS.