### PR TITLE
ext/gmp: Add gmp_powm_sec()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -17,6 +17,7 @@ PHP                                                                        NEWS
     declares a default value for the attribute). (iliaal)
 
 - GMP:
+  . Added gmp_powm_sec(). (Weilin Du)
   . Added gmp_prevprime(). (Weilin Du, David Carlier)
   . Fixed GMP power and shift operators to reject GMP right operands outside
     the unsigned long range instead of silently truncating them. (Weilin Du)

--- a/UPGRADING
+++ b/UPGRADING
@@ -272,6 +272,8 @@ PHP 8.6 UPGRADE NOTES
   . finfo_file() now works with remote streams.
 
 - GMP:
+  . Added gmp_powm_sec() for side-channel quiet modular exponentiation.
+    Requires GNU MP 5.0.0 or later.
   . Added gmp_prevprime() to get the largest prime smaller than the given
     number. A ValueError is thrown if no such prime exists. This function is
     available only when PHP is built against GNU MP 6.3.0 or later; it is not
@@ -428,6 +430,7 @@ PHP 8.6 UPGRADE NOTES
 ========================================
 
 - GMP:
+  . gmp_powm_sec()
   . gmp_prevprime()
 
 - Intl:

--- a/ext/gmp/config.m4
+++ b/ext/gmp/config.m4
@@ -22,7 +22,7 @@ if test "$PHP_GMP" != "no"; then
   LIBS="$LIBS $GMP_LIBS"
   gmp_check=no
   AC_CHECK_HEADER([gmp.h], [AC_CHECK_FUNC([__gmpz_rootrem], [gmp_check=yes])])
-  AC_CHECK_FUNCS([__gmpz_prevprime])
+  AC_CHECK_FUNCS([__gmpz_powm_sec __gmpz_prevprime])
   CFLAGS=$CFLAGS_SAVED
   LIBS=$LIBS_SAVED
 

--- a/ext/gmp/config.w32
+++ b/ext/gmp/config.w32
@@ -5,6 +5,9 @@ ARG_WITH("gmp", "Include GNU MP support.", "no");
 if (PHP_GMP != "no") {
 	if (CHECK_LIB("mpir_a.lib", "gmp", PHP_GMP) &&
 		CHECK_HEADER("gmp.h", "CFLAGS_GMP", PHP_GMP +  ";" + PHP_PHP_BUILD + "\\include\\mpir")) {
+		if (GREP_HEADER("gmp.h", "mpz_powm_sec", PHP_GMP +  ";" + PHP_PHP_BUILD + "\\include\\mpir")) {
+			AC_DEFINE('HAVE___GMPZ_POWM_SEC', 1, "Define to 1 if GMP has the 'mpz_powm_sec' function.");
+		}
 		if (GREP_HEADER("gmp.h", "mpz_prevprime", PHP_GMP +  ";" + PHP_PHP_BUILD + "\\include\\mpir")) {
 			AC_DEFINE('HAVE___GMPZ_PREVPRIME', 1, "Define to 1 if GMP has the 'mpz_prevprime' function.");
 		}

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -1234,9 +1234,9 @@ ZEND_FUNCTION(gmp_powm_sec)
 		RETURN_THROWS();
 	}
 
-	if (!mpz_odd_p(gmpnum_mod)) {
+	if (UNEXPECTED(!mpz_odd_p(gmpnum_mod))) {
 		/* Zero is an even modulus, but report it like gmp_powm() does. */
-		if (UNEXPECTED(!mpz_cmp_ui(gmpnum_mod, 0))) {
+		if (!mpz_cmp_ui(gmpnum_mod, 0)) {
 			zend_argument_error(zend_ce_division_by_zero_error, 3, "Modulo by zero");
 		} else {
 			zend_argument_value_error(3, "must be odd");

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -1217,6 +1217,39 @@ ZEND_FUNCTION(gmp_powm)
 }
 /* }}} */
 
+#ifdef HAVE___GMPZ_POWM_SEC
+/* {{{ Raise base to power exp and take result modulo mod using a side-channel quiet algorithm */
+ZEND_FUNCTION(gmp_powm_sec)
+{
+	mpz_ptr gmpnum_base, gmpnum_exp, gmpnum_mod, gmpnum_result;
+
+	ZEND_PARSE_PARAMETERS_START(3, 3)
+		GMP_Z_PARAM_INTO_MPZ_PTR(gmpnum_base)
+		GMP_Z_PARAM_INTO_MPZ_PTR(gmpnum_exp)
+		GMP_Z_PARAM_INTO_MPZ_PTR(gmpnum_mod)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (mpz_sgn(gmpnum_exp) <= 0) {
+		zend_argument_value_error(2, "must be greater than 0");
+		RETURN_THROWS();
+	}
+
+	if (UNEXPECTED(!mpz_odd_p(gmpnum_mod))) {
+		/* Zero is an even modulus, but report it like gmp_powm() does. */
+		if (UNEXPECTED(!mpz_cmp_ui(gmpnum_mod, 0))) {
+			zend_argument_error(zend_ce_division_by_zero_error, 3, "Modulo by zero");
+		} else {
+			zend_argument_value_error(3, "must be odd");
+		}
+		RETURN_THROWS();
+	}
+
+	INIT_GMP_RETVAL(gmpnum_result);
+	mpz_powm_sec(gmpnum_result, gmpnum_base, gmpnum_exp, gmpnum_mod);
+}
+/* }}} */
+#endif
+
 /* {{{ Takes integer part of square root of a */
 ZEND_FUNCTION(gmp_sqrt)
 {

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -1234,7 +1234,7 @@ ZEND_FUNCTION(gmp_powm_sec)
 		RETURN_THROWS();
 	}
 
-	if (UNEXPECTED(!mpz_odd_p(gmpnum_mod))) {
+	if (!mpz_odd_p(gmpnum_mod)) {
 		/* Zero is an even modulus, but report it like gmp_powm() does. */
 		if (UNEXPECTED(!mpz_cmp_ui(gmpnum_mod, 0))) {
 			zend_argument_error(zend_ce_division_by_zero_error, 3, "Modulo by zero");

--- a/ext/gmp/gmp.stub.php
+++ b/ext/gmp/gmp.stub.php
@@ -125,6 +125,10 @@ function gmp_pow(GMP|int|string $num, int $exponent): GMP {}
 
 function gmp_powm(GMP|int|string $num, GMP|int|string $exponent, GMP|int|string $modulus): GMP {}
 
+#ifdef HAVE___GMPZ_POWM_SEC
+function gmp_powm_sec(GMP|int|string $num, GMP|int|string $exponent, GMP|int|string $modulus): GMP {}
+#endif
+
 function gmp_perfect_square(GMP|int|string $num): bool {}
 
 function gmp_perfect_power(GMP|int|string $num): bool {}

--- a/ext/gmp/gmp_arginfo.h
+++ b/ext/gmp/gmp_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit gmp.stub.php instead.
- * Stub hash: 9d651cc4ba238a496ebe8302fe3e0f985d48d769 */
+ * Stub hash: 57d016aed930bb41ff4357917e3ae8abd612e973 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_gmp_init, 0, 1, GMP, 0)
 	ZEND_ARG_TYPE_MASK(0, num, MAY_BE_LONG|MAY_BE_STRING, NULL)
@@ -90,6 +90,14 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_gmp_powm, 0, 3, GMP, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, exponent, GMP, MAY_BE_LONG|MAY_BE_STRING, NULL)
 	ZEND_ARG_OBJ_TYPE_MASK(0, modulus, GMP, MAY_BE_LONG|MAY_BE_STRING, NULL)
 ZEND_END_ARG_INFO()
+
+#if defined(HAVE___GMPZ_POWM_SEC)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_gmp_powm_sec, 0, 3, GMP, 0)
+	ZEND_ARG_OBJ_TYPE_MASK(0, num, GMP, MAY_BE_LONG|MAY_BE_STRING, NULL)
+	ZEND_ARG_OBJ_TYPE_MASK(0, exponent, GMP, MAY_BE_LONG|MAY_BE_STRING, NULL)
+	ZEND_ARG_OBJ_TYPE_MASK(0, modulus, GMP, MAY_BE_LONG|MAY_BE_STRING, NULL)
+ZEND_END_ARG_INFO()
+#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_gmp_perfect_square, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, num, GMP, MAY_BE_LONG|MAY_BE_STRING, NULL)
@@ -224,6 +232,9 @@ ZEND_FUNCTION(gmp_root);
 ZEND_FUNCTION(gmp_rootrem);
 ZEND_FUNCTION(gmp_pow);
 ZEND_FUNCTION(gmp_powm);
+#if defined(HAVE___GMPZ_POWM_SEC)
+ZEND_FUNCTION(gmp_powm_sec);
+#endif
 ZEND_FUNCTION(gmp_perfect_square);
 ZEND_FUNCTION(gmp_perfect_power);
 ZEND_FUNCTION(gmp_prob_prime);
@@ -283,6 +294,9 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(gmp_rootrem, arginfo_gmp_rootrem)
 	ZEND_FE(gmp_pow, arginfo_gmp_pow)
 	ZEND_FE(gmp_powm, arginfo_gmp_powm)
+#if defined(HAVE___GMPZ_POWM_SEC)
+	ZEND_FE(gmp_powm_sec, arginfo_gmp_powm_sec)
+#endif
 	ZEND_FE(gmp_perfect_square, arginfo_gmp_perfect_square)
 	ZEND_FE(gmp_perfect_power, arginfo_gmp_perfect_power)
 	ZEND_FE(gmp_prob_prime, arginfo_gmp_prob_prime)

--- a/ext/gmp/tests/bug80560.phpt
+++ b/ext/gmp/tests/bug80560.phpt
@@ -63,6 +63,9 @@ $functions2 = [
 $functions3 = [
     'gmp_powm',
 ];
+if (function_exists('gmp_powm_sec')) {
+    $functions3[] = 'gmp_powm_sec';
+}
 
 echo 'Explicit base with gmp_init:', \PHP_EOL;
 echo 'Hexadecimal', \PHP_EOL;

--- a/ext/gmp/tests/gmp_powm_sec.phpt
+++ b/ext/gmp/tests/gmp_powm_sec.phpt
@@ -1,0 +1,46 @@
+--TEST--
+gmp_powm_sec()
+--EXTENSIONS--
+gmp
+--SKIPIF--
+<?php
+if (!function_exists('gmp_powm_sec')) {
+    die('skip gmp_powm_sec() is not available');
+}
+?>
+--FILE--
+<?php
+
+var_dump(gmp_strval(gmp_powm_sec(4, 13, 497)));
+var_dump(gmp_strval(gmp_powm_sec(gmp_init(7), gmp_init(3), gmp_init(13))));
+
+foreach ([0, -1] as $exp) {
+    try {
+        var_dump(gmp_powm_sec(4, $exp, 497));
+    } catch (\ValueError $e) {
+        echo $e::class, ": ", $e->getMessage(), \PHP_EOL;
+    }
+}
+
+try {
+    var_dump(gmp_powm_sec(4, 13, 0));
+} catch (\DivisionByZeroError $e) {
+    echo $e::class, ": ", $e->getMessage(), \PHP_EOL;
+}
+
+try {
+    var_dump(gmp_powm_sec(4, 13, 496));
+} catch (\ValueError $e) {
+    echo $e::class, ": ", $e->getMessage(), \PHP_EOL;
+}
+
+echo "Done\n";
+?>
+--EXPECT--
+string(3) "445"
+string(1) "5"
+ValueError: gmp_powm_sec(): Argument #2 ($exponent) must be greater than 0
+ValueError: gmp_powm_sec(): Argument #2 ($exponent) must be greater than 0
+DivisionByZeroError: gmp_powm_sec(): Argument #3 ($modulus) Modulo by zero
+ValueError: gmp_powm_sec(): Argument #3 ($modulus) must be odd
+Done


### PR DESCRIPTION
I am currently migrating a cryptographic lib (RSA signature & decryption) from python to PHP, relying on ext-gmp. Now, I want to compute modular exponentiation with secret private exponents. For RSA decryption and signing I need to compute base^d mod N where d is a secret private exponent.

Ah, I need to consider security issue because clearly `gmp_powm` (implemented with `mpz_powm` in libgmp) leaks exponent bits via timing and cache side channels, which creates a security vulnerability.

Now, we've got [`mpz_powm_sec`](https://gmplib.org/manual/Integer-Exponentiation#index-mpz_005fpowm_005fsec) in gmp >= 5.0 which perfectly solve my issue. And, is used by gmpy2 (a very popular python lib for gmp, and is the lib my original python app relies on). In gmpy2, we have [`powmod_sec`](https://gmpy-skirpichev.readthedocs.io/en/latest/mpz.html#gmpy2.powmod_sec) and [`powmod`](https://gmpy-skirpichev.readthedocs.io/en/latest/mpz.html#gmpy2.powmod). It is also supported in [.Net apps](https://documentation.help/Math.Gmp.Native.NET/93210ab6-2523-3130-044a-80bcf43c181d.htm) (and more...). However in PHP we only have `gmp_powm`.

...And I need to implement the securer version by myself!

So let's expose the gmp API `mpz_powm_sec` to userland. It is really useful. Any pow calculation which requires cryptographic security should use this instead of `mpz_powm`

And as a direct exposure to the GMP internal API, this doesn't requires a RFC.