### PR TITLE
ext/sqlite3: reject NUL bytes in SQLite3::escapeString()

### DIFF
--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -469,7 +469,7 @@ PHP_METHOD(SQLite3, escapeString)
 	zend_string *sql;
 	char *ret;
 
-	if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "S", &sql)) {
+	if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "P", &sql)) {
 		RETURN_THROWS();
 	}
 

--- a/ext/sqlite3/tests/gh_sqlite3_escapestring_nul.phpt
+++ b/ext/sqlite3/tests/gh_sqlite3_escapestring_nul.phpt
@@ -1,0 +1,35 @@
+--TEST--
+SQLite3::escapeString() rejects strings with embedded NUL bytes
+--EXTENSIONS--
+sqlite3
+--FILE--
+<?php
+
+$cases = [
+    "\0",
+    "a\0b",
+    "secret\0x",
+    "foo\0\0bar",
+];
+
+foreach ($cases as $in) {
+    try {
+        SQLite3::escapeString($in);
+        echo "FAIL: no exception for ", bin2hex($in), "\n";
+    } catch (ValueError $e) {
+        echo "ValueError: ", $e->getMessage(), "\n";
+    }
+}
+
+echo "ok: ", SQLite3::escapeString("ok"), "\n";
+echo "quote: ", SQLite3::escapeString("test''%"), "\n";
+echo "empty: ", var_export(SQLite3::escapeString(""), true), "\n";
+?>
+--EXPECT--
+ValueError: SQLite3::escapeString(): Argument #1 ($string) must not contain any null bytes
+ValueError: SQLite3::escapeString(): Argument #1 ($string) must not contain any null bytes
+ValueError: SQLite3::escapeString(): Argument #1 ($string) must not contain any null bytes
+ValueError: SQLite3::escapeString(): Argument #1 ($string) must not contain any null bytes
+ok: ok
+quote: test''''%
+empty: ''


### PR DESCRIPTION
`SQLite3::escapeString()` builds its result with `sqlite3_mprintf("%q")`, which stops at the first C NUL. PHP strings carry a length and may embed NULs, so `"a\0b"` came back as `"a"` and any SQL built from it silently lost everything after the NUL. Prepared binds pass an explicit length and are unaffected.

`ext/pdo_sqlite` rejected the same inputs for `PDO::quote` in 0a10f6db268 (GH-13952), landing on 8.5 and up rather than 8.4. That check consults `dbh->error_mode` and throws a PDOException, warns, or returns NULL; `escapeString()` is static, so there is no connection to consult and a ValueError is the only option available to it.

Targeting master because rejecting an input that previously returned a truncated string is a behaviour change, and 0a10f6db268 kept the same change off 8.4.
