### PR TITLE
ext/opcache: zend_jit_resolve_tsrm_ls_cache_offsets() TEXTREL from ba…

### DIFF
--- a/ext/opcache/jit/tls/zend_jit_tls_x86_64.c
+++ b/ext/opcache/jit/tls/zend_jit_tls_x86_64.c
@@ -102,7 +102,7 @@ zend_result zend_jit_resolve_tsrm_ls_cache_offsets(
 		"leaq   _tsrm_ls_cache@tlsgd(%%rip), %%rdi\n"
 		".word  0x6666\n"
 		"rex64\n"
-		"call   __tls_get_addr\n"
+		"call   __tls_get_addr@PLT\n"
 		/* Load thread pointer address */
 		"movq   %%fs:0, %%rsi\n"
 		: "=a" (addr), "=b" (code), "=S" (thread_pointer)


### PR DESCRIPTION
…re __tls_get_addr call.

Fix GH-22693

The x86_64 General Dynamic TLS sequence called __tls_get_addr without @PLT, which could emit a PC-relative relocation against the external symbol landing in read-only .text, producing a DT_TEXTREL and a linker warning about a possible runtime segfault. Routing the call through the PLT matches the x86-64 TLS ABI canonical sequence and the already correct i386 variant, without changing the emitted instruction bytes.