### PR TITLE
Fix leak when cURL PREREQFUNCTION returns a type other than int

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -770,6 +770,7 @@ static int curl_prereqfunction(void *clientp, char *conn_primary_ip, char *conn_
 				zend_value_error("The CURLOPT_PREREQFUNCTION callback must return either CURL_PREREQFUNC_OK or CURL_PREREQFUNC_ABORT");
 			}
 		} else {
+			zval_ptr_dtor(&retval);
 			zend_type_error("The CURLOPT_PREREQFUNCTION callback must return either CURL_PREREQFUNC_OK or CURL_PREREQFUNC_ABORT");
 		}
 	}

--- a/ext/curl/tests/curl_setopt_CURLOPT_PREREQFUNCTION.phpt
+++ b/ext/curl/tests/curl_setopt_CURLOPT_PREREQFUNCTION.phpt
@@ -77,7 +77,7 @@ try {
 
 echo "\nTesting with invalid type\n";
 curl_setopt($ch, CURLOPT_PREREQFUNCTION, function() use ($port) {
-	return str_repeat('this should be an integer', 20);
+	return ['this should be an integer' => random_bytes(64)];
 });
 try {
     curl_exec($ch);

--- a/ext/curl/tests/curl_setopt_CURLOPT_PREREQFUNCTION.phpt
+++ b/ext/curl/tests/curl_setopt_CURLOPT_PREREQFUNCTION.phpt
@@ -77,7 +77,7 @@ try {
 
 echo "\nTesting with invalid type\n";
 curl_setopt($ch, CURLOPT_PREREQFUNCTION, function() use ($port) {
-	return 'this should be an integer';
+	return str_repeat('this should be an integer', 20);
 });
 try {
     curl_exec($ch);


### PR DESCRIPTION
The return value of the function registered with CURLOPT_PREREQFUNCTION was not cleaned up. Destroy the return value. Increase the returned string in the test so that the address sanitizer picks up the leak.