### PR TITLE
Fix GH-22759: Keep Io\Poll watcher registry in sync

### DIFF
--- a/ext/standard/io_poll.c
+++ b/ext/standard/io_poll.c
@@ -351,7 +351,7 @@ static zend_always_inline zend_ulong php_io_poll_compute_ptr_key(void *ptr)
 static zend_result php_io_poll_watcher_modify_events(
 		php_io_poll_watcher_object *watcher, uint32_t events)
 {
-	if (!watcher->active || !watcher->context || !watcher->context->ctx) {
+	if (!watcher->active || !watcher->context) {
 		zend_throw_exception(
 				php_io_poll_inactive_watcher_class_entry, "Cannot modify inactive watcher", 0);
 		return FAILURE;
@@ -635,7 +635,7 @@ PHP_METHOD(Io_Poll_Watcher, remove)
 
 	php_io_poll_watcher_object *intern = PHP_POLL_WATCHER_OBJ_FROM_ZV(getThis());
 
-	if (!intern->active || !intern->context || !intern->context->ctx) {
+	if (!intern->active || !intern->context) {
 		zend_throw_exception(
 				php_io_poll_inactive_watcher_class_entry, "Cannot remove inactive watcher", 0);
 		RETURN_THROWS();

--- a/ext/standard/io_poll.c
+++ b/ext/standard/io_poll.c
@@ -52,6 +52,7 @@ typedef struct php_io_poll_watcher_object {
 	zval data;
 	bool active;
 	php_poll_ctx *poll_ctx; /* Back reference to poll context */
+	HashTable *watchers; /* Back reference to context watcher registry */
 	zend_object std;
 } php_io_poll_watcher_object;
 
@@ -252,6 +253,7 @@ static zend_object *php_io_poll_watcher_create_object(zend_class_entry *ce)
 	intern->triggered_events = 0;
 	intern->active = false;
 	intern->poll_ctx = NULL;
+	intern->watchers = NULL;
 	ZVAL_NULL(&intern->data);
 
 	return &intern->std;
@@ -294,6 +296,7 @@ static void php_io_poll_context_free_object(zend_object *obj)
 			php_io_poll_watcher_object *watcher = PHP_POLL_WATCHER_OBJ_FROM_ZOBJ(Z_OBJ_P(zv));
 			watcher->active = false;
 			watcher->poll_ctx = NULL;
+			watcher->watchers = NULL;
 		} ZEND_HASH_FOREACH_END();
 	}
 
@@ -638,13 +641,21 @@ PHP_METHOD(Io_Poll_Watcher, remove)
 		RETURN_THROWS();
 	}
 
+	php_poll_ctx *poll_ctx = intern->poll_ctx;
+	HashTable *watchers = intern->watchers;
+	zend_ulong hash_key = php_io_poll_compute_ptr_key(intern->handle);
 	php_socket_t fd = php_poll_handle_get_fd(intern->handle);
 	if (fd != SOCK_ERR) {
-		php_poll_remove(intern->poll_ctx, (int) fd);
+		php_poll_remove(poll_ctx, (int) fd);
 	}
 
 	intern->active = false;
 	intern->poll_ctx = NULL;
+	intern->watchers = NULL;
+
+	if (watchers) {
+		zend_hash_index_del(watchers, hash_key);
+	}
 }
 
 PHP_METHOD(Io_Poll_Context, __construct)
@@ -727,8 +738,6 @@ PHP_METHOD(Io_Poll_Context, add)
 	watcher->handle = handle;
 	watcher->watched_events = events;
 	watcher->triggered_events = 0;
-	watcher->active = true;
-	watcher->poll_ctx = intern->ctx;
 
 	GC_ADDREF(&handle->std);
 
@@ -757,7 +766,17 @@ PHP_METHOD(Io_Poll_Context, add)
 	GC_ADDREF(&watcher->std);
 
 	zend_ulong hash_key = php_io_poll_compute_ptr_key(handle);
-	zend_hash_index_add(intern->watchers, hash_key, &watcher_zv);
+	if (zend_hash_index_add(intern->watchers, hash_key, &watcher_zv) == NULL) {
+		php_poll_remove(intern->ctx, (int) fd);
+		zval_ptr_dtor(&watcher_zv);
+		zend_throw_exception(
+				php_io_poll_handle_already_watched_class_entry, "Handle already added", 0);
+		RETURN_THROWS();
+	}
+
+	watcher->active = true;
+	watcher->poll_ctx = intern->ctx;
+	watcher->watchers = intern->watchers;
 }
 
 PHP_METHOD(Io_Poll_Context, wait)

--- a/ext/standard/io_poll.c
+++ b/ext/standard/io_poll.c
@@ -51,8 +51,7 @@ typedef struct php_io_poll_watcher_object {
 	uint32_t triggered_events;
 	zval data;
 	bool active;
-	php_poll_ctx *poll_ctx; /* Back reference to poll context */
-	HashTable *watchers; /* Back reference to context watcher registry */
+	php_io_poll_context_object *context; /* Back reference to Context object */
 	zend_object std;
 } php_io_poll_watcher_object;
 

--- a/ext/standard/io_poll.c
+++ b/ext/standard/io_poll.c
@@ -766,13 +766,7 @@ PHP_METHOD(Io_Poll_Context, add)
 	GC_ADDREF(&watcher->std);
 
 	zend_ulong hash_key = php_io_poll_compute_ptr_key(handle);
-	if (zend_hash_index_add(intern->watchers, hash_key, &watcher_zv) == NULL) {
-		php_poll_remove(intern->ctx, (int) fd);
-		zval_ptr_dtor(&watcher_zv);
-		zend_throw_exception(
-				php_io_poll_handle_already_watched_class_entry, "Handle already added", 0);
-		RETURN_THROWS();
-	}
+	zend_hash_index_add_new(intern->watchers, hash_key, &watcher_zv);
 
 	watcher->active = true;
 	watcher->poll_ctx = intern->ctx;

--- a/ext/standard/io_poll.c
+++ b/ext/standard/io_poll.c
@@ -44,6 +44,8 @@ static zend_object_handlers php_io_poll_context_object_handlers;
 static zend_object_handlers php_io_poll_watcher_object_handlers;
 static zend_object_handlers php_io_poll_handle_object_handlers;
 
+typedef struct php_io_poll_context_object php_io_poll_context_object;
+
 /* Watcher object structure */
 typedef struct php_io_poll_watcher_object {
 	php_poll_handle_object *handle;
@@ -56,11 +58,11 @@ typedef struct php_io_poll_watcher_object {
 } php_io_poll_watcher_object;
 
 /* Context object structure */
-typedef struct php_io_poll_context_object {
+struct php_io_poll_context_object {
 	php_poll_ctx *ctx;
 	HashTable *watchers; /* Maps handle pointer -> watcher object */
 	zend_object std;
-} php_io_poll_context_object;
+};
 
 /* Stream poll handle specific data */
 typedef struct php_stream_poll_handle_data {
@@ -251,8 +253,7 @@ static zend_object *php_io_poll_watcher_create_object(zend_class_entry *ce)
 	intern->watched_events = 0;
 	intern->triggered_events = 0;
 	intern->active = false;
-	intern->poll_ctx = NULL;
-	intern->watchers = NULL;
+	intern->context = NULL;
 	ZVAL_NULL(&intern->data);
 
 	return &intern->std;
@@ -294,8 +295,7 @@ static void php_io_poll_context_free_object(zend_object *obj)
 		ZEND_HASH_FOREACH_VAL(intern->watchers, zval *zv) {
 			php_io_poll_watcher_object *watcher = PHP_POLL_WATCHER_OBJ_FROM_ZOBJ(Z_OBJ_P(zv));
 			watcher->active = false;
-			watcher->poll_ctx = NULL;
-			watcher->watchers = NULL;
+			watcher->context = NULL;
 		} ZEND_HASH_FOREACH_END();
 	}
 
@@ -351,7 +351,7 @@ static zend_always_inline zend_ulong php_io_poll_compute_ptr_key(void *ptr)
 static zend_result php_io_poll_watcher_modify_events(
 		php_io_poll_watcher_object *watcher, uint32_t events)
 {
-	if (!watcher->active || !watcher->poll_ctx) {
+	if (!watcher->active || !watcher->context || !watcher->context->ctx) {
 		zend_throw_exception(
 				php_io_poll_inactive_watcher_class_entry, "Cannot modify inactive watcher", 0);
 		return FAILURE;
@@ -365,8 +365,9 @@ static zend_result php_io_poll_watcher_modify_events(
 	}
 
 	/* Modify in poll context */
-	if (php_poll_modify(watcher->poll_ctx, (int) fd, events, watcher) != SUCCESS) {
-		php_poll_error err = php_poll_get_error(watcher->poll_ctx);
+	php_poll_ctx *poll_ctx = watcher->context->ctx;
+	if (php_poll_modify(poll_ctx, (int) fd, events, watcher) != SUCCESS) {
+		php_poll_error err = php_poll_get_error(poll_ctx);
 		php_io_poll_throw_failed_operation(php_io_poll_failed_watcher_mod_class_entry,
 				"Failed to modify watcher in polling system", err);
 		return FAILURE;
@@ -634,14 +635,15 @@ PHP_METHOD(Io_Poll_Watcher, remove)
 
 	php_io_poll_watcher_object *intern = PHP_POLL_WATCHER_OBJ_FROM_ZV(getThis());
 
-	if (!intern->active || !intern->poll_ctx) {
+	if (!intern->active || !intern->context || !intern->context->ctx) {
 		zend_throw_exception(
 				php_io_poll_inactive_watcher_class_entry, "Cannot remove inactive watcher", 0);
 		RETURN_THROWS();
 	}
 
-	php_poll_ctx *poll_ctx = intern->poll_ctx;
-	HashTable *watchers = intern->watchers;
+	php_io_poll_context_object *context = intern->context;
+	php_poll_ctx *poll_ctx = context->ctx;
+	HashTable *watchers = context->watchers;
 	zend_ulong hash_key = php_io_poll_compute_ptr_key(intern->handle);
 	php_socket_t fd = php_poll_handle_get_fd(intern->handle);
 	if (fd != SOCK_ERR) {
@@ -649,8 +651,7 @@ PHP_METHOD(Io_Poll_Watcher, remove)
 	}
 
 	intern->active = false;
-	intern->poll_ctx = NULL;
-	intern->watchers = NULL;
+	intern->context = NULL;
 
 	if (watchers) {
 		zend_hash_index_del(watchers, hash_key);
@@ -768,8 +769,7 @@ PHP_METHOD(Io_Poll_Context, add)
 	zend_hash_index_add_new(intern->watchers, hash_key, &watcher_zv);
 
 	watcher->active = true;
-	watcher->poll_ctx = intern->ctx;
-	watcher->watchers = intern->watchers;
+	watcher->context = intern;
 }
 
 PHP_METHOD(Io_Poll_Context, wait)

--- a/ext/standard/tests/poll/gh22759.phpt
+++ b/ext/standard/tests/poll/gh22759.phpt
@@ -14,7 +14,7 @@ $first->remove();
 $ref = WeakReference::create($first);
 unset($first);
 gc_collect_cycles();
-var_dump($ref->get()); // should be NULL
+var_dump($ref->get());
 
 $second = $context->add($handle, [Io\Poll\Event::Read]);
 
@@ -32,6 +32,7 @@ try {
 echo "done\n";
 ?>
 --EXPECT--
+NULL
 bool(false)
 Cannot remove inactive watcher
 done

--- a/ext/standard/tests/poll/gh22759.phpt
+++ b/ext/standard/tests/poll/gh22759.phpt
@@ -1,0 +1,32 @@
+--TEST--
+GH-22759 (Io\Poll: re-adding a removed handle keeps the new watcher tracked)
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+
+[$r, $w] = pt_new_socket_pair();
+$context = pt_new_stream_poll();
+$handle = new StreamPollHandle($r);
+
+$first = $context->add($handle, [Io\Poll\Event::Read]);
+$first->remove();
+
+$second = $context->add($handle, [Io\Poll\Event::Read]);
+
+unset($context);
+gc_collect_cycles();
+
+var_dump($second->isActive());
+
+try {
+    $second->remove();
+} catch (Io\Poll\InactiveWatcherException $e) {
+    echo $e->getMessage(), "\n";
+}
+
+echo "done\n";
+?>
+--EXPECT--
+bool(false)
+Cannot remove inactive watcher
+done

--- a/ext/standard/tests/poll/gh22759.phpt
+++ b/ext/standard/tests/poll/gh22759.phpt
@@ -11,6 +11,11 @@ $handle = new StreamPollHandle($r);
 $first = $context->add($handle, [Io\Poll\Event::Read]);
 $first->remove();
 
+$ref = WeakReference::create($first);
+unset($first);
+gc_collect_cycles();
+var_dump($ref->get()); // should be NULL
+
 $second = $context->add($handle, [Io\Poll\Event::Read]);
 
 unset($context);


### PR DESCRIPTION
Also remove the watcher from the Context registry when it is explicitly removed. and roll back the backend registration on failure.

Fixed #22759