### PR TITLE
ext/standard: Fix `setlocale()` NUL byte truncation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -59,6 +59,10 @@ PHP                                                                        NEWS
     TCP_USER_TIMEOUT, and SO_LINGER options. (Weilin Du)
   . Fixed various memory related issues in ext/sockets. (David Carlier)
 
+- Standard:
+  . Fixed setlocale() to reject locale names containing NUL bytes instead of
+    silently truncating them. (Weilin Du)
+
 - Streams:
   . Added a new IO copy API used by php_stream_copy_to_stream_ex() that
     leverages platform primitives (sendfile, splice, copy_file_range,

--- a/NEWS
+++ b/NEWS
@@ -62,7 +62,8 @@ PHP                                                                        NEWS
 - Standard:
   . Fixed setlocale() to reject locale names containing NUL bytes instead of
     silently truncating them, and to reject arrays passed after the $locales
-    argument. (Weilin Du)
+    argument or additional arguments passed after an array $locales argument.
+    (Weilin Du)
 
 - Streams:
   . Added a new IO copy API used by php_stream_copy_to_stream_ex() that

--- a/NEWS
+++ b/NEWS
@@ -61,7 +61,8 @@ PHP                                                                        NEWS
 
 - Standard:
   . Fixed setlocale() to reject locale names containing NUL bytes instead of
-    silently truncating them. (Weilin Du)
+    silently truncating them, and to reject arrays passed after the $locales
+    argument. (Weilin Du)
 
 - Streams:
   . Added a new IO copy API used by php_stream_copy_to_stream_ex() that

--- a/UPGRADING
+++ b/UPGRADING
@@ -201,6 +201,8 @@ PHP 8.6 UPGRADE NOTES
     bytes.
   . parse_str() now raises a ValueError when the $string argument contains NUL
     bytes.
+  . setlocale() now raises a ValueError when a locale name contains NUL bytes,
+    instead of silently truncating it.
   . linkinfo() now raises a ValueError when the $path argument is empty.
   . pathinfo() now raises a ValueError when an invalid $flag argument value is
     passed.

--- a/UPGRADING
+++ b/UPGRADING
@@ -203,6 +203,9 @@ PHP 8.6 UPGRADE NOTES
     bytes.
   . setlocale() now raises a ValueError when a locale name contains NUL bytes,
     instead of silently truncating it.
+    Arrays are now accepted only for the $locales argument. Passing an array as
+    a later variadic locale argument now throws a TypeError; if $locales is an
+    array, only that array is processed.
   . linkinfo() now raises a ValueError when the $path argument is empty.
   . pathinfo() now raises a ValueError when an invalid $flag argument value is
     passed.

--- a/UPGRADING
+++ b/UPGRADING
@@ -204,8 +204,9 @@ PHP 8.6 UPGRADE NOTES
   . setlocale() now raises a ValueError when a locale name contains NUL bytes,
     instead of silently truncating it.
     Arrays are now accepted only for the $locales argument. Passing an array as
-    a later variadic locale argument now throws a TypeError; if $locales is an
-    array, only that array is processed.
+    a later variadic locale argument now throws a TypeError. Passing any
+    additional locale arguments when $locales is an array now throws an
+    ArgumentCountError.
   . linkinfo() now raises a ValueError when the $path argument is empty.
   . pathinfo() now raises a ValueError when an invalid $flag argument value is
     passed.

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -4837,16 +4837,12 @@ PHP_FUNCTION(strip_tags)
 }
 /* }}} */
 
-static zend_string *try_setlocale_str(zend_long cat, zend_string *loc, uint32_t arg_num) {
+static zend_string *try_setlocale_str(zend_long cat, zend_string *loc) {
 	const char *retval;
 
 	if (zend_string_equals_literal(loc, "0")) {
 		loc = NULL;
 	} else {
-		if (zend_str_has_nul_byte(loc)) {
-			zend_argument_value_error(arg_num, "must not contain any null bytes");
-			return NULL;
-		}
 		if (ZSTR_LEN(loc) >= 255) {
 			php_error_docref(NULL, E_WARNING, "Specified locale name is too long");
 			return NULL;
@@ -4907,13 +4903,18 @@ static zend_string *try_setlocale_str(zend_long cat, zend_string *loc, uint32_t 
 	return zend_string_init(retval, strlen(retval), 0);
 }
 
-static zend_string *try_setlocale_zval(zend_long cat, zval *loc_zv, uint32_t arg_num) {
+static zend_string *try_setlocale_zval(zend_long cat, zval *loc_zv) {
 	zend_string *tmp_loc_str;
 	zend_string *loc_str = zval_try_get_tmp_string(loc_zv, &tmp_loc_str);
 	if (UNEXPECTED(loc_str == NULL)) {
 		return NULL;
 	}
-	zend_string *result = try_setlocale_str(cat, loc_str, arg_num);
+	if (zend_str_has_nul_byte(loc_str)) {
+		zend_argument_value_error(2, "must not contain any null bytes");
+		zend_tmp_string_release(tmp_loc_str);
+		return NULL;
+	}
+	zend_string *result = try_setlocale_str(cat, loc_str);
 	zend_tmp_string_release(tmp_loc_str);
 	return result;
 }
@@ -4934,8 +4935,11 @@ PHP_FUNCTION(setlocale)
 	zend_string **strings = do_alloca(sizeof(zend_string *) * num_args, use_heap);
 
 	for (uint32_t i = 0; i < num_args; i++) {
-		if (UNEXPECTED(Z_TYPE(args[i]) != IS_ARRAY && !zend_parse_arg_str(&args[i], &strings[i], true, i + 2))) {
-			zend_wrong_parameter_type_error(i + 2, Z_EXPECTED_ARRAY_OR_STRING_OR_NULL, &args[i]);
+		if (UNEXPECTED(Z_TYPE(args[i]) != IS_ARRAY && !zend_parse_arg_path_str(&args[i], &strings[i], true, i + 2))) {
+			zend_wrong_parameter_type_error(
+				i + 2,
+				Z_TYPE(args[i]) == IS_STRING ? Z_EXPECTED_PATH : Z_EXPECTED_ARRAY_OR_STRING_OR_NULL,
+				&args[i]);
 			goto out;
 		}
 	}
@@ -4945,7 +4949,7 @@ PHP_FUNCTION(setlocale)
 		if (Z_TYPE(args[i]) == IS_ARRAY) {
 			zval *elem;
 			ZEND_HASH_FOREACH_VAL(Z_ARRVAL(args[i]), elem) {
-				result = try_setlocale_zval(cat, elem, i + 2);
+				result = try_setlocale_zval(cat, elem);
 				if (EG(exception)) {
 					goto out;
 				}
@@ -4956,9 +4960,9 @@ PHP_FUNCTION(setlocale)
 			} ZEND_HASH_FOREACH_END();
 			continue;
 		} else if (Z_ISNULL(args[i])) {
-			result = try_setlocale_str(cat, ZSTR_EMPTY_ALLOC(), i + 2);
+			result = try_setlocale_str(cat, ZSTR_EMPTY_ALLOC());
 		} else {
-			result = try_setlocale_str(cat, strings[i], i + 2);
+			result = try_setlocale_str(cat, strings[i]);
 		}
 		if (EG(exception)) {
 			goto out;

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -4837,12 +4837,16 @@ PHP_FUNCTION(strip_tags)
 }
 /* }}} */
 
-static zend_string *try_setlocale_str(zend_long cat, zend_string *loc) {
+static zend_string *try_setlocale_str(zend_long cat, zend_string *loc, uint32_t arg_num) {
 	const char *retval;
 
 	if (zend_string_equals_literal(loc, "0")) {
 		loc = NULL;
 	} else {
+		if (zend_str_has_nul_byte(loc)) {
+			zend_argument_value_error(arg_num, "must not contain any null bytes");
+			return NULL;
+		}
 		if (ZSTR_LEN(loc) >= 255) {
 			php_error_docref(NULL, E_WARNING, "Specified locale name is too long");
 			return NULL;
@@ -4903,13 +4907,13 @@ static zend_string *try_setlocale_str(zend_long cat, zend_string *loc) {
 	return zend_string_init(retval, strlen(retval), 0);
 }
 
-static zend_string *try_setlocale_zval(zend_long cat, zval *loc_zv) {
+static zend_string *try_setlocale_zval(zend_long cat, zval *loc_zv, uint32_t arg_num) {
 	zend_string *tmp_loc_str;
 	zend_string *loc_str = zval_try_get_tmp_string(loc_zv, &tmp_loc_str);
 	if (UNEXPECTED(loc_str == NULL)) {
 		return NULL;
 	}
-	zend_string *result = try_setlocale_str(cat, loc_str);
+	zend_string *result = try_setlocale_str(cat, loc_str, arg_num);
 	zend_tmp_string_release(tmp_loc_str);
 	return result;
 }
@@ -4941,7 +4945,7 @@ PHP_FUNCTION(setlocale)
 		if (Z_TYPE(args[i]) == IS_ARRAY) {
 			zval *elem;
 			ZEND_HASH_FOREACH_VAL(Z_ARRVAL(args[i]), elem) {
-				result = try_setlocale_zval(cat, elem);
+				result = try_setlocale_zval(cat, elem, i + 2);
 				if (EG(exception)) {
 					goto out;
 				}
@@ -4952,9 +4956,9 @@ PHP_FUNCTION(setlocale)
 			} ZEND_HASH_FOREACH_END();
 			continue;
 		} else if (Z_ISNULL(args[i])) {
-			result = try_setlocale_str(cat, ZSTR_EMPTY_ALLOC());
+			result = try_setlocale_str(cat, ZSTR_EMPTY_ALLOC(), i + 2);
 		} else {
-			result = try_setlocale_str(cat, strings[i]);
+			result = try_setlocale_str(cat, strings[i], i + 2);
 		}
 		if (EG(exception)) {
 			goto out;

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -4903,14 +4903,14 @@ static zend_string *try_setlocale_str(zend_long cat, zend_string *loc) {
 	return zend_string_init(retval, strlen(retval), 0);
 }
 
-static zend_string *try_setlocale_zval(zend_long cat, zval *loc_zv, uint32_t arg_num) {
+static zend_string *try_setlocale_zval(zend_long cat, zval *loc_zv) {
 	zend_string *tmp_loc_str;
 	zend_string *loc_str = zval_try_get_tmp_string(loc_zv, &tmp_loc_str);
 	if (UNEXPECTED(loc_str == NULL)) {
 		return NULL;
 	}
 	if (zend_str_has_nul_byte(loc_str)) {
-		zend_argument_value_error(arg_num, "must not contain any null bytes");
+		zend_argument_value_error(2, "must not contain any null bytes");
 		zend_tmp_string_release(tmp_loc_str);
 		return NULL;
 	}
@@ -4940,6 +4940,12 @@ PHP_FUNCTION(setlocale)
 				zend_wrong_parameter_type_error(i + 2, Z_EXPECTED_STRING_OR_NULL, &args[i]);
 				goto out;
 			}
+			if (UNEXPECTED(num_args > 1)) {
+				zend_argument_count_error(
+					"setlocale() expects exactly 2 arguments when argument #2 ($locales) is an array, %d given",
+					ZEND_NUM_ARGS());
+				goto out;
+			}
 			num_args = 1;
 			break;
 		}
@@ -4959,7 +4965,7 @@ PHP_FUNCTION(setlocale)
 		if (Z_TYPE(args[i]) == IS_ARRAY) {
 			zval *elem;
 			ZEND_HASH_FOREACH_VAL(Z_ARRVAL(args[i]), elem) {
-				result = try_setlocale_zval(cat, elem, i + 2);
+				result = try_setlocale_zval(cat, elem);
 				if (EG(exception)) {
 					goto out;
 				}

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -4946,7 +4946,6 @@ PHP_FUNCTION(setlocale)
 					ZEND_NUM_ARGS());
 				goto out;
 			}
-			num_args = 1;
 			break;
 		}
 		if (UNEXPECTED(!zend_parse_arg_path_str(&args[i], &strings[i], true, i + 2))) {

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -4903,14 +4903,14 @@ static zend_string *try_setlocale_str(zend_long cat, zend_string *loc) {
 	return zend_string_init(retval, strlen(retval), 0);
 }
 
-static zend_string *try_setlocale_zval(zend_long cat, zval *loc_zv) {
+static zend_string *try_setlocale_zval(zend_long cat, zval *loc_zv, uint32_t arg_num) {
 	zend_string *tmp_loc_str;
 	zend_string *loc_str = zval_try_get_tmp_string(loc_zv, &tmp_loc_str);
 	if (UNEXPECTED(loc_str == NULL)) {
 		return NULL;
 	}
 	if (zend_str_has_nul_byte(loc_str)) {
-		zend_argument_value_error(2, "must not contain any null bytes");
+		zend_argument_value_error(arg_num, "must not contain any null bytes");
 		zend_tmp_string_release(tmp_loc_str);
 		return NULL;
 	}
@@ -4935,10 +4935,20 @@ PHP_FUNCTION(setlocale)
 	zend_string **strings = do_alloca(sizeof(zend_string *) * num_args, use_heap);
 
 	for (uint32_t i = 0; i < num_args; i++) {
-		if (UNEXPECTED(Z_TYPE(args[i]) != IS_ARRAY && !zend_parse_arg_path_str(&args[i], &strings[i], true, i + 2))) {
+		if (Z_TYPE(args[i]) == IS_ARRAY) {
+			if (UNEXPECTED(i != 0)) {
+				zend_wrong_parameter_type_error(i + 2, Z_EXPECTED_STRING_OR_NULL, &args[i]);
+				goto out;
+			}
+			num_args = 1;
+			break;
+		}
+		if (UNEXPECTED(!zend_parse_arg_path_str(&args[i], &strings[i], true, i + 2))) {
 			zend_wrong_parameter_type_error(
 				i + 2,
-				Z_TYPE(args[i]) == IS_STRING ? Z_EXPECTED_PATH : Z_EXPECTED_ARRAY_OR_STRING_OR_NULL,
+				Z_TYPE(args[i]) == IS_STRING
+					? Z_EXPECTED_PATH
+					: (i == 0 ? Z_EXPECTED_ARRAY_OR_STRING_OR_NULL : Z_EXPECTED_STRING_OR_NULL),
 				&args[i]);
 			goto out;
 		}
@@ -4949,7 +4959,7 @@ PHP_FUNCTION(setlocale)
 		if (Z_TYPE(args[i]) == IS_ARRAY) {
 			zval *elem;
 			ZEND_HASH_FOREACH_VAL(Z_ARRVAL(args[i]), elem) {
-				result = try_setlocale_zval(cat, elem);
+				result = try_setlocale_zval(cat, elem, i + 2);
 				if (EG(exception)) {
 					goto out;
 				}

--- a/ext/standard/tests/strings/gh18823_strict.phpt
+++ b/ext/standard/tests/strings/gh18823_strict.phpt
@@ -16,4 +16,4 @@ try {
 ?>
 --EXPECT--
 setlocale(): Argument #2 ($locales) must be of type array|string|null, int given
-setlocale(): Argument #3 must be of type array|string|null, int given
+setlocale(): Argument #3 must be of type ?string, int given

--- a/ext/standard/tests/strings/setlocale_null_byte.phpt
+++ b/ext/standard/tests/strings/setlocale_null_byte.phpt
@@ -21,12 +21,19 @@ try {
 }
 
 try {
+    var_dump(setlocale(LC_ALL, ["invalid", "C\0invalid"]));
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
     var_dump(setlocale(LC_ALL, [], new NullByteStringable()));
 } catch (ValueError $e) {
     echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
+setlocale(): Argument #2 ($locales) must not contain any null bytes
 setlocale(): Argument #2 ($locales) must not contain any null bytes
 setlocale(): Argument #2 ($locales) must not contain any null bytes
 setlocale(): Argument #3 must not contain any null bytes

--- a/ext/standard/tests/strings/setlocale_null_byte.phpt
+++ b/ext/standard/tests/strings/setlocale_null_byte.phpt
@@ -4,24 +4,24 @@ setlocale() rejects locale names with null bytes
 <?php
 class NullByteStringable {
     public function __toString(): string {
-        return "C\0invalid";
+        return "C\0locale";
     }
 }
 
 try {
-    var_dump(setlocale(LC_ALL, "C\0invalid"));
+    var_dump(setlocale(LC_ALL, "C\0locale"));
 } catch (ValueError $e) {
     echo $e->getMessage(), "\n";
 }
 
 try {
-    var_dump(setlocale(LC_ALL, ["invalid\0locale", "C"]));
+    var_dump(setlocale(LC_ALL, ["locale\0name", "C"]));
 } catch (ValueError $e) {
     echo $e->getMessage(), "\n";
 }
 
 try {
-    var_dump(setlocale(LC_ALL, ["invalid", "C\0invalid"]));
+    var_dump(@setlocale(LC_ALL, [str_repeat("x", 255), "C\0locale"]));
 } catch (ValueError $e) {
     echo $e->getMessage(), "\n";
 }

--- a/ext/standard/tests/strings/setlocale_null_byte.phpt
+++ b/ext/standard/tests/strings/setlocale_null_byte.phpt
@@ -1,0 +1,32 @@
+--TEST--
+setlocale() rejects locale names with null bytes
+--FILE--
+<?php
+class NullByteStringable {
+    public function __toString(): string {
+        return "C\0invalid";
+    }
+}
+
+try {
+    var_dump(setlocale(LC_ALL, "C\0invalid"));
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    var_dump(setlocale(LC_ALL, ["invalid\0locale", "C"]));
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    var_dump(setlocale(LC_ALL, [], new NullByteStringable()));
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+setlocale(): Argument #2 ($locales) must not contain any null bytes
+setlocale(): Argument #2 ($locales) must not contain any null bytes
+setlocale(): Argument #3 must not contain any null bytes

--- a/ext/standard/tests/strings/setlocale_null_byte.phpt
+++ b/ext/standard/tests/strings/setlocale_null_byte.phpt
@@ -55,6 +55,6 @@ ValueError: setlocale(): Argument #2 ($locales) must not contain any null bytes
 ValueError: setlocale(): Argument #2 ($locales) must not contain any null bytes
 ValueError: setlocale(): Argument #2 ($locales) must not contain any null bytes
 ValueError: setlocale(): Argument #2 ($locales) must not contain any null bytes
-TypeError: setlocale(): Argument #3 must be of type array|string|null, int given
+TypeError: setlocale(): Argument #3 must be of type ?string, array given
 ValueError: setlocale(): Argument #3 must not contain any null bytes
 ArgumentCountError: setlocale() expects exactly 2 arguments when argument #2 ($locales) is an array, 3 given

--- a/ext/standard/tests/strings/setlocale_null_byte.phpt
+++ b/ext/standard/tests/strings/setlocale_null_byte.phpt
@@ -27,19 +27,19 @@ try {
 }
 
 try {
-    var_dump(setlocale(LC_ALL, ["en_US.invalid", "C\0locale"]));
+    var_dump(setlocale(LC_ALL, ["zz_ZZ.nope", "C\0locale"]));
 } catch (ValueError $e) {
     echo $e::class, ": ", $e->getMessage(), \PHP_EOL;
 }
 
 try {
-    var_dump(setlocale(LC_ALL, "invalid", ["C\0locale"]));
+    var_dump(setlocale(LC_ALL, "zz_ZZ.nope", ["C\0locale"]));
 } catch (TypeError $e) {
     echo $e::class, ": ", $e->getMessage(), \PHP_EOL;
 }
 
 try {
-    var_dump(setlocale(LC_ALL, "invalid", new NullByteStringable()));
+    var_dump(setlocale(LC_ALL, "zz_ZZ.nope", new NullByteStringable()));
 } catch (ValueError $e) {
     echo $e::class, ": ", $e->getMessage(), \PHP_EOL;
 }

--- a/ext/standard/tests/strings/setlocale_null_byte.phpt
+++ b/ext/standard/tests/strings/setlocale_null_byte.phpt
@@ -27,12 +27,6 @@ try {
 }
 
 try {
-    var_dump(setlocale(LC_ALL, ["zz_ZZ.nope", "C\0locale"]));
-} catch (ValueError $e) {
-    echo $e::class, ": ", $e->getMessage(), \PHP_EOL;
-}
-
-try {
     var_dump(setlocale(LC_ALL, "zz_ZZ.nope", ["C\0locale"]));
 } catch (TypeError $e) {
     echo $e::class, ": ", $e->getMessage(), \PHP_EOL;
@@ -51,7 +45,6 @@ try {
 }
 ?>
 --EXPECT--
-ValueError: setlocale(): Argument #2 ($locales) must not contain any null bytes
 ValueError: setlocale(): Argument #2 ($locales) must not contain any null bytes
 ValueError: setlocale(): Argument #2 ($locales) must not contain any null bytes
 ValueError: setlocale(): Argument #2 ($locales) must not contain any null bytes

--- a/ext/standard/tests/strings/setlocale_null_byte.phpt
+++ b/ext/standard/tests/strings/setlocale_null_byte.phpt
@@ -11,29 +11,46 @@ class NullByteStringable {
 try {
     var_dump(setlocale(LC_ALL, "C\0locale"));
 } catch (ValueError $e) {
-    echo $e->getMessage(), "\n";
+    echo $e::class, ": ", $e->getMessage(), \PHP_EOL;
 }
 
 try {
     var_dump(setlocale(LC_ALL, ["locale\0name", "C"]));
 } catch (ValueError $e) {
-    echo $e->getMessage(), "\n";
+    echo $e::class, ": ", $e->getMessage(), \PHP_EOL;
 }
 
 try {
     var_dump(@setlocale(LC_ALL, [str_repeat("x", 255), "C\0locale"]));
 } catch (ValueError $e) {
-    echo $e->getMessage(), "\n";
+    echo $e::class, ": ", $e->getMessage(), \PHP_EOL;
 }
 
 try {
-    var_dump(setlocale(LC_ALL, [], new NullByteStringable()));
+    var_dump(setlocale(LC_ALL, ["invalid", "C\0locale"]));
 } catch (ValueError $e) {
-    echo $e->getMessage(), "\n";
+    echo $e::class, ": ", $e->getMessage(), \PHP_EOL;
 }
+
+try {
+    var_dump(setlocale(LC_ALL, "invalid", ["C\0locale"]));
+} catch (TypeError $e) {
+    echo $e::class, ": ", $e->getMessage(), \PHP_EOL;
+}
+
+try {
+    var_dump(setlocale(LC_ALL, "invalid", new NullByteStringable()));
+} catch (ValueError $e) {
+    echo $e::class, ": ", $e->getMessage(), \PHP_EOL;
+}
+
+var_dump(setlocale(LC_ALL, [], new NullByteStringable()));
 ?>
 --EXPECT--
-setlocale(): Argument #2 ($locales) must not contain any null bytes
-setlocale(): Argument #2 ($locales) must not contain any null bytes
-setlocale(): Argument #2 ($locales) must not contain any null bytes
-setlocale(): Argument #3 must not contain any null bytes
+ValueError: setlocale(): Argument #2 ($locales) must not contain any null bytes
+ValueError: setlocale(): Argument #2 ($locales) must not contain any null bytes
+ValueError: setlocale(): Argument #2 ($locales) must not contain any null bytes
+ValueError: setlocale(): Argument #2 ($locales) must not contain any null bytes
+TypeError: setlocale(): Argument #3 must be of type ?string, array given
+ValueError: setlocale(): Argument #3 must not contain any null bytes
+bool(false)

--- a/ext/standard/tests/strings/setlocale_null_byte.phpt
+++ b/ext/standard/tests/strings/setlocale_null_byte.phpt
@@ -44,13 +44,17 @@ try {
     echo $e::class, ": ", $e->getMessage(), \PHP_EOL;
 }
 
-var_dump(setlocale(LC_ALL, [], new NullByteStringable()));
+try {
+    var_dump(setlocale(LC_ALL, [], new NullByteStringable()));
+} catch (ArgumentCountError $e) {
+    echo $e::class, ": ", $e->getMessage(), \PHP_EOL;
+}
 ?>
 --EXPECT--
 ValueError: setlocale(): Argument #2 ($locales) must not contain any null bytes
 ValueError: setlocale(): Argument #2 ($locales) must not contain any null bytes
 ValueError: setlocale(): Argument #2 ($locales) must not contain any null bytes
 ValueError: setlocale(): Argument #2 ($locales) must not contain any null bytes
-TypeError: setlocale(): Argument #3 must be of type ?string, array given
+TypeError: setlocale(): Argument #3 must be of type array|string|null, int given
 ValueError: setlocale(): Argument #3 must not contain any null bytes
-bool(false)
+ArgumentCountError: setlocale() expects exactly 2 arguments when argument #2 ($locales) is an array, 3 given

--- a/ext/standard/tests/strings/setlocale_null_byte.phpt
+++ b/ext/standard/tests/strings/setlocale_null_byte.phpt
@@ -27,7 +27,7 @@ try {
 }
 
 try {
-    var_dump(setlocale(LC_ALL, ["invalid", "C\0locale"]));
+    var_dump(setlocale(LC_ALL, ["en_US.invalid", "C\0locale"]));
 } catch (ValueError $e) {
     echo $e::class, ": ", $e->getMessage(), \PHP_EOL;
 }


### PR DESCRIPTION
```php
<?php
var_dump(setlocale(LC_ALL, "C\0invalid"));
```
```
string(1) "C"
```
See: https://3v4l.org/rHId2#v
New argument logic in `try_setlocale_zval` is inevitable because we need to know the argument position when we raise the ValueError (both the second and the third parameter of the `setlocale` function have the truncation issue)