### PR TITLE
Free pending named positions on partial-argument compile errors

### DIFF
--- a/Zend/tests/partial_application/compile_errors_007.phpt
+++ b/Zend/tests/partial_application/compile_errors_007.phpt
@@ -1,0 +1,14 @@
+--TEST--
+PFA compile errors: positional after a named placeholder frees pending named positions
+--DESCRIPTION--
+A named placeholder allocates the named-positions table; a following
+positional placeholder is a compile error. The table must not leak on
+that bailout. The leak is only visible under valgrind/ASAN; this test
+exercises the path so CI catches a regression.
+--FILE--
+<?php
+function foo($a, $b) {}
+$p = foo(b: ?, ?);
+?>
+--EXPECTF--
+Fatal error: Cannot use positional argument after named argument in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -3775,6 +3775,14 @@ static uint32_t zend_get_arg_num(const zend_function *fn, const zend_string *arg
 	return (uint32_t) -1;
 }
 
+static zend_always_inline void zend_free_pending_named_positions(zval *named_positions)
+{
+	if (named_positions != NULL && !Z_ISUNDEF_P(named_positions)) {
+		zend_array_destroy(Z_ARRVAL_P(named_positions));
+		ZVAL_UNDEF(named_positions);
+	}
+}
+
 static uint32_t zend_compile_args_ex(
 		zend_ast *ast, const zend_function *fbc,
 		bool *may_have_extra_named_args,
@@ -3806,6 +3814,7 @@ static uint32_t zend_compile_args_ex(
 
 		if (arg->kind == ZEND_AST_UNPACK) {
 			if (uses_named_args) {
+				zend_free_pending_named_positions(named_positions);
 				zend_error_noreturn(E_COMPILE_ERROR,
 					"Cannot use argument unpacking after named arguments");
 			}
@@ -3857,6 +3866,7 @@ static uint32_t zend_compile_args_ex(
 			}
 
 			if (uses_variadic_placeholder) {
+				zend_free_pending_named_positions(named_positions);
 				zend_error_noreturn(E_COMPILE_ERROR,
 					"Variadic placeholder must be last");
 			}
@@ -3870,12 +3880,14 @@ static uint32_t zend_compile_args_ex(
 				&& arg->attr == ZEND_PLACEHOLDER_VARIADIC;
 
 			if (uses_named_args && !is_variadic_placeholder) {
+				zend_free_pending_named_positions(named_positions);
 				zend_error_noreturn(E_COMPILE_ERROR,
 					"Cannot use positional argument after named argument");
 			}
 
 			if (uses_variadic_placeholder) {
 				if (is_variadic_placeholder) {
+					zend_free_pending_named_positions(named_positions);
 					zend_error_noreturn(E_COMPILE_ERROR,
 						"Variadic placeholder may only appear once");
 				} else {


### PR DESCRIPTION
A partial application that uses a named placeholder (`foo(x: ?, ...)`) lazily allocates a named-positions table in `zend_compile_args_ex`, consumed only after argument compilation succeeds. A following argument that is itself a compile error (a positional or unpack after the named placeholder, or a misplaced variadic placeholder) `longjmp`s out of the function before the table is consumed and leaks it.

This frees the table before the four reachable errors. The leak is on a `zend_bailout` path, so ZEND_MM's leak reporter never sees it; it shows only under valgrind/ASAN. Verified with `USE_ZEND_ALLOC=0 valgrind`: 376 bytes to 0 on `foo(x: ?, ?)`, and 0 on the unpack, named-after-variadic, and variadic-twice variants. The added test exercises the path for CI valgrind; the error output is identical before and after, so it is a path check, not an output red/green.

