### PR TITLE
stream: registering cannot fail, thus voidify function

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -2311,10 +2311,7 @@ zend_result php_module_startup(sapi_module_struct *sf, zend_module_entry *additi
 	/* initialize stream wrappers registry
 	 * (this uses configuration parameters from php.ini)
 	 */
-	if (php_init_stream_wrappers(module_number) == FAILURE)	{
-		fprintf(stderr, "PHP:  Unable to initialize stream url wrappers.\n");
-		return FAILURE;
-	}
+	php_init_stream_wrappers(module_number);
 
 	zuv.html_errors = 1;
 	php_startup_auto_globals();

--- a/main/php_streams.h
+++ b/main/php_streams.h
@@ -629,7 +629,7 @@ END_EXTERN_C()
 /* this flag is only used by include/require functions */
 #define STREAM_OPEN_FOR_ZEND_STREAM     0x00010000
 
-zend_result php_init_stream_wrappers(int module_number);
+void php_init_stream_wrappers(int module_number);
 void php_shutdown_stream_wrappers(int module_number);
 void php_shutdown_stream_hashes(void);
 PHP_RSHUTDOWN_FUNCTION(streams);

--- a/main/streams/php_stream_transport.h
+++ b/main/streams/php_stream_transport.h
@@ -29,8 +29,8 @@ typedef php_stream *(php_stream_transport_factory_func)(const char *proto, size_
 typedef php_stream_transport_factory_func *php_stream_transport_factory;
 
 BEGIN_EXTERN_C()
-PHPAPI int php_stream_xport_register(const char *protocol, php_stream_transport_factory factory);
-PHPAPI int php_stream_xport_unregister(const char *protocol);
+PHPAPI void php_stream_xport_register(const char *protocol, php_stream_transport_factory factory);
+PHPAPI zend_result php_stream_xport_unregister(const char *protocol);
 
 #define STREAM_XPORT_CLIENT			0
 #define STREAM_XPORT_SERVER			1

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -1739,7 +1739,7 @@ void php_shutdown_stream_hashes(void)
 	php_stream_error_state_cleanup();
 }
 
-zend_result php_init_stream_wrappers(int module_number)
+void php_init_stream_wrappers(int module_number)
 {
 	le_stream = zend_register_list_destructors_ex(stream_resource_regular_dtor, NULL, "stream", module_number);
 	le_pstream = zend_register_list_destructors_ex(NULL, stream_resource_persistent_dtor, "persistent stream", module_number);
@@ -1751,16 +1751,12 @@ zend_result php_init_stream_wrappers(int module_number)
 	zend_hash_init(php_get_stream_filters_hash_global(), 8, NULL, NULL, 1);
 	zend_hash_init(php_stream_xport_get_hash(), 8, NULL, NULL, 1);
 
-	return (php_stream_xport_register("tcp", php_stream_generic_socket_factory) == SUCCESS
-			&&
-			php_stream_xport_register("udp", php_stream_generic_socket_factory) == SUCCESS
+	php_stream_xport_register("tcp", php_stream_generic_socket_factory);
+	php_stream_xport_register("udp", php_stream_generic_socket_factory);
 #if defined(AF_UNIX) && !(defined(PHP_WIN32) || defined(__riscos__))
-			&&
-			php_stream_xport_register("unix", php_stream_generic_socket_factory) == SUCCESS
-			&&
-			php_stream_xport_register("udg", php_stream_generic_socket_factory) == SUCCESS
+	php_stream_xport_register("unix", php_stream_generic_socket_factory);
+	php_stream_xport_register("udg", php_stream_generic_socket_factory);
 #endif
-		) ? SUCCESS : FAILURE;
 }
 
 void php_shutdown_stream_wrappers(int module_number)

--- a/main/streams/transports.c
+++ b/main/streams/transports.c
@@ -14,7 +14,7 @@
 
 #include "php.h"
 #include "php_streams_int.h"
-#include "ext/standard/file.h"
+#include "ext/standard/file.h" /* For FG(default_socket_timeout) */
 
 static HashTable xport_hash;
 
@@ -23,16 +23,15 @@ PHPAPI HashTable *php_stream_xport_get_hash(void)
 	return &xport_hash;
 }
 
-PHPAPI int php_stream_xport_register(const char *protocol, php_stream_transport_factory factory)
+PHPAPI void php_stream_xport_register(const char *protocol, php_stream_transport_factory factory)
 {
-	zend_string *str = zend_string_init_interned(protocol, strlen(protocol), 1);
+	zend_string *str = zend_string_init_interned(protocol, strlen(protocol), true);
 
 	zend_hash_update_ptr(&xport_hash, str, factory);
-	zend_string_release_ex(str, 1);
-	return SUCCESS;
+	zend_string_release_ex(str, true);
 }
 
-PHPAPI int php_stream_xport_unregister(const char *protocol)
+PHPAPI zend_result php_stream_xport_unregister(const char *protocol)
 {
 	return zend_hash_str_del(&xport_hash, protocol, strlen(protocol));
 }


### PR DESCRIPTION
Propagate changes up which means we can also voidify php_init_stream_wrappers() removing an if() check during startup.