### PR TITLE
ext/date: guard property-table reads in php_date_interval_initialize_from_hash()

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -4733,7 +4733,7 @@ static void php_date_interval_initialize_from_hash(php_interval_obj *intobj, con
 	PHP_DATE_INTERVAL_READ_PROPERTY("s", s, timelib_sll, -1)
 	{
 		const zval *z_arg = zend_hash_str_find(myht, "f", sizeof("f") - 1);
-		if (z_arg) {
+		if (z_arg && Z_TYPE_P(z_arg) <= IS_STRING) {
 			intobj->diff->us = zend_dval_to_lval(zval_get_double(z_arg) * 1000000.0);
 		}
 	}
@@ -4749,7 +4749,7 @@ static void php_date_interval_initialize_from_hash(php_interval_obj *intobj, con
 	{
 		const zval *z_arg = zend_hash_str_find(myht, "civil_or_wall", sizeof("civil_or_wall") - 1);
 		intobj->civil_or_wall = PHP_DATE_CIVIL;
-		if (z_arg) {
+		if (z_arg && Z_TYPE_P(z_arg) <= IS_STRING) {
 			zend_long val = zval_get_long(z_arg);
 			intobj->civil_or_wall = val;
 		}

--- a/ext/date/tests/date_interval_wakeup_declared_property.phpt
+++ b/ext/date/tests/date_interval_wakeup_declared_property.phpt
@@ -1,0 +1,41 @@
+--TEST--
+DateInterval::__wakeup() must not pass raw property-table zvals to zval_get_double()/zval_get_long()
+--FILE--
+<?php
+error_reporting(E_ALL & ~E_DEPRECATED);
+
+/* date_object_get_properties_interval() returns the object's raw property table
+ * when the interval is not initialized. Declared properties are IS_INDIRECT in
+ * that table, which the conversion helpers do not accept. */
+
+class DeclaredInitialized extends DateInterval { public float $f = 1.5; }
+class DeclaredUninitialized extends DateInterval { public float $f; }
+class DeclaredCivilOrWall extends DateInterval { public int $civil_or_wall = 1; }
+#[AllowDynamicProperties] class Dynamic extends DateInterval {}
+
+foreach (['DeclaredInitialized', 'DeclaredUninitialized', 'DeclaredCivilOrWall'] as $cls) {
+    $o = (new ReflectionClass($cls))->newInstanceWithoutConstructor();
+    $o->__wakeup();
+    echo $cls, ": ok\n";
+}
+
+/* A dynamic property is a plain zval, so it is still read normally. */
+$o = (new ReflectionClass('Dynamic'))->newInstanceWithoutConstructor();
+$o->f = 0.25;
+$o->__wakeup();
+echo "Dynamic: ", $o->f, "\n";
+
+/* The normal round-trip is unaffected. */
+$i = new DateInterval('PT1S');
+$i->f = 0.5;
+$restored = unserialize(serialize($i));
+echo "roundtrip f: ", $restored->f, "\n";
+echo "roundtrip s: ", $restored->s, "\n";
+?>
+--EXPECT--
+DeclaredInitialized: ok
+DeclaredUninitialized: ok
+DeclaredCivilOrWall: ok
+Dynamic: 0.25
+roundtrip f: 0.5
+roundtrip s: 1


### PR DESCRIPTION
### Problem

`php_date_interval_initialize_from_hash()` reads the interval fields out of a `HashTable`
that, for an uninitialized `DateInterval`, is the object's **raw property table**:
`date_object_get_properties_interval()` returns `zend_std_get_properties()` unchanged when
`!intervalobj->initialized`.

A raw property table stores declared properties as `IS_INDIRECT` slots. Two of the fields are
read open-coded without a type guard and hand that zval straight to `zval_get_double()` /
`zval_get_long()`, which have no `case IS_INDIRECT:` and fall into `ZEND_UNREACHABLE()`.

### Reproducer

```php
<?php
class B extends DateInterval { public float $f = 1.5; }

$o = (new ReflectionClass('B'))->newInstanceWithoutConstructor();
$o->__wakeup();
var_dump($o->f);
```

Debug build:

```
Assertion failed: (0), function zval_get_double_func, file zend_operators.c, line 1056.
```

Release build: no diagnostic at all — the declared value is silently discarded.

`newInstanceWithoutConstructor()` is what leaves `initialized` false. `unserialize()` is not a
route here, because `DateInterval` defines `__unserialize()` and that takes precedence over
`__wakeup()`.

### Fix

The `PHP_DATE_INTERVAL_READ_PROPERTY()` family already accounts for this — all three variants
(plain, `_I64`, `_DAYS`) guard with `Z_TYPE_P(z_arg) <= IS_STRING`, which excludes
`IS_INDIRECT` (12). Eighteen fields are read through them and are safe. Only `"f"` and
`"civil_or_wall"` are read open-coded, and they lack the guard; this applies the same guard to
both.

`ext/zlib` solves the same class of problem at the call site with `ZVAL_DEINDIRECT()`; the
comment there notes that the `|H` ZPP specifier may leave `HashTable` entries wrapped in
`IS_INDIRECT`.

### Behaviour

On an uninitialized instance, a `DateInterval` subclass declaring `$f` or `$civil_or_wall` now
has those fields ignored deterministically — exactly as the eighteen sibling fields already
are — instead of hitting undefined behaviour. Nothing else changes: a plain `DateInterval`,
dynamic properties, and the normal serialize/unserialize round-trip are unaffected.

### Tests

New `ext/date/tests/date_interval_wakeup_declared_property.phpt` covers the
declared-initialized, declared-uninitialized and `civil_or_wall` cases, plus a
dynamic-property control (still read correctly) and a serialize/unserialize round-trip.

`ext/date/tests`: 680/680 pass, debug build.
