### PR TITLE
ext/standard: fix out-of-bounds access in the ftp:// directory stream

### DIFF
--- a/ext/ftp/tests/server.inc
+++ b/ext/ftp/tests/server.inc
@@ -290,7 +290,7 @@ if ($pid) {
             }
 
             if (empty($m[1]) || $m[1] !== 'emptydir') {
-                fputs($fs, "file1\r\nfile1\r\nfile\nb0rk\r\n");
+                fputs($fs, $nlst_data ?? "file1\r\nfile1\r\nfile\nb0rk\r\n");
             }
 
             fputs($s, "226 Closing data Connection.\r\n");

--- a/ext/standard/ftp_fopen_wrapper.c
+++ b/ext/standard/ftp_fopen_wrapper.c
@@ -625,9 +625,9 @@ static ssize_t php_ftp_dirstream_read(php_stream *stream, char *buf, size_t coun
 
 	basename = php_basename(ent->d_name, tmp_len, NULL, 0);
 
-	tmp_len = MIN(sizeof(ent->d_name), ZSTR_LEN(basename) - 1);
+	tmp_len = MIN(sizeof(ent->d_name) - 1, ZSTR_LEN(basename));
 	memcpy(ent->d_name, ZSTR_VAL(basename), tmp_len);
-	ent->d_name[tmp_len - 1] = '\0';
+	ent->d_name[tmp_len] = '\0';
 	zend_string_release_ex(basename, 0);
 	ent->d_type = DT_UNKNOWN;
 

--- a/ext/standard/tests/streams/ftp_dirstream_oob.phpt
+++ b/ext/standard/tests/streams/ftp_dirstream_oob.phpt
@@ -1,5 +1,5 @@
 --TEST--
-opendir() with 'ftp://' stream.
+opendir() with 'ftp://' stream must not go out of bounds on an empty or slash-only listing line
 --SKIPIF--
 <?php
 if (array_search('ftp',stream_get_wrappers()) === FALSE) die("skip ftp wrapper not available.");
@@ -8,6 +8,10 @@ if (!function_exists('pcntl_fork')) die("skip pcntl_fork() not available.");
 --FILE--
 <?php
 
+/* An empty line makes php_basename() return "\n" and a slash-only final line
+ * makes it return "", the two lengths the buffer math underflowed on. */
+$nlst_data = "file1\r\n\nb0rk\r\n/";
+
 require __DIR__ . "/../../../ftp/tests/server.inc";
 
 $path="ftp://localhost:" . $port."/";
@@ -15,7 +19,7 @@ $path="ftp://localhost:" . $port."/";
 $ds=opendir($path);
 var_dump($ds);
 
-while ($fn=readdir($ds)) {
+while (($fn=readdir($ds)) !== false) {
       var_dump($fn);
 }
 
@@ -24,6 +28,6 @@ closedir($ds);
 --EXPECTF--
 resource(%d) of type (stream)
 string(5) "file1"
-string(5) "file1"
-string(4) "file"
+string(0) ""
 string(4) "b0rk"
+string(0) ""

--- a/ext/standard/tests/streams/opendir-004.phpt
+++ b/ext/standard/tests/streams/opendir-004.phpt
@@ -27,5 +27,5 @@ while ($fn=readdir($ds)) {
 resource(%d) of type (stream)
 string(5) "file1"
 string(5) "file1"
-string(3) "fil"
+string(4) "file"
 string(4) "b0rk"


### PR DESCRIPTION
`php_ftp_dirstream_read()` sized the basename copy with `MIN(sizeof, len - 1)` and terminated at `[tmp_len - 1]`. An empty listing line gives a basename of length 1, so tmp_len is 0 and the terminator lands one byte before d_name; a slash-only line gives length 0, so len - 1 underflows to SIZE_MAX and memcpy reads 4096 bytes past the interned empty string. ASAN flags both. The same off-by-one truncated entry names that do not end in CRLF, which opendir-002 and opendir-004 had baked in as expected output.

Floor: PHP-8.4.
