### PR TITLE
Fix memory leak of pdo_odbc output parameter buffer

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -55,6 +55,7 @@ PHP                                                                        NEWS
     longer than the declared maxlen). (iliaal)
   . Fixed bug GH-22665 (Out-of-bounds write when the ODBC driver reports a
     diagnostic message length beyond the error buffer). (iliaal)
+  . Fixed memory leak of the buffer bound for an output parameter. (iliaal)
 
 - Phar:
   . Fixed inconsistent handling of the magic ".phar" directory. Paths such as

--- a/ext/pdo_odbc/odbc_stmt.c
+++ b/ext/pdo_odbc/odbc_stmt.c
@@ -133,6 +133,11 @@ static void free_cols(pdo_stmt_t *stmt, pdo_odbc_stmt *S)
 	}
 }
 
+static void odbc_free_out_buffer(zval *el)
+{
+	efree(Z_PTR_P(el));
+}
+
 static int odbc_stmt_dtor(pdo_stmt_t *stmt)
 {
 	pdo_odbc_stmt *S = (pdo_odbc_stmt*)stmt->driver_data;
@@ -152,6 +157,10 @@ static int odbc_stmt_dtor(pdo_stmt_t *stmt)
 	free_cols(stmt, S);
 	if (S->convbuf) {
 		efree(S->convbuf);
+	}
+	if (S->out_buffers) {
+		zend_hash_destroy(S->out_buffers);
+		FREE_HASHTABLE(S->out_buffers);
 	}
 	efree(S);
 
@@ -386,6 +395,11 @@ static int odbc_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param_data *p
 						}
 						P->outbuf = emalloc(P->len + (P->is_unicode ? 2:1));
 						P->outbuflen = P->len;
+						if (!S->out_buffers) {
+							ALLOC_HASHTABLE(S->out_buffers);
+							zend_hash_init(S->out_buffers, 8, NULL, odbc_free_out_buffer, 0);
+						}
+						zend_hash_next_index_insert_ptr(S->out_buffers, P->outbuf);
 					}
 				}
 

--- a/ext/pdo_odbc/php_pdo_odbc_int.h
+++ b/ext/pdo_odbc/php_pdo_odbc_int.h
@@ -145,6 +145,7 @@ typedef struct {
 	pdo_odbc_errinfo einfo;
 	char *convbuf;
 	zend_ulong convbufsize;
+	HashTable *out_buffers;
 	unsigned going_long:1;
 	unsigned assume_utf8:1;
 	signed col_count:16;

--- a/ext/pdo_odbc/tests/output_param_leak.phpt
+++ b/ext/pdo_odbc/tests/output_param_leak.phpt
@@ -1,0 +1,29 @@
+--TEST--
+pdo_odbc: bound output parameter buffer is released (no leak)
+--EXTENSIONS--
+pdo_odbc
+--SKIPIF--
+<?php
+require __DIR__ . '/config.inc';
+try {
+    $pdo = new PDO(PDO_ODBC_SQLITE_DSN);
+} catch (PDOException $e) {
+    die("skip requires the SQLite3 ODBC driver");
+}
+?>
+--FILE--
+<?php
+require __DIR__ . '/config.inc';
+$pdo = new PDO(PDO_ODBC_SQLITE_DSN);
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
+
+$stmt = $pdo->prepare('SELECT ? AS v');
+$var = 'seed';
+$stmt->bindParam(1, $var, PDO::PARAM_STR | PDO::PARAM_INPUT_OUTPUT, 256);
+$stmt->execute();
+$row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+var_dump($row['v']);
+?>
+--EXPECT--
+string(4) "seed"


### PR DESCRIPTION
`odbc_stmt_param_hook()` emallocs `P->outbuf` for output and INPUT_OUTPUT parameters at `PDO_PARAM_EVT_ALLOC`, hands it to the driver with `SQLBindParameter`, and never frees it. The buffer outlives the bound-parameter struct (PDO destroys that mid-statement on `execute($array)` or when a position is rebound), so it cannot be freed at parameter-free time without leaving the ODBC statement pointing at freed memory. Track the allocated buffers on the statement and free them in the destructor, after `SQLFreeHandle` has dropped the bindings.

Reproducer, leaks under a debug or ASAN build:

```php
$pdo = new PDO('odbc:Driver=SQLite3;Database=:memory:');
$stmt = $pdo->prepare('SELECT ? AS v');
$var = 'seed';
$stmt->bindParam(1, $var, PDO::PARAM_STR | PDO::PARAM_INPUT_OUTPUT, 256);
$stmt->execute();
```
