### PR TITLE
opcache: add ephpm to the allow list

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -2842,6 +2842,7 @@ static inline zend_result accel_find_sapi(void)
 		"fuzzer",
 		"frankenphp",
 		"ngx-php",
+		"ephpm",
 		NULL
 	};
 	const char **sapi_name;


### PR DESCRIPTION
ePHPm is an embed-based PHP application server — it sets `sapi_module.name = "ephpm"` before `php_embed_init()`, so OPcache's `supported_sapis` allow list doesn't recognize it and silently refuses to start.

Same situation and same one-line fix as frankenphp (#9755) and ngx-php (#11013).

The allow list was removed in 8.5, so this only targets PHP-8.4.
