### PR TITLE
ext/filter: fix use-after-free in parse_str() with filter.default

### DIFF
--- a/ext/filter/filter.c
+++ b/ext/filter/filter.c
@@ -349,15 +349,18 @@ static unsigned int php_sapi_filter(int arg, const char *var, char **val, size_t
 	}
 
 	if (retval) {
+		zend_string *tmp_str;
+		zend_string *str = zval_get_tmp_string(&new_var, &tmp_str);
 		if (new_val_len) {
-			*new_val_len = Z_STRLEN(new_var);
+			*new_val_len = ZSTR_LEN(str);
 		}
 		efree(*val);
-		if (Z_STRLEN(new_var)) {
-			*val = estrndup(Z_STRVAL(new_var), Z_STRLEN(new_var));
+		if (ZSTR_LEN(str)) {
+			*val = estrndup(ZSTR_VAL(str), ZSTR_LEN(str));
 		} else {
 			*val = estrdup("");
 		}
+		zend_tmp_string_release(tmp_str);
 		zval_ptr_dtor(&new_var);
 	}
 

--- a/ext/filter/tests/filter_default_parse_str.phpt
+++ b/ext/filter/tests/filter_default_parse_str.phpt
@@ -1,0 +1,19 @@
+--TEST--
+filter.default with parse_str must not crash on non-string filter results
+--EXTENSIONS--
+filter
+--INI--
+filter.default=int
+--FILE--
+<?php
+parse_str('a=1&b=notint', $out);
+var_dump($out);
+?>
+--EXPECTF--
+Deprecated: The filter.default ini setting is deprecated in %s on line %d
+array(2) {
+  ["a"]=>
+  string(1) "1"
+  ["b"]=>
+  string(0) ""
+}


### PR DESCRIPTION
`php_sapi_filter()` re-exports parse_str() results through `Z_STRLEN`/`Z_STRVAL` without checking what type `php_zval_filter()` left behind. A failed validation frees the string and stores IS_FALSE, so the macros read the freed zend_string; a successful `FILTER_VALIDATE_INT` stores IS_LONG, so they dereference the integer as a pointer.

Reproducer, with filter.default set:

    php -d filter.default=int -r 'parse_str("a=1&b=notint", $out); var_dump($out);'

ASAN on 8.4, unpatched:

    ERROR: AddressSanitizer: heap-use-after-free
    READ of size 8 at ... in php_sapi_filter ext/filter/filter.c:353
      freed by      php_zval_filter   ext/filter/filter.c:275
      allocated at  php_sapi_filter   ext/filter/filter.c:338

    ERROR: AddressSanitizer: SEGV on unknown address 0x000000000011
      in php_sapi_filter ext/filter/filter.c:353

Convert with `zval_get_string()` before writing back. Present on 8.3 through master, targeting 8.4 as the lowest actively supported branch.
