### PR TITLE
CI: fix template-injection findings in GitHub Actions workflows

### DIFF
--- a/.github/workflows/nightly-results.yml
+++ b/.github/workflows/nightly-results.yml
@@ -10,7 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'php/php-src' && github.event.workflow_run.event == 'schedule' && github.event.workflow_run.conclusion == 'failure' }}
     steps:
-      - run: |
+      - env:
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          SLACK_WEBHOOK: ${{ secrets.ACTION_MONITORING_SLACK }}
+        run: |
           export DEBIAN_FRONTEND=noninteractive
           sudo apt-get install -y curl
-          curl -X POST -H 'Content-type: application/json' --data '{"attachments": [{"text": "Job(s) in *nightly* failed", "footer": "<${{ github.event.workflow_run.html_url }}|View Run>", "color": "danger", "mrkdwn_in": ["text"]}]}' ${{ secrets.ACTION_MONITORING_SLACK }}
+          curl -X POST -H 'Content-type: application/json' --data "$(printf '{"attachments": [{"text": "Job(s) in *nightly* failed", "footer": "<%s|View Run>", "color": "danger", "mrkdwn_in": ["text"]}]}' "$RUN_URL")" "$SLACK_WEBHOOK"

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -516,8 +516,10 @@ jobs:
           exit $X
       - name: Test Laravel
         if: ${{ !cancelled() }}
+        env:
+          LARAVEL_VERSION: ${{ fromJson(inputs.branch).jobs.COMMUNITY.config.laravel_version }}
         run: |
-          branch=${{ fromJson(inputs.branch).jobs.COMMUNITY.config.laravel_version }}
+          branch="$LARAVEL_VERSION"
           git clone https://github.com/laravel/framework.git --depth=1 ${branch:+--branch="$branch"}
           cd framework
           git rev-parse HEAD
@@ -562,8 +564,10 @@ jobs:
           fi
       - name: Test Symfony
         if: ${{ !cancelled() }}
+        env:
+          SYMFONY_VERSION: ${{ fromJson(inputs.branch).jobs.COMMUNITY.config.symfony_version }}
         run: |
-          branch=${{ fromJson(inputs.branch).jobs.COMMUNITY.config.symfony_version }}
+          branch="$SYMFONY_VERSION"
           git clone https://github.com/symfony/symfony.git --depth=1 ${branch:+--branch="$branch"}
           cd symfony
           git rev-parse HEAD

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,13 @@ jobs:
             nightly-
       - name: Generate Matrix
         id: set-matrix
-        run: php .github/matrix.php "${{ github.event_name }}" "${{ github.run_attempt }}" "${{ github.event_name == 'pull_request' && github.ref || github.ref_name }}" '${{ toJSON(github.event.pull_request.labels) }}' "${{ github.repository }}"
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          REF: ${{ github.event_name == 'pull_request' && github.ref || github.ref_name }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels) }}
+          REPOSITORY: ${{ github.repository }}
+        run: php .github/matrix.php "$EVENT_NAME" "$RUN_ATTEMPT" "$REF" "$PR_LABELS" "$REPOSITORY"
   TEST:
     needs: GENERATE_MATRIX
     if: ${{ needs.GENERATE_MATRIX.outputs.branches != '[]' }}

--- a/.github/workflows/windows-builds.yml
+++ b/.github/workflows/windows-builds.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.WINDOWS_BUILDS_TOKEN }}
+          TAG: ${{ inputs.tag || github.ref_name }}
         run: |
-          TAG="${{ inputs.tag || github.ref_name }}"
           gh workflow run php.yml -R php/php-windows-builder -f php-version="${TAG#php-}"


### PR DESCRIPTION
`zizmor` flagged several workflow steps that expand untrusted `${{ }}` expressions directly into `run:` shell scripts. Route these values through `env:`.

I can also revert the change for safe GitHub-provided values, like `github.repository`.