### PR TITLE
streams: use built-in argument handling for warnings instead of 2 param functions

### DIFF
--- a/ext/standard/tests/file/rename_variation.phpt
+++ b/ext/standard/tests/file/rename_variation.phpt
@@ -55,7 +55,7 @@ bool(false)
 bool(true)
 -- Iteration 2 --
 
-Warning: rename(%s,%s): Not a directory in %s on line %d
+Warning: rename(): Not a directory in %s on line %d
 bool(false)
 bool(false)
 bool(false)

--- a/ext/standard/tests/file/rename_variation12.phpt
+++ b/ext/standard/tests/file/rename_variation12.phpt
@@ -2,6 +2,9 @@
 Test rename() function : variation - various relative, absolute paths
 --CREDITS--
 Dave Kelsey <d_kelsey@uk.ibm.com>
+--INI--
+zend.exception_string_param_max_len=1000000
+error_include_args=On
 --SKIPIF--
 <?php
 if (substr(PHP_OS, 0, 3) == 'WIN') die('skip..  not for Windows');
@@ -83,12 +86,12 @@ bool(true)
 
 -- Iteration 5 --
 
-Warning: rename(%s/renameVar12/renameVar12Sub/..///renameVar12Sub//..//../renameVar12Sub/renameMe.tmp,%s/renameVar12/renameVar12Sub/..///renameVar12Sub//..//../renameVar12Sub/IwasRenamed.tmp): %s in %s on line %d
+Warning: rename('%s/renameVar12/renameVar12Sub/..///renameVar12Sub//..//../renameVar12Sub/renameMe.tmp', '%s/renameVar12/renameVar12Sub/..///renameVar12Sub//..//../renameVar12Sub/IwasRenamed.tmp'): %s in %s on line %d
 bool(false)
 
 -- Iteration 6 --
 
-Warning: rename(%s/renameVar12/renameVar12Sub/BADDIR/renameMe.tmp,%s/renameVar12/renameVar12Sub/BADDIR/IwasRenamed.tmp): %s in %s on line %d
+Warning: rename('%s/renameVar12/renameVar12Sub/BADDIR/renameMe.tmp', '%s/renameVar12/renameVar12Sub/BADDIR/IwasRenamed.tmp'): %s in %s on line %d
 bool(false)
 
 -- Iteration 7 --
@@ -109,7 +112,7 @@ bool(true)
 
 -- Iteration 11 --
 
-Warning: rename(BADDIR/renameMe.tmp,BADDIR/IwasRenamed.tmp): %s in %s on line %d
+Warning: rename('BADDIR/renameMe.tmp', 'BADDIR/IwasRenamed.tmp'): %s in %s on line %d
 bool(false)
 
 *** Done ***

--- a/ext/standard/tests/file/rename_variation13.phpt
+++ b/ext/standard/tests/file/rename_variation13.phpt
@@ -2,6 +2,9 @@
 Test rename() function : variation - various invalid paths
 --CREDITS--
 Dave Kelsey <d_kelsey@uk.ibm.com>
+--INI--
+zend.exception_string_param_max_len=1000000
+error_include_args=On
 --SKIPIF--
 <?php
 if(substr(PHP_OS, 0, 3) == "WIN")
@@ -56,43 +59,43 @@ rmdir($file_path);
 -- testing '-1' --
 bool(true)
 
-Warning: rename(-1,%s/renameVar13/afile.tmp): No such file or directory in %s on line %d
+Warning: rename('-1', '%s/renameVar13/afile.tmp'): No such file or directory in %s on line %d
 bool(false)
 -- testing '1' --
 bool(true)
 
-Warning: rename(1,%s/renameVar13/afile.tmp): No such file or directory in %s on line %d
+Warning: rename('1', '%s/renameVar13/afile.tmp'): No such file or directory in %s on line %d
 bool(false)
 -- testing '' --
 
-Warning: rename(%s/renameVar13/afile.tmp,): %s in %s on line %d
+Warning: rename('%s/renameVar13/afile.tmp', ''): %s in %s on line %d
 bool(false)
 
-Warning: rename(,%s/renameVar13/afile.tmp): %s in %s on line %d
+Warning: rename('', '%s/renameVar13/afile.tmp'): %s in %s on line %d
 bool(false)
 -- testing '' --
 
-Warning: rename(%s/renameVar13/afile.tmp,): %s in %s on line %d
+Warning: rename('%s/renameVar13/afile.tmp', ''): %s in %s on line %d
 bool(false)
 
-Warning: rename(,%s/renameVar13/afile.tmp): %s in %s on line %d
+Warning: rename('', '%s/renameVar13/afile.tmp'): %s in %s on line %d
 bool(false)
 -- testing ' ' --
 bool(true)
 
-Warning: rename( ,%s/renameVar13/afile.tmp): No such file or directory in %s on line %d
+Warning: rename(' ', '%s/renameVar13/afile.tmp'): No such file or directory in %s on line %d
 bool(false)
 -- testing '/no/such/file/dir' --
 
-Warning: rename(%s/renameVar13/afile.tmp,/no/such/file/dir): No such file or directory in %s on line %d
+Warning: rename('%s/renameVar13/afile.tmp', '/no/such/file/dir'): No such file or directory in %s on line %d
 bool(false)
 
-Warning: rename(/no/such/file/dir,%s/renameVar13/afile.tmp): No such file or directory in %s on line %d
+Warning: rename('/no/such/file/dir', '%s/renameVar13/afile.tmp'): No such file or directory in %s on line %d
 bool(false)
 -- testing 'php/php' --
 
-Warning: rename(%s/renameVar13/afile.tmp,php/php): %s directory in %s on line %d
+Warning: rename('%s/renameVar13/afile.tmp', 'php/php'): %s directory in %s on line %d
 bool(false)
 
-Warning: rename(php/php,%s/renameVar13/afile.tmp): %s directory in %s on line %d
+Warning: rename('php/php', '%s/renameVar13/afile.tmp'): %s directory in %s on line %d
 bool(false)

--- a/ext/standard/tests/file/rename_variation5.phpt
+++ b/ext/standard/tests/file/rename_variation5.phpt
@@ -70,7 +70,7 @@ bool(true)
 
 -- Renaming existing link to existing directory name --
 
-Warning: rename(%s,%s): Is a directory in %s on line %d
+Warning: rename(): Is a directory in %s on line %d
 bool(false)
 
 -- Renaming existing link to existing file name --
@@ -78,7 +78,7 @@ bool(true)
 
 -- Renaming existing file to existing directory name --
 
-Warning: rename(%s,%s): Is a directory in %s on line %d
+Warning: rename(): Is a directory in %s on line %d
 bool(false)
 
 -- Renaming existing file to existing link name --
@@ -86,11 +86,11 @@ bool(true)
 
 -- Renaming existing directory to existing file name --
 
-Warning: rename(%s,%s): Not a directory in %s on line %d
+Warning: rename(): Not a directory in %s on line %d
 bool(false)
 
 -- Renaming existing directory to existing link name --
 
-Warning: rename(%s,%s): Not a directory in %s on line %d
+Warning: rename(): Not a directory in %s on line %d
 bool(false)
 Done

--- a/ext/standard/tests/file/rename_variation8.phpt
+++ b/ext/standard/tests/file/rename_variation8.phpt
@@ -46,7 +46,7 @@ rmdir(__DIR__."/rename_basic_dir1");
 --EXPECTF--
 *** Testing rename() on non-existing file ***
 
-Warning: rename(%s/non_existent_file.tmp,%s/rename_variation8_new.tmp): No such file or directory in %s on line %d
+Warning: rename(): No such file or directory in %s on line %d
 bool(false)
 bool(false)
 bool(false)
@@ -58,7 +58,7 @@ bool(true)
 
 *** Testing rename() on non-existing directory ***
 
-Warning: rename(%s/non_existent_dir,%s/rename_basic_dir2): No such file or directory in %s on line %d
+Warning: rename(): No such file or directory in %s on line %d
 bool(false)
 bool(false)
 bool(false)

--- a/main/streams/php_stream_errors.h
+++ b/main/streams/php_stream_errors.h
@@ -135,11 +135,6 @@ PHPAPI void php_stream_wrapper_error_param(php_stream_wrapper *wrapper, php_stre
 		zend_enum_StreamErrorCode code, const char *param, const char *fmt, ...)
 		ZEND_ATTRIBUTE_FORMAT(printf, 9, 10);
 
-PHPAPI void php_stream_wrapper_error_param2(php_stream_wrapper *wrapper,
-		php_stream_context *context, const char *docref, int options, int severity,
-		bool terminating, zend_enum_StreamErrorCode code, const char *param1, const char *param2,
-		const char *fmt, ...) ZEND_ATTRIBUTE_FORMAT(printf, 10, 11);
-
 PHPAPI void php_stream_error(php_stream *stream, const char *docref, int severity,
 		bool terminating, zend_enum_StreamErrorCode code, const char *fmt, ...)
 		ZEND_ATTRIBUTE_FORMAT(printf, 6, 7);
@@ -193,16 +188,6 @@ PHPAPI void php_stream_tidy_wrapper_error_log(php_stream_wrapper *wrapper);
 	php_stream_wrapper_error_param( \
 			wrapper, context, NULL, options, E_WARNING, false, \
 			PHP_STREAM_EC(code), param, __VA_ARGS__)
-
-#define php_stream_wrapper_warn_param2(wrapper, context, options, code, param1, param2, ...) \
-	php_stream_wrapper_error_param2( \
-			wrapper, context, NULL, options, E_WARNING, true, \
-			PHP_STREAM_EC(code), param1, param2, __VA_ARGS__)
-
-#define php_stream_wrapper_warn_param2_nt(wrapper, context, options, code, param1, param2, ...) \
-	php_stream_wrapper_error_param2( \
-			wrapper, context, NULL, options, E_WARNING, false, \
-			PHP_STREAM_EC(code), param1, param2, __VA_ARGS__)
 
 #define php_stream_warn(stream, code, ...) \
 	php_stream_error(stream, NULL, E_WARNING, true, PHP_STREAM_EC(code), __VA_ARGS__)

--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -1385,8 +1385,8 @@ static int php_plain_files_rename(php_stream_wrapper *wrapper, const char *url_f
 						if (errno != EPERM) {
 							success = 0;
 						}
-						php_stream_wrapper_error_param2(wrapper, context, NULL, options, E_WARNING,
-								!success, PHP_STREAM_EC(ChownFailed), url_from, url_to,
+						php_stream_wrapper_error(wrapper, context, NULL, options, E_WARNING,
+								!success, PHP_STREAM_EC(ChownFailed),
 								"%s", php_socket_strerror_s(errno, errstr, sizeof(errstr)));
 					}
 
@@ -1395,8 +1395,8 @@ static int php_plain_files_rename(php_stream_wrapper *wrapper, const char *url_f
 							if (errno != EPERM) {
 								success = 0;
 							}
-							php_stream_wrapper_error_param2(wrapper, context, NULL, options, E_WARNING,
-									!success, PHP_STREAM_EC(ChownFailed), url_from, url_to,
+							php_stream_wrapper_error(wrapper, context, NULL, options, E_WARNING,
+									!success, PHP_STREAM_EC(ChownFailed),
 									"%s", php_socket_strerror_s(errno, errstr, sizeof(errstr)));
 						}
 					}
@@ -1405,13 +1405,11 @@ static int php_plain_files_rename(php_stream_wrapper *wrapper, const char *url_f
 						VCWD_UNLINK(url_from);
 					}
 				} else {
-					php_stream_wrapper_warn_param2_nt(wrapper, context, options, StatFailed,
-							url_from, url_to,
+					php_stream_wrapper_warn_nt(wrapper, context, options, StatFailed,
 							"%s", php_socket_strerror_s(errno, errstr, sizeof(errstr)));
 				}
 			} else {
-				php_stream_wrapper_warn_param2_nt(wrapper, context, options, CopyFailed,
-						url_from, url_to,
+				php_stream_wrapper_warn_nt(wrapper, context, options, CopyFailed,
 						"%s", php_socket_strerror_s(errno, errstr, sizeof(errstr)));
 			}
 #  if !defined(ZTS) && !defined(TSRM_WIN32)
@@ -1425,8 +1423,8 @@ static int php_plain_files_rename(php_stream_wrapper *wrapper, const char *url_f
 #ifdef PHP_WIN32
 		php_win32_docref2_from_error(GetLastError(), url_from, url_to);
 #else
-		php_stream_wrapper_warn_param2(wrapper, context, options,
-				RenameFailed, url_from, url_to,
+		php_stream_wrapper_warn(wrapper, context, options,
+				RenameFailed,
 				"%s", php_socket_strerror_s(errno, errstr, sizeof(errstr)));
 #endif
 		return 0;

--- a/main/streams/stream_errors.c
+++ b/main/streams/stream_errors.c
@@ -646,29 +646,6 @@ PHPAPI void php_stream_wrapper_error_param(php_stream_wrapper *wrapper, php_stre
 			code, param_copy, message);
 }
 
-PHPAPI void php_stream_wrapper_error_param2(php_stream_wrapper *wrapper,
-		php_stream_context *context, const char *docref, int options, int severity,
-		bool terminating, zend_enum_StreamErrorCode code, const char *param1, const char *param2,
-		const char *fmt, ...)
-{
-	if (!(options & REPORT_ERRORS)) {
-		return;
-	}
-
-	char *combined_param;
-	spprintf(&combined_param, 0, "%s,%s", param1, param2);
-
-	va_list args;
-	va_start(args, fmt);
-	zend_string *message = vstrpprintf(0, fmt, args);
-	va_end(args);
-
-	const char *wrapper_name = PHP_STREAM_ERROR_WRAPPER_NAME(wrapper);
-
-	php_stream_wrapper_error_internal(wrapper_name, context, docref, options, severity, terminating,
-			code, combined_param, message);
-}
-
 /* Stream error reporting */
 
 PHPAPI void php_stream_error(php_stream *stream, const char *docref, int severity,


### PR DESCRIPTION
Since all warnings can now display the arguments of the call, the stream layer can just piggyback on-top of it instead of the additional complexity of handling it.

This is only a first step as there is still the 1 param variant that needs to be converted.