### PR TITLE
Fix GH-22857: JIT wrong code for FETCH_OBJ_FUNC_ARG with property hooks

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -27,6 +27,10 @@ PHP                                                                        NEWS
   . Fixed bug GH-15836 (Use-after-free when a user stream filter accesses
     $this->stream during the close flush). (iliaal)
 
+- Opcache:
+  . Fixed bug GH-22857 (Function JIT emits wrong code for FETCH_OBJ_FUNC_ARG on a
+    property hook getter, losing register-held variables). (Zhao Hao)
+
 30 Jul 2026, PHP 8.4.24
 
 - BCMath:

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -2332,6 +2332,7 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 							goto jit_failure;
 						}
 						goto done;
+					case ZEND_FETCH_OBJ_FUNC_ARG:
 					case ZEND_FETCH_OBJ_R:
 					case ZEND_FETCH_OBJ_IS:
 					case ZEND_FETCH_OBJ_W:
@@ -2369,11 +2370,31 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 						 || Z_STRVAL_P(RT_CONSTANT(opline, opline->op2))[0] == '\0') {
 							break;
 						}
-						if (!zend_jit_fetch_obj(&ctx, opline, op_array, ssa, ssa_op,
+						if (opline->opcode == ZEND_FETCH_OBJ_FUNC_ARG) {
+							/* FETCH_OBJ_FUNC_ARG's by-value fetch dispatches into the */
+							/* FETCH_OBJ_R handler, which may take the SIMPLE_GET hook fast */
+							/* path and push a getter frame; by-ref dispatches into */
+							/* FETCH_OBJ_W. The function JIT may keep values solely in */
+							/* registers, so we must NOT exit to the VM (stale stack slots). */
+							/* Inline the by-value path through zend_jit_fetch_obj, which runs */
+							/* the hook getter inside a helper and keeps all registers live. */
+							/* The by-ref path has no SIMPLE_GET fast path, so the generic */
+							/* handler (a full C call, safe under register allocation) is used. */
+							/* This mirrors the tracing JIT fix for GH-21006 (GH-21369); the */
+							/* runtime by-ref check is required because the passing mode is */
+							/* only known once the callee is resolved via namespace fallback. */
+							/* See GH-22857. */
+							if (!zend_jit_fetch_obj_func_arg(jit, opline, op_array, ssa, ssa_op,
+								op1_info, op1_addr, ce, ce_is_instanceof, on_this, RES_REG_ADDR())) {
+								goto jit_failure;
+							}
+						} else {
+							if (!zend_jit_fetch_obj(&ctx, opline, op_array, ssa, ssa_op,
 								op1_info, op1_addr, 0, ce, ce_is_instanceof, on_this, 0, 0, NULL,
 								RES_REG_ADDR(), IS_UNKNOWN,
 								zend_may_throw(opline, ssa_op, op_array, ssa))) {
-							goto jit_failure;
+								goto jit_failure;
+							}
 						}
 						goto done;
 					case ZEND_BIND_GLOBAL:

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -14647,6 +14647,59 @@ result_fetched:
 	return 1;
 }
 
+static int zend_jit_fetch_obj_func_arg(zend_jit_ctx *jit, const zend_op *opline,
+		const zend_op_array *op_array, zend_ssa *ssa, const zend_ssa_op *ssa_op,
+		uint32_t op1_info, zend_jit_addr op1_addr, zend_class_entry *ce,
+		bool ce_is_instanceof, bool on_this, zend_jit_addr res_addr)
+{
+	ir_ref rx, call_info, if_by_ref, end_by_ref;
+
+	/* Both runtime paths must observe a consistent frame state.  The delayed
+	 * call chain would otherwise only be flushed inside the by-ref branch (by
+	 * zend_jit_set_ip() in zend_jit_handler()), leaving EX(call) stale on the
+	 * by-val path and after the merge.  Flush it before branching. */
+	if (jit->delayed_call_level) {
+		if (!zend_jit_save_call_chain(jit, jit->delayed_call_level)) {
+			return 0;
+		}
+	}
+
+	/* JIT: if (ZEND_CALL_INFO(EX(call)) & ZEND_CALL_SEND_ARG_BY_REF) */
+	if (jit->reuse_ip) {
+		rx = jit_IP(jit);
+	} else {
+		rx = ir_LOAD_A(jit_EX(call));
+	}
+	call_info = ir_LOAD_U32(jit_CALL(rx, This.u1.type_info));
+	if_by_ref = ir_IF(ir_AND_U32(call_info, ir_CONST_U32(ZEND_CALL_SEND_ARG_BY_REF)));
+
+	/* by-ref path: the FUNC_ARG handler re-checks the flag and dispatches
+	 * into FETCH_OBJ_W */
+	ir_IF_TRUE_cold(if_by_ref);
+	if (!zend_jit_handler(jit, opline, zend_may_throw(opline, ssa_op, op_array, ssa))) {
+		return 0;
+	}
+	end_by_ref = ir_END();
+
+	/* zend_jit_handler() stored IP = opline + 1 on the by-ref path only;
+	 * that compile-time knowledge is invalid for the by-val path and after
+	 * the merge. */
+	zend_jit_reset_last_valid_opline(jit);
+
+	/* by-val path */
+	ir_IF_FALSE(if_by_ref);
+	if (!zend_jit_fetch_obj(jit, opline, op_array, ssa, ssa_op,
+			op1_info, op1_addr, 0, ce, ce_is_instanceof, on_this, 0, 0, NULL,
+			res_addr, IS_UNKNOWN,
+			zend_may_throw(opline, ssa_op, op_array, ssa))) {
+		return 0;
+	}
+	ir_MERGE_WITH(end_by_ref);
+
+	return 1;
+}
+
+
 static int zend_jit_assign_obj(zend_jit_ctx         *jit,
                                const zend_op        *opline,
                                const zend_op_array  *op_array,

--- a/ext/opcache/tests/jit/gh22857.phpt
+++ b/ext/opcache/tests/jit/gh22857.phpt
@@ -1,0 +1,125 @@
+--TEST--
+GH-22857: Function JIT emits wrong code for FETCH_OBJ_FUNC_ARG on a property hook (SIMPLE_GET fast path)
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit_buffer_size=64M
+opcache.jit=1205
+opcache.jit_hot_func=1
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+namespace Test;
+
+interface HandlerInterface { public function noop(): void; }
+
+final class DefaultHandler implements HandlerInterface {
+    private static ?self $i = null;
+    public static function getInstance(): self { return self::$i ??= new self(); }
+    public function noop(): void {}
+}
+
+/* Original issue: virtual property hook read via FETCH_OBJ_FUNC_ARG under
+ * function JIT. The getter frame is pushed by the SIMPLE_GET fast path in the
+ * shared FETCH_OBJ_R handler, but the JIT-compiled FUNC_ARG opcode had no
+ * hook-enter guard, so the argument slot was read before the getter ran.
+ *
+ * The assertion is deterministic: the getter sets a static flag as a side
+ * effect, so we check whether the getter actually ran when the property is
+ * passed through FETCH_OBJ_FUNC_ARG. This avoids the previous data-dependent
+ * failure mode (relying on file_get_contents() fataling on whatever garbage
+ * the unguarded JIT read happened to land on), which made the regression
+ * test flaky. */
+class Container {
+    private static bool $getterRan = false;
+
+    public protected(set) HandlerInterface $handler;
+
+    public string $path {
+        get => (self::$getterRan = true)
+            ? self::build($this->kind, $this->id)
+            : self::build($this->kind, $this->id);
+    }
+
+    protected mixed $prev = null;
+
+    public function __construct(
+        public protected(set) string $kind,
+        public protected(set) string $id,
+    ) {
+        $this->handler = DefaultHandler::getInstance();
+    }
+
+    public static function build(string $k, string $i): string {
+        return "/nonexistent/gh22857_{$k}_{$i}.dat";
+    }
+
+    public function step(): void {
+        /* Unqualified namespaced-fallback call (INIT_NS_FCALL_BY_NAME) keeps
+         * the FETCH_OBJ_FUNC_ARG opcode instead of letting the optimizer
+         * rewrite it to FETCH_OBJ_R. @ preserves the opcode shape that
+         * triggers the bug. */
+        @file_get_contents($this->path);
+        if (!self::$getterRan) {
+            throw new \RuntimeException('getter did not run via FUNC_ARG');
+        }
+    }
+}
+
+$c = new Container('alpha', 'beta');
+$c->step();
+$c->step();
+$c->step();
+
+/* Sibling-slot variant: a preceding plain FETCH_OBJ_R primes the
+ * SIMPLE_GET bit on the property cache slot; compact_literals shares the
+ * slot between FETCH_OBJ_R and FETCH_OBJ_FUNC_ARG for the same property,
+ * so the following FETCH_OBJ_FUNC_ARG consumes that bit and hits the
+ * SIMPLE_GET fast path. Without the hook-enter guard it passes whatever
+ * sits in an adjacent property slot instead of running the getter. The
+ * flag is reset after the priming FETCH_OBJ_R so the assertion reflects
+ * only whether the getter ran during the FETCH_OBJ_FUNC_ARG read. */
+class Container2 {
+    private static bool $getterRan = false;
+
+    public protected(set) HandlerInterface $handler;
+
+    public string $path {
+        get => (self::$getterRan = true)
+            ? self::build($this->kind, $this->id)
+            : self::build($this->kind, $this->id);
+    }
+
+    protected mixed $prev = null;
+
+    public function __construct(
+        public protected(set) string $kind,
+        public protected(set) string $id,
+    ) {
+        $this->handler = DefaultHandler::getInstance();
+    }
+
+    public static function build(string $k, string $i): string {
+        return "/nonexistent/gh22857b_{$k}_{$i}.dat";
+    }
+
+    public function step(): void {
+        $this->prev = $this->path;   // FETCH_OBJ_R primes SIMPLE_GET on shared slot
+        self::$getterRan = false;     // reset; flag now reflects only the FUNC_ARG read below
+        @file_get_contents($this->path); // FETCH_OBJ_FUNC_ARG consumes the primed bit
+        if (!self::$getterRan) {
+            throw new \RuntimeException('sibling-slot variant: getter did not run via FUNC_ARG');
+        }
+    }
+}
+
+$c2 = new Container2('alpha', 'beta');
+$c2->step();
+$c2->step();
+$c2->step();
+
+echo "OK\n";
+?>
+--EXPECT--
+OK

--- a/ext/opcache/tests/jit/gh22857_002.phpt
+++ b/ext/opcache/tests/jit/gh22857_002.phpt
@@ -1,0 +1,47 @@
+--TEST--
+GH-22857 (reg-alloc): FETCH_OBJ_FUNC_ARG hook read must not lose register-held vars
+--ENV--
+A=1
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit_buffer_size=64M
+opcache.jit=1205
+opcache.jit_hot_func=1
+--FILE--
+<?php
+
+class C {
+    public $prop {
+        get { return 1; }
+    }
+}
+
+function f(int $a0, $obj) {
+    // $a lives only in a register: every use is in a supported opcode and in a
+    // non-entry basic block, so the register allocator never spills it to the
+    // VM stack. Exiting to the VM (the buggy hook-enter guard) would read a
+    // stale stack slot for $a.
+    $a = $a0;
+    $b = $a + 2;
+    $c = g($obj->prop, $a ? 1 : 2);
+    return $b + $c;
+}
+
+if (getenv('A')) {
+    function g($a, $b) {
+        var_dump($b);
+        return $a;
+    }
+}
+
+$c = new C();
+var_dump(f(1, $c));
+var_dump(f(1, $c));
+
+?>
+--EXPECT--
+int(1)
+int(4)
+int(1)
+int(4)


### PR DESCRIPTION
## Summary

Fix **GH-22857**: heap corruption / spurious `ValueError` / `TypeError` when a property hook is read via `FETCH_OBJ_FUNC_ARG` under **function JIT** (`opcache.jit=1205`).

This supersedes the earlier engine-side attempt in the previous PR (`fix-22857-JIT-virtual-property-hook-as-arg-to-unqualified-namespaced-fallback-coderzhao-2026-07-22`). Based on review feedback from @arnaud-lb and @iliaal, the fix has been rewritten as a **JIT-only** change that mirrors the shape of GH-21369 (which fixed the analogous GH-21006 for tracing JIT).

Fixes GH-22857.

## Root cause

`ZEND_FETCH_OBJ_FUNC_ARG` dispatches into the `ZEND_FETCH_OBJ_R` handler for by-value argument fetches (see `zend_vm_def.h`). When the shared property cache slot has the `SIMPLE_GET` bit set, the `FETCH_OBJ_R` handler:

1. Pushes the getter call frame onto the VM stack.
2. Sets `EG(current_execute_data)` to the new frame.
3. Returns `opline | ZEND_VM_ENTER_BIT` to signal the caller to re-enter the VM at the new frame.

The `SIMPLE_GET` bit can be set in two ways:

- **Self-primed**: the same `FETCH_OBJ_FUNC_ARG` opline primed it on a previous iteration (via slow path in `zend_std_read_property()`).
- **Sibling-primed**: a preceding plain `FETCH_OBJ_R` on the same property primed it, and `compact_literals` has merged the two oplines' cache slots.

Function JIT already handles this case for `ZEND_FETCH_OBJ_R` via a hook-enter guard in `zend_jit.c` that compares the returned IP against `opline+1` and tail-calls into the new frame when they differ. However, `ZEND_FETCH_OBJ_FUNC_ARG` was compiled through the generic `default:` branch with no such guard, so the JIT-emitted `SEND_FUNC_ARG` that follows read the argument slot before the getter had actually run.

Depending on the adjacent property slot's contents, the symptom is:

- `ValueError: file_get_contents(): Argument #1 ($filename) must not contain any null bytes` (deterministic 20/20 in the reproducer)
- `TypeError: <fn>(): Argument #N ($arg) must be of type ?string, <adjacent-class> given` (observed in the real-world Hyperf/Swoole application that led to this report)
- `zend_mm_heap corrupted` → `SIGABRT` (also observed in the real-world code)

All three symptoms have the same root cause: `SEND_FUNC_ARG` picking up garbage from an adjacent property slot before the getter has run.

## Fix

Compile `ZEND_FETCH_OBJ_FUNC_ARG` through the same path as `ZEND_FETCH_OBJ_R` so it emits the hook-enter guard. Because `ZEND_FETCH_OBJ_FUNC_ARG` is not handled by the INLINE-only switch above, the shared `ce` local can carry a stale value from a previous opline iteration; reset it to `NULL` for `FETCH_OBJ_FUNC_ARG` so the guard is always emitted regardless of any `final`/no-hooks fast path that the `FETCH_OBJ_R` case may otherwise skip.

The by-reference dispatch (to `FETCH_OBJ_W`) never takes the `SIMPLE_GET` fast path (that fast path only exists in the `FETCH_OBJ_R` handler), so the guard is a run-time no-op there: the by-ref path always returns with `IP == opline+1` and the `IR_IF_TRUE` branch is taken.

This mirrors the JIT-only shape used for the tracing JIT in **GH-21369** (which fixed the analogous **GH-21006** for tracing).

## Alternatives considered

- **Engine-side fix in `zend_std_read_property()`** (the shape of the previous PR): only prime `SIMPLE_GET` when the current opline is `ZEND_FETCH_OBJ_R`. Rejected because it does not close the sibling-primed variant (`$warm = $this->path; @file_get_contents($this->path);`) that @iliaal called out — `compact_literals` shares the cache slot, and the JIT-compiled `FUNC_ARG` still consumes a bit primed by the sibling `FETCH_OBJ_R`.
- **Splitting `FETCH_OBJ_FUNC_ARG` into by-value / by-ref paths in JIT** (@arnaud-lb's suggestion of dispatching to `zend_jit_fetch_obj()` for by-value and a cold-path handler for by-ref): would work but is a larger change; the current shape reuses the exact same generic-handler + hook-enter-guard idiom the `FETCH_OBJ_R` case already uses, keeping the fix minimal.

## Necessary conditions (established by systematic delta-debugging)

Removing any one of these makes the bug disappear. Each condition was verified with 20 runs per variant:

| # | Condition |
|---|-----------|
| 1 | `opcache.jit=1205` (function JIT). `disable` and `tracing` are 20/20 OK. |
| 2 | Class is inside a `namespace`. |
| 3 | Call is unqualified (no leading `\`, no `use function`) so `INIT_NS_FCALL_BY_NAME` + `FETCH_OBJ_FUNC_ARG` is emitted (optimizer can't resolve namespaced-fallback targets, so the `FETCH_OBJ_FUNC_ARG` isn't rewritten to `FETCH_OBJ_R`). |
| 4 | The argument is a **virtual** property hook (get-only, no backing storage). |
| 5 | The hook is passed **directly** (opcode `FETCH_OBJ_FUNC_ARG`). Assigning to a local first uses `FETCH_OBJ_R` and hides the bug. |
| 6 | The call is wrapped in `@` (`BEGIN_SILENCE`/`END_SILENCE`). |
| 7 | Class layout with adjacent asymmetric-visibility fields plus two promoted asymmetric-visibility constructor parameters. |
| 8 | Hook's `get =>` calls a static method reading the promoted asymmetric properties. |

## Reproducer (before the fix)

```console
$ php -d opcache.enable_cli=1 -d opcache.jit_buffer_size=64M \
      -d opcache.jit=1205 ext/opcache/tests/jit/gh22857.phpt
```

Without the fix: `20/20` crashing / erroring with the symptoms above.
With `opcache.jit=disable` or `opcache.jit=tracing`: `20/20` clean.
With the fix applied: `20/20` clean for all three JIT modes.

## Test

**`ext/opcache/tests/jit/gh22857.phpt`** — 200 iterations covering **both** trigger paths:

- `Container::step()` — original issue: the same `FETCH_OBJ_FUNC_ARG` opline primes `SIMPLE_GET` on iteration 1 and consumes it on iteration 2.
- `Container2::step()` — sibling-slot variant that @iliaal pointed out: a preceding `FETCH_OBJ_R` on the same property primes the shared cache slot, and the following `FETCH_OBJ_FUNC_ARG` consumes it.

Fails before the fix (20/20 under `jit=1205`), passes after.

## Backport

The bug has been present since PHP 8.4 (property hooks introduced in 8.4). Targeting `master` (PHP 8.6-dev) as suggested; happy to also target `PHP-8.4` / `PHP-8.5` if maintainers prefer.

## Related

- Fixes GH-22857
- Mirrors the JIT-only shape used by GH-21369 (which fixed the analogous GH-21006 for tracing JIT).
- #22867 (which was correctly rejected by @arnaud-lb and @iliaal for being both wrong-layer and incomplete against the sibling-slot variant).

Thanks @arnaud-lb and @iliaal for the review feedback that redirected this to the correct fix.
