### PR TITLE
Change `pcre.backtrack_limit` in the ini templates to the default value

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -1033,7 +1033,7 @@ cli_server.color = On
 [Pcre]
 ; PCRE library backtracking limit.
 ; https://php.net/pcre.backtrack-limit
-;pcre.backtrack_limit=100000
+;pcre.backtrack_limit=1000000
 
 ; PCRE library recursion limit.
 ; Please note that if you set this value to a high number you may consume all

--- a/php.ini-production
+++ b/php.ini-production
@@ -1035,7 +1035,7 @@ cli_server.color = On
 [Pcre]
 ; PCRE library backtracking limit.
 ; https://php.net/pcre.backtrack-limit
-;pcre.backtrack_limit=100000
+;pcre.backtrack_limit=1000000
 
 ; PCRE library recursion limit.
 ; Please note that if you set this value to a high number you may consume all


### PR DESCRIPTION
The `pcre.backtrack_limit` in the ini templates still have the old default value which has changed in PHP 5.3.7. This PR updates them to the current default to prevent confusion.