### PR TITLE
Fix GH-22878: Use-after-free of callable via autoloader

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,7 @@ PHP                                                                        NEWS
 - Core:
   . Changed run-tests.php to run test subprocesses without a shell where
     possible. (NickSdot)
+  . Fixed bug GH-22878 (Use-after-free of callable via autoloader). (iliaal)
 
 - GMP:
   . Added optional $definitely_prime output parameter to gmp_prevprime().

--- a/Zend/tests/gh22878.phpt
+++ b/Zend/tests/gh22878.phpt
@@ -1,0 +1,41 @@
+--TEST--
+GH-22878 (Use-after-free of callable via autoloader)
+--FILE--
+<?php
+spl_autoload_register(function (string $class): void {
+    $GLOBALS['cb'] = null;
+    eval("class $class { public static function __callStatic(\$name, \$args) { echo strlen(\$name), \"\\n\"; } }");
+});
+
+$method = str_repeat('m', 256);
+$cb = ['GH22878ArrayCuf', $method];
+unset($method);
+call_user_func($cb);
+
+$method = str_repeat('m', 256);
+$cb = ['GH22878ArrayCufa', $method];
+unset($method);
+call_user_func_array($cb, []);
+
+$method = str_repeat('m', 256);
+$cb = ['GH22878ArrayDynamic', $method];
+unset($method);
+$cb();
+
+$method = str_repeat('m', 256);
+$cb = 'GH22878Str::' . $method;
+unset($method);
+call_user_func($cb);
+
+$cb = 'GH22878Lit::literalMethod';
+call_user_func($cb);
+
+echo "done\n";
+?>
+--EXPECT--
+256
+256
+256
+256
+13
+done

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -3859,6 +3859,7 @@ static zend_always_inline bool zend_is_method_callable(zend_string *callable, co
 			scope = get_scope(frame);
 		}
 
+		zend_string *held_callable = zend_string_copy(callable);
 		zend_string *class_name = zend_string_init_interned(ZSTR_VAL(callable), class_name_len, 0);
 		if (ZSTR_HAS_CE_CACHE(class_name) && ZSTR_GET_CE_CACHE(class_name)) {
 			fcc->calling_scope = ZSTR_GET_CE_CACHE(class_name);
@@ -3879,6 +3880,7 @@ static zend_always_inline bool zend_is_method_callable(zend_string *callable, co
 			strict_class = true;
 		} else if (!zend_is_callable_check_class(class_name, scope, frame, fcc, &strict_class, error, suppress_deprecation || ce_org != NULL)) {
 			zend_string_release_ex(class_name, 0);
+			zend_string_release(held_callable);
 			return 0;
 		}
 		zend_string_release_ex(class_name, 0);
@@ -3886,6 +3888,7 @@ static zend_always_inline bool zend_is_method_callable(zend_string *callable, co
 		ftable = &fcc->calling_scope->function_table;
 		if (ce_org && !instanceof_function(ce_org, fcc->calling_scope)) {
 			if (error) zend_spprintf(error, 0, "class %s is not a subclass of %s", ZSTR_VAL(ce_org->name), ZSTR_VAL(fcc->calling_scope->name));
+			zend_string_release(held_callable);
 			return 0;
 		}
 		if (ce_org && !suppress_deprecation) {
@@ -3894,6 +3897,7 @@ static zend_always_inline bool zend_is_method_callable(zend_string *callable, co
 				ZSTR_VAL(ce_org->name), ZSTR_VAL(callable));
 		}
 		mname = zend_string_init(ZSTR_VAL(callable) + class_name_len + 2, mlen, 0);
+		zend_string_release(held_callable);
 	} else if (ce_org) {
 		/* Try to fetch find static method of given class. */
 		mname = callable;
@@ -4216,12 +4220,17 @@ again:
 					return 0;
 				}
 
+				zend_string *method_name;
+
 				if (Z_TYPE_P(obj) == IS_STRING) {
 					if (check_flags & IS_CALLABLE_CHECK_SYNTAX_ONLY) {
 						return 1;
 					}
 
+					method_name = zend_string_copy(Z_STR_P(method));
+
 					if (!zend_is_callable_check_class(Z_STR_P(obj), get_scope(frame), frame, fcc, &strict_class, error, check_flags & IS_CALLABLE_SUPPRESS_DEPRECATIONS)) {
+						zend_string_release(method_name);
 						return 0;
 					}
 				} else {
@@ -4233,9 +4242,12 @@ again:
 						fcc->called_scope = fcc->calling_scope;
 						return 1;
 					}
+
+					method_name = zend_string_copy(Z_STR_P(method));
 				}
 
-				ret = zend_is_method_callable(Z_STR_P(method), frame, fcc, strict_class, error, check_flags & IS_CALLABLE_SUPPRESS_DEPRECATIONS);
+				ret = zend_is_method_callable(method_name, frame, fcc, strict_class, error, check_flags & IS_CALLABLE_SUPPRESS_DEPRECATIONS);
+				zend_string_release(method_name);
 				break;
 			}
 

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -5259,23 +5259,27 @@ static zend_never_inline zend_execute_data *zend_init_dynamic_call_array(const z
 		}
 
 		if (Z_TYPE_P(obj) == IS_STRING) {
+			zend_string *method_name = zend_string_copy(Z_STR_P(method));
 			zend_class_entry *called_scope = zend_fetch_class_by_name(Z_STR_P(obj), NULL, ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 
 			if (UNEXPECTED(called_scope == NULL)) {
+				zend_string_release(method_name);
 				return NULL;
 			}
 
 			if (called_scope->get_static_method) {
-				fbc = called_scope->get_static_method(called_scope, Z_STR_P(method));
+				fbc = called_scope->get_static_method(called_scope, method_name);
 			} else {
-				fbc = zend_std_get_static_method(called_scope, Z_STR_P(method), NULL);
+				fbc = zend_std_get_static_method(called_scope, method_name, NULL);
 			}
 			if (UNEXPECTED(fbc == NULL)) {
 				if (EXPECTED(!EG(exception))) {
-					zend_undefined_method(called_scope, Z_STR_P(method));
+					zend_undefined_method(called_scope, method_name);
 				}
+				zend_string_release(method_name);
 				return NULL;
 			}
+			zend_string_release(method_name);
 			if (!(fbc->common.fn_flags & ZEND_ACC_STATIC)) {
 				zend_non_static_method_call(fbc);
 				if (fbc->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE) {


### PR DESCRIPTION
Validating an array or string callable borrows the method name out of the callable and then runs user code before resolving the method: a string class name can trigger an autoloader, and a compound `Class::method` name emits an `E_DEPRECATED` that reaches a user error handler. Either can free the callable, leaving the borrowed string dangling. This holds that string across the reentrant lookup in `zend_is_callable_at_frame()`, `zend_is_method_callable()` and `zend_init_dynamic_call_array()`, covering `call_user_func()`, `call_user_func_array()` and `$cb()`.

Fixes #22878
