### PR TITLE
Fix GH-22779: mb_strrpos() wrong result in a non-UTF-8 encoding

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,10 @@ PHP                                                                        NEWS
 - Date:
   . Fixed leak on double DatePeriod::__construct() call. (ilutov)
 
+- MBString:
+  . Fixed bug GH-22779 (mb_strrpos() returns the wrong position for a negative
+    offset in a non-UTF-8 encoding). (Eyüp Can Akman)
+
 30 Jul 2026, PHP 8.4.24
 
 - Calendar:

--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -1931,7 +1931,7 @@ static size_t mb_find_strpos(zend_string *haystack, zend_string *needle, const m
 	} else if (offset >= 0) {
 		found_pos = zend_memnrstr((const char*)offset_pointer, ZSTR_VAL(needle_u8), ZSTR_LEN(needle_u8), ZSTR_VAL(haystack_u8) + ZSTR_LEN(haystack_u8));
 	} else {
-		size_t needle_len = pointer_to_offset_utf8((unsigned char*)ZSTR_VAL(needle), (unsigned char*)ZSTR_VAL(needle) + ZSTR_LEN(needle));
+		size_t needle_len = pointer_to_offset_utf8((unsigned char*)ZSTR_VAL(needle_u8), (unsigned char*)ZSTR_VAL(needle_u8) + ZSTR_LEN(needle_u8));
 		offset_pointer = offset_to_pointer_utf8(offset_pointer, (unsigned char*)ZSTR_VAL(haystack_u8) + ZSTR_LEN(haystack_u8), needle_len);
 		if (!offset_pointer) {
 			offset_pointer = (unsigned char*)ZSTR_VAL(haystack_u8) + ZSTR_LEN(haystack_u8);

--- a/ext/mbstring/tests/gh22779.phpt
+++ b/ext/mbstring/tests/gh22779.phpt
@@ -1,0 +1,34 @@
+--TEST--
+GH-22779: mb_strrpos() wrong result for a negative offset in a non-UTF-8 encoding
+--EXTENSIONS--
+mbstring
+--FILE--
+<?php
+/* mb_strrpos() with a negative offset must return the correct position in non-UTF-8 encodings. */
+$haystack = "\xA9\xA9X";
+$needle = "\xA9";
+foreach ([-1, -2, -3] as $offset) {
+    var_dump(mb_strrpos($haystack, $needle, $offset, 'ISO-8859-1'));
+}
+var_dump(mb_strrpos("X\xA9", "\xA9", -1, 'ISO-8859-1'));
+var_dump(mb_strrpos("\x95Z\x95Z", "\x95", -1, 'Windows-1252'));
+var_dump(mb_strrpos("\x95Z\x95Z", "\x95", -2, 'Windows-1252'));
+// Two-byte needle in a single-byte encoding.
+var_dump(mb_strrpos("\xA9\xB0\xA9\xB0Z", "\xA9\xB0", -2, 'ISO-8859-1'));
+// Multibyte: "ああA" in Shift_JIS, needle "あ" (\x82\xA0).
+var_dump(mb_strrpos("\x82\xA0\x82\xA0A", "\x82\xA0", -2, 'SJIS'));
+var_dump(mb_strrpos("\x82\xA0\x82\xA0A", "\x82\xA0", -3, 'SJIS'));
+// UTF-16: an ASCII needle miscounts the other way.
+var_dump(mb_strrpos("\x00A\x00X\x00A", "\x00A", -2, 'UTF-16BE'));
+?>
+--EXPECT--
+int(1)
+int(1)
+int(0)
+int(1)
+int(2)
+int(2)
+int(2)
+int(1)
+int(0)
+int(0)


### PR DESCRIPTION
`mb_strrpos()` with a negative offset returns the wrong position (or `false`) when the encoding is not UTF-8. `mb_find_strpos()` converts the haystack and needle to UTF-8 and does its length math on the converted strings, but the negative-offset branch measured the needle length from the raw `needle`. `mb_fast_strlen_utf8()` counts those bytes as UTF-8, so the length is wrong when the source bytes are not their own UTF-8 form. A byte in 0x80-0xBF makes it too low and an ASCII needle in UTF-16 makes it too high, shifting the reverse-search window.

The fix measures the length from `needle_u8`. The test covers ISO-8859-1, Windows-1252, Shift_JIS and UTF-16.

Fixes GH-22779
