### PR TITLE
ext/dba: bound CDB record lengths against the file size

### DIFF
--- a/ext/dba/dba_cdb.c
+++ b/ext/dba/dba_cdb.c
@@ -54,6 +54,7 @@ typedef struct {
 #endif
 	uint32 eod; /* size of constant database */
 	uint32 pos; /* current position for traversing */
+	size_t file_size;
 } dba_cdb;
 
 DBA_OPEN_FUNC(cdb)
@@ -110,6 +111,22 @@ DBA_OPEN_FUNC(cdb)
 #endif
 	cdb->file = file;
 
+#ifdef DBA_CDB_BUILTIN
+	if (!make) {
+		php_stream_statbuf ssb;
+		if (php_stream_stat(file, &ssb) == 0 && ssb.sb.st_size > 0) {
+			cdb->file_size = ssb.sb.st_size;
+		}
+	}
+#else
+	{
+		zend_stat_t sb;
+		if (zend_fstat(file, &sb) == 0 && sb.st_size > 0) {
+			cdb->file_size = sb.st_size;
+		}
+	}
+#endif
+
 	pinfo->dbf = cdb;
 	return SUCCESS;
 }
@@ -159,6 +176,9 @@ DBA_FETCH_FUNC(cdb)
 			}
 		}
 		len = cdb_datalen(&cdb->c);
+		if (len > cdb->file_size) {
+			return NULL;
+		}
 		fetched_val = zend_string_alloc(len, /* persistent */ false);
 
 		if (php_cdb_read(&cdb->c, ZSTR_VAL(fetched_val), len, cdb_datapos(&cdb->c)) == -1) {
@@ -262,6 +282,10 @@ DBA_FIRSTKEY_FUNC(cdb)
 	uint32_unpack(buf, &klen);
 	uint32_unpack(buf + 4, &dlen);
 
+	if (klen > cdb->file_size) {
+		return NULL;
+	}
+
 	key = zend_string_alloc(klen, /* persistent */ false);
 	if (cdb_file_read(cdb->file, ZSTR_VAL(key), klen) < klen) {
 		zend_string_release_ex(key, /* persistent */ false);
@@ -292,6 +316,10 @@ DBA_NEXTKEY_FUNC(cdb)
 	CREAD(8);
 	uint32_unpack(buf, &klen);
 	uint32_unpack(buf + 4, &dlen);
+
+	if (klen > cdb->file_size) {
+		return NULL;
+	}
 
 	key = zend_string_alloc(klen, /* persistent */ false);
 	if (cdb_file_read(cdb->file, ZSTR_VAL(key), klen) < klen) {

--- a/ext/dba/tests/dba_cdb_oob.phpt
+++ b/ext/dba/tests/dba_cdb_oob.phpt
@@ -1,0 +1,35 @@
+--TEST--
+DBA CDB handler bounds a record length that exceeds the file
+--EXTENSIONS--
+dba
+--SKIPIF--
+<?php
+require_once __DIR__ . '/setup/setup_dba_tests.inc';
+check_skip('cdb');
+?>
+--FILE--
+<?php
+$db_file = __DIR__ . '/dba_cdb_oob.db';
+
+// 2048-byte hash-table header, then a first record whose key-length field is
+// 0xFFFFFFFF. That length drove zend_string_alloc() directly; on 32-bit it
+// wrapped the struct size to a few bytes while the read copied the trailing
+// data past it. eod (bytes 0-3) must exceed 2048 so the record is reached.
+$buf = str_repeat("\0", 2048 + 8);
+$buf[0] = "\x00"; $buf[1] = "\x00"; $buf[2] = "\x10"; $buf[3] = "\x00"; // eod = 1 MiB
+$buf[2048] = "\xff"; $buf[2049] = "\xff"; $buf[2050] = "\xff"; $buf[2051] = "\xff"; // klen
+$buf .= str_repeat("A", 8192);
+file_put_contents($db_file, $buf);
+
+$db = dba_open($db_file, 'r', 'cdb');
+var_dump(dba_firstkey($db));
+dba_close($db);
+echo "done\n";
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/dba_cdb_oob.db');
+?>
+--EXPECT--
+bool(false)
+done


### PR DESCRIPTION
The cdb handler read the 32-bit key and data length fields from the file and passed them directly to zend_string_alloc(). On 32-bit a length near UINT32_MAX wraps the struct size to a few bytes while the following read copies the trailing file bytes past that allocation, a heap overflow reachable by opening a crafted .cdb (64-bit only OOMs). Capture the file size at open and reject any record length that exceeds it, in firstkey, nextkey and fetch. Reproducer: a 2048-byte header with a first-record key length of 0xFFFFFFFF plus trailing bytes segfaults dba_firstkey() on 32-bit.

