### PR TITLE
ext/intl: Fix various error messages

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,10 @@ PHP                                                                        NEWS
   . Fixed GMP integer string parsing to reject strings containing NUL bytes
     instead of silently truncating them. (Weilin Du)
 
+- Intl:
+  . Fixed grammatical issues in Normalizer invalid form and IntlCalendar time
+    zone offset error messages. (Weilin Du)
+
 - ODBC:
   . Fixed bug GH-22668 (Heap buffer over-read when a column value exceeds the
     driver-reported display size). (iliaal)

--- a/ext/intl/common/common_date.cpp
+++ b/ext/intl/common/common_date.cpp
@@ -57,7 +57,7 @@ U_CFUNC TimeZone *timezone_convert_datetimezone(
 
 			if (UNEXPECTED(offset_mins <= -24 * 60 || offset_mins >= 24 * 60)) {
 				intl_errors_set(outside_error, U_ILLEGAL_ARGUMENT_ERROR,
-					"object has an time zone offset that's too large");
+					"object has a time zone offset that is too large");
 				return NULL;
 			}
 

--- a/ext/intl/normalizer/normalizer_normalize.cpp
+++ b/ext/intl/normalizer/normalizer_normalize.cpp
@@ -115,7 +115,7 @@ U_CFUNC PHP_FUNCTION( normalizer_normalize )
 		case NORMALIZER_FORM_KC_CF:
 			break;
 		default:
-			zend_argument_value_error(2, "must be a a valid normalization form");
+			zend_argument_value_error(2, "must be a valid normalization form");
 			RETURN_THROWS();
 	}
 
@@ -232,7 +232,7 @@ U_CFUNC PHP_FUNCTION( normalizer_is_normalized )
 		case NORMALIZER_FORM_KC_CF:
 			break;
 		default:
-			zend_argument_value_error(2, "must be a a valid normalization form");
+			zend_argument_value_error(2, "must be a valid normalization form");
 			RETURN_THROWS();
 	}
 

--- a/ext/intl/tests/calendar_fromDateTime_error.phpt
+++ b/ext/intl/tests/calendar_fromDateTime_error.phpt
@@ -35,6 +35,6 @@ DateMalformedStringException: Failed to parse time string (foobar) at position 0
 NULL
 string(88) "IntlCalendar::fromDateTime(): DateTime object is unconstructed: U_ILLEGAL_ARGUMENT_ERROR"
 NULL
-string(103) "IntlCalendar::fromDateTime(): object has an time zone offset that's too large: U_ILLEGAL_ARGUMENT_ERROR"
+string(103) "IntlCalendar::fromDateTime(): object has a time zone offset that is too large: U_ILLEGAL_ARGUMENT_ERROR"
 NULL
 string(127) "IntlCalendar::fromDateTime(): time zone id 'WEST' extracted from ext/date DateTimeZone not recognized: U_ILLEGAL_ARGUMENT_ERROR"

--- a/ext/intl/tests/calendar_setTimeZone_error2.phpt
+++ b/ext/intl/tests/calendar_setTimeZone_error2.phpt
@@ -25,5 +25,5 @@ bool(false)
 string(126) "IntlCalendar::setTimeZone(): time zone id 'WEST' extracted from ext/date DateTimeZone not recognized: U_ILLEGAL_ARGUMENT_ERROR"
 string(16) "Europe/Amsterdam"
 bool(false)
-string(102) "IntlCalendar::setTimeZone(): object has an time zone offset that's too large: U_ILLEGAL_ARGUMENT_ERROR"
+string(102) "IntlCalendar::setTimeZone(): object has a time zone offset that is too large: U_ILLEGAL_ARGUMENT_ERROR"
 string(16) "Europe/Amsterdam"


### PR DESCRIPTION
```
object has an time zone offset that's too large
```
to
```
object has a time zone offset that is too large
```
and
```
must be a a valid normalization form
```
to
```
must be a valid normalization form
```