### PR TITLE
Run oversized bz2 resource tests in isolation to avoid OOM

### DIFF
--- a/ext/bz2/tests/bzdecompress_input_too_large.phpt
+++ b/ext/bz2/tests/bzdecompress_input_too_large.phpt
@@ -10,6 +10,8 @@ if (!getenv('RUN_RESOURCE_HEAVY_TESTS')) die('skip resource-heavy test');
 if (getenv('SKIP_SLOW_TESTS')) die('skip slow test');
 if (PHP_INT_SIZE != 8) die('skip 64-bit only');
 ?>
+--CONFLICTS--
+all
 --FILE--
 <?php
 

--- a/ext/bz2/tests/gh20620.phpt
+++ b/ext/bz2/tests/gh20620.phpt
@@ -8,6 +8,8 @@ if (!getenv('RUN_RESOURCE_HEAVY_TESTS')) die('skip resource-heavy test');
 if (PHP_INT_SIZE != 8) die('skip this test is for 64bit platforms only'); 
 if (getenv('SKIP_SLOW_TESTS')) die('skip slow tests excluded by request');
 ?>
+--CONFLICTS--
+all
 --INI--
 memory_limit=-1
 --FILE--


### PR DESCRIPTION
gh20620 and bzdecompress_input_too_large each allocate ~4GB under RUN_RESOURCE_HEAVY_TESTS; running both in parallel OOMs a memory-constrained runner and the killer aborts the whole run. Marking them --CONFLICTS-- all runs each in isolation, matching ext/tidy/tests/parsing_file_too_large.phpt. bzdecompress_input_too_large is master-only, so the two only coexist here.
