### PR TITLE
zend_jit_resolve_tsrm_ls_cache_offsets: clobber volatile registers

### DIFF
--- a/ext/opcache/jit/tls/zend_jit_tls_aarch64.c
+++ b/ext/opcache/jit/tls/zend_jit_tls_aarch64.c
@@ -126,16 +126,9 @@ zend_result zend_jit_resolve_tsrm_ls_cache_offsets(
 		"add   %2, x8, x0\n"
 		: "=r" (thread_pointer), "=r" (insn), "=r" (addr)
 		:
-		/* call may clobber volatile registers */
-		: "x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7",
-		  "x8", "x9", "x10", "x11", "x12", "x13", "x14", "x15",
-		  "x16", "x17", "x18", "x30",
-		  "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7",
-		  "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15",
-		  "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23",
-		  "v24", "v25", "v26", "v27", "v28", "v29", "v30", "v31",
-		  "cc", "memory"
-    );
+		/* Resolver call clobbers only a few registers: https://github.com/ARM-software/abi-aa/blob/ee4b3c12d57c8424ff60c2ae56e10690d0604ab6/sysvabi64/sysvabi64.rst#calling-convention.
+		 * We also clobber x8. */
+		: "x0", "x1", "x8", "x30", "cc", "memory");
 
 	ZEND_ASSERT(addr == &_tsrm_ls_cache);
 

--- a/ext/opcache/jit/tls/zend_jit_tls_aarch64.c
+++ b/ext/opcache/jit/tls/zend_jit_tls_aarch64.c
@@ -126,7 +126,16 @@ zend_result zend_jit_resolve_tsrm_ls_cache_offsets(
 		"add   %2, x8, x0\n"
 		: "=r" (thread_pointer), "=r" (insn), "=r" (addr)
 		:
-		: "x0", "x1", "x8");
+		/* call may clobber volatile registers */
+		: "x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7",
+		  "x8", "x9", "x10", "x11", "x12", "x13", "x14", "x15",
+		  "x16", "x17", "x18", "x30",
+		  "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7",
+		  "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15",
+		  "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23",
+		  "v24", "v25", "v26", "v27", "v28", "v29", "v30", "v31",
+		  "cc", "memory"
+    );
 
 	ZEND_ASSERT(addr == &_tsrm_ls_cache);
 

--- a/ext/opcache/jit/tls/zend_jit_tls_x86.c
+++ b/ext/opcache/jit/tls/zend_jit_tls_x86.c
@@ -110,6 +110,12 @@ zend_result zend_jit_resolve_tsrm_ls_cache_offsets(
 		/* Load thread pointer address */
 		"movl   %%gs:0, %%ebx\n"
 		: "=a" (t_addr), "=S" (code), "=b" (thread_pointer)
+		:
+		/* call may clobber volatile registers */
+		: "ecx", "edx",
+		  "st", "st(1)", "st(2)", "st(3)", "st(4)", "st(5)", "st(6)", "st(7)",
+		  "xmm0", "xmm1", "xmm2", "xmm3", "xmm4", "xmm5", "xmm6", "xmm7",
+		  "cc", "memory"
 	);
 
 	ZEND_ASSERT(t_addr == &_tsrm_ls_cache);

--- a/ext/opcache/jit/tls/zend_jit_tls_x86_64.c
+++ b/ext/opcache/jit/tls/zend_jit_tls_x86_64.c
@@ -106,6 +106,13 @@ zend_result zend_jit_resolve_tsrm_ls_cache_offsets(
 		/* Load thread pointer address */
 		"movq   %%fs:0, %%rsi\n"
 		: "=a" (addr), "=b" (code), "=S" (thread_pointer)
+		:
+		/* call may clobber volatile registers */
+		: "rcx", "rdx", "rdi",
+		  "r8", "r9", "r10", "r11",
+		  "xmm0", "xmm1", "xmm2", "xmm3", "xmm4", "xmm5", "xmm6", "xmm7",
+		  "xmm8", "xmm9", "xmm10", "xmm11", "xmm12", "xmm13", "xmm14", "xmm15",
+		  "cc", "memory"
 	);
 
 	ZEND_ASSERT(addr == &_tsrm_ls_cache);

--- a/ext/opcache/jit/tls/zend_jit_tls_x86_64.c
+++ b/ext/opcache/jit/tls/zend_jit_tls_x86_64.c
@@ -110,6 +110,7 @@ zend_result zend_jit_resolve_tsrm_ls_cache_offsets(
 		/* call may clobber volatile registers */
 		: "rcx", "rdx", "rdi",
 		  "r8", "r9", "r10", "r11",
+		  "st", "st(1)", "st(2)", "st(3)", "st(4)", "st(5)", "st(6)", "st(7)",
 		  "xmm0", "xmm1", "xmm2", "xmm3", "xmm4", "xmm5", "xmm6", "xmm7",
 		  "xmm8", "xmm9", "xmm10", "xmm11", "xmm12", "xmm13", "xmm14", "xmm15",
 		  "cc", "memory"


### PR DESCRIPTION
Found while looking at GH-22801: We need to declare all volatile registers as clobbered since we are performing a call