### PR TITLE
ext/sockets: Fix socket_set_option() validation error messages

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,10 @@ PHP                                                                        NEWS
 - Date:
   . Fixed leak on double DatePeriod::__construct() call. (ilutov)
 
+- Sockets:
+  . Fixed socket_set_option() validation error messages for UDP_SEGMENT and
+    SO_LINGER options. (Weilin Du)
+
 30 Jul 2026, PHP 8.5.9
 
 - Core:

--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -2168,7 +2168,7 @@ PHP_FUNCTION(socket_set_option)
 			}
 
 			if (val_linger < 0 || val_linger > USHRT_MAX) {
-				zend_argument_value_error(4, "\"%s\" must be between 0 and %d", l_linger, USHRT_MAX);
+				zend_argument_value_error(4, "\"%s\" must be between 0 and %u", l_linger_key, USHRT_MAX);
 				RETURN_THROWS();
 			}
 
@@ -2332,8 +2332,8 @@ PHP_FUNCTION(socket_set_option)
 
 			// UDP segmentation offload maximum size or 0 to disable it
 			if (ov < 0 || ov > USHRT_MAX) {
-				zend_argument_value_error(4, "must be of between 0 and %u", USHRT_MAX);
-				RETURN_FALSE;
+				zend_argument_value_error(4, "must be between 0 and %u", USHRT_MAX);
+				RETURN_THROWS();
 			}
 
 			optlen = sizeof(ov);

--- a/ext/sockets/tests/socket_cmsg_udp_segment.phpt
+++ b/ext/sockets/tests/socket_cmsg_udp_segment.phpt
@@ -22,5 +22,5 @@ try {
 }
 ?>
 --EXPECT--
-socket_setopt(): Argument #4 ($value) must be of between 0 and 65535
-socket_setopt(): Argument #4 ($value) must be of between 0 and 65535
+socket_setopt(): Argument #4 ($value) must be between 0 and 65535
+socket_setopt(): Argument #4 ($value) must be between 0 and 65535

--- a/ext/sockets/tests/socket_set_option_timeo_error.phpt
+++ b/ext/sockets/tests/socket_set_option_timeo_error.phpt
@@ -13,6 +13,7 @@ $options_2 = array("sec" => new stdClass(), "usec" => "1");
 $options_3 = array("l_onoff" => "aaaa", "l_linger" => "1");
 $options_4 = array("l_onoff" => "1", "l_linger" => []);
 $options_5 = array("l_onoff" => PHP_INT_MAX, "l_linger" => "1");
+$options_6 = array("l_onoff" => "1", "l_linger" => PHP_INT_MAX);
 
 try {
 	socket_set_option( $socket, SOL_SOCKET, SO_RCVTIMEO, new stdClass);
@@ -56,6 +57,11 @@ try {
 } catch (\ValueError $e) {
 	echo $e->getMessage() . PHP_EOL;
 }
+try {
+	socket_set_option( $socket, SOL_SOCKET, SO_LINGER, $options_6);
+} catch (\ValueError $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
 ?>
 --EXPECTF--
 socket_set_option(): Argument #4 ($value) must have key "sec"
@@ -64,3 +70,4 @@ Warning: Object of class stdClass could not be converted to int in %s on line %d
 socket_set_option(): Argument #4 ($value) must be of type array when argument #3 ($option) is SO_RCVTIMEO, string given
 socket_set_option(): Argument #4 ($value) must be of type array when argument #3 ($option) is SO_LINGER, string given
 socket_set_option(): Argument #4 ($value) "l_onoff" must be between 0 and %d
+socket_set_option(): Argument #4 ($value) "l_linger" must be between 0 and %d


### PR DESCRIPTION
Fix a few incorrect socket_set_option() validation error messages.
```
must be of between 0 and 65535
```
to
```
must be between 0 and 65535
```
and several other changes.