### PR TITLE
ext/gmp: Fix GMP error messages using outdated parameter names

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,8 @@ PHP                                                                        NEWS
     the unsigned long range instead of silently truncating them. (Weilin Du)
   . Fixed GMP integer string parsing to reject strings containing NUL bytes
     instead of silently truncating them. (Weilin Du)
+  . Fixed GMP error messages that referenced outdated parameter names.
+    (Weilin Du)
 
 - Intl:
   . Fixed grammatical issues in Normalizer invalid form and IntlCalendar time

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -1249,7 +1249,7 @@ ZEND_FUNCTION(gmp_root)
 	}
 
 	if (nth % 2 == 0 && mpz_sgn(gmpnum_a) < 0) {
-		zend_argument_value_error(2, "must be odd if argument #1 ($a) is negative");
+		zend_argument_value_error(2, "must be odd if argument #1 ($num) is negative");
 		RETURN_THROWS();
 	}
 
@@ -1276,7 +1276,7 @@ ZEND_FUNCTION(gmp_rootrem)
 	}
 
 	if (nth % 2 == 0 && mpz_sgn(gmpnum_a) < 0) {
-		zend_argument_value_error(2, "must be odd if argument #1 ($a) is negative");
+		zend_argument_value_error(2, "must be odd if argument #1 ($num) is negative");
 		RETURN_THROWS();
 	}
 
@@ -1528,7 +1528,7 @@ ZEND_FUNCTION(gmp_random_range)
 
 	gmp_init_random();
 	if (mpz_cmp(gmpnum_max, gmpnum_min) <= 0) {
-		zend_argument_value_error(1, "must be less than argument #2 ($maximum)");
+		zend_argument_value_error(1, "must be less than argument #2 ($max)");
 		RETURN_THROWS();
 	}
 

--- a/ext/gmp/tests/gmp_random_range.phpt
+++ b/ext/gmp/tests/gmp_random_range.phpt
@@ -74,7 +74,7 @@ while (1) {
 echo "Done\n";
 ?>
 --EXPECT--
-gmp_random_range(): Argument #1 ($min) must be less than argument #2 ($maximum)
-gmp_random_range(): Argument #1 ($min) must be less than argument #2 ($maximum)
-gmp_random_range(): Argument #1 ($min) must be less than argument #2 ($maximum)
+gmp_random_range(): Argument #1 ($min) must be less than argument #2 ($max)
+gmp_random_range(): Argument #1 ($min) must be less than argument #2 ($max)
+gmp_random_range(): Argument #1 ($min) must be less than argument #2 ($max)
 Done

--- a/ext/gmp/tests/gmp_remroot.phpt
+++ b/ext/gmp/tests/gmp_remroot.phpt
@@ -92,7 +92,7 @@ array(2) {
     string(2) "19"
   }
 }
-gmp_rootrem(): Argument #2 ($nth) must be odd if argument #1 ($a) is negative
+gmp_rootrem(): Argument #2 ($nth) must be odd if argument #1 ($num) is negative
 array(2) {
   [0]=>
   object(GMP)#%d (1) {

--- a/ext/gmp/tests/gmp_root.phpt
+++ b/ext/gmp/tests/gmp_root.phpt
@@ -53,7 +53,7 @@ object(GMP)#%d (1) {
   ["num"]=>
   string(1) "3"
 }
-gmp_root(): Argument #2 ($nth) must be odd if argument #1 ($a) is negative
+gmp_root(): Argument #2 ($nth) must be odd if argument #1 ($num) is negative
 object(GMP)#%d (1) {
   ["num"]=>
   string(1) "0"


### PR DESCRIPTION
The argument name in these error messages are different from what is claimed in the documentation and public signatures.

  - gmp_root(GMP|int|string $num, int $nth): GMP
    https://www.php.net/manual/en/function.gmp-root.php

  - gmp_rootrem(GMP|int|string $num, int $nth): array
    https://www.php.net/manual/en/function.gmp-rootrem.php

  - gmp_random_range(GMP|int|string $min, GMP|int|string $max): GMP
    https://www.php.net/manual/en/function.gmp-random-range.php

  Updated messages:

  - gmp_root() and gmp_rootrem() now refer to argument 1 as $num instead of $a.
  - gmp_random_range() now refers to argument 2 as $max instead of $maximum.

TBH this is discovered when I am developing an application using gmp, and it take me some time to figure out what $a is in the error message.

Maybe we shouldn't hard code the argument name at first. IMO this is classic bad practice.