### PR TITLE
streams: remove useless function parameters and $param property for StreamError as always null

### DIFF
--- a/main/streams/php_stream_errors.h
+++ b/main/streams/php_stream_errors.h
@@ -73,7 +73,6 @@ typedef struct _php_stream_error_entry {
 	zend_string *message;
 	zend_enum_StreamErrorCode code;
 	char *wrapper_name;
-	char *param;
 	char *docref;
 	int severity;
 	bool terminating;

--- a/main/streams/stream_errors.c
+++ b/main/streams/stream_errors.c
@@ -66,9 +66,6 @@ static void php_stream_error_create_object(zval *zv, php_stream_error_entry *ent
 
 	zend_update_property_bool(
 			php_ce_stream_error, Z_OBJ_P(zv), ZEND_STRL("terminating"), entry->terminating);
-
-	/* TODO: Remove property */
-	zend_update_property_null(php_ce_stream_error, Z_OBJ_P(zv), ZEND_STRL("param"));
 }
 
 /* Create array of StreamError objects from error chain */

--- a/main/streams/stream_errors.c
+++ b/main/streams/stream_errors.c
@@ -326,7 +326,7 @@ PHPAPI php_stream_error_operation *php_stream_error_operation_begin(void)
 }
 
 static void php_stream_error_add(zend_enum_StreamErrorCode code, const char *wrapper_name,
-		zend_string *message, const char *docref, char *param, int severity, bool terminating)
+		zend_string *message, const char *docref, int severity, bool terminating)
 {
 	php_stream_error_operation *op = FG(stream_error_state).current_operation;
 	ZEND_ASSERT(op != NULL);
@@ -335,7 +335,7 @@ static void php_stream_error_add(zend_enum_StreamErrorCode code, const char *wra
 	entry->message = message;
 	entry->code = code;
 	entry->wrapper_name = wrapper_name ? estrdup(wrapper_name) : NULL;
-	entry->param = param;
+	entry->param = NULL;
 	entry->docref = docref ? estrdup(docref) : NULL;
 	entry->severity = severity;
 	entry->terminating = terminating;
@@ -575,15 +575,15 @@ PHPAPI void php_stream_error_operation_abort(void)
 /* Wrapper error reporting */
 
 static void php_stream_wrapper_error_internal(const char *wrapper_name, php_stream_context *context,
-		const char *docref, int options, int severity, bool terminating,
-		zend_enum_StreamErrorCode code, char *param, zend_string *message)
+		const char *docref, int severity, bool terminating,
+		zend_enum_StreamErrorCode code, zend_string *message)
 {
 	bool implicit_operation = (FG(stream_error_state).current_operation == NULL);
 	if (implicit_operation) {
 		php_stream_error_operation_begin();
 	}
 
-	php_stream_error_add(code, wrapper_name, message, docref, param, severity, terminating);
+	php_stream_error_add(code, wrapper_name, message, docref, severity, terminating);
 
 	if (implicit_operation) {
 		php_stream_error_operation_end(context);
@@ -604,7 +604,7 @@ PHPAPI void php_stream_wrapper_error_with_name(const char *wrapper_name,
 	va_end(args);
 
 	php_stream_wrapper_error_internal(
-			wrapper_name, context, docref, options, severity, terminating, code, NULL, message);
+			wrapper_name, context, docref, severity, terminating, code, message);
 }
 
 PHPAPI void php_stream_wrapper_error(php_stream_wrapper *wrapper, php_stream_context *context,
@@ -623,7 +623,7 @@ PHPAPI void php_stream_wrapper_error(php_stream_wrapper *wrapper, php_stream_con
 	const char *wrapper_name = PHP_STREAM_ERROR_WRAPPER_NAME(wrapper);
 
 	php_stream_wrapper_error_internal(
-			wrapper_name, context, docref, options, severity, terminating, code, NULL, message);
+			wrapper_name, context, docref, severity, terminating, code, message);
 }
 
 /* Stream error reporting */
@@ -641,8 +641,8 @@ PHPAPI void php_stream_error(php_stream *stream, const char *docref, int severit
 
 	php_stream_context *context = PHP_STREAM_CONTEXT(stream);
 
-	php_stream_wrapper_error_internal(wrapper_name, context, docref, REPORT_ERRORS, severity,
-			terminating, code, NULL, message);
+	php_stream_wrapper_error_internal(wrapper_name, context, docref, severity,
+			terminating, code, message);
 }
 
 /* Legacy wrapper error logging */
@@ -705,7 +705,7 @@ PHPAPI void php_stream_wrapper_log_error(const php_stream_wrapper *wrapper,
 
 	if (options & REPORT_ERRORS) {
 		php_stream_wrapper_error_internal(
-				wrapper_name, context, NULL, options, severity, terminating, code, NULL, message);
+				wrapper_name, context, NULL, severity, terminating, code, message);
 	} else {
 		php_stream_wrapper_log_store_error(
 				message, code, wrapper_name, severity, terminating);
@@ -784,8 +784,8 @@ PHPAPI void php_stream_display_wrapper_name_errors(const char *wrapper_name,
 
 	zend_string *message = strpprintf(0, "%s: %s", caption, msg);
 
-	php_stream_wrapper_error_internal(wrapper_name, context, NULL, REPORT_ERRORS, E_WARNING, true,
-			code, NULL, message);
+	php_stream_wrapper_error_internal(wrapper_name, context, NULL, E_WARNING, true,
+			code, message);
 
 	if (free_msg) {
 		efree(msg);

--- a/main/streams/stream_errors.c
+++ b/main/streams/stream_errors.c
@@ -67,12 +67,8 @@ static void php_stream_error_create_object(zval *zv, php_stream_error_entry *ent
 	zend_update_property_bool(
 			php_ce_stream_error, Z_OBJ_P(zv), ZEND_STRL("terminating"), entry->terminating);
 
-	if (entry->param) {
-		zend_update_property_string(
-				php_ce_stream_error, Z_OBJ_P(zv), ZEND_STRL("param"), entry->param);
-	} else {
-		zend_update_property_null(php_ce_stream_error, Z_OBJ_P(zv), ZEND_STRL("param"));
-	}
+	/* TODO: Remove property */
+	zend_update_property_null(php_ce_stream_error, Z_OBJ_P(zv), ZEND_STRL("param"));
 }
 
 /* Create array of StreamError objects from error chain */
@@ -213,7 +209,6 @@ static void php_stream_error_entry_free(php_stream_error_entry *entry)
 		php_stream_error_entry *next = entry->next;
 		zend_string_release(entry->message);
 		efree(entry->wrapper_name);
-		efree(entry->param);
 		efree(entry->docref);
 		efree(entry);
 		entry = next;
@@ -335,7 +330,6 @@ static void php_stream_error_add(zend_enum_StreamErrorCode code, const char *wra
 	entry->message = message;
 	entry->code = code;
 	entry->wrapper_name = wrapper_name ? estrdup(wrapper_name) : NULL;
-	entry->param = NULL;
 	entry->docref = docref ? estrdup(docref) : NULL;
 	entry->severity = severity;
 	entry->terminating = terminating;
@@ -399,15 +393,9 @@ static void php_stream_report_errors(php_stream_context *context, php_stream_err
 {
 	switch (error_mode) {
 		case PHP_STREAM_ERROR_MODE_ERROR: {
-			php_stream_error_entry *entry = op->first_error;
+			const php_stream_error_entry *entry = op->first_error;
 			while (entry) {
-				if (entry->param) {
-					php_error_docref1(entry->docref, entry->param, entry->severity, "%s",
-							ZSTR_VAL(entry->message));
-				} else {
-					php_error_docref(
-							entry->docref, entry->severity, "%s", ZSTR_VAL(entry->message));
-				}
+				php_error_docref(entry->docref, entry->severity, "%s", ZSTR_VAL(entry->message));
 				entry = entry->next;
 			}
 			break;
@@ -652,7 +640,6 @@ static void php_stream_error_entry_dtor_legacy(void *error)
 	php_stream_error_entry *entry = *(php_stream_error_entry **) error;
 	zend_string_release(entry->message);
 	efree(entry->wrapper_name);
-	efree(entry->param);
 	efree(entry->docref);
 	efree(entry);
 }
@@ -671,7 +658,6 @@ static void php_stream_wrapper_log_store_error(zend_string *message, zend_enum_S
 	entry->message = message;
 	entry->code = code;
 	entry->wrapper_name = wrapper_name ? estrdup(wrapper_name) : NULL;
-	entry->param = NULL;
 	entry->severity = severity;
 	entry->terminating = terminating;
 

--- a/main/streams/stream_errors.stub.php
+++ b/main/streams/stream_errors.stub.php
@@ -132,7 +132,6 @@ final readonly class StreamError
     public string $wrapperName;
     public int $severity;
     public bool $terminating;
-    public ?string $param;
 }
 
 class StreamException extends Exception

--- a/main/streams/stream_errors_arginfo.h
+++ b/main/streams/stream_errors_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit stream_errors.stub.php instead.
- * Stub hash: 4cddf758cc9f2041802d8cbbaaa45593022a5db1
+ * Stub hash: d3087b608996f81bf0dd19c25792feec9744e768
  * Has decl header: yes */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_StreamException_getErrors, 0, 0, IS_ARRAY, 0)
@@ -236,12 +236,6 @@ static zend_class_entry *register_class_StreamError(void)
 	zend_string *property_terminating_name = zend_string_init("terminating", sizeof("terminating") - 1, true);
 	zend_declare_typed_property(class_entry, property_terminating_name, &property_terminating_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release_ex(property_terminating_name, true);
-
-	zval property_param_default_value;
-	ZVAL_UNDEF(&property_param_default_value);
-	zend_string *property_param_name = zend_string_init("param", sizeof("param") - 1, true);
-	zend_declare_typed_property(class_entry, property_param_name, &property_param_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
-	zend_string_release_ex(property_param_name, true);
 
 	return class_entry;
 }

--- a/main/streams/stream_errors_decl.h
+++ b/main/streams/stream_errors_decl.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit stream_errors.stub.php instead.
- * Stub hash: 4cddf758cc9f2041802d8cbbaaa45593022a5db1 */
+ * Stub hash: d3087b608996f81bf0dd19c25792feec9744e768 */
 
-#ifndef ZEND_STREAM_ERRORS_DECL_4cddf758cc9f2041802d8cbbaaa45593022a5db1_H
-#define ZEND_STREAM_ERRORS_DECL_4cddf758cc9f2041802d8cbbaaa45593022a5db1_H
+#ifndef ZEND_STREAM_ERRORS_DECL_d3087b608996f81bf0dd19c25792feec9744e768_H
+#define ZEND_STREAM_ERRORS_DECL_d3087b608996f81bf0dd19c25792feec9744e768_H
 
 typedef enum zend_enum_StreamErrorCode {
 	ZEND_ENUM_StreamErrorCode_None = 1,
@@ -184,4 +184,4 @@ typedef enum zend_enum_StreamErrorStore {
 	ZEND_ENUM_StreamErrorStore_All = 5,
 } zend_enum_StreamErrorStore;
 
-#endif /* ZEND_STREAM_ERRORS_DECL_4cddf758cc9f2041802d8cbbaaa45593022a5db1_H */
+#endif /* ZEND_STREAM_ERRORS_DECL_d3087b608996f81bf0dd19c25792feec9744e768_H */


### PR DESCRIPTION
This effectively finishes the API clean-up regarding the old docref1 function usage for displaying parameters.

After this is merged @NattyNarwhal you can rebase your PR and we can finally get rid of the docref{1|2} functions \o/