### PR TITLE
Fix use-after-free in OpenSSL empty cafile warning

### DIFF
--- a/ext/openssl/tests/stream_cafile_no_valid_certs.phpt
+++ b/ext/openssl/tests/stream_cafile_no_valid_certs.phpt
@@ -1,0 +1,42 @@
+--TEST--
+SSL cafile stream containing no valid certificates
+--EXTENSIONS--
+openssl
+--SKIPIF--
+<?php
+if (!function_exists('proc_open')) die('skip no proc_open');
+?>
+--FILE--
+<?php
+$serverCode = <<<'CODE'
+    $server = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+    phpt_notify_server_start($server);
+
+    $client = stream_socket_accept($server, 2);
+    if ($client) {
+        fclose($client);
+    }
+CODE;
+
+$clientCode = <<<'CODE'
+    $context = stream_context_create(['ssl' => [
+        'cafile' => 'file://%s',
+    ]]);
+    var_dump(stream_socket_client(
+        'ssl://{{ ADDR }}',
+        timeout: 2,
+        context: $context,
+    ));
+CODE;
+$clientCode = sprintf($clientCode, __DIR__ . '/plain.txt');
+
+include 'ServerClientTestCase.inc';
+ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
+?>
+--EXPECTF--
+Warning: stream_socket_client(): no valid certs found cafile stream: '%s' in %sServerClientTestCase.inc(%d) : eval()'d code on line 4
+
+Warning: stream_socket_client(): Failed to enable crypto in %sServerClientTestCase.inc(%d) : eval()'d code on line 4
+
+Warning: stream_socket_client(): Unable to connect to ssl://127.0.0.1:%d (Unknown error) in %sServerClientTestCase.inc(%d) : eval()'d code on line 4
+bool(false)

--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -921,15 +921,14 @@ static long php_openssl_load_stream_cafile(X509_STORE *cert_store, const char *c
 		goto cert_start;
 	}
 
-	stream_complete: {
-		php_stream_close(stream);
-		if (buffer_active == 1) {
-			BIO_free(buffer);
-		}
+stream_complete:
+	if (certs_added == 0) {
+		php_stream_warn(stream, DecodingFailed, "no valid certs found cafile stream: '%s'", cafile);
 	}
 
-	if (certs_added == 0) {
-		php_stream_warn(stream, DecodingFailed, "no valid certs found cafile stream: `%s'", cafile);
+	php_stream_close(stream);
+	if (buffer_active == 1) {
+		BIO_free(buffer);
 	}
 
 	return certs_added;


### PR DESCRIPTION
For context:

https://github.com/php/php-src/actions/runs/30059575887/job/89378471139

```
  ==95682==ERROR: AddressSanitizer: heap-use-after-free on address 0x511000b929c0 at pc 0x55fd3a139556 bp 0x7ffc2810e7b0 sp 0x7ffc2810e7a0
  READ of size 8 at 0x511000b929c0 thread T0
      #0 0x55fd3a139555 in php_stream_error /home/runner/work/php-src/php-src/main/streams/stream_errors.c:625
      #1 0x55fd37419153 in php_openssl_load_stream_cafile /home/runner/work/php-src/php-src/ext/openssl/xp_ssl.c:932
      #2 0x55fd37419c86 in php_openssl_enable_peer_verification /home/runner/work/php-src/php-src/ext/openssl/xp_ssl.c:971
      #3 0x55fd3742ba07 in php_openssl_create_server_ctx /home/runner/work/php-src/php-src/ext/openssl/xp_ssl.c:2479
      #4 0x55fd3742ec22 in php_openssl_setup_crypto /home/runner/work/php-src/php-src/ext/openssl/xp_ssl.c:2651
      #5 0x55fd3743b244 in php_openssl_sockop_set_option /home/runner/work/php-src/php-src/ext/openssl/xp_ssl.c:3511
      #6 0x55fd3a1515e7 in _php_stream_set_option /home/runner/work/php-src/php-src/main/streams/streams.c:1419
      #7 0x55fd3a1613ef in php_stream_xport_crypto_setup /home/runner/work/php-src/php-src/main/streams/transports.c:366
      #8 0x55fd3743bcb3 in php_openssl_sockop_set_option /home/runner/work/php-src/php-src/ext/openssl/xp_ssl.c:3547
      #9 0x55fd3a1515e7 in _php_stream_set_option /home/runner/work/php-src/php-src/main/streams/streams.c:1419
      #10 0x55fd3a1602b9 in php_stream_xport_connect /home/runner/work/php-src/php-src/main/streams/transports.c:247
      #11 0x55fd3a15ebcc in _php_stream_xport_create /home/runner/work/php-src/php-src/main/streams/transports.c:144
      #12 0x55fd3995fa2c in zif_stream_socket_client /home/runner/work/php-src/php-src/ext/standard/streamsfuncs.c:171
      #13 0x55fd3a699bb0 in ZEND_DO_FCALL_BY_NAME_SPEC_RETVAL_USED_HANDLER /home/runner/work/php-src/php-src/Zend/zend_vm_execute.h:1767
      #14 0x55fd38b7ed43 in zend_jit_trace_execute /home/runner/work/php-src/php-src/ext/opcache/jit/zend_jit_vm_helpers.c:1070
      #15 0x55fd38e4d681 in zend_jit_trace_hot_root ext/opcache/jit/zend_jit_trace.c:8195
      #16 0x7f6e2a1344f5  (/dev/zero (deleted)+0x100004f5)
```