### PR TITLE
ext/soap: fix NULL deref on malformed HTTP status line

### DIFF
--- a/ext/soap/php_http.c
+++ b/ext/soap/php_http.c
@@ -956,14 +956,14 @@ try_again:
 				if (tmp != NULL) {
 					tmp++;
 					http_status = atoi(tmp);
-				}
-				tmp = strstr(tmp," ");
-				if (tmp != NULL) {
-					tmp++;
-					if (http_msg) {
-						efree(http_msg);
+					tmp = strstr(tmp," ");
+					if (tmp != NULL) {
+						tmp++;
+						if (http_msg) {
+							efree(http_msg);
+						}
+						http_msg = estrdup(tmp);
 					}
-					http_msg = estrdup(tmp);
 				}
 				efree(http_version);
 

--- a/ext/soap/tests/http_status_line_no_code.phpt
+++ b/ext/soap/tests/http_status_line_no_code.phpt
@@ -1,0 +1,33 @@
+--TEST--
+SoapClient: malformed HTTP status line without status code must not crash
+--EXTENSIONS--
+soap
+--FILE--
+<?php
+$serverCode = <<<'CODE'
+$server = stream_socket_server("tcp://127.0.0.1:0", $errno, $errstr);
+phpt_notify_server_start($server);
+$conn = stream_socket_accept($server);
+while (($line = fgets($conn)) !== false) {
+	if ($line === "\r\n" || $line === "\n") {
+		break;
+	}
+}
+fwrite($conn, "HTTP/1.1\r\nContent-Type: text/xml\r\nContent-Length: 0\r\n\r\n");
+fclose($conn);
+CODE;
+
+$clientCode = <<<'CODE'
+$client = new SoapClient(null, [
+	'location' => 'http://{{ ADDR }}',
+	'uri' => 'http://testuri.org',
+	'connection_timeout' => 3,
+]);
+var_dump($client->__doRequest('<x/>', 'http://{{ ADDR }}', 'T', 1));
+CODE;
+
+include sprintf('%s/../../openssl/tests/ServerClientTestCase.inc', __DIR__);
+ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
+?>
+--EXPECT--
+string(0) ""


### PR DESCRIPTION
`make_http_soap_request()` looks for the reason phrase with strstr(tmp, " ") even when the first strstr() found no space. A status line carrying a version but no status code, such as "HTTP/1.1", leaves tmp NULL, so strstr() dereferences it and the client segfaults. A broken or hostile SOAP endpoint can crash the client talking to it.

The test drives a SoapClient against a socket answering "HTTP/1.1\r\nContent-Type: text/xml\r\nContent-Length: 0\r\n\r\n" and asserts __doRequest() returns an empty string.

Present on 8.3 through master, targeting 8.4 as the lowest actively supported branch.
