### PR TITLE
ext/gd: remove libde265 and x265 checks on Windows

### DIFF
--- a/ext/gd/config.w32
+++ b/ext/gd/config.w32
@@ -66,9 +66,7 @@ if (PHP_GD != "no") {
 				heif_location = false;
 			}
 			if (heif_location && heif_location.match(/heif_a\.lib$/)) {
-				if (!(CHECK_LIB("libde265_a.lib", "gd", PHP_GD) &&
-					CHECK_LIB("x265_a.lib", "gd", PHP_GD) &&
-					CHECK_LIB("aom_a.lib", "gd", PHP_GD) &&
+				if (!(CHECK_LIB("aom_a.lib", "gd", PHP_GD) &&
 					CHECK_LIB("dav1d_a.lib", "gd", PHP_GD))) {
 					WARNING("static libheif not enabled; codec libraries not found");
 					heif_location = false;


### PR DESCRIPTION
This is a followup to GH-22532.
These libraries have licenses that are not compatible with the current PHP license and should not be included in the Windows builds.

Ref: https://github.com/Multicorewareinc/x265/issues/917