### PR TITLE
Fix GH-22845: use-after-free with a stashed user-filter bucket brigade

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,10 @@ PHP                                                                        NEWS
 - Sockets:
   . Fixed various memory related issues in ext/sockets. (David Carlier)
 
+- Standard:
+  . Fixed bug GH-22845 (Use-after-free when a user filter stashes its bucket
+    brigade resource). (iliaal)
+
 30 Jul 2026, PHP 8.4.24
 
 - Calendar:

--- a/ext/standard/tests/filters/gh22845.phpt
+++ b/ext/standard/tests/filters/gh22845.phpt
@@ -1,0 +1,40 @@
+--TEST--
+GH-22845 (Use-after-free when a user filter stashes its bucket brigade resource)
+--FILE--
+<?php
+class stash_filter extends php_user_filter {
+    public function filter($in, $out, &$consumed, $closing): int {
+        $GLOBALS['stash_in'] = $in;
+        $GLOBALS['stash_out'] = $out;
+        while ($bucket = stream_bucket_make_writeable($in)) {
+            $consumed += strlen($bucket->data);
+            stream_bucket_append($out, $bucket);
+        }
+        return PSFS_PASS_ON;
+    }
+}
+stream_filter_register('stash', 'stash_filter');
+
+$fp = fopen('php://memory', 'r+');
+fwrite($fp, "hello world");
+rewind($fp);
+stream_filter_append($fp, 'stash', STREAM_FILTER_READ);
+var_dump(fread($fp, 100));
+
+// The brigades lived on the filter caller's stack. Both stashed resources must be
+// closed now that the callback has returned, not left pointing at freed stack.
+foreach (['stash_in', 'stash_out'] as $name) {
+    try {
+        stream_bucket_make_writeable($GLOBALS[$name]);
+        echo "$name: no error\n";
+    } catch (\Throwable $e) {
+        echo "$name: ", $e::class, "\n";
+    }
+}
+echo "done\n";
+?>
+--EXPECT--
+string(11) "hello world"
+stash_in: TypeError
+stash_out: TypeError
+done

--- a/ext/standard/tests/filters/gh22845_bailout.phpt
+++ b/ext/standard/tests/filters/gh22845_bailout.phpt
@@ -1,0 +1,39 @@
+--TEST--
+GH-22845 (user filter bucket brigade resource is closed when the callback bails out)
+--EXTENSIONS--
+zend_test
+--SKIPIF--
+<?php
+if (!function_exists('zend_trigger_bailout')) die("skip zend_trigger_bailout() not available before PHP 8.5");
+?>
+--FILE--
+<?php
+class bf extends php_user_filter {
+    public function filter($in, $out, &$consumed, $closing): int {
+        $GLOBALS['stash_in'] = $in;
+        while ($b = stream_bucket_make_writeable($in)) {
+            $consumed += strlen($b->data);
+            stream_bucket_append($out, $b);
+        }
+        register_shutdown_function(function() {
+            try {
+                stream_bucket_make_writeable($GLOBALS['stash_in']);
+                echo "shutdown: no error\n";
+            } catch (\Throwable $e) {
+                echo "shutdown: ", $e::class, "\n";
+            }
+        });
+        zend_trigger_bailout();
+    }
+}
+stream_filter_register('bf', 'bf');
+
+$fp = fopen('php://memory', 'r+');
+fwrite($fp, "hello world");
+rewind($fp);
+stream_filter_append($fp, 'bf', STREAM_FILTER_READ);
+fread($fp, 100);
+?>
+--EXPECTF--
+Fatal error: Bailout in %s on line %d
+shutdown: TypeError

--- a/ext/standard/user_filters.c
+++ b/ext/standard/user_filters.c
@@ -137,7 +137,8 @@ static php_stream_filter_status_t userfilter_filter(
 	zval func_name;
 	zval retval;
 	zval args[4];
-	int call_result;
+	int call_result = FAILURE;
+	bool bailout = false;
 
 	/* the userfilter object probably doesn't exist anymore */
 	if (CG(unclean_shutdown)) {
@@ -188,27 +189,33 @@ static php_stream_filter_status_t userfilter_filter(
 
 	ZVAL_BOOL(&args[3], flags & PSFS_FLAG_FLUSH_CLOSE);
 
-	call_result = call_user_function(NULL,
-			obj,
-			&func_name,
-			&retval,
-			4, args);
+	zend_try {
+		call_result = call_user_function(NULL,
+				obj,
+				&func_name,
+				&retval,
+				4, args);
+	} zend_catch {
+		bailout = true;
+	} zend_end_try();
 
 	zval_ptr_dtor(&func_name);
 
-	if (call_result == SUCCESS && Z_TYPE(retval) != IS_UNDEF) {
-		convert_to_long(&retval);
-		ret = (int)Z_LVAL(retval);
-	} else if (call_result == FAILURE) {
-		php_error_docref(NULL, E_WARNING, "Failed to call filter function");
-	}
+	if (!bailout) {
+		if (call_result == SUCCESS && Z_TYPE(retval) != IS_UNDEF) {
+			convert_to_long(&retval);
+			ret = (int)Z_LVAL(retval);
+		} else if (call_result == FAILURE) {
+			php_error_docref(NULL, E_WARNING, "Failed to call filter function");
+		}
 
-	if (bytes_consumed) {
-		*bytes_consumed = zval_get_long(&args[2]);
-	}
+		if (bytes_consumed) {
+			*bytes_consumed = zval_get_long(&args[2]);
+		}
 
-	if (buckets_in->head) {
-		php_error_docref(NULL, E_WARNING, "Unprocessed filter buckets remaining on input brigade");
+		if (buckets_in->head) {
+			php_error_docref(NULL, E_WARNING, "Unprocessed filter buckets remaining on input brigade");
+		}
 	}
 
 	/* filter resources are cleaned up by the stream destructor,
@@ -223,6 +230,9 @@ static php_stream_filter_status_t userfilter_filter(
 
 	zend_string_release(stream_name);
 
+	zend_list_close(Z_RES(args[1]));
+	zend_list_close(Z_RES(args[0]));
+
 	zval_ptr_dtor(&args[3]);
 	zval_ptr_dtor(&args[2]);
 	zval_ptr_dtor(&args[1]);
@@ -230,6 +240,10 @@ static php_stream_filter_status_t userfilter_filter(
 
 	stream->flags &= ~PHP_STREAM_FLAG_NO_FCLOSE;
 	stream->flags |= orig_no_fclose;
+
+	if (bailout) {
+		zend_bailout();
+	}
 
 	return ret;
 }


### PR DESCRIPTION
A user stream filter's `filter($in, $out, ...)` receives its bucket brigades as `le_bucket_brigade` resources, but every caller that dispatches a filter allocates those brigades on its own C stack. `userfilter_filter` only `zval_ptr_dtor`s the argument zvals after the callback and never closes the resources, so a filter that stashes `$in` or `$out` keeps a resource whose `ptr` still points at the popped stack frame. `stream_bucket_make_writeable()` and `stream_bucket_append()` fetch by resource type only, so reusing a stashed brigade dereferences freed stack (ASAN reports stack-use-after-return). Closing both resources right after the callback invalidates any stashed copy, which then throws a TypeError instead of corrupting memory.

The callback is wrapped in `zend_try`/`zend_catch` so the close runs even when the filter bails out (a fatal error would otherwise longjmp past it, leaving the resource fetchable from a `register_shutdown_function`).

Fixes #22845