### PR TITLE
ext/soap: Fix SOAP classmap validation for integer keys

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -52,7 +52,8 @@ PHP                                                                        NEWS
   . Fixed header injection through the Content-Type context option, the
     soapaction and the cookie names and values. (David Carlier)
   . Fixed the SoapClient and SoapServer "classmap" option to reject arrays
-    containing integer keys. (Weilin Du, David Carlier)
+    containing integer keys, and made SoapClient throw ValueError for invalid
+    "classmap" options. (Weilin Du, David Carlier)
 
 - MBString:
   . Fixed bug GH-22779 (mb_strrpos() returns the wrong position for a negative

--- a/NEWS
+++ b/NEWS
@@ -52,8 +52,8 @@ PHP                                                                        NEWS
   . Fixed header injection through the Content-Type context option, the
     soapaction and the cookie names and values. (David Carlier)
   . Fixed the SoapClient and SoapServer "classmap" option to reject arrays
-    containing integer keys, and made SoapClient throw ValueError for invalid
-    "classmap" options. (Weilin Du, David Carlier)
+    containing integer keys, and made SoapClient throw TypeError/ValueError
+    for invalid "classmap" options. (Weilin Du, David Carlier)
 
 - MBString:
   . Fixed bug GH-22779 (mb_strrpos() returns the wrong position for a negative

--- a/NEWS
+++ b/NEWS
@@ -51,6 +51,8 @@ PHP                                                                        NEWS
 - SOAP:
   . Fixed header injection through the Content-Type context option, the
     soapaction and the cookie names and values. (David Carlier)
+  . Fixed the SoapClient and SoapServer "classmap" option to reject arrays
+    containing integer keys. (Weilin Du, David Carlier)
 
 - MBString:
   . Fixed bug GH-22779 (mb_strrpos() returns the wrong position for a negative

--- a/UPGRADING
+++ b/UPGRADING
@@ -157,8 +157,9 @@ PHP 8.6 UPGRADE NOTES
 - SOAP:
   . The "classmap" option of SoapClient and SoapServer now rejects arrays
     containing integer keys. Previously, sparse integer-keyed and mixed-keyed
-    arrays could be accepted. SoapClient now throws a ValueError for invalid
-    "classmap" options, also when the "exceptions" option is disabled.
+    arrays could be accepted. SoapClient now throws TypeError for non-array
+    "classmap" options and ValueError for arrays containing integer keys, also
+    when the "exceptions" option is disabled.
   . WSDL/XML Schema parsing now rejects out-of-range integer values for
     occurrence constraints and integer restriction facets. Negative minOccurs
     and maxOccurs values are rejected as well.

--- a/UPGRADING
+++ b/UPGRADING
@@ -157,7 +157,8 @@ PHP 8.6 UPGRADE NOTES
 - SOAP:
   . The "classmap" option of SoapClient and SoapServer now rejects arrays
     containing integer keys. Previously, sparse integer-keyed and mixed-keyed
-    arrays could be accepted.
+    arrays could be accepted. SoapClient now throws a ValueError for invalid
+    "classmap" options, also when the "exceptions" option is disabled.
   . WSDL/XML Schema parsing now rejects out-of-range integer values for
     occurrence constraints and integer restriction facets. Negative minOccurs
     and maxOccurs values are rejected as well.

--- a/UPGRADING
+++ b/UPGRADING
@@ -155,6 +155,9 @@ PHP 8.6 UPGRADE NOTES
     system.
 
 - SOAP:
+  . The "classmap" option of SoapClient and SoapServer now rejects arrays
+    containing integer keys. Previously, sparse integer-keyed and mixed-keyed
+    arrays could be accepted.
   . WSDL/XML Schema parsing now rejects out-of-range integer values for
     occurrence constraints and integer restriction facets. Negative minOccurs
     and maxOccurs values are rejected as well.

--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -440,7 +440,7 @@ static xmlNodePtr master_to_xml_int(encodePtr encode, zval *data, int style, xml
 			zval *tmp;
 			zend_string *type_name;
 
-			ZEND_HASH_MAP_FOREACH_STR_KEY_VAL(SOAP_GLOBAL(class_map), type_name, tmp) {
+			ZEND_HASH_FOREACH_STR_KEY_VAL(SOAP_GLOBAL(class_map), type_name, tmp) {
 				ZVAL_DEREF(tmp);
 				if (Z_TYPE_P(tmp) == IS_STRING &&
 				    ZSTR_LEN(ce->name) == Z_STRLEN_P(tmp) &&

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -2330,6 +2330,7 @@ PHP_METHOD(SoapClient, __construct)
 	}
 
 finish:
+	;
 	SOAP_CLIENT_END_CODE();
 }
 /* }}} */

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -930,6 +930,18 @@ static HashTable* soap_create_typemap(sdlPtr sdl, HashTable *ht) /* {{{ */
 }
 /* }}} */
 
+static bool soap_class_map_has_only_string_keys(const HashTable *class_map)
+{
+	zend_string *key;
+	ZEND_HASH_FOREACH_STR_KEY(class_map, key) {
+		if (UNEXPECTED(key == NULL)) {
+			return false;
+		}
+	} ZEND_HASH_FOREACH_END();
+
+	return true;
+}
+
 /* {{{ SoapServer constructor */
 PHP_METHOD(SoapServer, __construct)
 {
@@ -1007,8 +1019,7 @@ PHP_METHOD(SoapServer, __construct)
 				zend_argument_type_error(2, "\"classmap\" option must be of type array, %s given", zend_zval_type_name(class_map_zv));
 				goto cleanup;
 			}
-			// TODO: this still accepts mixed keys arrays and not all numerically indexed arrays are packed
-			if (UNEXPECTED(HT_IS_PACKED(Z_ARRVAL_P(class_map_zv)))) {
+			if (UNEXPECTED(!soap_class_map_has_only_string_keys(Z_ARRVAL_P(class_map_zv)))) {
 				zend_argument_value_error(2, "\"classmap\" option must be an associative array");
 				goto cleanup;
 			}
@@ -2233,7 +2244,7 @@ PHP_METHOD(SoapClient, __construct)
 		}
 		if ((tmp = zend_hash_str_find(ht, "classmap", sizeof("classmap")-1)) != NULL &&
 			Z_TYPE_P(tmp) == IS_ARRAY) {
-			if (UNEXPECTED(HT_IS_PACKED(Z_ARRVAL_P(tmp)))) {
+			if (UNEXPECTED(!soap_class_map_has_only_string_keys(Z_ARRVAL_P(tmp)))) {
 				php_error_docref(NULL, E_ERROR, "'classmap' option must be an associative array");
 			}
 			ZVAL_COPY(Z_CLIENT_CLASSMAP_P(this_ptr), tmp);

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -2115,6 +2115,20 @@ PHP_METHOD(SoapClient, __construct)
 		RETURN_THROWS();
 	}
 
+	if (options != NULL) {
+		zval *classmap = zend_hash_str_find(Z_ARRVAL_P(options), "classmap", sizeof("classmap")-1);
+		if (classmap != NULL) {
+			if (UNEXPECTED(Z_TYPE_P(classmap) != IS_ARRAY)) {
+				zend_argument_type_error(2, "\"classmap\" option must be of type array, %s given", zend_zval_type_name(classmap));
+				RETURN_THROWS();
+			}
+			if (UNEXPECTED(!soap_class_map_has_only_string_keys(Z_ARRVAL_P(classmap)))) {
+				zend_argument_value_error(2, "\"classmap\" option must be an associative array");
+				RETURN_THROWS();
+			}
+		}
+	}
+
 	SOAP_CLIENT_BEGIN_CODE();
 
 	cache_wsdl = SOAP_GLOBAL(cache_enabled) ? SOAP_GLOBAL(cache_mode) : 0;
@@ -2225,10 +2239,6 @@ PHP_METHOD(SoapClient, __construct)
 		}
 		if ((tmp = zend_hash_str_find(ht, "classmap", sizeof("classmap")-1)) != NULL &&
 			Z_TYPE_P(tmp) == IS_ARRAY) {
-			if (UNEXPECTED(!soap_class_map_has_only_string_keys(Z_ARRVAL_P(tmp)))) {
-				zend_argument_value_error(2, "\"classmap\" option must be an associative array");
-				goto finish;
-			}
 			ZVAL_COPY(Z_CLIENT_CLASSMAP_P(this_ptr), tmp);
 		}
 
@@ -2327,8 +2337,6 @@ PHP_METHOD(SoapClient, __construct)
 		soap_client_object_fetch(Z_OBJ_P(this_ptr))->typemap = soap_create_typemap(sdl, typemap_ht);
 	}
 
-finish:
-	;
 	SOAP_CLIENT_END_CODE();
 }
 /* }}} */

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -2245,7 +2245,11 @@ PHP_METHOD(SoapClient, __construct)
 		if ((tmp = zend_hash_str_find(ht, "classmap", sizeof("classmap")-1)) != NULL &&
 			Z_TYPE_P(tmp) == IS_ARRAY) {
 			if (UNEXPECTED(!soap_class_map_has_only_string_keys(Z_ARRVAL_P(tmp)))) {
-				php_error_docref(NULL, E_ERROR, "'classmap' option must be an associative array");
+				zend_argument_value_error(2, "\"classmap\" option must be an associative array");
+				if (context) {
+					zend_list_delete(context->res);
+				}
+				goto finish;
 			}
 			ZVAL_COPY(Z_CLIENT_CLASSMAP_P(this_ptr), tmp);
 		}
@@ -2324,6 +2328,8 @@ PHP_METHOD(SoapClient, __construct)
 	if (typemap_ht) {
 		soap_client_object_fetch(Z_OBJ_P(this_ptr))->typemap = soap_create_typemap(sdl, typemap_ht);
 	}
+
+finish:
 	SOAP_CLIENT_END_CODE();
 }
 /* }}} */

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -2145,6 +2145,15 @@ PHP_METHOD(SoapClient, __construct)
 			}
 		}
 
+		if ((tmp = zend_hash_str_find(ht, "classmap", sizeof("classmap")-1)) != NULL &&
+			Z_TYPE_P(tmp) == IS_ARRAY) {
+			if (UNEXPECTED(!soap_class_map_has_only_string_keys(Z_ARRVAL_P(tmp)))) {
+				zend_argument_value_error(2, "\"classmap\" option must be an associative array");
+				goto finish;
+			}
+			ZVAL_COPY(Z_CLIENT_CLASSMAP_P(this_ptr), tmp);
+		}
+
 		if ((tmp = zend_hash_str_find(ht, "stream_context", sizeof("stream_context")-1)) != NULL &&
 				Z_TYPE_P(tmp) == IS_RESOURCE) {
 			context = php_stream_context_from_zval(tmp, 1);
@@ -2242,18 +2251,6 @@ PHP_METHOD(SoapClient, __construct)
 				ZVAL_STR_COPY(Z_CLIENT_ENCODING_P(this_ptr), Z_STR_P(tmp));
 			}
 		}
-		if ((tmp = zend_hash_str_find(ht, "classmap", sizeof("classmap")-1)) != NULL &&
-			Z_TYPE_P(tmp) == IS_ARRAY) {
-			if (UNEXPECTED(!soap_class_map_has_only_string_keys(Z_ARRVAL_P(tmp)))) {
-				zend_argument_value_error(2, "\"classmap\" option must be an associative array");
-				if (context) {
-					zend_list_delete(context->res);
-				}
-				goto finish;
-			}
-			ZVAL_COPY(Z_CLIENT_CLASSMAP_P(this_ptr), tmp);
-		}
-
 		if ((tmp = zend_hash_str_find(ht, "typemap", sizeof("typemap")-1)) != NULL &&
 			Z_TYPE_P(tmp) == IS_ARRAY &&
 			zend_hash_num_elements(Z_ARRVAL_P(tmp)) > 0) {

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -2145,23 +2145,6 @@ PHP_METHOD(SoapClient, __construct)
 			}
 		}
 
-		if ((tmp = zend_hash_str_find(ht, "classmap", sizeof("classmap")-1)) != NULL &&
-			Z_TYPE_P(tmp) == IS_ARRAY) {
-			if (UNEXPECTED(!soap_class_map_has_only_string_keys(Z_ARRVAL_P(tmp)))) {
-				zend_argument_value_error(2, "\"classmap\" option must be an associative array");
-				goto finish;
-			}
-			ZVAL_COPY(Z_CLIENT_CLASSMAP_P(this_ptr), tmp);
-		}
-
-		if ((tmp = zend_hash_str_find(ht, "stream_context", sizeof("stream_context")-1)) != NULL &&
-				Z_TYPE_P(tmp) == IS_RESOURCE) {
-			context = php_stream_context_from_zval(tmp, 1);
-			Z_ADDREF_P(tmp);
-		} else {
-			context = php_stream_context_alloc();
-		}
-
 		if ((tmp = zend_hash_str_find(ht, "location", sizeof("location")-1)) != NULL &&
 		    Z_TYPE_P(tmp) == IS_STRING) {
 			ZVAL_STR_COPY(Z_CLIENT_LOCATION_P(this_ptr), Z_STR_P(tmp));
@@ -2207,17 +2190,6 @@ PHP_METHOD(SoapClient, __construct)
 				}
 			}
 		}
-		if ((tmp = zend_hash_str_find(ht, "local_cert", sizeof("local_cert")-1)) != NULL &&
-		    Z_TYPE_P(tmp) == IS_STRING) {
-			if (!context) {
-				context = php_stream_context_alloc();
-			}
-			php_stream_context_set_option(context, "ssl", "local_cert", tmp);
-			if ((tmp = zend_hash_str_find(ht, "passphrase", sizeof("passphrase")-1)) != NULL &&
-			    Z_TYPE_P(tmp) == IS_STRING) {
-				php_stream_context_set_option(context, "ssl", "passphrase", tmp);
-			}
-		}
 		if ((tmp = zend_hash_find(ht, ZSTR_KNOWN(ZEND_STR_TRACE))) != NULL &&
 		    (Z_TYPE_P(tmp) == IS_TRUE ||
 		     (Z_TYPE_P(tmp) == IS_LONG && Z_LVAL_P(tmp) == 1))) {
@@ -2251,6 +2223,35 @@ PHP_METHOD(SoapClient, __construct)
 				ZVAL_STR_COPY(Z_CLIENT_ENCODING_P(this_ptr), Z_STR_P(tmp));
 			}
 		}
+		if ((tmp = zend_hash_str_find(ht, "classmap", sizeof("classmap")-1)) != NULL &&
+			Z_TYPE_P(tmp) == IS_ARRAY) {
+			if (UNEXPECTED(!soap_class_map_has_only_string_keys(Z_ARRVAL_P(tmp)))) {
+				zend_argument_value_error(2, "\"classmap\" option must be an associative array");
+				goto finish;
+			}
+			ZVAL_COPY(Z_CLIENT_CLASSMAP_P(this_ptr), tmp);
+		}
+
+		if ((tmp = zend_hash_str_find(ht, "stream_context", sizeof("stream_context")-1)) != NULL &&
+				Z_TYPE_P(tmp) == IS_RESOURCE) {
+			context = php_stream_context_from_zval(tmp, 1);
+			Z_ADDREF_P(tmp);
+		} else {
+			context = php_stream_context_alloc();
+		}
+
+		if ((tmp = zend_hash_str_find(ht, "local_cert", sizeof("local_cert")-1)) != NULL &&
+		    Z_TYPE_P(tmp) == IS_STRING) {
+			if (!context) {
+				context = php_stream_context_alloc();
+			}
+			php_stream_context_set_option(context, "ssl", "local_cert", tmp);
+			if ((tmp = zend_hash_str_find(ht, "passphrase", sizeof("passphrase")-1)) != NULL &&
+			    Z_TYPE_P(tmp) == IS_STRING) {
+				php_stream_context_set_option(context, "ssl", "passphrase", tmp);
+			}
+		}
+
 		if ((tmp = zend_hash_str_find(ht, "typemap", sizeof("typemap")-1)) != NULL &&
 			Z_TYPE_P(tmp) == IS_ARRAY &&
 			zend_hash_num_elements(Z_ARRVAL_P(tmp)) > 0) {

--- a/ext/soap/tests/bugs/gh16256.phpt
+++ b/ext/soap/tests/bugs/gh16256.phpt
@@ -20,5 +20,5 @@ try {
 }
 ?>
 --EXPECT--
-SoapClient::__construct(): 'classmap' option must be an associative array
+SoapClient::__construct(): Argument #2 ($options) "classmap" option must be an associative array
 SoapServer::__construct(): Argument #2 ($options) "classmap" option must be an associative array

--- a/ext/soap/tests/classmap_invalid_keys.phpt
+++ b/ext/soap/tests/classmap_invalid_keys.phpt
@@ -1,0 +1,68 @@
+--TEST--
+SoapClient and SoapServer classmap options must only contain string keys
+--EXTENSIONS--
+soap
+--FILE--
+<?php
+
+$emptyHash = ['type' => 'stdClass'];
+unset($emptyHash['type']);
+
+$cases = [
+    'empty' => [],
+    'empty hash' => $emptyHash,
+    'packed' => ['stdClass'],
+    'sparse numeric' => [100 => 'stdClass'],
+    'numeric string' => ['1' => 'stdClass'],
+    'mixed' => ['type' => 'stdClass', 1 => 'stdClass'],
+    'associative' => ['type' => 'stdClass'],
+];
+
+foreach ($cases as $name => $classmap) {
+    echo "-- $name --\n";
+
+    try {
+        new SoapClient(null, [
+            'location' => 'http://example.com/',
+            'uri' => 'urn:test',
+            'classmap' => $classmap,
+        ]);
+        echo "SoapClient: OK\n";
+    } catch (Throwable $e) {
+        echo $e->getMessage(), "\n";
+    }
+
+    try {
+        new SoapServer(null, [
+            'uri' => 'urn:test',
+            'classmap' => $classmap,
+        ]);
+        echo "SoapServer: OK\n";
+    } catch (Throwable $e) {
+        echo $e->getMessage(), "\n";
+    }
+}
+
+?>
+--EXPECT--
+-- empty --
+SoapClient: OK
+SoapServer: OK
+-- empty hash --
+SoapClient: OK
+SoapServer: OK
+-- packed --
+SoapClient::__construct(): 'classmap' option must be an associative array
+SoapServer::__construct(): Argument #2 ($options) "classmap" option must be an associative array
+-- sparse numeric --
+SoapClient::__construct(): 'classmap' option must be an associative array
+SoapServer::__construct(): Argument #2 ($options) "classmap" option must be an associative array
+-- numeric string --
+SoapClient::__construct(): 'classmap' option must be an associative array
+SoapServer::__construct(): Argument #2 ($options) "classmap" option must be an associative array
+-- mixed --
+SoapClient::__construct(): 'classmap' option must be an associative array
+SoapServer::__construct(): Argument #2 ($options) "classmap" option must be an associative array
+-- associative --
+SoapClient: OK
+SoapServer: OK

--- a/ext/soap/tests/classmap_invalid_keys.phpt
+++ b/ext/soap/tests/classmap_invalid_keys.phpt
@@ -52,17 +52,17 @@ SoapServer: OK
 SoapClient: OK
 SoapServer: OK
 -- packed --
-SoapClient::__construct(): Argument #2 ($options) "classmap" option must be an associative array
-SoapServer::__construct(): Argument #2 ($options) "classmap" option must be an associative array
+ValueError: SoapClient::__construct(): Argument #2 ($options) "classmap" option must be an associative array
+ValueError: SoapServer::__construct(): Argument #2 ($options) "classmap" option must be an associative array
 -- sparse numeric --
-SoapClient::__construct(): Argument #2 ($options) "classmap" option must be an associative array
-SoapServer::__construct(): Argument #2 ($options) "classmap" option must be an associative array
+ValueError: SoapClient::__construct(): Argument #2 ($options) "classmap" option must be an associative array
+ValueError: SoapServer::__construct(): Argument #2 ($options) "classmap" option must be an associative array
 -- numeric string --
-SoapClient::__construct(): Argument #2 ($options) "classmap" option must be an associative array
-SoapServer::__construct(): Argument #2 ($options) "classmap" option must be an associative array
+ValueError: SoapClient::__construct(): Argument #2 ($options) "classmap" option must be an associative array
+ValueError: SoapServer::__construct(): Argument #2 ($options) "classmap" option must be an associative array
 -- mixed --
-SoapClient::__construct(): Argument #2 ($options) "classmap" option must be an associative array
-SoapServer::__construct(): Argument #2 ($options) "classmap" option must be an associative array
+ValueError: SoapClient::__construct(): Argument #2 ($options) "classmap" option must be an associative array
+ValueError: SoapServer::__construct(): Argument #2 ($options) "classmap" option must be an associative array
 -- associative --
 SoapClient: OK
 SoapServer: OK

--- a/ext/soap/tests/classmap_invalid_keys.phpt
+++ b/ext/soap/tests/classmap_invalid_keys.phpt
@@ -29,7 +29,7 @@ foreach ($cases as $name => $classmap) {
         ]);
         echo "SoapClient: OK\n";
     } catch (Throwable $e) {
-        echo $e->getMessage(), "\n";
+        echo $e::class, ': ', $e->getMessage(), PHP_EOL;
     }
 
     try {
@@ -39,7 +39,7 @@ foreach ($cases as $name => $classmap) {
         ]);
         echo "SoapServer: OK\n";
     } catch (Throwable $e) {
-        echo $e->getMessage(), "\n";
+        echo $e::class, ': ', $e->getMessage(), PHP_EOL;
     }
 }
 

--- a/ext/soap/tests/classmap_invalid_keys.phpt
+++ b/ext/soap/tests/classmap_invalid_keys.phpt
@@ -52,16 +52,16 @@ SoapServer: OK
 SoapClient: OK
 SoapServer: OK
 -- packed --
-SoapClient::__construct(): 'classmap' option must be an associative array
+SoapClient::__construct(): Argument #2 ($options) "classmap" option must be an associative array
 SoapServer::__construct(): Argument #2 ($options) "classmap" option must be an associative array
 -- sparse numeric --
-SoapClient::__construct(): 'classmap' option must be an associative array
+SoapClient::__construct(): Argument #2 ($options) "classmap" option must be an associative array
 SoapServer::__construct(): Argument #2 ($options) "classmap" option must be an associative array
 -- numeric string --
-SoapClient::__construct(): 'classmap' option must be an associative array
+SoapClient::__construct(): Argument #2 ($options) "classmap" option must be an associative array
 SoapServer::__construct(): Argument #2 ($options) "classmap" option must be an associative array
 -- mixed --
-SoapClient::__construct(): 'classmap' option must be an associative array
+SoapClient::__construct(): Argument #2 ($options) "classmap" option must be an associative array
 SoapServer::__construct(): Argument #2 ($options) "classmap" option must be an associative array
 -- associative --
 SoapClient: OK

--- a/ext/soap/tests/classmap_invalid_keys_error_types.phpt
+++ b/ext/soap/tests/classmap_invalid_keys_error_types.phpt
@@ -1,0 +1,32 @@
+--TEST--
+SoapClient and SoapServer report an invalid classmap option differently
+--EXTENSIONS--
+soap
+--FILE--
+<?php
+
+$classmap = ['type' => 'stdClass', 1 => 'stdClass'];
+
+try {
+    new SoapClient(null, [
+        'location' => 'http://example.com/',
+        'uri' => 'urn:test',
+        'classmap' => $classmap,
+    ]);
+} catch (Throwable $e) {
+    echo 'SoapClient: ', $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    new SoapServer(null, [
+        'uri' => 'urn:test',
+        'classmap' => $classmap,
+    ]);
+} catch (Throwable $e) {
+    echo 'SoapServer: ', $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+SoapClient: SoapFault: SoapClient::__construct(): 'classmap' option must be an associative array
+SoapServer: ValueError: SoapServer::__construct(): Argument #2 ($options) "classmap" option must be an associative array

--- a/ext/soap/tests/classmap_invalid_keys_error_types.phpt
+++ b/ext/soap/tests/classmap_invalid_keys_error_types.phpt
@@ -1,5 +1,5 @@
 --TEST--
-SoapClient and SoapServer report an invalid classmap option differently
+SoapClient and SoapServer report an invalid classmap option as ValueError
 --EXTENSIONS--
 soap
 --FILE--
@@ -28,5 +28,5 @@ try {
 
 ?>
 --EXPECT--
-SoapClient: SoapFault: SoapClient::__construct(): 'classmap' option must be an associative array
+SoapClient: ValueError: SoapClient::__construct(): Argument #2 ($options) "classmap" option must be an associative array
 SoapServer: ValueError: SoapServer::__construct(): Argument #2 ($options) "classmap" option must be an associative array

--- a/ext/soap/tests/classmap_invalid_keys_exceptions_disabled.phpt
+++ b/ext/soap/tests/classmap_invalid_keys_exceptions_disabled.phpt
@@ -1,0 +1,18 @@
+--TEST--
+SoapClient reports an invalid classmap option as a fatal error when exceptions are disabled
+--EXTENSIONS--
+soap
+--FILE--
+<?php
+
+new SoapClient(null, [
+    'location' => 'http://example.com/',
+    'uri' => 'urn:test',
+    'exceptions' => false,
+    'classmap' => ['type' => 'stdClass', 1 => 'stdClass'],
+]);
+echo 'not reached', PHP_EOL;
+
+?>
+--EXPECTF--
+Fatal error: SoapClient::__construct(): 'classmap' option must be an associative array in %s on line %d

--- a/ext/soap/tests/classmap_invalid_keys_exceptions_disabled.phpt
+++ b/ext/soap/tests/classmap_invalid_keys_exceptions_disabled.phpt
@@ -1,18 +1,21 @@
 --TEST--
-SoapClient reports an invalid classmap option as a fatal error when exceptions are disabled
+SoapClient reports an invalid classmap option as ValueError when exceptions are disabled
 --EXTENSIONS--
 soap
 --FILE--
 <?php
 
-new SoapClient(null, [
-    'location' => 'http://example.com/',
-    'uri' => 'urn:test',
-    'exceptions' => false,
-    'classmap' => ['type' => 'stdClass', 1 => 'stdClass'],
-]);
-echo 'not reached', PHP_EOL;
+try {
+    new SoapClient(null, [
+        'location' => 'http://example.com/',
+        'uri' => 'urn:test',
+        'exceptions' => false,
+        'classmap' => ['type' => 'stdClass', 1 => 'stdClass'],
+    ]);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
 
 ?>
---EXPECTF--
-Fatal error: SoapClient::__construct(): 'classmap' option must be an associative array in %s on line %d
+--EXPECT--
+ValueError: SoapClient::__construct(): Argument #2 ($options) "classmap" option must be an associative array

--- a/ext/soap/tests/classmap_invalid_type.phpt
+++ b/ext/soap/tests/classmap_invalid_type.phpt
@@ -1,0 +1,30 @@
+--TEST--
+SoapClient and SoapServer classmap options must be arrays
+--EXTENSIONS--
+soap
+--FILE--
+<?php
+
+try {
+    new SoapClient(null, [
+        'location' => 'http://example.com/',
+        'uri' => 'urn:test',
+        'classmap' => 1,
+    ]);
+} catch (Throwable $e) {
+    echo 'SoapClient: ', $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    new SoapServer(null, [
+        'uri' => 'urn:test',
+        'classmap' => 1,
+    ]);
+} catch (Throwable $e) {
+    echo 'SoapServer: ', $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+SoapClient: TypeError: SoapClient::__construct(): Argument #2 ($options) "classmap" option must be of type array, int given
+SoapServer: TypeError: SoapServer::__construct(): Argument #2 ($options) "classmap" option must be of type array, int given

--- a/ext/soap/tests/classmap_private_property_packed_array.phpt
+++ b/ext/soap/tests/classmap_private_property_packed_array.phpt
@@ -1,0 +1,45 @@
+--TEST--
+SoapClient must not read packed private classmap as string-keyed map
+--EXTENSIONS--
+soap
+--FILE--
+<?php
+
+class LocalSoapClient extends SoapClient {
+    public function __doRequest($request, $location, $action, $version, $one_way = false, ?string $uriParserClass = null): string {
+        echo "__doRequest called\n";
+
+        return <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+  <SOAP-ENV:Body>
+    <SOAP-ENV:Fault>
+      <faultcode>SOAP-ENV:Server</faultcode>
+      <faultstring>expected fault</faultstring>
+    </SOAP-ENV:Fault>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
+XML;
+    }
+}
+
+class Foo {}
+
+$client = new LocalSoapClient(null, [
+    'location' => 'http://example.org/',
+    'uri' => 'http://example.org/',
+]);
+
+$property = new ReflectionProperty(SoapClient::class, '_classmap');
+$property->setValue($client, ['Foo']);
+
+try {
+    $client->__soapCall('foo', [new Foo()]);
+} catch (SoapFault) {
+    echo "SOAP Fault thrown\n";
+}
+
+?>
+--EXPECT--
+__doRequest called
+SOAP Fault thrown


### PR DESCRIPTION
Previously, SOAP only rejected packed arrays, which still allowed sparse integer-keyed arrays and mixed string integer-keyed arrays to be accepted.

Since `classmap` is expected to be an associative mapping, arrays containing integer keys are now rejected consistently.