### PR TITLE
ext/standard: check the from address for control characters before PASS

### DIFF
--- a/ext/standard/ftp_fopen_wrapper.c
+++ b/ext/standard/ftp_fopen_wrapper.c
@@ -269,6 +269,8 @@ static php_stream *php_ftp_fopen_connect(php_stream_wrapper *wrapper, const char
 			/* if the user has configured who they are,
 			   send that as the password */
 			if (FG(from_address)) {
+				PHP_FTP_CNTRL_CHK(ZSTR_VAL(FG(from_address)), ZSTR_LEN(FG(from_address)), "Invalid password %s")
+
 				php_stream_printf(stream, "PASS %s\r\n", ZSTR_VAL(FG(from_address)));
 			} else {
 				php_stream_write_string(stream, "PASS anonymous\r\n");

--- a/ext/standard/ftp_fopen_wrapper.c
+++ b/ext/standard/ftp_fopen_wrapper.c
@@ -269,6 +269,8 @@ static php_stream *php_ftp_fopen_connect(php_stream_wrapper *wrapper, const char
 			/* if the user has configured who they are,
 			   send that as the password */
 			if (FG(from_address)) {
+				PHP_FTP_CNTRL_CHK(ZSTR_VAL(FG(from_address)), ZSTR_LEN(FG(from_address)), "Invalid from address %s")
+
 				php_stream_printf(stream, "PASS %s\r\n", ZSTR_VAL(FG(from_address)));
 			} else {
 				php_stream_write_string(stream, "PASS anonymous\r\n");

--- a/ext/standard/tests/streams/ftp_from_address_cntrl.phpt
+++ b/ext/standard/tests/streams/ftp_from_address_cntrl.phpt
@@ -1,0 +1,54 @@
+--TEST--
+ftp:// wrapper must reject control characters in the from address sent as the anonymous password
+--SKIPIF--
+<?php
+if (array_search('ftp', stream_get_wrappers()) === false) die("skip ftp wrapper not available.");
+if (!function_exists('pcntl_fork')) die("skip pcntl_fork() not available.");
+?>
+--FILE--
+<?php
+
+$log = tmpfile();
+
+$socket = stream_socket_server("tcp://127.0.0.1:0", $errno, $errstr);
+if (!$socket) {
+    die("server failed\n");
+}
+$name = stream_socket_get_name($socket, false);
+$port = (int) substr($name, strrpos($name, ':') + 1);
+
+$pid = pcntl_fork();
+if ($pid === 0) {
+    pcntl_alarm(60);
+    $s = stream_socket_accept($socket, 10);
+    if (!$s) {
+        exit(1);
+    }
+    fputs($s, "220 ready\r\n");
+    stream_set_timeout($s, 1);
+    $seen = '';
+    while (($buf = fgets($s)) !== false) {
+        $seen .= $buf;
+        if (str_starts_with($buf, 'USER')) {
+            fputs($s, "331 need pass\r\n");
+        } else {
+            fputs($s, "500 no\r\n");
+        }
+    }
+    fwrite($log, $seen);
+    exit(0);
+}
+
+ini_set('from', "evil\r\nSITE INJECT");
+var_dump(@fopen("ftp://127.0.0.1:{$port}/x", "r"));
+pcntl_waitpid($pid, $status);
+
+rewind($log);
+$seen = stream_get_contents($log);
+var_dump(str_contains($seen, 'SITE INJECT'));
+var_dump(str_contains($seen, 'PASS'));
+?>
+--EXPECT--
+bool(false)
+bool(false)
+bool(false)

--- a/ext/standard/tests/streams/ftp_from_address_cntrl.phpt
+++ b/ext/standard/tests/streams/ftp_from_address_cntrl.phpt
@@ -1,0 +1,56 @@
+--TEST--
+ftp:// wrapper must reject control characters in the from address sent as the anonymous password
+--SKIPIF--
+<?php
+if (array_search('ftp', stream_get_wrappers()) === false) die("skip ftp wrapper not available.");
+if (!function_exists('pcntl_fork')) die("skip pcntl_fork() not available.");
+?>
+--FILE--
+<?php
+
+$log = tmpfile();
+
+$socket = stream_socket_server("tcp://127.0.0.1:0", $errno, $errstr);
+if (!$socket) {
+    die("server failed: $errstr\n");
+}
+$name = stream_socket_get_name($socket, false);
+$port = (int) substr($name, strrpos($name, ':') + 1);
+
+$pid = pcntl_fork();
+if ($pid === 0) {
+    pcntl_alarm(60);
+    $s = stream_socket_accept($socket, 10);
+    if (!$s) {
+        exit(1);
+    }
+    stream_set_timeout($s, 1);
+    fputs($s, "220 ready\r\n");
+    $seen = '';
+    while (($buf = fgets($s)) !== false) {
+        $seen .= $buf;
+        if (str_starts_with($buf, 'USER')) {
+            fputs($s, "331 need pass\r\n");
+        } else {
+            fputs($s, "500 no\r\n");
+        }
+    }
+    fwrite($log, $seen);
+    exit(0);
+}
+
+ini_set('from', "evil\r\nSITE INJECT");
+var_dump(@fopen("ftp://127.0.0.1:{$port}/x", "r"));
+pcntl_waitpid($pid, $status);
+
+rewind($log);
+$seen = stream_get_contents($log);
+var_dump(str_contains($seen, 'SITE INJECT'));
+var_dump(str_contains($seen, 'PASS'));
+var_dump(str_contains($seen, 'USER'));
+?>
+--EXPECT--
+bool(false)
+bool(false)
+bool(false)
+bool(true)


### PR DESCRIPTION
GH-17976 sanitized `from` and `user_agent` at the HTTP wrapper's header-emit point and deferred the FTP wrapper. `php_ftp_fopen_connect()` still sends `FG(from_address)` as the anonymous password unchecked, so with `ini_set('from', "evil\r\nSITE INJECT")` the server receives a literal SITE INJECT on the control channel. The URL-supplied-password branch a few lines above already calls PHP_FTP_CNTRL_CHK; this uses the same macro over ZSTR_LEN, so the two branches now read identically.
