### PR TITLE
main: Add AIX to PHP_OS_FAMILY

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -566,6 +566,8 @@ PHP 8.6 UPGRADE NOTES
 - Core:
   . In case of a hard OOM PHP now calls abort() instead of exit(1), changing
     the exit code to 134 and possibly creating a core dump.
+  . The PHP_OS_FAMILY constant has an AIX value for when running on AIX or
+    IBM i via PASE.
 
 ========================================
 14. Performance Improvements

--- a/main/php.h
+++ b/main/php.h
@@ -42,6 +42,8 @@
 # define PHP_OS_FAMILY			"Darwin"
 #elif defined(__sun__)
 # define PHP_OS_FAMILY			"Solaris"
+#elif defined(_AIX)
+# define PHP_OS_FAMILY			"AIX"
 #elif defined(__linux__)
 # define PHP_OS_FAMILY			"Linux"
 #else


### PR DESCRIPTION
There are two OSes in this family: AIX itself, and IBM i PASE, which provides an AIX syscall emulation environment. uname is different between them (AIX/OS400).

Adding this for some PRs against tests I plan to make.