### PR TITLE
ext/filter: encode 0xFF in FILTER_SANITIZE_ENCODED

### DIFF
--- a/ext/filter/sanitizing_filters.c
+++ b/ext/filter/sanitizing_filters.c
@@ -68,7 +68,7 @@ static void php_filter_encode_url(zval *value, const unsigned char* chars, const
 	unsigned char *e = s + char_len;
 	zend_string *str;
 
-	memset(tmp, 1, sizeof(tmp)-1);
+	memset(tmp, 1, sizeof(tmp));
 
 	while (s < e) {
 		tmp[*s++] = '\0';

--- a/ext/filter/tests/filter_sanitize_encoded_0xff.phpt
+++ b/ext/filter/tests/filter_sanitize_encoded_0xff.phpt
@@ -1,0 +1,12 @@
+--TEST--
+FILTER_SANITIZE_ENCODED percent-encodes 0xFF
+--EXTENSIONS--
+filter
+--FILE--
+<?php
+var_dump(filter_var("\xFF", FILTER_SANITIZE_ENCODED));
+var_dump(filter_var("\xFE\xFF\x00A", FILTER_SANITIZE_ENCODED));
+?>
+--EXPECT--
+string(3) "%FF"
+string(10) "%FE%FF%00A"


### PR DESCRIPTION
`php_filter_encode_url()` builds a 256-byte table marking which bytes need percent-encoding, but initializes it with `memset(tmp, 1, sizeof(tmp) - 1)`, so tmp[255] is never written. Whether 0xFF gets encoded then depends on stack garbage.

On PHP-8.4 it currently reads as unencoded, which is visible from userland:

    filter_var("\xFE\xFF\x00A", FILTER_SANITIZE_ENCODED);  // "%FE\xFF%00A", 0xFE encoded, 0xFF not

valgrind on the unpatched build:

    Conditional jump or move depends on uninitialised value(s)
       at php_filter_encode_url (sanitizing_filters.c:83)
       by php_filter_encoded (sanitizing_filters.c:219)
     Uninitialised value was created by a stack allocation

Present on 8.3 through master, targeting 8.4 as the lowest actively supported branch.
