### PR TITLE
ext/soap: to_xml_array() heap use-after-free with illegal iterator keys.

### DIFF
--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -2312,13 +2312,15 @@ static xmlNodePtr to_xml_array(encodeTypePtr type, zval *data, int style, xmlNod
 				if (EG(exception)) {
 					goto iterator_done;
 				}
-				array_set_zval_key(Z_ARRVAL(array_copy), &key, val);
-				zval_ptr_dtor(val);
+				zend_result status = array_set_zval_key(Z_ARRVAL(array_copy), &key, val);
 				zval_ptr_dtor(&key);
+				if (status == FAILURE) {
+					goto iterator_done;
+				}
 			} else {
+				Z_TRY_ADDREF_P(val);
 				add_next_index_zval(&array_copy, val);
 			}
-			Z_TRY_ADDREF_P(val);
 
 			iter->funcs->move_forward(iter);
 			if (EG(exception)) {

--- a/ext/soap/tests/bugs/gh22895.phpt
+++ b/ext/soap/tests/bugs/gh22895.phpt
@@ -62,7 +62,7 @@ foreach ([$multiple, new ArrayKeyIterator()] as $iterator) {
     try {
         $client->__soapCall('audit', [new SoapVar($iterator, SOAP_ENC_ARRAY)]);
     } catch (TypeError $e) {
-        echo $e->getMessage(), PHP_EOL;
+        echo $e::class, ': ', $e->getMessage(), PHP_EOL;
     }
 }
 
@@ -71,7 +71,7 @@ $client->__soapCall('audit', [new SoapVar(new ArrayIterator(['a' => 1]), SOAP_EN
 echo $client->__getLastRequest();
 ?>
 --EXPECT--
-Cannot access offset of type array on array
-Cannot access offset of type array on array
+TypeError: Cannot access offset of type array on array
+TypeError: Cannot access offset of type array on array
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="urn:audit" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><SOAP-ENV:Body><ns1:audit><param0 SOAP-ENC:arrayType="xsd:int[1]" xsi:type="SOAP-ENC:Array"><item xsi:type="xsd:int">1</item></param0></ns1:audit></SOAP-ENV:Body></SOAP-ENV:Envelope>

--- a/ext/soap/tests/bugs/gh22895.phpt
+++ b/ext/soap/tests/bugs/gh22895.phpt
@@ -1,0 +1,77 @@
+--TEST--
+GH-22895 (Heap use-after-free while encoding a Traversable with an illegal key)
+--CREDITS--
+Amorsec
+--EXTENSIONS--
+soap
+--FILE--
+<?php
+class LocalSoapClient extends SoapClient
+{
+    public function __doRequest(
+        $request,
+        $location,
+        $action,
+        $version,
+        $one_way = false
+    ): ?string {
+        return '';
+    }
+}
+
+class ArrayKeyIterator implements Iterator
+{
+    private int $i = 0;
+
+    public function current(): mixed
+    {
+        return new stdClass();
+    }
+
+    public function key(): mixed
+    {
+        return ['illegal', 'key'];
+    }
+
+    public function next(): void
+    {
+        $this->i++;
+    }
+
+    public function rewind(): void
+    {
+        $this->i = 0;
+    }
+
+    public function valid(): bool
+    {
+        return $this->i < 2;
+    }
+}
+
+$client = new LocalSoapClient(null, [
+    'location' => 'http://127.0.0.1/',
+    'uri' => 'urn:audit',
+    'trace' => 1,
+]);
+
+$multiple = new MultipleIterator();
+$multiple->attachIterator(new ArrayIterator([0]));
+
+foreach ([$multiple, new ArrayKeyIterator()] as $iterator) {
+    try {
+        $client->__soapCall('audit', [new SoapVar($iterator, SOAP_ENC_ARRAY)]);
+    } catch (TypeError $e) {
+        echo $e->getMessage(), PHP_EOL;
+    }
+}
+
+/* A key the encoder can use must still be serialized, without leaking. */
+$client->__soapCall('audit', [new SoapVar(new ArrayIterator(['a' => 1]), SOAP_ENC_ARRAY)]);
+echo $client->__getLastRequest();
+?>
+--EXPECT--
+Cannot access offset of type array on array
+Cannot access offset of type array on array
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="urn:audit" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><SOAP-ENV:Body><ns1:audit><param0 SOAP-ENC:arrayType="xsd:int[1]" xsi:type="SOAP-ENC:Array"><item xsi:type="xsd:int">1</item></param0></ns1:audit></SOAP-ENV:Body></SOAP-ENV:Envelope>


### PR DESCRIPTION
Fix #22895

The return value of array_set_zval_key() was ignored, so when the key is not a legal array offset, e.g. MultipleIterator::key() returning an array, it threw and took no reference. The unconditional zval_ptr_dtor() then dropped the iterator's only reference to the borrowed value and the following Z_TRY_ADDREF_P() read freed memory.

Let array_set_zval_key() own its reference the way spl_iterator_to_array_apply() does, and stop iterating on failure.