### PR TITLE
Fix GH-22854: assertion failure at link_errno_read in ext/mysqli/mysqli_prop.c

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -23,6 +23,10 @@ PHP                                                                        NEWS
   . Fixed grammatical issues in Normalizer invalid form and IntlCalendar time
     zone offset error messages. (Weilin Du)
 
+- MySQLi:
+  . Fixed bug GH-22854 (Assertion failure when reading the errno/error
+    property of a mysqli object whose connection failed). (Khaled Alam)
+
 - ODBC:
   . Fixed bug GH-22668 (Heap buffer over-read when a column value exceeds the
     driver-reported display size). (iliaal)

--- a/ext/mysqli/mysqli_prop.c
+++ b/ext/mysqli/mysqli_prop.c
@@ -41,6 +41,12 @@ if (!obj->ptr || !(MY_MYSQL *)((MYSQLI_RESOURCE *)(obj->ptr))->ptr) { \
 } else { \
 	CHECK_STATUS(statusval, quiet);\
 	p = (MYSQL *)((MY_MYSQL *)((MYSQLI_RESOURCE *)(obj->ptr))->ptr)->mysql;\
+	if (!p) { \
+		if (!quiet) { \
+			zend_throw_error(NULL, "%s object is not fully initialized", ZSTR_VAL(obj->zo.ce->name)); \
+		} \
+		return FAILURE; \
+	} \
 }
 
 #define MYSQLI_GET_RESULT(statusval) \

--- a/ext/mysqli/tests/gh22854.phpt
+++ b/ext/mysqli/tests/gh22854.phpt
@@ -1,0 +1,33 @@
+--TEST--
+GH-22854 (Assertion failure at link_errno_read in ext/mysqli/mysqli_prop.c)
+--EXTENSIONS--
+mysqli
+--FILE--
+<?php
+mysqli_report(MYSQLI_REPORT_OFF);
+
+/* An initialized-but-not-connected object: after a failed connect(),
+ * the internal MYSQL* handle is NULL while the resource status stays
+ * INITIALIZED. Reading the errno/error properties used to dereference the
+ * NULL handle and abort on ZEND_ASSERT(p). */
+$mysqli = new mysqli();
+@$mysqli->connect('localhost', 'user', 'pass', 'db', 0, '/mysqli/gh22854/does/not/exist.sock');
+
+try {
+    var_dump($mysqli->errno);
+} catch (\Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    var_dump($mysqli->error);
+} catch (\Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+echo "done\n";
+?>
+--EXPECT--
+mysqli object is not fully initialized
+mysqli object is not fully initialized
+done


### PR DESCRIPTION
Fixes GH-22854.


### Problem
Reading the `errno` or `error` property of a mysqli object whose connection failed aborts the process with:

Assertion `p' failed. Aborted (core dumped)

(`link_errno_read`, ext/mysqli/mysqli_prop.c:225)