### PR TITLE
perf: direct syscall fastpath for absolute paths in zend_virtual_cwd

### DIFF
--- a/Zend/zend_virtual_cwd.c
+++ b/Zend/zend_virtual_cwd.c
@@ -1301,6 +1301,27 @@ CWD_API int virtual_filepath(const char *path, char **filepath) /* {{{ */
 }
 /* }}} */
 
+#ifndef ZEND_WIN32
+/* An absolute path without dot segments doesn't need a per-thread CWD emulation */
+static zend_always_inline bool virtual_path_is_direct(const char *path)
+{
+	const char *s = path;
+
+	if (*s != '/') {
+		return false;
+	}
+	do {
+		if (s[1] == '.'
+		 && (s[2] == '\0' || s[2] == '/'
+		  || (s[2] == '.' && (s[3] == '\0' || s[3] == '/')))) {
+			return false;
+		}
+		s = strchr(s + 1, '/');
+	} while (s != NULL);
+	return true;
+}
+#endif
+
 CWD_API FILE *virtual_fopen(const char *path, const char *mode) /* {{{ */
 {
 	cwd_state new_state;
@@ -1309,6 +1330,12 @@ CWD_API FILE *virtual_fopen(const char *path, const char *mode) /* {{{ */
 	if (path[0] == '\0') { /* Fail to open empty path */
 		return NULL;
 	}
+
+#ifndef ZEND_WIN32
+	if (virtual_path_is_direct(path)) {
+		return fopen(path, mode);
+	}
+#endif
 
 	CWD_STATE_COPY(&new_state, &CWDG(cwd));
 	if (virtual_file_ex(&new_state, path, NULL, CWD_EXPAND)) {
@@ -1332,6 +1359,12 @@ CWD_API int virtual_access(const char *pathname, int mode) /* {{{ */
 {
 	cwd_state new_state;
 	int ret;
+
+#ifndef ZEND_WIN32
+	if (virtual_path_is_direct(pathname)) {
+		return access(pathname, mode);
+	}
+#endif
 
 	CWD_STATE_COPY(&new_state, &CWDG(cwd));
 	if (virtual_file_ex(&new_state, pathname, NULL, CWD_REALPATH)) {
@@ -1442,6 +1475,21 @@ CWD_API int virtual_open(const char *path, int flags, ...) /* {{{ */
 	cwd_state new_state;
 	int f;
 
+#ifndef ZEND_WIN32
+	if (virtual_path_is_direct(path)) {
+		if (flags & O_CREAT) {
+			mode_t mode;
+			va_list arg;
+
+			va_start(arg, flags);
+			mode = (mode_t) va_arg(arg, int);
+			va_end(arg);
+			return open(path, flags, mode);
+		}
+		return open(path, flags);
+	}
+#endif
+
 	CWD_STATE_COPY(&new_state, &CWDG(cwd));
 	if (virtual_file_ex(&new_state, path, NULL, CWD_FILEPATH)) {
 		CWD_STATE_FREE_ERR(&new_state);
@@ -1533,6 +1581,12 @@ CWD_API int virtual_stat(const char *path, zend_stat_t *buf) /* {{{ */
 	cwd_state new_state;
 	int retval;
 
+#ifndef ZEND_WIN32
+	if (virtual_path_is_direct(path)) {
+		return php_sys_stat(path, buf);
+	}
+#endif
+
 	CWD_STATE_COPY(&new_state, &CWDG(cwd));
 	if (virtual_file_ex(&new_state, path, NULL, CWD_REALPATH)) {
 		CWD_STATE_FREE_ERR(&new_state);
@@ -1550,6 +1604,12 @@ CWD_API int virtual_lstat(const char *path, zend_stat_t *buf) /* {{{ */
 {
 	cwd_state new_state;
 	int retval;
+
+#ifndef ZEND_WIN32
+	if (virtual_path_is_direct(path)) {
+		return php_sys_lstat(path, buf);
+	}
+#endif
 
 	CWD_STATE_COPY(&new_state, &CWDG(cwd));
 	if (virtual_file_ex(&new_state, path, NULL, CWD_EXPAND)) {
@@ -1636,6 +1696,12 @@ CWD_API DIR *virtual_opendir(const char *pathname) /* {{{ */
 {
 	cwd_state new_state;
 	DIR *retval;
+
+#ifndef ZEND_WIN32
+	if (virtual_path_is_direct(pathname)) {
+		return opendir(pathname);
+	}
+#endif
 
 	CWD_STATE_COPY(&new_state, &CWDG(cwd));
 	if (virtual_file_ex(&new_state, pathname, NULL, CWD_REALPATH)) {

--- a/Zend/zend_virtual_cwd.c
+++ b/Zend/zend_virtual_cwd.c
@@ -1361,7 +1361,8 @@ CWD_API int virtual_access(const char *pathname, int mode) /* {{{ */
 	int ret;
 
 #ifndef ZEND_WIN32
-	if (virtual_path_is_direct(pathname)) {
+	if (pathname[0] == '/' &&
+		(CWDG(realpath_cache_size_limit) || virtual_path_is_direct(pathname))) {
 		return access(pathname, mode);
 	}
 #endif
@@ -1582,7 +1583,8 @@ CWD_API int virtual_stat(const char *path, zend_stat_t *buf) /* {{{ */
 	int retval;
 
 #ifndef ZEND_WIN32
-	if (virtual_path_is_direct(path)) {
+	if (path[0] == '/' &&
+		(CWDG(realpath_cache_size_limit) || virtual_path_is_direct(path))) {
 		return php_sys_stat(path, buf);
 	}
 #endif
@@ -1606,6 +1608,9 @@ CWD_API int virtual_lstat(const char *path, zend_stat_t *buf) /* {{{ */
 	int retval;
 
 #ifndef ZEND_WIN32
+	/* CWD_EXPAND strips '..' textually (save=0 -> no symlink lookups),
+	 * but the kernel resolves it physically. Different file
+	 * when a parent component is a symlink. */
 	if (virtual_path_is_direct(path)) {
 		return php_sys_lstat(path, buf);
 	}


### PR DESCRIPTION
Absolute paths don't need to go through the per-thread cwd emulation, add a fast-path to directly hand them to libc.

since relative paths won't start with a leading slash, this adds negligible cost for them

```php
<?php
chdir(__DIR__);

$s = microtime(true);
for ($i = 0; $i < 1000000; $i++) {
    file_exists("data.txt");
}
$rel = microtime(true) - $s;

$abs = __DIR__ . "/data.txt";
$s = microtime(true);
for ($i = 0; $i < 1000000; $i++) {
    file_exists($abs);
}
$abs_t = microtime(true) - $s;
```

| workload | master | patch | delta |
|---|---|---|---|
| relative path | 0.3521s | 0.3524s | +0.09% |
| absolute path | 0.3162s | 0.2623s | −17.05% |

Benchmark for Symfony demo:
<table><thead><tr><th>compiler</th><th>route</th><th>master</th><th>vcwd-direct</th><th>delta</th></tr></thead><tbody><tr><td>gcc 15</td><td>/en (home)</td><td>2741.8</td><td>2868.2</td><td>+4.61%</td></tr><tr><td>gcc 15</td><td>/en/blog/</td><td>1038.8</td><td>1066.5</td><td>+2.67%</td></tr><tr><td>clang 21</td><td>/en (home)</td><td>2740.7</td><td>2876.8</td><td>+4.97%</td></tr><tr><td>clang 21</td><td>/en/blog/</td><td>1031.4</td><td>1065.8</td><td>+3.34%</td></tr></tbody></table>


cc @dunglas because this will be a nice improvement for frankenphp (though fpm alike) in 8.6 :)