### PR TITLE
Remove docref1/docref2

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -80,6 +80,9 @@ PHP 8.6 INTERNALS UPGRADE NOTES
     directly.
   . The {_}php_stream_fopen_with_path() functions have been removed as they are
     unused.
+  . The php_error_docref1() and php_error_docref2() functions have been
+    removed, instead rely on the error_include_args INI option to show the
+    arguments to functions in a consistent manner.
 
 - Changed:
   . Internal functions that return by reference are now expected to

--- a/main/main.c
+++ b/main/main.c
@@ -1258,35 +1258,6 @@ PHPAPI ZEND_COLD void php_error_docref_unchecked(const char *docref, int type, c
 }
 /* }}} */
 
-/* {{{ php_error_docref1 */
-/* See: CODING_STANDARDS.md for details. */
-PHPAPI ZEND_COLD void php_error_docref1(const char *docref, const char *param1, int type, const char *format, ...)
-{
-	va_list args;
-
-	va_start(args, format);
-	php_verror(docref, param1, type, format, args);
-	va_end(args);
-}
-/* }}} */
-
-/* {{{ php_error_docref2 */
-/* See: CODING_STANDARDS.md for details. */
-PHPAPI ZEND_COLD void php_error_docref2(const char *docref, const char *param1, const char *param2, int type, const char *format, ...)
-{
-	char *params;
-	va_list args;
-
-	spprintf(&params, 0, "%s,%s", param1, param2);
-	va_start(args, format);
-	php_verror(docref, params ? params : "...", type, format, args);
-	va_end(args);
-	if (params) {
-		efree(params);
-	}
-}
-/* }}} */
-
 /* {{{ php_html_puts */
 PHPAPI void php_html_puts(const char *str, size_t size)
 {

--- a/main/php.h
+++ b/main/php.h
@@ -305,10 +305,6 @@ PHPAPI ZEND_COLD void php_verror(const char *docref, const char *params, int typ
 PHPAPI ZEND_COLD void php_error_docref(const char *docref, int type, const char *format, ...)
 	PHP_ATTRIBUTE_FORMAT(printf, 3, 4);
 PHPAPI ZEND_COLD void php_error_docref_unchecked(const char *docref, int type, const char *format, ...);
-PHPAPI ZEND_COLD void php_error_docref1(const char *docref, const char *param1, int type, const char *format, ...)
-	PHP_ATTRIBUTE_FORMAT(printf, 4, 5);
-PHPAPI ZEND_COLD void php_error_docref2(const char *docref, const char *param1, const char *param2, int type, const char *format, ...)
-	PHP_ATTRIBUTE_FORMAT(printf, 5, 6);
 END_EXTERN_C()
 
 #define zenderror phperror


### PR DESCRIPTION
Stream tests have been changed in previous PRs and the internal callers removed, so a compatibility interface isn't needed.