### PR TITLE
#22855 Fix JIT fast path for FETCH_OBJ_R/IS/W to route hooked properties

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -29,6 +29,10 @@ PHP                                                                        NEWS
 
 - Opcache:
   . Re-enable JIT for ZTS builds on Apple Silicon. (realFlowControl)
+  . Fixed JIT-emitted fast path for FETCH_OBJ_R/IS/W to also route hooked
+    property offsets (including virtual property hooks alongside asymmetric
+    -visibility declared properties) through the slow path, instead of using
+    the small hooked-offset value as an in-object byte offset. (coderzhao)
 
 - PDO_ODBC:
   . Fixed bug GH-22667 (Heap buffer over-read when a column value exceeds the

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -682,7 +682,6 @@ static bool zend_may_be_dynamic_property(zend_class_entry *ce, zend_string *memb
 		}
 	}
 
-	// TODO: Treat property hooks more precisely.
 	info = (zend_property_info*)zend_hash_find_ptr(&ce->properties_info, member);
 	if (info == NULL ||
 	    !IS_VALID_PROPERTY_OFFSET(info->offset) ||
@@ -693,6 +692,63 @@ static bool zend_may_be_dynamic_property(zend_class_entry *ce, zend_string *memb
 
 	if (!(info->flags & ZEND_ACC_PUBLIC) &&
 	    (!on_this || info->ce != ce)) {
+		return 1;
+	}
+
+	return 0;
+}
+
+/* Determines whether the runtime cache slot for the given (ce, member) pair
+ * may hold ZEND_HOOKED_PROPERTY_OFFSET, i.e. whether the resolved property
+ * may be a hooked property (with a get/set hook, including virtual
+ * properties without backing storage).
+ *
+ * This complements zend_may_be_dynamic_property(): the two together tell the
+ * JIT whether the cached offset is guaranteed to be a valid property offset
+ * (>= ZEND_FIRST_PROPERTY_OFFSET). If either function returns true, the
+ * JIT-emitted fast path MUST verify the offset before dereferencing it,
+ * otherwise a hooked offset (which is a small integer in the range
+ * [1..15]) will be interpreted as an in-object offset, producing memory
+ * reads at bogus locations (typically within an adjacent property slot).
+ *
+ * A conservative "true" is always safe. */
+static bool zend_may_be_hooked_property(zend_class_entry *ce, zend_string *member, bool on_this, const zend_op_array *op_array)
+{
+	zend_property_info *info;
+
+	if (!ce || (ce->ce_flags & ZEND_ACC_TRAIT) || (op_array->fn_flags & ZEND_ACC_TRAIT_CLONE)) {
+		return 1;
+	}
+
+	if (!(ce->ce_flags & ZEND_ACC_IMMUTABLE)) {
+		if (ce->info.user.filename != op_array->filename) {
+			/* class declaration might be changed independently */
+			return 1;
+		}
+	}
+
+	info = (zend_property_info*)zend_hash_find_ptr(&ce->properties_info, member);
+	if (info == NULL) {
+		/* Unknown property. Might resolve to a hooked property at runtime
+		 * (e.g. added by a subclass) unless we can rule that out. */
+		return 1;
+	}
+
+	if (info->flags & ZEND_ACC_STATIC) {
+		/* Static properties never go through the instance fetch path. */
+		return 0;
+	}
+
+	if (info->hooks) {
+		return 1;
+	}
+
+	/* When accessing through $this and the class is not final, a subclass may
+	 * shadow this property with a hooked one (asymmetric visibility does not
+	 * prevent shadowing). Only inaccessible-from-scope shadowing is safe. */
+	if (on_this
+	 && !(ce->ce_flags & ZEND_ACC_FINAL)
+	 && (info->flags & ZEND_ACC_PUBLIC)) {
 		return 1;
 	}
 

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -14275,6 +14275,7 @@ static int zend_jit_fetch_obj(zend_jit_ctx         *jit,
 	zval *member;
 	zend_property_info *prop_info;
 	bool may_be_dynamic = true;
+	bool may_be_hooked = true;
 	zend_jit_addr prop_addr;
 	uint32_t res_info = RES_INFO();
 	ir_ref prop_type_ref = IR_UNUSED;
@@ -14401,7 +14402,23 @@ static int zend_jit_fetch_obj(zend_jit_ctx         *jit,
 			ir_ADD_OFFSET(run_time_cache, (opline->extended_value & ~ZEND_FETCH_OBJ_FLAGS) + sizeof(void*)));
 
 		may_be_dynamic = zend_may_be_dynamic_property(ce, Z_STR_P(member), opline->op1_type == IS_UNUSED, op_array);
-		if (may_be_dynamic) {
+		/* When the cache slot may hold a hooked-property offset (a small
+		 * positive integer in the range [1..15]), the fast path must first
+		 * verify offset >= ZEND_FIRST_PROPERTY_OFFSET. Otherwise the hooked
+		 * offset is used as an in-object byte offset and the JIT reads a
+		 * bogus zval from within the object (typically overlapping an
+		 * adjacent property slot). This affects e.g. virtual property hooks
+		 * (get-only, no backing storage) combined with asymmetric-visibility
+		 * declared properties on the same class.
+		 *
+		 * IS_HOOKED_PROPERTY_OFFSET(offset) is true when 0 < offset < 16 and
+		 * IS_DYNAMIC_PROPERTY_OFFSET(offset) is true when offset < 0, so a
+		 * single signed comparison offset < ZEND_FIRST_PROPERTY_OFFSET (=16)
+		 * covers both cases and delegates them to zend_jit_fetch_obj_*_dynamic
+		 * helpers, which route hooked offsets to the slow path (which calls
+		 * the get hook via read_property). */
+		may_be_hooked = zend_may_be_hooked_property(ce, Z_STR_P(member), opline->op1_type == IS_UNUSED, op_array);
+		if (may_be_dynamic || may_be_hooked) {
 			ir_ref if_dynamic = ir_IF(ir_LT(offset_ref, ir_CONST_ADDR(ZEND_FIRST_PROPERTY_OFFSET)));
 			if (opline->opcode == ZEND_FETCH_OBJ_W) {
 				ir_IF_TRUE_cold(if_dynamic);

--- a/ext/opcache/tests/jit/prophook_avis_1.phpt
+++ b/ext/opcache/tests/jit/prophook_avis_1.phpt
@@ -1,0 +1,57 @@
+--TEST--
+JIT: virtual property hook must be invoked when a preceding asymmetric-visibility property lives in the same class - jit 1235
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit=1235
+opcache.jit_buffer_size=16M
+opcache.jit_hot_func=1
+opcache.jit_hot_loop=1
+opcache.jit_hot_return=1
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+
+interface HandlerInterface {
+    public function name(): string;
+}
+
+class DefaultHandler implements HandlerInterface {
+    public function name(): string { return 'default'; }
+}
+
+class Container
+{
+    public protected(set) HandlerInterface $handler;
+
+    public string $label {
+        get => "container[{$this->kind}:{$this->key}]";
+    }
+
+    public function __construct(
+        public protected(set) string $kind,
+        public protected(set) string $key
+    ) {
+        $this->handler = new DefaultHandler();
+    }
+
+    public function read(): string
+    {
+        return $this->label;
+    }
+}
+
+$c = new Container('alpha', 'beta');
+
+/* Warm-up: trip tracing JIT thresholds for Container::read(). */
+for ($i = 0; $i < 100000; $i++) {
+    $r = $c->read();
+}
+
+var_dump($r);
+var_dump(gettype($r));
+?>
+--EXPECT--
+string(21) "container[alpha:beta]"
+string(6) "string"

--- a/ext/opcache/tests/jit/prophook_avis_2.phpt
+++ b/ext/opcache/tests/jit/prophook_avis_2.phpt
@@ -1,0 +1,60 @@
+--TEST--
+JIT: virtual property hook must be invoked when a preceding asymmetric-visibility property lives in the same class - jit 1205 (function JIT)
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit=1205
+opcache.jit_buffer_size=16M
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+
+interface HandlerInterface {
+    public function name(): string;
+}
+
+class DefaultHandler implements HandlerInterface {
+    public function name(): string { return 'default'; }
+}
+
+class Container
+{
+    public protected(set) HandlerInterface $handler;
+
+    public string $label {
+        get => "container[{$this->kind}:{$this->key}]";
+    }
+
+    public function __construct(
+        public protected(set) string $kind,
+        public protected(set) string $key
+    ) {
+        $this->handler = new DefaultHandler();
+    }
+
+    /* Method-scoped access: op_array->scope == Container and opline
+     * op1_type == IS_UNUSED for $this->label, exercising the JIT code path
+     * that must emit an offset check for hooked properties. */
+    public function read(): string
+    {
+        return $this->label;
+    }
+}
+
+/* Also exercise the non-$this path, where op1 is a variable holding an
+ * instance of Container. */
+function readLabel(Container $c): string {
+    return $c->label;
+}
+
+$c = new Container('alpha', 'beta');
+
+var_dump($c->read());
+var_dump(readLabel($c));
+var_dump($c->handler->name());
+?>
+--EXPECT--
+string(21) "container[alpha:beta]"
+string(21) "container[alpha:beta]"
+string(7) "default"


### PR DESCRIPTION
…ooked

    property offsets (including virtual property hooks alongside asymmetric
    -visibility declared properties) through the slow path, instead of using
    the small hooked-offset value as an in-object byte offset. (coderzhao)