### PR TITLE
exif: change usage of php_error_docref1() to php_error_docref()

### DIFF
--- a/ext/exif/exif.c
+++ b/ext/exif/exif.c
@@ -4938,7 +4938,7 @@ PHP_FUNCTION(exif_read_data)
 	exif_discard_imageinfo(&ImageInfo);
 
 #ifdef EXIF_DEBUG
-	php_error_docref1(NULL, (Z_TYPE_P(stream) == IS_RESOURCE ? "<stream>" : Z_STRVAL_P(stream)), E_NOTICE, "Done");
+	php_error_docref(NULL, E_NOTICE, "Done");
 #endif
 }
 /* }}} */
@@ -5026,7 +5026,7 @@ PHP_FUNCTION(exif_thumbnail)
 	exif_discard_imageinfo(&ImageInfo);
 
 #ifdef EXIF_DEBUG
-	php_error_docref1(NULL, (Z_TYPE_P(stream) == IS_RESOURCE ? "<stream>" : Z_STRVAL_P(stream)), E_NOTICE, "Done");
+	php_error_docref(NULL, E_NOTICE, "Done");
 #endif
 }
 /* }}} */


### PR DESCRIPTION
As arguments to functions are now handled globally via an INI setting