### PR TITLE
ext/curl: Fix mem leak when duphandle fails in curl_clone_obj

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -441,7 +441,6 @@ static zend_object *curl_clone_obj(zend_object *object) {
 
 	clone_object = curl_create_object(curl_ce);
 	clone_ch = curl_from_obj(clone_object);
-	init_curl_handle(clone_ch);
 
 	ch = curl_from_obj(object);
 	cp = curl_easy_duphandle(ch->cp);
@@ -450,6 +449,7 @@ static zend_object *curl_clone_obj(zend_object *object) {
 		return &clone_ch->std;
 	}
 
+	init_curl_handle(clone_ch);
 	clone_ch->cp = cp;
 	_php_setup_easy_copy_handlers(clone_ch, ch);
 


### PR DESCRIPTION
Move init_curl_handle so that we don't leak memory if curl_easy_duphandle fails within curl_clone_obj.

init_curl_handle allocates things, and curl_free_obj frees that again. But curl_free_obj does nothing if ch->cp is not set. In curl_clone_obj, do the allocation only once we have a valid cp, so that curl_free_obj actually deallocates the memory again. If curl_easy_duphandle fails we have not allocated anything and nothing is cleaned up.

Same as https://github.com/php/php-src/pull/22894, but for PHP 8.4.