### PR TITLE
standard/file.c: use normal docref function for E_WARNINGs in popen()

### DIFF
--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -822,7 +822,7 @@ PHP_FUNCTION(popen)
 
 	fp = VCWD_POPEN(command, posix_mode);
 	if (!fp) {
-		php_error_docref2(NULL, command, posix_mode, E_WARNING, "%s", strerror(errno));
+		php_error_docref(NULL, E_WARNING, "%s", strerror(errno));
 		efree(posix_mode);
 		RETURN_FALSE;
 	}
@@ -831,7 +831,7 @@ PHP_FUNCTION(popen)
 	stream = php_stream_fopen_from_pipe(fp, mode);
 
 	if (stream == NULL)	{
-		php_error_docref2(NULL, command, mode, E_WARNING, "%s", strerror(errno));
+		php_error_docref(NULL, E_WARNING, "%s", strerror(errno));
 		RETVAL_FALSE;
 	} else {
 		php_stream_to_zval(stream, return_value);


### PR DESCRIPTION
Now that arguments in warnings can be configured to always appear it is no longer necessary to use `php_error_docref2()`.

Especially as this is the last usage outside of Windows wrapper.