### PR TITLE
ext/sockets: run the AF_PACKET error test in isolation

### DIFF
--- a/ext/sockets/tests/socket_sendto_recvfrom_afpacket_errors.phpt
+++ b/ext/sockets/tests/socket_sendto_recvfrom_afpacket_errors.phpt
@@ -15,6 +15,8 @@ if (!function_exists("posix_getuid") || posix_getuid() != 0) {
     die('SKIP AF_PACKET requires root permissions.');
 }
 ?>
+--CONFLICTS--
+all
 --FILE--
 <?php
 


### PR DESCRIPTION
The no-data case does this:

    $s = socket_create(AF_PACKET, SOCK_RAW, ETH_P_ALL);
    socket_bind($s, 'lo');
    socket_set_nonblock($s);
    $ret = @socket_recvfrom($s, $buf, 65536, 0, $addr);
    var_dump($ret === false);   // asserts nothing is on lo

An ETH_P_ALL socket bound to lo captures every loopback frame, so that assertion holds only while no other test talks to localhost. run-tests spawns workers in parallel and the job runs as root (the SKIPIF requires it), so a concurrent test doing HTTP on 127.0.0.1, or a mysqli connect over TCP, makes recvfrom() return a frame and the assert flips. Seen on LINUX_X32_DEBUG_ZTS as `bool(false)` where `bool(true)` was expected, with the other three cases in the file passing.

`--CONFLICTS-- all` is what ext/tidy/tests/parsing_file_too_large.phpt already uses for a test that cannot share the machine.

One caveat worth stating: the race is rare, so a green CI run here does not prove the fix, it just fails to disprove it. The argument is that the assertion is unsound under any concurrency and this removes the concurrency.
