### PR TITLE
ext/gmp: Fix GMP accepting integer strings with NUL bytes

### DIFF
--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -644,6 +644,15 @@ static zend_result convert_zstr_to_gmp(mpz_t gmp_number, const zend_string *val,
 	const char *num_str = ZSTR_VAL(val);
 	bool skip_lead = false;
 
+	if (UNEXPECTED(zend_str_has_nul_byte(val))) {
+		if (arg_pos == 0) {
+			zend_value_error("Number is not an integer string");
+		} else {
+			zend_argument_value_error(arg_pos, "is not an integer string");
+		}
+		return FAILURE;
+	}
+
 	size_t num_len = ZSTR_LEN(val);
 	while (isspace((unsigned char)*num_str)) {
 		++num_str;

--- a/ext/gmp/tests/gmp_null_bytes.phpt
+++ b/ext/gmp/tests/gmp_null_bytes.phpt
@@ -1,0 +1,28 @@
+--TEST--
+GMP rejects integer strings containing null bytes
+--EXTENSIONS--
+gmp
+--FILE--
+<?php
+
+$tests = [
+    'gmp_init' => fn() => gmp_init("123\0abc"),
+    'gmp_init prefix' => fn() => gmp_init("0x10\0ff"),
+    'gmp_add' => fn() => gmp_add("123\0abc", 1),
+    'constructor' => fn() => new GMP("123\0abc"),
+];
+
+foreach ($tests as $label => $test) {
+    try {
+        $test();
+    } catch (ValueError $e) {
+        echo $label, ": ", $e->getMessage(), PHP_EOL;
+    }
+}
+
+?>
+--EXPECT--
+gmp_init: gmp_init(): Argument #1 ($num) is not an integer string
+gmp_init prefix: gmp_init(): Argument #1 ($num) is not an integer string
+gmp_add: gmp_add(): Argument #1 ($num1) is not an integer string
+constructor: GMP::__construct(): Argument #1 ($num) is not an integer string


### PR DESCRIPTION
```php
<?php
var_dump(gmp_strval(gmp_init("123\0abc")));
```
```
string(3) "123"
```
The logic of dealing with argument position is copied from 
https://github.com/php/php-src/blob/e3de8edbaef4fdd97d7f377ecf6322ee23c46d20/ext/gmp/gmp.c#L667-L675