### PR TITLE
Remove `param` argument from `php_verror`

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -114,6 +114,7 @@ PHP 8.6 INTERNALS UPGRADE NOTES
     longer is a pointer, but a directly embedded HashTable struct.
   . Extended php_stream_filter_ops with seek method.
   . zend_argument_error_variadic() now takes a new 'function' parameter.
+  . The param argument in the php_verror() function has been removed.
 
 - Added:
   . New zend_class_entry.ce_flags2 and zend_function.fn_flags2 fields were

--- a/ext/exif/exif.c
+++ b/ext/exif/exif.c
@@ -2036,11 +2036,11 @@ static void exif_error_docref(const char *docref EXIFERR_DC, image_info_type *Im
 		char *buf;
 
 		spprintf(&buf, 0, "%s(%ld): %s", _file, _line, format);
-		php_verror(docref, ImageInfo && ImageInfo->FileName ? ImageInfo->FileName:"", type, buf, args);
+		php_verror(docref, type, buf, args);
 		efree(buf);
 	}
 #else
-	php_verror(docref, ImageInfo && ImageInfo->FileName ? ImageInfo->FileName:"", type, format, args);
+	php_verror(docref, type, format, args);
 #endif
 	va_end(args);
 }

--- a/ext/exif/tests/bug48378.phpt
+++ b/ext/exif/tests/bug48378.phpt
@@ -10,8 +10,8 @@ __DIR__ . "/bug48378.jpg",
 );
 ?>
 --EXPECTF--
-Warning: exif_read_data(%s): Invalid IFD start in %s48378.php on line %d
+Warning: exif_read_data(): Invalid IFD start in %s48378.php on line %d
 
-Warning: exif_read_data(%s): Error reading from file: got=x08B4(=2228) != itemlen-2=x1FFE(=8190) in %s48378.php on line %d
+Warning: exif_read_data(): Error reading from file: got=x08B4(=2228) != itemlen-2=x1FFE(=8190) in %s48378.php on line %d
 
-Warning: exif_read_data(%s): Invalid JPEG file in %s48378.php on line %d
+Warning: exif_read_data(): Invalid JPEG file in %s48378.php on line %d

--- a/ext/exif/tests/bug54002.phpt
+++ b/ext/exif/tests/bug54002.phpt
@@ -11,6 +11,6 @@ exif_read_data(__DIR__ . '/bug54002_2.jpg');
 
 ?>
 --EXPECTF--
-Warning: exif_read_data(bug54002_1.jpg): Process tag(x0205=UndefinedTag): Illegal byte_count in %sbug54002.php on line %d
+Warning: exif_read_data(): Process tag(x0205=UndefinedTag): Illegal byte_count in %sbug54002.php on line %d
 
-Warning: exif_read_data(bug54002_2.jpg): Process tag(x0205=UndefinedTag): Illegal byte_count in %sbug54002.php on line %d
+Warning: exif_read_data(): Process tag(x0205=UndefinedTag): Illegal byte_count in %sbug54002.php on line %d

--- a/ext/exif/tests/bug60150.phpt
+++ b/ext/exif/tests/bug60150.phpt
@@ -11,9 +11,9 @@ $infile = __DIR__.'/bug60150.jpg';
 var_dump(exif_read_data($infile));
 ?>
 --EXPECTF--
-Warning: exif_read_data(bug60150.jpg): Process tag(x9003=DateTimeOriginal): Illegal pointer offset(%s) in %s on line %d
+Warning: exif_read_data(): Process tag(x9003=DateTimeOriginal): Illegal pointer offset(%s) in %s on line %d
 
-Warning: exif_read_data(bug60150.jpg): Error reading from file: got=x%x(=%d) != itemlen-%d=x%x(=%d) in %s on line %d
+Warning: exif_read_data(): Error reading from file: got=x%x(=%d) != itemlen-%d=x%x(=%d) in %s on line %d
 
-Warning: exif_read_data(bug60150.jpg): Invalid JPEG file in %s on line %d
+Warning: exif_read_data(): Invalid JPEG file in %s on line %d
 bool(false)

--- a/ext/exif/tests/bug62523_3.phpt
+++ b/ext/exif/tests/bug62523_3.phpt
@@ -11,6 +11,6 @@ Done
 --EXPECTF--
 Test
 
-Warning: exif_read_data(bug62523_3.jpg): File not supported in %sbug62523_3.php on line %d
+Warning: exif_read_data(): File not supported in %sbug62523_3.php on line %d
 bool(false)
 Done

--- a/ext/exif/tests/bug68113-mb.phpt
+++ b/ext/exif/tests/bug68113-mb.phpt
@@ -8,8 +8,8 @@ var_dump(exif_thumbnail(__DIR__."/bug68113私はガラスを食べられます.j
 ?>
 Done
 --EXPECTF--
-Warning: exif_thumbnail(bug68113私はガラスを食べられます.jpg): File structure corrupted in %s%ebug68113-mb.php on line 2
+Warning: exif_thumbnail(): File structure corrupted in %s%ebug68113-mb.php on line 2
 
-Warning: exif_thumbnail(bug68113私はガラスを食べられます.jpg): Invalid JPEG file in %s%ebug68113-mb.php on line 2
+Warning: exif_thumbnail(): Invalid JPEG file in %s%ebug68113-mb.php on line 2
 bool(false)
 Done

--- a/ext/exif/tests/bug68113.phpt
+++ b/ext/exif/tests/bug68113.phpt
@@ -8,8 +8,8 @@ var_dump(exif_thumbnail(__DIR__."/bug68113.jpg"));
 ?>
 Done
 --EXPECTF--
-Warning: exif_thumbnail(bug68113.jpg): File structure corrupted in %s%ebug68113.php on line 2
+Warning: exif_thumbnail(): File structure corrupted in %s%ebug68113.php on line 2
 
-Warning: exif_thumbnail(bug68113.jpg): Invalid JPEG file in %s%ebug68113.php on line 2
+Warning: exif_thumbnail(): Invalid JPEG file in %s%ebug68113.php on line 2
 bool(false)
 Done

--- a/ext/exif/tests/bug72094.phpt
+++ b/ext/exif/tests/bug72094.phpt
@@ -11,49 +11,49 @@ print_r(exif_read_data(__DIR__ . '/bug72094_4.jpg'));
 ?>
 DONE
 --EXPECTF--
-Warning: exif_read_data(bug72094_1.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
+Warning: exif_read_data(): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_1.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
+Warning: exif_read_data(): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_1.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
+Warning: exif_read_data(): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_1.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
+Warning: exif_read_data(): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_1.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
+Warning: exif_read_data(): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_1.jpg): Process tag(x8298=Copyright): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
+Warning: exif_read_data(): Process tag(x8298=Copyright): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_1.jpg): Illegal IFD offset in %sbug72094.php on line %d
+Warning: exif_read_data(): Illegal IFD offset in %sbug72094.php on line %d
 
-Warning: exif_read_data(bug72094_1.jpg): File structure corrupted in %s%ebug72094.php on line %d
+Warning: exif_read_data(): File structure corrupted in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_1.jpg): Invalid JPEG file in %s%ebug72094.php on line %d
+Warning: exif_read_data(): Invalid JPEG file in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_2.jpg): Illegal IFD size in %s%ebug72094.php on line %d
+Warning: exif_read_data(): Illegal IFD size in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_2.jpg): File structure corrupted in %s%ebug72094.php on line %d
+Warning: exif_read_data(): File structure corrupted in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_2.jpg): Invalid JPEG file in %s%ebug72094.php on line %d
+Warning: exif_read_data(): Invalid JPEG file in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_3.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
+Warning: exif_read_data(): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_3.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
+Warning: exif_read_data(): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_3.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
+Warning: exif_read_data(): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_3.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
+Warning: exif_read_data(): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_3.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
+Warning: exif_read_data(): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_3.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
+Warning: exif_read_data(): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_3.jpg): File structure corrupted in %s%ebug72094.php on line %d
+Warning: exif_read_data(): File structure corrupted in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_3.jpg): Invalid JPEG file in %s%ebug72094.php on line %d
+Warning: exif_read_data(): Invalid JPEG file in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_4.jpg): Invalid TIFF start (1) in %s%ebug72094.php on line %d
+Warning: exif_read_data(): Invalid TIFF start (1) in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_4.jpg): File structure corrupted in %s%ebug72094.php on line %d
+Warning: exif_read_data(): File structure corrupted in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_4.jpg): Invalid JPEG file in %s%ebug72094.php on line %d
+Warning: exif_read_data(): Invalid JPEG file in %s%ebug72094.php on line %d
 DONE

--- a/ext/exif/tests/bug72603.phpt
+++ b/ext/exif/tests/bug72603.phpt
@@ -7,5 +7,5 @@ exif
 var_dump(count(exif_read_data(__DIR__ . "/bug72603.jpg")));
 ?>
 --EXPECTF--
-Warning: exif_read_data(bug72603.jpg): %s in %s%ebug72603.php on line %d
+Warning: exif_read_data(): %s in %s%ebug72603.php on line %d
 int(%d)

--- a/ext/exif/tests/bug72618.phpt
+++ b/ext/exif/tests/bug72618.phpt
@@ -7,5 +7,5 @@ exif
 var_dump(count(exif_read_data(__DIR__ . "/bug72618.jpg")));
 ?>
 --EXPECTF--
-Warning: exif_read_data(bug72618.jpg): %s in %s%ebug72618.php on line %d
+Warning: exif_read_data(): %s in %s%ebug72618.php on line %d
 int(%d)

--- a/ext/exif/tests/bug72627.phpt
+++ b/ext/exif/tests/bug72627.phpt
@@ -8,11 +8,11 @@ exif
     var_dump($exif);
 ?>
 --EXPECTF--
-Warning: exif_read_data(%s): Thumbnail goes IFD boundary or end of file reached in %sbug72627.php on line %d
+Warning: exif_read_data(): Thumbnail goes IFD boundary or end of file reached in %sbug72627.php on line %d
 
-Warning: exif_read_data(%s): Error in TIFF: filesize(x04E2) less than start of IFD dir(x829A0004) in %sbug72627.php on line %d
+Warning: exif_read_data(): Error in TIFF: filesize(x04E2) less than start of IFD dir(x829A0004) in %sbug72627.php on line %d
 
-Warning: exif_read_data(%s): Thumbnail goes IFD boundary or end of file reached in %sbug72627.php on line %d
+Warning: exif_read_data(): Thumbnail goes IFD boundary or end of file reached in %sbug72627.php on line %d
 array(11) {
   ["FileName"]=>
   string(13) "bug72627.tiff"

--- a/ext/exif/tests/bug73737.phpt
+++ b/ext/exif/tests/bug73737.phpt
@@ -8,7 +8,7 @@ exif
     var_dump($exif);
 ?>
 --EXPECTF--
-Warning: exif_thumbnail(bug73737.tiff): Process tag(x0100=ImageWidth): Cannot be empty in %s on line %d
+Warning: exif_thumbnail(): Process tag(x0100=ImageWidth): Cannot be empty in %s on line %d
 
-Warning: exif_thumbnail(bug73737.tiff): Error in TIFF: filesize(x0030) less than start of IFD dir(x10102) in %s line %d
+Warning: exif_thumbnail(): Error in TIFF: filesize(x0030) less than start of IFD dir(x10102) in %s line %d
 bool(false)

--- a/ext/exif/tests/bug76423.phpt
+++ b/ext/exif/tests/bug76423.phpt
@@ -7,8 +7,8 @@ exif
 exif_read_data(__DIR__ . '/bug76423.jpg', 0, true, true);
 ?>
 --EXPECTF--
-Warning: exif_read_data(%s.jpg): Thumbnail goes IFD boundary or end of file reached in %s on line %d
+Warning: exif_read_data(): Thumbnail goes IFD boundary or end of file reached in %s on line %d
 
-Warning: exif_read_data(%s.jpg): File structure corrupted in %s on line %d
+Warning: exif_read_data(): File structure corrupted in %s on line %d
 
-Warning: exif_read_data(%s.jpg): Invalid JPEG file in %s on line %d
+Warning: exif_read_data(): Invalid JPEG file in %s on line %d

--- a/ext/exif/tests/bug76557.phpt
+++ b/ext/exif/tests/bug76557.phpt
@@ -8,25 +8,25 @@ var_dump(exif_read_data(__DIR__ . "/bug76557.jpg"));
 ?>
 DONE
 --EXPECTF--
-Warning: exif_read_data(bug76557.jpg): Process tag(x010F=Make): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
+Warning: exif_read_data(): Process tag(x010F=Make): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
 
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
+Warning: exif_read_data(): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
 
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
+Warning: exif_read_data(): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
 
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
+Warning: exif_read_data(): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
 
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
+Warning: exif_read_data(): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
 
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
+Warning: exif_read_data(): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
 
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
+Warning: exif_read_data(): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
 
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
+Warning: exif_read_data(): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
 
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
+Warning: exif_read_data(): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
 
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
+Warning: exif_read_data(): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
 
 Warning: exif_read_data(): Further exif parsing errors have been suppressed in %s on line %d
 bool(false)

--- a/ext/exif/tests/bug77563.phpt
+++ b/ext/exif/tests/bug77563.phpt
@@ -8,11 +8,11 @@ $s = exif_thumbnail(__DIR__."/bug77563.jpg");
 ?>
 DONE
 --EXPECTF--
-Warning: exif_thumbnail(bug77563.jpg): IFD data too short: 0x0009 offset 0x0008 in %s%ebug77563.php on line %d
+Warning: exif_thumbnail(): IFD data too short: 0x0009 offset 0x0008 in %s%ebug77563.php on line %d
 
-Warning: exif_thumbnail(bug77563.jpg): Illegal IFD offset in %s%ebug77563.php on line %d
+Warning: exif_thumbnail(): Illegal IFD offset in %s%ebug77563.php on line %d
 
-Warning: exif_thumbnail(bug77563.jpg): File structure corrupted in %s%ebug77563.php on line %d
+Warning: exif_thumbnail(): File structure corrupted in %s%ebug77563.php on line %d
 
-Warning: exif_thumbnail(bug77563.jpg): Invalid JPEG file in %s%ebug77563.php on line %d
+Warning: exif_thumbnail(): Invalid JPEG file in %s%ebug77563.php on line %d
 DONE

--- a/ext/exif/tests/bug77564/bug77564.phpt
+++ b/ext/exif/tests/bug77564/bug77564.phpt
@@ -9,10 +9,10 @@ var_dump(exif_read_data(__DIR__ . '/bug77564.jpg'));
 DONE
 --EXPECTF--
 
-Warning: exif_read_data(bug77564.jpg): Illegal IFD offset in %sbug77564.php on line %d
+Warning: exif_read_data(): Illegal IFD offset in %sbug77564.php on line %d
 
-Warning: exif_read_data(bug77564.jpg): File structure corrupted in %sbug77564.php on line %d
+Warning: exif_read_data(): File structure corrupted in %sbug77564.php on line %d
 
-Warning: exif_read_data(bug77564.jpg): Invalid JPEG file in %sbug77564.php on line %d
+Warning: exif_read_data(): Invalid JPEG file in %sbug77564.php on line %d
 bool(false)
 DONE

--- a/ext/exif/tests/heic_box_overflow.phpt
+++ b/ext/exif/tests/heic_box_overflow.phpt
@@ -23,5 +23,5 @@ var_dump(exif_read_data(__DIR__."/heic_box_overflow"));
 @unlink(__DIR__."/heic_box_overflow");
 ?>
 --EXPECTF--
-Warning: exif_read_data(heic_box_overflow): Invalid HEIF file in %s on line %d
+Warning: exif_read_data(): Invalid HEIF file in %s on line %d
 bool(false)

--- a/ext/exif/tests/heic_iloc_underflow.phpt
+++ b/ext/exif/tests/heic_iloc_underflow.phpt
@@ -15,5 +15,5 @@ var_dump(exif_read_data(__DIR__."/heic_iloc_underflow.heic"));
 @unlink(__DIR__."/heic_iloc_underflow.heic");
 ?>
 --EXPECTF--
-Warning: exif_read_data(heic_iloc_underflow.heic): Invalid HEIF file in %s on line %d
+Warning: exif_read_data(): Invalid HEIF file in %s on line %d
 bool(false)

--- a/ext/exif/tests/oss_fuzz_442954659/oss_fuzz_442954659.phpt
+++ b/ext/exif/tests/oss_fuzz_442954659/oss_fuzz_442954659.phpt
@@ -7,4 +7,4 @@ exif
 exif_read_data(__DIR__."/input");
 ?>
 --EXPECTF--
-Warning: exif_read_data(%s): Invalid HEIF file in %s on line %d
+Warning: exif_read_data(): Invalid HEIF file in %s on line %d

--- a/ext/exif/tests/oss_fuzz_444479893/oss_fuzz_444479893.phpt
+++ b/ext/exif/tests/oss_fuzz_444479893/oss_fuzz_444479893.phpt
@@ -7,4 +7,4 @@ exif
 exif_read_data(__DIR__."/input");
 ?>
 --EXPECTF--
-Warning: exif_read_data(%s): Invalid HEIF file in %s on line %d
+Warning: exif_read_data(): Invalid HEIF file in %s on line %d

--- a/ext/exif/tests/tag_with_illegal_zero_components.phpt
+++ b/ext/exif/tests/tag_with_illegal_zero_components.phpt
@@ -9,9 +9,9 @@ var_dump(exif_read_data(__DIR__ . '/tag_with_illegal_zero_components.jpeg'));
 
 ?>
 --EXPECTF--
-Warning: exif_read_data(tag_with_illegal_zero_components.jpeg): Process tag(x0202=JPEGInterchangeFormatLength): Cannot be empty in %s on line %d
+Warning: exif_read_data(): Process tag(x0202=JPEGInterchangeFormatLength): Cannot be empty in %s on line %d
 
-Warning: exif_read_data(tag_with_illegal_zero_components.jpeg): File structure corrupted in %s on line %d
+Warning: exif_read_data(): File structure corrupted in %s on line %d
 
-Warning: exif_read_data(tag_with_illegal_zero_components.jpeg): Invalid JPEG file in %s on line %d
+Warning: exif_read_data(): Invalid JPEG file in %s on line %d
 bool(false)

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -322,7 +322,7 @@ void php_gd_error_method(int type, const char *format, va_list args)
 		default:
 			type = E_ERROR;
 	}
-	php_verror(NULL, "", type, format, args);
+	php_verror(NULL, type, format, args);
 }
 /* }}} */
 

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -635,15 +635,13 @@ void php_openssl_errors_restore_mark(void) {
 static void php_openssl_check_path_error(uint32_t arg_num, int type, const char *format, ...)
 {
 	va_list va;
-	const char *arg_name;
 
 	va_start(va, format);
 
 	if (type == E_ERROR) {
 		zend_argument_error_variadic(zend_ce_value_error, zend_active_function(), arg_num, format, va);
 	} else {
-		arg_name = get_active_function_arg_name(arg_num);
-		php_verror(NULL, arg_name, type, format, va);
+		php_verror(NULL, type, format, va);
 	}
 	va_end(va);
 }

--- a/ext/openssl/tests/openssl_csr_export_to_file_leak.phpt
+++ b/ext/openssl/tests/openssl_csr_export_to_file_leak.phpt
@@ -10,5 +10,5 @@ var_dump(openssl_csr_export_to_file($path, str_repeat("a", 10000)));
 
 ?>
 --EXPECTF--
-Warning: openssl_csr_export_to_file(output_filename): must be a valid file path %s
+Warning: openssl_csr_export_to_file(): must be a valid file path %s
 bool(false)

--- a/ext/openssl/tests/openssl_pkey_export_to_file_leak.phpt
+++ b/ext/openssl/tests/openssl_pkey_export_to_file_leak.phpt
@@ -11,5 +11,5 @@ var_dump(openssl_pkey_export_to_file($key, str_repeat("a", 10000), passphrase: "
 
 ?>
 --EXPECTF--
-Warning: openssl_pkey_export_to_file(output_filename): must be a valid file path %s
+Warning: openssl_pkey_export_to_file(): must be a valid file path %s
 bool(false)

--- a/ext/openssl/tests/openssl_x509_export_to_file_leak.phpt
+++ b/ext/openssl/tests/openssl_x509_export_to_file_leak.phpt
@@ -10,5 +10,5 @@ var_dump(openssl_x509_export_to_file($path, str_repeat("a", 10000)));
 
 ?>
 --EXPECTF--
-Warning: openssl_x509_export_to_file(output_filename): must be a valid file path %s
+Warning: openssl_x509_export_to_file(): must be a valid file path %s
 bool(false)

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -218,7 +218,7 @@ static void php_snmp_error(zval *object, int type, const char *format, ...)
 		zend_throw_exception_ex(php_snmp_exception_ce, type, "%s", snmp_object->snmp_errstr);
 	} else {
 		va_start(args, format);
-		php_verror(NULL, "", E_WARNING, format, args);
+		php_verror(NULL, E_WARNING, format, args);
 		va_end(args);
 	}
 }

--- a/main/main.c
+++ b/main/main.c
@@ -1058,7 +1058,7 @@ static zend_string *escape_html(const char *buffer, size_t buffer_len) {
  * html error messages if corresponding ini setting (html_errors) is activated.
  * See: CODING_STANDARDS.md for details.
  */
-PHPAPI ZEND_COLD void php_verror(const char *docref, const char *params, int type, const char *format, va_list args)
+PHPAPI ZEND_COLD void php_verror(const char *docref, int type, const char *format, va_list args)
 {
 	zend_string *replace_origin = NULL;
 	char *docref_buf = NULL, *target = NULL;
@@ -1138,7 +1138,7 @@ PHPAPI ZEND_COLD void php_verror(const char *docref, const char *params, int typ
 		if (PG(error_include_args)) {
 			dynamic_params = zend_trace_current_function_args_string();
 		}
-		origin_len = spprintf(&origin, 0, "%s%s%s(%s)", class_name, space, function, dynamic_params ? ZSTR_VAL(dynamic_params) : params);
+		origin_len = spprintf(&origin, 0, "%s%s%s(%s)", class_name, space, function, dynamic_params ? ZSTR_VAL(dynamic_params) : "");
 		if (dynamic_params) {
 			zend_string_release(dynamic_params);
 		}
@@ -1243,7 +1243,7 @@ PHPAPI ZEND_COLD void php_verror(const char *docref, const char *params, int typ
 #define php_error_docref_impl(docref, type, format) do {\
 		va_list args; \
 		va_start(args, format); \
-		php_verror(docref, "", type, format, args); \
+		php_verror(docref, type, format, args); \
 		va_end(args); \
 	} while (0)
 

--- a/main/php.h
+++ b/main/php.h
@@ -299,7 +299,7 @@ static inline ZEND_ATTRIBUTE_DEPRECATED void php_set_error_handling(error_handli
 }
 static inline ZEND_ATTRIBUTE_DEPRECATED void php_std_error_handling(void) {}
 
-PHPAPI ZEND_COLD void php_verror(const char *docref, const char *params, int type, const char *format, va_list args) PHP_ATTRIBUTE_FORMAT(printf, 4, 0);
+PHPAPI ZEND_COLD void php_verror(const char *docref, int type, const char *format, va_list args) PHP_ATTRIBUTE_FORMAT(printf, 3, 0);
 
 /* PHPAPI void php_error(int type, const char *format, ...); */
 PHPAPI ZEND_COLD void php_error_docref(const char *docref, int type, const char *format, ...)


### PR DESCRIPTION
Update tests and `UPGRADING.INTERNALS`.

Note there is some impact to extensions if they call this; however, it's usually in a centralized wrapper function which is easy to update. In my quick skim of external extensions, apcu is the only maintained one that'll need an update.

Also note that `php_verror` is a bit weirdly named. It should probably be called something like `php_docref_verror`, since `php_error_docref` the vararg wrapper around it (now that 1/2 are gone); let me know if this is something worth pursuing. There is `php_error`, which is just an alias for `zend_error`, which doesn't take a docref, nor does it have the function and args prefix that `php_verror` has. It should be used for engine stuff, but I think there are a few places where it's called from places where `php_error_docref` should be used instead in extensions. I can take a look at that too.