### PR TITLE
 Fixes leaked System V shared-memory segments in tests

### DIFF
--- a/ext/shmop/tests/shmop_open_private.phpt
+++ b/ext/shmop/tests/shmop_open_private.phpt
@@ -13,6 +13,8 @@ $shm2 = shmop_open(0, 'c', 0777, 1024);
 $read = shmop_read($shm2, 0, 4);
 
 var_dump(is_string($read) && $read !== $write);
+shmop_delete($shm1);
+shmop_delete($shm2);
 ?>
 --EXPECT--
 bool(true)

--- a/ext/sysvshm/tests/gh16591.phpt
+++ b/ext/sysvshm/tests/gh16591.phpt
@@ -13,11 +13,15 @@ class C {
     }
 }
 
-$mem = shm_attach(1);
+$key = ftok(__FILE__, 't');
+$mem = shm_attach($key);
+$cleanup = shm_attach($key);
 try {
     shm_put_var($mem, 1, new C);
 } catch (Error $e) {
     echo $e->getMessage(), "\n";
+} finally {
+    shm_remove($cleanup);
 }
 
 ?>


### PR DESCRIPTION
The two tests leave System V IPC segments behind after successful execution. Repeated test-suite runs can exhaust IPC limits and cause unrelated SHMOP/SysV tests to fail.