### PR TITLE
Fix double-free of closure run_time_cache in partial application

### DIFF
--- a/Zend/tests/partial_application/closure_rt_cache_lifetime.phpt
+++ b/Zend/tests/partial_application/closure_rt_cache_lifetime.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Partial application over a Closure::fromCallable() must not double-free the run_time_cache
+--FILE--
+<?php
+class C {
+    public function m($x, $y) { return $x + $y; }
+}
+
+$cl = Closure::fromCallable([new C, 'm']);
+$partial = $cl(10, ?);
+var_dump($partial(5));
+unset($partial);
+unset($cl);
+gc_collect_cycles();
+echo "OK\n";
+?>
+--EXPECT--
+int(15)
+OK

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -2146,8 +2146,7 @@ zend_op_array *zend_accel_compile_pfa(zend_ast *ast,
 			 * See comment in zend_accel_pfa_key(). */
 			zend_op_array *copy = zend_arena_alloc(&CG(arena), sizeof(*copy));
 			memcpy(copy, called_function, sizeof(*copy));
-			zend_string_addref(copy->function_name);
-			(*copy->refcount)++;
+			function_add_ref((zend_function *) copy);
 			/* Reference the copy in op_array->dynamic_func_defs so that it's
 			 * destroyed when op_array is destroyed. */
 			ZEND_ASSERT(!op_array->dynamic_func_defs && !op_array->num_dynamic_func_defs);


### PR DESCRIPTION
A partial built over a closure whose op_array is not persistent (created in eval() or via the CLI -r path, or when opcache is not caching the declaring script) makes zend_accel_compile_pfa shallow-copy the closure op_array into the per-request PFA cache as a lifetime anchor. The copy inherited ZEND_ACC_HEAP_RT_CACHE and the run_time_cache pointer, so destroy_op_array freed the shared run_time_cache twice: once when the closure was released and again at PFA cache teardown, corrupting the heap. Use function_add_ref() on the copy, the canonical shallow-copy refcount helper, which resets the per-request run_time_cache and static_variables_ptr map pointers so only the live closure owns and frees the cache.

Reproducer, invalid free under valgrind (USE_ZEND_ALLOC=0) before the fix, clean after:

php -d opcache.enable_cli=1 -r 'class C { function m($x,$y){ return $x+$y; } } $cl = Closure::fromCallable([new C,"m"]); $pc = $cl(10,?); var_dump($pc(5));'
