### PR TITLE
poll: fetch method ptr directly

### DIFF
--- a/main/poll/poll_handle.c
+++ b/main/poll/poll_handle.c
@@ -20,13 +20,14 @@ static php_socket_t php_poll_handle_default_get_fd(php_poll_handle_object *handl
 {
 	zval retval;
 
-	zend_function *method = zend_hash_str_find_ptr_lc(&handle->std.ce->function_table, ZEND_STRL("getFileDescriptor"));
+	/* Grab getFileDescriptor() method pointer which is stored in lowercase in the function table */
+	zend_function *method = zend_hash_str_find_ptr_lc(&handle->std.ce->function_table, ZEND_STRL("getfiledescriptor"));
 	ZEND_ASSERT(method && "no default method???");
 
 	/* Call getFileDescriptor() method */
 	zend_call_known_function(method, &handle->std, handle->std.ce, &retval, 0, NULL, NULL);
 
-
+	/* No need to deref the return value as the class is final and thus the method cannot be changed to return by-ref */
 	if (EXPECTED(Z_TYPE(retval) == IS_LONG)) {
 		php_socket_t fd = Z_LVAL(retval) < 0 ? SOCK_ERR : (php_socket_t) Z_LVAL(retval);
 		/* No need to clean the retval as we know it is an integer, and thus it's just on the stack */

--- a/main/poll/poll_handle.c
+++ b/main/poll/poll_handle.c
@@ -19,26 +19,21 @@
 static php_socket_t php_poll_handle_default_get_fd(php_poll_handle_object *handle)
 {
 	zval retval;
-	zval obj;
-	zval func_name;
 
-	ZVAL_OBJ(&obj, &handle->std);
-
-	/* Prepare function name as zval */
-	ZVAL_STRING(&func_name, "getFileDescriptor");
+	zend_function *method = zend_hash_str_find_ptr_lc(&handle->std.ce->function_table, ZEND_STRL("getFileDescriptor"));
+	ZEND_ASSERT(method && "no default method???");
 
 	/* Call getFileDescriptor() method */
-	if (EXPECTED(call_user_function(NULL, &obj, &func_name, &retval, 0, NULL) == SUCCESS)) {
-		if (Z_TYPE(retval) == IS_LONG) {
-			php_socket_t fd = Z_LVAL(retval) < 0 ? SOCK_ERR : (php_socket_t) Z_LVAL(retval);
-			zval_ptr_dtor(&retval);
-			zval_ptr_dtor(&func_name); /* Clean up function name */
-			return fd;
-		}
-		zval_ptr_dtor(&retval);
+	zend_call_known_function(method, &handle->std, handle->std.ce, &retval, 0, NULL, NULL);
+
+
+	if (EXPECTED(Z_TYPE(retval) == IS_LONG)) {
+		php_socket_t fd = Z_LVAL(retval) < 0 ? SOCK_ERR : (php_socket_t) Z_LVAL(retval);
+		/* No need to clean the retval as we know it is an integer, and thus it's just on the stack */
+		return fd;
 	}
 
-	zval_ptr_dtor(&func_name); /* Clean up function name */
+	zval_ptr_dtor(&retval);
 	return SOCK_ERR; /* Invalid socket */
 }
 


### PR DESCRIPTION
Rather than going through a whole callability check via call_user_function() we can grab the known method pointer and call it directly.

This removes some allocations