### PR TITLE
Fix convert.quoted-printable-decode of lowercase hex digits

### DIFF
--- a/ext/standard/filters.c
+++ b/ext/standard/filters.c
@@ -953,7 +953,7 @@ static php_conv_err_t php_conv_qprint_decode_convert(php_conv_qprint_decode *ins
 					err = PHP_CONV_ERR_INVALID_SEQ;
 					goto out;
 				}
-				next_char = (next_char << 4) | (*ps >= 'A' ? *ps - 0x37 : *ps - 0x30);
+				next_char = (next_char << 4) | (*ps >= 'a' ? *ps - 0x57 : (*ps >= 'A' ? *ps - 0x37 : *ps - 0x30));
 				scan_stat++;
 				ps++, icnt--;
 				if (scan_stat != 3) {

--- a/ext/standard/tests/filters/qp_decode_lowercase.phpt
+++ b/ext/standard/tests/filters/qp_decode_lowercase.phpt
@@ -1,0 +1,20 @@
+--TEST--
+convert.quoted-printable-decode: lowercase hex digits decode correctly
+--FILE--
+<?php
+foreach (['=cd', '=0a', '=da', '=CD', '=AB', '=ab'] as $in) {
+    $fp = fopen('php://temp', 'r+');
+    fwrite($fp, $in);
+    rewind($fp);
+    stream_filter_append($fp, 'convert.quoted-printable-decode', STREAM_FILTER_READ);
+    echo $in, ' => ', bin2hex(stream_get_contents($fp)), "\n";
+    fclose($fp);
+}
+?>
+--EXPECT--
+=cd => cd
+=0a => 0a
+=da => da
+=CD => cd
+=AB => ab
+=ab => ab


### PR DESCRIPTION
The convert.quoted-printable-decode stream filter accepts lowercase hex digits (isxdigit() passes a-f) but its nibble math only handles uppercase, so a hex escape with a lowercase digit decodes to the wrong byte. quoted_printable_decode() decodes lowercase correctly, so the filter and the function disagree.

    $fp = fopen('php://temp', 'r+');
    fwrite($fp, '=cd'); rewind($fp);
    stream_filter_append($fp, 'convert.quoted-printable-decode', STREAM_FILTER_READ);
    var_dump(bin2hex(stream_get_contents($fp))); // "ed", should be "cd"
