### PR TITLE
Fix GH-22857: virtual property hook mis-primes SIMPLE_GET under FUNC_ARG

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,17 @@ PHP                                                                        NEWS
   . Implemented partial function application RFC. (Arnaud)
   . Fixed bug GH-22263 (reset typed property default on every unserialize
     failure path). (David Carlier)
+  . Fixed zend_std_read_property() priming the SIMPLE_GET property-hook
+    cache-slot bit while the currently-executing opline was anything
+    other than a plain ZEND_FETCH_OBJ_R (in particular
+    ZEND_FETCH_OBJ_FUNC_ARG, which dispatches into the same handler for
+    by-value argument fetches). Once primed, subsequent hook reads went
+    through the SIMPLE_GET fast path with a mismatched opline and read
+    garbage from an adjacent property slot, typically surfacing as a
+    ValueError "must not contain any null bytes", a TypeError
+    referencing the neighbouring slot's class, or a heap-corruption
+    abort. Mirrors the opline check already used for SIMPLE_READ.
+    (coderzhao)
 
 - DOM:
   . Fixed bug GH-22825 (DOMElement::setAttribute() fails silently when the DTD

--- a/Zend/tests/property_hooks/virtual_hook_as_func_arg.phpt
+++ b/Zend/tests/property_hooks/virtual_hook_as_func_arg.phpt
@@ -1,0 +1,94 @@
+--TEST--
+Virtual property hook read via FETCH_OBJ_FUNC_ARG must invoke the getter (function JIT)
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit_buffer_size=64M
+opcache.jit=1205
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+
+namespace Regression;
+
+interface HandlerInterface { public function noop(): void; }
+
+final class DefaultHandler implements HandlerInterface {
+    private static ?self $i = null;
+    public static function getInstance(): self { return self::$i ??= new self(); }
+    public function noop(): void {}
+}
+
+class Container {
+    public protected(set) HandlerInterface $handler;
+
+    public string $path {
+        get => self::build($this->kind, $this->id);
+    }
+
+    protected mixed $prev = null;
+
+    public function __construct(
+        public protected(set) string $kind,
+        public protected(set) string $id,
+    ) {
+        $this->handler = DefaultHandler::getInstance();
+    }
+
+    public static function build(string $k, string $i): string {
+        return "/nonexistent/regression_{$k}_{$i}.dat";
+    }
+
+    /* Passes a virtual property hook directly as the first argument of an
+     * unqualified (namespace-fallback) global function. That fallback path
+     * emits INIT_NS_FCALL_BY_NAME + CHECK_FUNC_ARG + FETCH_OBJ_FUNC_ARG,
+     * and the FETCH_OBJ_FUNC_ARG handler tail-calls into the FETCH_OBJ_R
+     * handler for by-value arguments.
+     *
+     * zend_std_read_property() must not prime the SIMPLE_GET property-hook
+     * cache-slot bit while the currently-executing opline is anything
+     * other than a plain ZEND_FETCH_OBJ_R. If it does, subsequent hook
+     * reads (potentially via a JIT-compiled fast path for FUNC_ARG that
+     * has no hook-enter check) go through the SIMPLE_GET path with a
+     * mismatched opline and read garbage from an adjacent property slot,
+     * typically surfacing as ValueError "must not contain any null bytes"
+     * or a TypeError referencing the neighbour's class.
+     *
+     * Also exercises the same fetch under @-silencing (BEGIN_SILENCE /
+     * END_SILENCE) which is the exact shape observed in the wild. */
+    public function step(): void {
+        // First: a bare FETCH_OBJ_FUNC_ARG under a namespaced call.
+        $len = strlen($this->path);
+        if ($len === 0) {
+            throw new \RuntimeException('empty path from hook');
+        }
+        // Second: a silenced namespaced call with the hook as arg #1.
+        // file_get_contents() is a by-value string parameter so the
+        // FETCH_OBJ_FUNC_ARG dispatches into the FETCH_OBJ_R handler.
+        $r = @file_get_contents($this->path);
+        // The file does not exist, so a false return with a warning is
+        // expected. The important thing is that no ValueError / TypeError
+        // / heap corruption occurs while producing the argument.
+        if ($r !== false) {
+            throw new \RuntimeException('unexpected non-false return');
+        }
+    }
+}
+
+$c = new Container('alpha', 'beta');
+
+for ($i = 0; $i < 200; $i++) {
+    try {
+        $c->step();
+    } catch (\Throwable $e) {
+        printf("iter=%d threw %s: %s\n", $i, $e::class, $e->getMessage());
+        exit(1);
+    }
+}
+
+echo "OK\n";
+
+?>
+--EXPECT--
+OK

--- a/Zend/tests/property_hooks/virtual_hook_as_func_arg.phpt
+++ b/Zend/tests/property_hooks/virtual_hook_as_func_arg.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Virtual property hook read via FETCH_OBJ_FUNC_ARG must invoke the getter (function JIT)
+Virtual property hook read via FETCH_OBJ_FUNC_ARG must not prime SIMPLE_GET (function JIT)
 --INI--
 opcache.enable=1
 opcache.enable_cli=1
@@ -40,36 +40,38 @@ class Container {
         return "/nonexistent/regression_{$k}_{$i}.dat";
     }
 
-    /* Passes a virtual property hook directly as the first argument of an
-     * unqualified (namespace-fallback) global function. That fallback path
-     * emits INIT_NS_FCALL_BY_NAME + CHECK_FUNC_ARG + FETCH_OBJ_FUNC_ARG,
-     * and the FETCH_OBJ_FUNC_ARG handler tail-calls into the FETCH_OBJ_R
-     * handler for by-value arguments.
+    /* Reads a virtual property hook directly as arg #1 of an unqualified
+     * (namespace-fallback) global builtin. The emitted opcode chain is
      *
-     * zend_std_read_property() must not prime the SIMPLE_GET property-hook
-     * cache-slot bit while the currently-executing opline is anything
-     * other than a plain ZEND_FETCH_OBJ_R. If it does, subsequent hook
-     * reads (potentially via a JIT-compiled fast path for FUNC_ARG that
-     * has no hook-enter check) go through the SIMPLE_GET path with a
-     * mismatched opline and read garbage from an adjacent property slot,
-     * typically surfacing as ValueError "must not contain any null bytes"
-     * or a TypeError referencing the neighbour's class.
+     *   INIT_NS_FCALL_BY_NAME "Regression\\file_get_contents"
+     *   CHECK_FUNC_ARG        1
+     *   FETCH_OBJ_FUNC_ARG    THIS, "path"    -> tmp
+     *   SEND_FUNC_ARG         tmp, 1
+     *   DO_FCALL_BY_NAME
      *
-     * Also exercises the same fetch under @-silencing (BEGIN_SILENCE /
-     * END_SILENCE) which is the exact shape observed in the wild. */
+     * FETCH_OBJ_FUNC_ARG dispatches into the FETCH_OBJ_R handler for
+     * by-value arguments while keeping opline pointing at the FUNC_ARG
+     * opcode. If zend_std_read_property() primes the SIMPLE_GET
+     * property-hook cache-slot bit under such an opline, subsequent
+     * FETCH_OBJ_FUNC_ARG dispatches take the SIMPLE_GET fast path in
+     * zend_vm_def.h -- which pushes a hook call frame and returns with
+     * ZEND_VM_ENTER_BIT set. JIT function mode dispatches FETCH_OBJ_FUNC_ARG
+     * via the generic zend_jit_handler path in zend_jit.c which, unlike
+     * the specialised FETCH_OBJ_R handler, has no "if hook entered, exit
+     * to VM" guard and continues into JIT-compiled SEND_FUNC_ARG code
+     * before the hook has actually run. The pending argument slot then
+     * holds an adjacent property's raw bytes, typically surfacing as
+     *
+     *   ValueError:  file_get_contents(): Argument #1 ($filename) must
+     *                not contain any null bytes
+     *   TypeError:   expected string, <adjacent class> given
+     *   zend_mm_heap corrupted (SIGABRT)
+     *
+     * All three symptoms have the same root cause. */
     public function step(): void {
-        // First: a bare FETCH_OBJ_FUNC_ARG under a namespaced call.
-        $len = strlen($this->path);
-        if ($len === 0) {
-            throw new \RuntimeException('empty path from hook');
-        }
-        // Second: a silenced namespaced call with the hook as arg #1.
-        // file_get_contents() is a by-value string parameter so the
-        // FETCH_OBJ_FUNC_ARG dispatches into the FETCH_OBJ_R handler.
+        // Namespace-fallback, by-value string arg -> FETCH_OBJ_FUNC_ARG.
+        // Wrapped in @ to match the real-world observed shape.
         $r = @file_get_contents($this->path);
-        // The file does not exist, so a false return with a warning is
-        // expected. The important thing is that no ValueError / TypeError
-        // / heap corruption occurs while producing the argument.
         if ($r !== false) {
             throw new \RuntimeException('unexpected non-false return');
         }

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -863,7 +863,23 @@ try_again:
 			goto try_again;
 		}
 
+		/* Only prime the SIMPLE_GET fast path for a plain ZEND_FETCH_OBJ_R
+		 * opline. ZEND_FETCH_OBJ_FUNC_ARG dispatches into this same handler
+		 * for by-value argument fetches, but its opline->extended_value can
+		 * carry the ZEND_FETCH_REF bit and its result slot lives inside the
+		 * pending call frame -- neither of which is accounted for by the
+		 * SIMPLE_GET fast path in zend_vm_def.h. Caching the bit under a
+		 * FETCH_OBJ_FUNC_ARG opline would let a later FETCH_OBJ_R (or a
+		 * JIT-compiled FUNC_ARG that has no hook-enter check) hit that fast
+		 * path with a mismatched opline and read garbage from the adjacent
+		 * property slot -- typically surfacing as a "must not contain any
+		 * null bytes" ValueError, an "expected string, got <Class>"
+		 * TypeError, or a heap corruption abort. Mirrors the opline check
+		 * already used for SIMPLE_READ above. */
+		const zend_execute_data *execute_data = EG(current_execute_data);
 		if (EXPECTED(cache_slot
+		 && EX(opline)
+		 && EX(opline)->opcode == ZEND_FETCH_OBJ_R
 		 && zend_execute_ex == execute_ex
 		 && ce->default_object_handlers->read_property == zend_std_read_property
 		 && !ce->create_object


### PR DESCRIPTION
## Summary

Fixes GH-22857: heap corruption / spurious `ValueError`s / `TypeError`s when a virtual property hook is read via `FETCH_OBJ_FUNC_ARG` under function-mode JIT (`opcache.jit=1205`).

## Root cause

`zend_std_read_property()` primed the `SIMPLE_GET` property-hook cache-slot bit unconditionally after every successful hook invocation, ignoring which opcode had triggered the read.

`ZEND_FETCH_OBJ_FUNC_ARG` dispatches into the `ZEND_FETCH_OBJ_R` handler for by-value arguments via `ZEND_VM_TAIL_CALL`, keeping `EX(opline)` on the FUNC_ARG opcode. When the cache-slot bit was cached under such a mismatched opline, the next read went through the `SIMPLE_GET` fast path in `zend_vm_def.h`, which pushes a hook call frame and returns `opline | ZEND_VM_ENTER_BIT` to signal the caller to re-enter the VM.

Function-mode JIT handles this only for `FETCH_OBJ_R` (via the specialised hook-enter guard in `zend_jit.c`) — for `FETCH_OBJ_FUNC_ARG` the generic `zend_jit_handler` path is used, which has no such guard. The JIT-compiled `SEND_FUNC_ARG` therefore reads from the argument slot before the hook has actually run.

Depending on the adjacent property slot's contents, symptoms are:

- `ValueError: file_get_contents(): Argument #1 ($filename) must not contain any null bytes`
- `TypeError: <fn>(): Argument #N ($arg) must be of type ?string, <adjacent-class> given`
- `zend_mm_heap corrupted` (SIGABRT)

All three have the same root cause.

## Fix

Only prime `SIMPLE_GET` when the currently-executing opline is a plain `ZEND_FETCH_OBJ_R`. This mirrors the guard already used for `SIMPLE_READ` a few lines above in the same function.

## Reproducer (before the fix)

```console
$ php -d opcache.enable_cli=1 -d opcache.jit_buffer_size=64M \
      -d opcache.jit=1205 Zend/tests/property_hooks/virtual_hook_as_func_arg.phpt
```
was 20/20 crashing; with `-d opcache.jit=disable` or `-d opcache.jit=tracing` was 20/20 clean. After the fix, both modes are clean.

The reproducer needs all of:

1. `opcache.jit=1205` (function JIT).
2. Class inside a `namespace`.
3. Call is **unqualified** (no leading `\`, no `use function`) so that `INIT_NS_FCALL_BY_NAME` + `FETCH_OBJ_FUNC_ARG` is emitted.
4. Argument is a **virtual** property hook (get-only, no backing storage).
5. Hook passed **directly** — assigning to a local first uses `FETCH_OBJ_R` and hides the bug.
6. Call wrapped in `@` (`BEGIN_SILENCE` / `END_SILENCE`).
7. Class layout with adjacent asymmetric-visibility fields and two promoted asymmetric-visibility constructor parameters.
8. Hook `get =>` calls a static method reading the promoted asymmetric properties.

Delta-debugging established that removing any one of these hides the bug.

## Test

`Zend/tests/property_hooks/virtual_hook_as_func_arg.phpt` — 200 iterations exercising the exact eight-condition shape from the issue. Fails before the fix (20/20 under `jit=1205`), passes after.

## Backport

Bug is present since 8.4 (property hooks introduced in 8.4). Targeting `PHP-8.4` so it lands in 8.4/8.5/master via the normal merge chain.
