### PR TITLE
streams: drop leading _ for most stream functions

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -1658,7 +1658,7 @@ PHPAPI zend_result php_stream_open_for_zend_ex(zend_file_handle *handle, int mod
 		handle->filename = filename;
 		handle->opened_path = opened_path;
 		handle->handle.stream.handle  = stream;
-		handle->handle.stream.reader  = (zend_stream_reader_t)_php_stream_read;
+		handle->handle.stream.reader  = (zend_stream_reader_t)php_stream_read;
 		handle->handle.stream.fsizer  = php_zend_stream_fsizer;
 		handle->handle.stream.isatty  = 0;
 		handle->handle.stream.closer = php_zend_stream_closer;

--- a/main/php_streams.h
+++ b/main/php_streams.h
@@ -377,8 +377,7 @@ PHPAPI int php_stream_getc(php_stream *stream);
 
 PHPAPI int php_stream_putc(php_stream *stream, int c);
 
-PHPAPI int _php_stream_flush(php_stream *stream, int closing);
-#define php_stream_flush(stream)	_php_stream_flush((stream), 0)
+PHPAPI int php_stream_flush(php_stream *stream);
 
 PHPAPI int php_stream_sync(php_stream *stream, bool data_only);
 

--- a/main/php_streams.h
+++ b/main/php_streams.h
@@ -408,9 +408,8 @@ PHPAPI php_stream_dirent *php_stream_readdir(php_stream *dirstream, php_stream_d
 PHPAPI int php_stream_dirent_alphasort(const zend_string **a, const zend_string **b);
 PHPAPI int php_stream_dirent_alphasortr(const zend_string **a, const zend_string **b);
 
-PHPAPI int _php_stream_scandir(const char *dirname, zend_string **namelist[], int flags, php_stream_context *context,
+PHPAPI int php_stream_scandir(const char *dirname, zend_string **namelist[], php_stream_context *context,
 			int (*compare) (const zend_string **a, const zend_string **b));
-#define php_stream_scandir(dirname, namelist, context, compare) _php_stream_scandir((dirname), (namelist), 0, (context), (compare))
 
 PHPAPI int php_stream_set_option(php_stream *stream, int option, int value, void *ptrparam);
 

--- a/main/php_streams.h
+++ b/main/php_streams.h
@@ -333,8 +333,7 @@ static zend_always_inline bool php_stream_zend_parse_arg_into_stream(
 #define PHP_Z_PARAM_STREAM_OR_NULL(dest) PHP_Z_PARAM_STREAM_EX(dest, true)
 
 PHPAPI php_stream *php_stream_encloses(php_stream *enclosing, php_stream *enclosed);
-#define php_stream_free_enclosed(stream_enclosed, close_options) _php_stream_free_enclosed((stream_enclosed), (close_options))
-PHPAPI int _php_stream_free_enclosed(php_stream *stream_enclosed, int close_options);
+PHPAPI int php_stream_free_enclosed(php_stream *stream_enclosed, int close_options);
 
 PHPAPI int php_stream_from_persistent_id(const char *persistent_id, php_stream **stream);
 #define PHP_STREAM_PERSISTENT_SUCCESS	0 /* id exists */
@@ -352,77 +351,57 @@ PHPAPI int php_stream_from_persistent_id(const char *persistent_id, php_stream *
 #define PHP_STREAM_FREE_CLOSE_CASTED		(PHP_STREAM_FREE_CLOSE | PHP_STREAM_FREE_PRESERVE_HANDLE)
 #define PHP_STREAM_FREE_CLOSE_PERSISTENT	(PHP_STREAM_FREE_CLOSE | PHP_STREAM_FREE_PERSISTENT)
 
-PHPAPI int _php_stream_free(php_stream *stream, int close_options);
-#define php_stream_free(stream, close_options)	_php_stream_free((stream), (close_options))
-#define php_stream_close(stream)	_php_stream_free((stream), PHP_STREAM_FREE_CLOSE)
-#define php_stream_pclose(stream)	_php_stream_free((stream), PHP_STREAM_FREE_CLOSE_PERSISTENT)
+PHPAPI int php_stream_free(php_stream *stream, int close_options);
+#define php_stream_close(stream)	php_stream_free((stream), PHP_STREAM_FREE_CLOSE)
+#define php_stream_pclose(stream)	php_stream_free((stream), PHP_STREAM_FREE_CLOSE_PERSISTENT)
 
-PHPAPI int _php_stream_seek(php_stream *stream, zend_off_t offset, int whence);
-#define php_stream_rewind(stream)	_php_stream_seek((stream), 0L, SEEK_SET)
-#define php_stream_seek(stream, offset, whence)	_php_stream_seek((stream), (offset), (whence))
+PHPAPI int php_stream_seek(php_stream *stream, zend_off_t offset, int whence);
+#define php_stream_rewind(stream)	php_stream_seek((stream), 0L, SEEK_SET)
 
-PHPAPI zend_off_t _php_stream_tell(const php_stream *stream);
-#define php_stream_tell(stream)	_php_stream_tell((stream))
+PHPAPI zend_off_t php_stream_tell(const php_stream *stream);
 
-PHPAPI ssize_t _php_stream_read(php_stream *stream, char *buf, size_t count);
-#define php_stream_read(stream, buf, count)		_php_stream_read((stream), (buf), (count))
+PHPAPI ssize_t php_stream_read(php_stream *stream, char *buf, size_t count);
 
 PHPAPI zend_string *php_stream_read_to_str(php_stream *stream, size_t len);
 
-PHPAPI ssize_t _php_stream_write(php_stream *stream, const char *buf, size_t count);
-#define php_stream_write_string(stream, str)	_php_stream_write(stream, str, strlen(str))
-#define php_stream_write(stream, buf, count)	_php_stream_write(stream, (buf), (count))
+PHPAPI ssize_t php_stream_write(php_stream *stream, const char *buf, size_t count);
+#define php_stream_write_string(stream, str)	php_stream_write(stream, str, strlen(str))
 
-PHPAPI zend_result _php_stream_fill_read_buffer(php_stream *stream, size_t size);
-#define php_stream_fill_read_buffer(stream, size)	_php_stream_fill_read_buffer((stream), (size))
+PHPAPI zend_result php_stream_fill_read_buffer(php_stream *stream, size_t size);
 
-PHPAPI ssize_t _php_stream_printf(php_stream *stream, const char *fmt, ...) PHP_ATTRIBUTE_FORMAT(printf, 2, 3);
+PHPAPI ssize_t php_stream_printf(php_stream *stream, const char *fmt, ...) PHP_ATTRIBUTE_FORMAT(printf, 2, 3);
 
-/* php_stream_printf macro & function require */
-#define php_stream_printf _php_stream_printf
+PHPAPI bool php_stream_eof(php_stream *stream);
 
-PHPAPI bool _php_stream_eof(php_stream *stream);
-#define php_stream_eof(stream)	_php_stream_eof((stream))
+PHPAPI int php_stream_getc(php_stream *stream);
 
-PHPAPI int _php_stream_getc(php_stream *stream);
-#define php_stream_getc(stream)	_php_stream_getc((stream))
-
-PHPAPI int _php_stream_putc(php_stream *stream, int c);
-#define php_stream_putc(stream, c)	_php_stream_putc((stream), (c))
+PHPAPI int php_stream_putc(php_stream *stream, int c);
 
 PHPAPI int _php_stream_flush(php_stream *stream, int closing);
 #define php_stream_flush(stream)	_php_stream_flush((stream), 0)
 
-PHPAPI int _php_stream_sync(php_stream *stream, bool data_only);
-#define php_stream_sync(stream, d)	    _php_stream_sync((stream), (d))
+PHPAPI int php_stream_sync(php_stream *stream, bool data_only);
 
-PHPAPI char *_php_stream_get_line(php_stream *stream, char *buf, size_t maxlen, size_t *returned_len);
-#define php_stream_gets(stream, buf, maxlen)	_php_stream_get_line((stream), (buf), (maxlen), NULL)
+PHPAPI char *php_stream_get_line(php_stream *stream, char *buf, size_t maxlen, size_t *returned_len);
+#define php_stream_gets(stream, buf, maxlen)	php_stream_get_line((stream), (buf), (maxlen), NULL)
 
-#define php_stream_get_line(stream, buf, maxlen, retlen) _php_stream_get_line((stream), (buf), (maxlen), (retlen))
 PHPAPI zend_string *php_stream_get_record(php_stream *stream, size_t maxlen, const char *delim, size_t delim_len);
 
 /* Returns true if buffer has been appended, false on error */
-PHPAPI bool _php_stream_puts(php_stream *stream, const char *buf);
-#define php_stream_puts(stream, buf)	_php_stream_puts((stream), (buf))
+PHPAPI bool php_stream_puts(php_stream *stream, const char *buf);
 
-PHPAPI int _php_stream_stat(php_stream *stream, php_stream_statbuf *ssb);
-#define php_stream_stat(stream, ssb)	_php_stream_stat((stream), (ssb))
+PHPAPI int php_stream_stat(php_stream *stream, php_stream_statbuf *ssb);
 
-PHPAPI int _php_stream_stat_path(const char *path, int flags, php_stream_statbuf *ssb, php_stream_context *context);
-#define php_stream_stat_path(path, ssb)	_php_stream_stat_path((path), 0, (ssb), NULL)
-#define php_stream_stat_path_ex(path, flags, ssb, context)	_php_stream_stat_path((path), (flags), (ssb), (context))
+PHPAPI int php_stream_stat_path_ex(const char *path, int flags, php_stream_statbuf *ssb, php_stream_context *context);
+#define php_stream_stat_path(path, ssb)	php_stream_stat_path_ex((path), 0, (ssb), NULL)
 
-PHPAPI int _php_stream_mkdir(const char *path, int mode, int options, php_stream_context *context);
-#define php_stream_mkdir(path, mode, options, context)	_php_stream_mkdir(path, mode, options, context)
+PHPAPI int php_stream_mkdir(const char *path, int mode, int options, php_stream_context *context);
 
-PHPAPI int _php_stream_rmdir(const char *path, int options, php_stream_context *context);
-#define php_stream_rmdir(path, options, context)	_php_stream_rmdir(path, options, context)
+PHPAPI int php_stream_rmdir(const char *path, int options, php_stream_context *context);
 
 PHPAPI php_stream *_php_stream_opendir(const char *path, int options, php_stream_context *context STREAMS_DC);
 #define php_stream_opendir(path, options, context)	_php_stream_opendir((path), (options), (context) STREAMS_CC)
-PHPAPI php_stream_dirent *_php_stream_readdir(php_stream *dirstream, php_stream_dirent *ent);
-#define php_stream_readdir(dirstream, dirent)	_php_stream_readdir((dirstream), (dirent))
+PHPAPI php_stream_dirent *php_stream_readdir(php_stream *dirstream, php_stream_dirent *ent);
 #define php_stream_closedir(dirstream)	php_stream_close((dirstream))
 #define php_stream_rewinddir(dirstream)	php_stream_rewind((dirstream))
 
@@ -433,10 +412,9 @@ PHPAPI int _php_stream_scandir(const char *dirname, zend_string **namelist[], in
 			int (*compare) (const zend_string **a, const zend_string **b));
 #define php_stream_scandir(dirname, namelist, context, compare) _php_stream_scandir((dirname), (namelist), 0, (context), (compare))
 
-PHPAPI int _php_stream_set_option(php_stream *stream, int option, int value, void *ptrparam);
-#define php_stream_set_option(stream, option, value, ptrvalue)	_php_stream_set_option((stream), (option), (value), (ptrvalue))
+PHPAPI int php_stream_set_option(php_stream *stream, int option, int value, void *ptrparam);
 
-#define php_stream_set_chunk_size(stream, size) _php_stream_set_option((stream), PHP_STREAM_OPTION_SET_CHUNK_SIZE, (size), NULL)
+#define php_stream_set_chunk_size(stream, size) php_stream_set_option((stream), PHP_STREAM_OPTION_SET_CHUNK_SIZE, (size), NULL)
 
 END_EXTERN_C()
 
@@ -475,8 +453,8 @@ END_EXTERN_C()
 /* whether or not locking is supported */
 #define PHP_STREAM_LOCK_SUPPORTED		1
 
-#define php_stream_supports_lock(stream)	(_php_stream_set_option((stream), PHP_STREAM_OPTION_LOCKING, 0, (void *) PHP_STREAM_LOCK_SUPPORTED) == 0 ? 1 : 0)
-#define php_stream_lock(stream, mode)		_php_stream_set_option((stream), PHP_STREAM_OPTION_LOCKING, (mode), (void *) NULL)
+#define php_stream_supports_lock(stream)	(php_stream_set_option((stream), PHP_STREAM_OPTION_LOCKING, 0, (void *) PHP_STREAM_LOCK_SUPPORTED) == 0 ? 1 : 0)
+#define php_stream_lock(stream, mode)		php_stream_set_option((stream), PHP_STREAM_OPTION_LOCKING, (mode), (void *) NULL)
 
 /* option code used by the php_stream_xport_XXX api */
 #define PHP_STREAM_OPTION_XPORT_API			7 /* see php_stream_transport.h */
@@ -487,15 +465,14 @@ END_EXTERN_C()
 #define PHP_STREAM_TRUNCATE_SUPPORTED	0
 #define PHP_STREAM_TRUNCATE_SET_SIZE	1	/* ptrparam is a pointer to a size_t */
 
-#define php_stream_truncate_supported(stream)	(_php_stream_set_option((stream), PHP_STREAM_OPTION_TRUNCATE_API, PHP_STREAM_TRUNCATE_SUPPORTED, NULL) == PHP_STREAM_OPTION_RETURN_OK ? 1 : 0)
+#define php_stream_truncate_supported(stream)	(php_stream_set_option((stream), PHP_STREAM_OPTION_TRUNCATE_API, PHP_STREAM_TRUNCATE_SUPPORTED, NULL) == PHP_STREAM_OPTION_RETURN_OK ? 1 : 0)
 
 BEGIN_EXTERN_C()
-PHPAPI int _php_stream_truncate_set_size(php_stream *stream, size_t newsize);
-#define php_stream_truncate_set_size(stream, size)	_php_stream_truncate_set_size((stream), (size))
+PHPAPI int php_stream_truncate_set_size(php_stream *stream, size_t newsize);
 END_EXTERN_C()
 
 #define PHP_STREAM_OPTION_META_DATA_API		11 /* ptrparam is a zval* to which to add metadata information */
-#define php_stream_populate_meta_data(stream, zv)	(_php_stream_set_option((stream), PHP_STREAM_OPTION_META_DATA_API, 0, zv) == PHP_STREAM_OPTION_RETURN_OK ? 1 : 0)
+#define php_stream_populate_meta_data(stream, zv)	(php_stream_set_option((stream), PHP_STREAM_OPTION_META_DATA_API, 0, zv) == PHP_STREAM_OPTION_RETURN_OK ? 1 : 0)
 
 /* Check if the stream is still "live"; for sockets/pipes this means the socket
  * is still connected; for files, this does not really have meaning */
@@ -510,7 +487,7 @@ END_EXTERN_C()
 #define PHP_STREAM_SYNC_FSYNC 1
 #define PHP_STREAM_SYNC_FDSYNC 2
 
-#define php_stream_sync_supported(stream)	(_php_stream_set_option((stream), PHP_STREAM_OPTION_SYNC_API, PHP_STREAM_SYNC_SUPPORTED, NULL) == PHP_STREAM_OPTION_RETURN_OK ? 1 : 0)
+#define php_stream_sync_supported(stream)	(php_stream_set_option((stream), PHP_STREAM_OPTION_SYNC_API, PHP_STREAM_SYNC_SUPPORTED, NULL) == PHP_STREAM_OPTION_RETURN_OK ? 1 : 0)
 
 
 #define PHP_STREAM_OPTION_RETURN_OK			 0 /* option set OK */
@@ -564,11 +541,10 @@ END_EXTERN_C()
 #define PHP_STREAM_CAST_INTERNAL	0x20000000	/* stream cast for internal use */
 #define PHP_STREAM_CAST_MASK		(PHP_STREAM_CAST_TRY_HARD | PHP_STREAM_CAST_RELEASE | PHP_STREAM_CAST_INTERNAL)
 BEGIN_EXTERN_C()
-PHPAPI zend_result _php_stream_cast(php_stream *stream, int castas, void **ret, int show_err);
+PHPAPI zend_result php_stream_cast(php_stream *stream, int castas, void **ret, int show_err);
 END_EXTERN_C()
 /* use this to check if a stream can be cast into another form */
-#define php_stream_can_cast(stream, as)	_php_stream_cast((stream), (as), NULL, 0)
-#define php_stream_cast(stream, as, ret, show_err)	_php_stream_cast((stream), (as), (ret), (show_err))
+#define php_stream_can_cast(stream, as)	php_stream_cast((stream), (as), NULL, 0)
 
 /* use this to check if a stream is of a particular type:
  * PHPAPI int php_stream_is(php_stream *stream, php_stream_ops *ops); */
@@ -660,11 +636,9 @@ PHPAPI php_stream_make_seekable_status _php_stream_make_seekable(php_stream *ori
 #define php_stream_make_seekable(origstream, newstream, flags)	_php_stream_make_seekable((origstream), (newstream), (flags) STREAMS_CC)
 
 /* Give other modules access to the url_stream_wrappers_hash and stream_filters_hash */
-PHPAPI HashTable *_php_stream_get_url_stream_wrappers_hash(void);
-#define php_stream_get_url_stream_wrappers_hash()	_php_stream_get_url_stream_wrappers_hash()
+PHPAPI HashTable *php_stream_get_url_stream_wrappers_hash(void);
 PHPAPI HashTable *php_stream_get_url_stream_wrappers_hash_global(void);
-PHPAPI HashTable *_php_get_stream_filters_hash(void);
-#define php_get_stream_filters_hash()	_php_get_stream_filters_hash()
+PHPAPI HashTable *php_get_stream_filters_hash(void);
 PHPAPI HashTable *php_get_stream_filters_hash_global(void);
 extern const php_stream_wrapper_ops *php_stream_user_wrapper_ops;
 

--- a/main/streams/cast.c
+++ b/main/streams/cast.c
@@ -188,7 +188,7 @@ void php_stream_mode_sanitize_fdopen_fopencookie(php_stream *stream, char *resul
 }
 /* }}} */
 /* {{{ php_stream_cast */
-PHPAPI zend_result _php_stream_cast(php_stream *stream, int castas, void **ret, int show_err)
+PHPAPI zend_result php_stream_cast(php_stream *stream, int castas, void **ret, int show_err)
 {
 	int flags = castas & PHP_STREAM_CAST_MASK;
 	castas &= ~PHP_STREAM_CAST_MASK;

--- a/main/streams/filter.c
+++ b/main/streams/filter.c
@@ -30,7 +30,7 @@ PHPAPI HashTable *php_get_stream_filters_hash_global(void)
 }
 
 /* Normal hash selection/retrieval call */
-PHPAPI HashTable *_php_get_stream_filters_hash(void)
+PHPAPI HashTable *php_get_stream_filters_hash(void)
 {
 	return (FG(stream_filters) ? FG(stream_filters) : &stream_filters_hash);
 }
@@ -342,7 +342,7 @@ PHPAPI void php_stream_filter_prepend_ex(php_stream_filter_chain *chain, php_str
 	filter->chain = chain;
 }
 
-PHPAPI void _php_stream_filter_prepend(php_stream_filter_chain *chain, php_stream_filter *filter)
+PHPAPI void php_stream_filter_prepend(php_stream_filter_chain *chain, php_stream_filter *filter)
 {
 	php_stream_filter_prepend_ex(chain, filter);
 }
@@ -434,7 +434,7 @@ PHPAPI zend_result php_stream_filter_append_ex(php_stream_filter_chain *chain, p
 	return SUCCESS;
 }
 
-PHPAPI void _php_stream_filter_append(php_stream_filter_chain *chain, php_stream_filter *filter)
+PHPAPI void php_stream_filter_append(php_stream_filter_chain *chain, php_stream_filter *filter)
 {
 	if (php_stream_filter_append_ex(chain, filter) != SUCCESS) {
 		if (chain->head == filter) {
@@ -447,7 +447,7 @@ PHPAPI void _php_stream_filter_append(php_stream_filter_chain *chain, php_stream
 	}
 }
 
-PHPAPI zend_result _php_stream_filter_flush(php_stream_filter *filter, bool finish)
+PHPAPI zend_result php_stream_filter_flush(php_stream_filter *filter, bool finish)
 {
 	php_stream_bucket_brigade brig_a = { NULL, NULL }, brig_b = { NULL, NULL }, *inp = &brig_a, *outp = &brig_b, *brig_temp;
 	php_stream_bucket *bucket;

--- a/main/streams/mmap.c
+++ b/main/streams/mmap.c
@@ -34,12 +34,12 @@ PHPAPI char *_php_stream_mmap_range(php_stream *stream, size_t offset, size_t le
 	return NULL;
 }
 
-PHPAPI int _php_stream_mmap_unmap(php_stream *stream)
+PHPAPI int php_stream_mmap_unmap(php_stream *stream)
 {
 	return php_stream_set_option(stream, PHP_STREAM_OPTION_MMAP_API, PHP_STREAM_MMAP_UNMAP, NULL) == PHP_STREAM_OPTION_RETURN_OK;
 }
 
-PHPAPI int _php_stream_mmap_unmap_ex(php_stream *stream, zend_off_t readden)
+PHPAPI int php_stream_mmap_unmap_ex(php_stream *stream, zend_off_t readden)
 {
 	int ret = 1;
 

--- a/main/streams/php_stream_filter_api.h
+++ b/main/streams/php_stream_filter_api.h
@@ -134,11 +134,11 @@ struct _php_stream_filter {
 
 /* stack filter onto a stream */
 BEGIN_EXTERN_C()
-PHPAPI void _php_stream_filter_prepend(php_stream_filter_chain *chain, php_stream_filter *filter);
+PHPAPI void php_stream_filter_prepend(php_stream_filter_chain *chain, php_stream_filter *filter);
 PHPAPI void php_stream_filter_prepend_ex(php_stream_filter_chain *chain, php_stream_filter *filter);
-PHPAPI void _php_stream_filter_append(php_stream_filter_chain *chain, php_stream_filter *filter);
+PHPAPI void php_stream_filter_append(php_stream_filter_chain *chain, php_stream_filter *filter);
 PHPAPI zend_result php_stream_filter_append_ex(php_stream_filter_chain *chain, php_stream_filter *filter);
-PHPAPI zend_result _php_stream_filter_flush(php_stream_filter *filter, bool finish);
+PHPAPI zend_result php_stream_filter_flush(php_stream_filter *filter, bool finish);
 PHPAPI php_stream_filter *php_stream_filter_remove(php_stream_filter *filter, bool call_dtor);
 PHPAPI void php_stream_filter_free(php_stream_filter *filter);
 PHPAPI php_stream_filter *_php_stream_filter_alloc(const php_stream_filter_ops *fops,
@@ -153,9 +153,6 @@ END_EXTERN_C()
 		_php_stream_filter_alloc((fops), (thisptr), (persistent), (rseek), (wseek) STREAMS_CC)
 #define php_stream_filter_alloc_rel(fops, thisptr, persistent, rseek, wseek) \
 	_php_stream_filter_alloc((fops), (thisptr), (persistent), (rseek), (wseek) STREAMS_REL_CC)
-#define php_stream_filter_prepend(chain, filter) _php_stream_filter_prepend((chain), (filter))
-#define php_stream_filter_append(chain, filter) _php_stream_filter_append((chain), (filter))
-#define php_stream_filter_flush(filter, finish) _php_stream_filter_flush((filter), (finish))
 
 #define php_stream_is_filtered(stream)	((stream)->readfilters.head || (stream)->writefilters.head)
 

--- a/main/streams/php_stream_mmap.h
+++ b/main/streams/php_stream_mmap.h
@@ -56,7 +56,7 @@ typedef struct {
 
 #define PHP_STREAM_MMAP_MAX (512 * 1024 * 1024)
 
-#define php_stream_mmap_supported(stream)	(_php_stream_set_option((stream), PHP_STREAM_OPTION_MMAP_API, PHP_STREAM_MMAP_SUPPORTED, NULL) == 0 ? 1 : 0)
+#define php_stream_mmap_supported(stream)	(php_stream_set_option((stream), PHP_STREAM_OPTION_MMAP_API, PHP_STREAM_MMAP_SUPPORTED, NULL) == 0 ? 1 : 0)
 
 /* Returns 1 if the stream in its current state can be memory mapped,
  * 0 otherwise */
@@ -67,9 +67,7 @@ PHPAPI char *_php_stream_mmap_range(php_stream *stream, size_t offset, size_t le
 #define php_stream_mmap_range(stream, offset, length, mode, mapped_len)	_php_stream_mmap_range((stream), (offset), (length), (mode), (mapped_len))
 
 /* un-maps the last mapped range */
-PHPAPI int _php_stream_mmap_unmap(php_stream *stream);
-#define php_stream_mmap_unmap(stream)				_php_stream_mmap_unmap((stream))
+PHPAPI int php_stream_mmap_unmap(php_stream *stream);
 
-PHPAPI int _php_stream_mmap_unmap_ex(php_stream *stream, zend_off_t readden);
-#define php_stream_mmap_unmap_ex(stream, readden)			_php_stream_mmap_unmap_ex((stream), (readden))
+PHPAPI int php_stream_mmap_unmap_ex(php_stream *stream, zend_off_t readden);
 END_EXTERN_C()

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -2371,8 +2371,7 @@ PHPAPI int php_stream_dirent_alphasortr(const zend_string **a, const zend_string
 }
 /* }}} */
 
-/* {{{ php_stream_scandir */
-PHPAPI int _php_stream_scandir(const char *dirname, zend_string **namelist[], int flags, php_stream_context *context,
+PHPAPI int php_stream_scandir(const char *dirname, zend_string **namelist[], php_stream_context *context,
 			  int (*compare) (const zend_string **a, const zend_string **b))
 {
 	php_stream *stream;
@@ -2427,4 +2426,3 @@ overflow:
 	efree(vector);
 	return -1;
 }
-/* }}} */

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -249,6 +249,7 @@ static int _php_stream_free_persistent(zval *zv, void *pStream)
 	return le->ptr == pStream;
 }
 
+static int php_stream_flush_ex(php_stream *stream, bool closing);
 
 PHPAPI int php_stream_free(php_stream *stream, int close_options) /* {{{ */
 {
@@ -336,7 +337,7 @@ fprintf(stderr, "stream_free: %s:%p[%s] preserve_handle=%d release_cast=%d remov
 
 	if (stream->flags & PHP_STREAM_FLAG_WAS_WRITTEN || stream->writefilters.head) {
 		/* make sure everything is saved */
-		_php_stream_flush(stream, 1);
+		php_stream_flush_ex(stream, true);
 	}
 
 	/* If not called from the resource dtor, remove the stream from the resource list. */
@@ -1183,7 +1184,7 @@ static ssize_t php_stream_write_filtered(php_stream *stream, const char *buf, si
 	return consumed;
 }
 
-PHPAPI int _php_stream_flush(php_stream *stream, int closing)
+static int php_stream_flush_ex(php_stream *stream, bool closing)
 {
 	int ret = 0;
 
@@ -1198,6 +1199,10 @@ PHPAPI int _php_stream_flush(php_stream *stream, int closing)
 	}
 
 	return ret;
+}
+
+PHPAPI int php_stream_flush(php_stream *stream) {
+	return php_stream_flush_ex(stream, false);
 }
 
 PHPAPI ssize_t php_stream_write(php_stream *stream, const char *buf, size_t count)
@@ -1324,7 +1329,7 @@ PHPAPI int php_stream_seek(php_stream *stream, zend_off_t offset, int whence)
 	bool is_start_seeking = whence == SEEK_SET && offset == 0;
 
 	if (stream->writefilters.head) {
-		_php_stream_flush(stream, 0);
+		php_stream_flush(stream);
 		if (!php_stream_are_filters_seekable(stream->writefilters.head, is_start_seeking,
 				PHP_STREAM_FILTER_WRITE)) {
 			return -1;

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -54,7 +54,7 @@ PHPAPI int php_file_le_stream_filter(void)
 	return le_stream_filter;
 }
 
-PHPAPI HashTable *_php_stream_get_url_stream_wrappers_hash(void)
+PHPAPI HashTable *php_stream_get_url_stream_wrappers_hash(void)
 {
 	return (FG(stream_wrappers) ? FG(stream_wrappers) : &url_stream_wrappers_hash);
 }
@@ -215,7 +215,7 @@ fprintf(stderr, "stream_alloc: %s:%p persistent=%s\n", ops->label, ret, persiste
 }
 /* }}} */
 
-PHPAPI int _php_stream_free_enclosed(php_stream *stream_enclosed, int close_options) /* {{{ */
+PHPAPI int php_stream_free_enclosed(php_stream *stream_enclosed, int close_options) /* {{{ */
 {
 	return php_stream_free(stream_enclosed,
 		close_options | PHP_STREAM_FREE_IGNORE_ENCLOSING);
@@ -250,7 +250,7 @@ static int _php_stream_free_persistent(zval *zv, void *pStream)
 }
 
 
-PHPAPI int _php_stream_free(php_stream *stream, int close_options) /* {{{ */
+PHPAPI int php_stream_free(php_stream *stream, int close_options) /* {{{ */
 {
 	int ret = 1;
 	int preserve_handle = close_options & PHP_STREAM_FREE_PRESERVE_HANDLE ? 1 : 0;
@@ -431,7 +431,7 @@ fprintf(stderr, "stream_free: %s:%p[%s] preserve_handle=%d release_cast=%d remov
 
 /* {{{ generic stream operations */
 
-PHPAPI zend_result _php_stream_fill_read_buffer(php_stream *stream, size_t size)
+PHPAPI zend_result php_stream_fill_read_buffer(php_stream *stream, size_t size)
 {
 	/* allocate/fill the buffer */
 
@@ -603,7 +603,7 @@ out_is_eof:
 	return retval;
 }
 
-PHPAPI ssize_t _php_stream_read(php_stream *stream, char *buf, size_t size)
+PHPAPI ssize_t php_stream_read(php_stream *stream, char *buf, size_t size)
 {
 	ssize_t toread = 0, didread = 0;
 
@@ -707,7 +707,7 @@ PHPAPI zend_string *php_stream_read_to_str(php_stream *stream, size_t len)
 	return str;
 }
 
-PHPAPI bool _php_stream_eof(php_stream *stream)
+PHPAPI bool php_stream_eof(php_stream *stream)
 {
 	/* if there is data in the buffer, it's not EOF */
 	if (stream->writepos - stream->readpos > 0) {
@@ -724,7 +724,7 @@ PHPAPI bool _php_stream_eof(php_stream *stream)
 	return stream->eof;
 }
 
-PHPAPI int _php_stream_putc(php_stream *stream, int c)
+PHPAPI int php_stream_putc(php_stream *stream, int c)
 {
 	unsigned char buf = c;
 
@@ -734,7 +734,7 @@ PHPAPI int _php_stream_putc(php_stream *stream, int c)
 	return EOF;
 }
 
-PHPAPI int _php_stream_getc(php_stream *stream)
+PHPAPI int php_stream_getc(php_stream *stream)
 {
 	char buf;
 
@@ -744,7 +744,7 @@ PHPAPI int _php_stream_getc(php_stream *stream)
 	return EOF;
 }
 
-PHPAPI bool _php_stream_puts(php_stream *stream, const char *buf)
+PHPAPI bool php_stream_puts(php_stream *stream, const char *buf)
 {
 	size_t len;
 	char newline[2] = "\n"; /* is this OK for Win? */
@@ -756,7 +756,7 @@ PHPAPI bool _php_stream_puts(php_stream *stream, const char *buf)
 	return 0;
 }
 
-PHPAPI int _php_stream_stat(php_stream *stream, php_stream_statbuf *ssb)
+PHPAPI int php_stream_stat(php_stream *stream, php_stream_statbuf *ssb)
 {
 	memset(ssb, 0, sizeof(*ssb));
 
@@ -818,7 +818,7 @@ PHPAPI const char *php_stream_locate_eol(php_stream *stream, zend_string *buf)
 /* If buf == NULL, the buffer will be allocated automatically and will be of an
  * appropriate length to hold the line, regardless of the line length, memory
  * permitting */
-PHPAPI char *_php_stream_get_line(php_stream *stream, char *buf, size_t maxlen,
+PHPAPI char *php_stream_get_line(php_stream *stream, char *buf, size_t maxlen,
 		size_t *returned_len)
 {
 	size_t avail = 0;
@@ -1056,7 +1056,7 @@ PHPAPI zend_string *php_stream_get_record(php_stream *stream, size_t maxlen, con
 }
 
 /* Writes a buffer directly to a stream, using multiple of the chunk size */
-static ssize_t _php_stream_write_buffer(php_stream *stream, const char *buf, size_t count)
+static ssize_t php_stream_write_buffer(php_stream *stream, const char *buf, size_t count)
 {
 	ssize_t didwrite = 0;
 	ssize_t retval;
@@ -1112,7 +1112,7 @@ out:
  * This may trigger a real write to the stream.
  * Returns the number of bytes consumed from buf by the first filter in the chain.
  * */
-static ssize_t _php_stream_write_filtered(php_stream *stream, const char *buf, size_t count, int flags)
+static ssize_t php_stream_write_filtered(php_stream *stream, const char *buf, size_t count, int flags)
 {
 	size_t consumed = 0;
 	php_stream_bucket *bucket;
@@ -1149,7 +1149,7 @@ static ssize_t _php_stream_write_filtered(php_stream *stream, const char *buf, s
 			 * underlying stream */
 			while (brig_inp->head) {
 				bucket = brig_inp->head;
-				if (_php_stream_write_buffer(stream, bucket->buf, bucket->buflen) < 0) {
+				if (php_stream_write_buffer(stream, bucket->buf, bucket->buflen) < 0) {
 					consumed = (ssize_t) -1;
 				}
 
@@ -1188,7 +1188,7 @@ PHPAPI int _php_stream_flush(php_stream *stream, int closing)
 	int ret = 0;
 
 	if (stream->writefilters.head && stream->ops->write) {
-		_php_stream_write_filtered(stream, NULL, 0, closing ? PSFS_FLAG_FLUSH_CLOSE : PSFS_FLAG_FLUSH_INC );
+		php_stream_write_filtered(stream, NULL, 0, closing ? PSFS_FLAG_FLUSH_CLOSE : PSFS_FLAG_FLUSH_INC );
 	}
 
 	stream->flags &= ~PHP_STREAM_FLAG_WAS_WRITTEN;
@@ -1200,7 +1200,7 @@ PHPAPI int _php_stream_flush(php_stream *stream, int closing)
 	return ret;
 }
 
-PHPAPI ssize_t _php_stream_write(php_stream *stream, const char *buf, size_t count)
+PHPAPI ssize_t php_stream_write(php_stream *stream, const char *buf, size_t count)
 {
 	ssize_t bytes;
 
@@ -1215,9 +1215,9 @@ PHPAPI ssize_t _php_stream_write(php_stream *stream, const char *buf, size_t cou
 	}
 
 	if (stream->writefilters.head) {
-		bytes = _php_stream_write_filtered(stream, buf, count, PSFS_FLAG_NORMAL);
+		bytes = php_stream_write_filtered(stream, buf, count, PSFS_FLAG_NORMAL);
 	} else {
-		bytes = _php_stream_write_buffer(stream, buf, count);
+		bytes = php_stream_write_buffer(stream, buf, count);
 	}
 
 	if (bytes) {
@@ -1227,7 +1227,7 @@ PHPAPI ssize_t _php_stream_write(php_stream *stream, const char *buf, size_t cou
 	return bytes;
 }
 
-PHPAPI ssize_t _php_stream_printf(php_stream *stream, const char *fmt, ...)
+PHPAPI ssize_t php_stream_printf(php_stream *stream, const char *fmt, ...)
 {
 	ssize_t count;
 	char *buf;
@@ -1247,7 +1247,7 @@ PHPAPI ssize_t _php_stream_printf(php_stream *stream, const char *fmt, ...)
 	return count;
 }
 
-PHPAPI zend_off_t _php_stream_tell(const php_stream *stream)
+PHPAPI zend_off_t php_stream_tell(const php_stream *stream)
 {
 	return stream->position;
 }
@@ -1309,7 +1309,7 @@ static bool php_stream_has_notifier(php_stream *stream)
 	return context && context->notifier;
 }
 
-PHPAPI int _php_stream_seek(php_stream *stream, zend_off_t offset, int whence)
+PHPAPI int php_stream_seek(php_stream *stream, zend_off_t offset, int whence)
 {
 	if (stream->fclose_stdiocast == PHP_STREAM_FCLOSE_FOPENCOOKIE) {
 		/* flush can call seek internally so we need to prevent an infinite loop */
@@ -1416,7 +1416,7 @@ PHPAPI int _php_stream_seek(php_stream *stream, zend_off_t offset, int whence)
 	return -1;
 }
 
-PHPAPI int _php_stream_set_option(php_stream *stream, int option, int value, void *ptrparam)
+PHPAPI int php_stream_set_option(php_stream *stream, int option, int value, void *ptrparam)
 {
 	int ret = PHP_STREAM_OPTION_RETURN_NOTIMPL;
 
@@ -1450,7 +1450,7 @@ PHPAPI int _php_stream_set_option(php_stream *stream, int option, int value, voi
 	return ret;
 }
 
-PHPAPI int _php_stream_sync(php_stream *stream, bool data_only)
+PHPAPI int php_stream_sync(php_stream *stream, bool data_only)
 {
 	int op = PHP_STREAM_SYNC_FSYNC;
 	if (data_only) {
@@ -1459,7 +1459,7 @@ PHPAPI int _php_stream_sync(php_stream *stream, bool data_only)
 	return php_stream_set_option(stream, PHP_STREAM_OPTION_SYNC_API, op, NULL);
 }
 
-PHPAPI int _php_stream_truncate_set_size(php_stream *stream, size_t newsize)
+PHPAPI int php_stream_truncate_set_size(php_stream *stream, size_t newsize)
 {
 	return php_stream_set_option(stream, PHP_STREAM_OPTION_TRUNCATE_API, PHP_STREAM_TRUNCATE_SET_SIZE, &newsize);
 }
@@ -1976,8 +1976,7 @@ PHPAPI php_stream_wrapper *php_stream_locate_url_wrapper(const char *path, const
 }
 /* }}} */
 
-/* {{{ _php_stream_mkdir */
-PHPAPI int _php_stream_mkdir(const char *path, int mode, int options, php_stream_context *context)
+PHPAPI int php_stream_mkdir(const char *path, int mode, int options, php_stream_context *context)
 {
 	php_stream_wrapper *wrapper = NULL;
 
@@ -1988,10 +1987,8 @@ PHPAPI int _php_stream_mkdir(const char *path, int mode, int options, php_stream
 
 	return wrapper->wops->stream_mkdir(wrapper, path, mode, options, context);
 }
-/* }}} */
 
-/* {{{ _php_stream_rmdir */
-PHPAPI int _php_stream_rmdir(const char *path, int options, php_stream_context *context)
+PHPAPI int php_stream_rmdir(const char *path, int options, php_stream_context *context)
 {
 	php_stream_wrapper *wrapper = NULL;
 
@@ -2002,10 +1999,8 @@ PHPAPI int _php_stream_rmdir(const char *path, int options, php_stream_context *
 
 	return wrapper->wops->stream_rmdir(wrapper, path, options, context);
 }
-/* }}} */
 
-/* {{{ _php_stream_stat_path */
-PHPAPI int _php_stream_stat_path(const char *path, int flags, php_stream_statbuf *ssb, php_stream_context *context)
+PHPAPI int php_stream_stat_path_ex(const char *path, int flags, php_stream_statbuf *ssb, php_stream_context *context)
 {
 	php_stream_wrapper *wrapper = NULL;
 	const char *path_to_open = path;
@@ -2018,7 +2013,6 @@ PHPAPI int _php_stream_stat_path(const char *path, int flags, php_stream_statbuf
 	}
 	return -1;
 }
-/* }}} */
 
 /* {{{ php_stream_opendir */
 PHPAPI php_stream *_php_stream_opendir(const char *path, int options,
@@ -2059,8 +2053,7 @@ PHPAPI php_stream *_php_stream_opendir(const char *path, int options,
 }
 /* }}} */
 
-/* {{{ _php_stream_readdir */
-PHPAPI php_stream_dirent *_php_stream_readdir(php_stream *dirstream, php_stream_dirent *ent)
+PHPAPI php_stream_dirent *php_stream_readdir(php_stream *dirstream, php_stream_dirent *ent)
 {
 
 	if (sizeof(php_stream_dirent) == php_stream_read(dirstream, (char*)ent, sizeof(php_stream_dirent))) {
@@ -2069,7 +2062,6 @@ PHPAPI php_stream_dirent *_php_stream_readdir(php_stream *dirstream, php_stream_
 
 	return NULL;
 }
-/* }}} */
 
 /* {{{ php_stream_open_wrapper_ex */
 PHPAPI php_stream *_php_stream_open_wrapper_ex(const char *path, const char *mode, int options,


### PR DESCRIPTION
The only macro versions being preserved are those passing STREAMS_DC in debug builds.

Symbols prefixed with `_` are actually reserved by C and thus should not be used in general.

This also makes determining usage of those functions *really* confusing, as it has no benefit, renaming the functions is fine.