### PR TITLE
Prevents tests from leaking System V IPC objects  

### DIFF
--- a/Zend/tests/arginfo_zpp_mismatch.phpt
+++ b/Zend/tests/arginfo_zpp_mismatch.phpt
@@ -10,6 +10,36 @@ if (getenv('SKIP_MSAN')) die("skip msan misses interceptors for some functions")
 
 require __DIR__ . "/arginfo_zpp_mismatch.inc";
 
+function testWeakSysvIpcFunction($function): bool {
+    if (!in_array($function, ['msg_queue_exists', 'msg_get_queue', 'sem_get', 'shm_attach'], true)) {
+        return false;
+    }
+
+    for ($argumentCount = 0; $argumentCount <= 8; $argumentCount++) {
+        $arguments = array_fill(0, $argumentCount, null);
+        if ($function === 'msg_queue_exists' && $argumentCount >= 1) {
+            $arguments[0] = 1;
+        }
+        if (($function === 'sem_get' || $function === 'shm_attach') && $argumentCount >= 3) {
+            $arguments[2] = 0600;
+        }
+
+        try {
+            $result = @$function(...$arguments);
+            if ($result instanceof SysvMessageQueue) {
+                msg_remove_queue($result);
+            } elseif ($result instanceof SysvSemaphore) {
+                sem_remove($result);
+            } elseif ($result instanceof SysvSharedMemory) {
+                shm_remove($result);
+            }
+        } catch (Throwable) {
+        }
+    }
+
+    return true;
+}
+
 function test($function) {
     if (skipFunction($function)) {
         return;
@@ -20,6 +50,10 @@ function test($function) {
         echo "Testing $function\n";
     } else {
         echo "Testing " . get_class($function[0]) . "::$function[1]\n";
+    }
+    if (testWeakSysvIpcFunction($function)) {
+        ob_end_clean();
+        return;
     }
     try {
         @$function();

--- a/ext/sysvmsg/tests/gh16592.phpt
+++ b/ext/sysvmsg/tests/gh16592.phpt
@@ -8,11 +8,14 @@ class Test {
     function __serialize() {}
 }
 
-$q = msg_get_queue(1);
+// use a private queue, so we only remove our own.
+$q = msg_get_queue(0, 0600);
 try {
 	msg_send($q, 1, new Test, true);
 } catch (\TypeError $e) {
 	echo $e->getMessage();
+} finally {
+	msg_remove_queue($q);
 }
 ?>
 --EXPECT--


### PR DESCRIPTION
The two tests leave System V IPC objects behind. Repeated test-suite runs can exhaust platform IPC limits and cause unrelated SysV tests to fail. Happened on macOS where the message queue limit is relatively low.

**1) `arginfo_zpp_mismatch.phpt`**
Calls every internal function with 0..8 `null` arguments. Means, 4 System V IPC functions create 3 queues, 3 shared-memory segments, and 4 semaphore sets per run -- these survive the process that created them.

The 4 affected functions are now handled early with a helper. The argument counts stay the same, but `sem_get()` and `shm_attach()` use `0600` for their permission argument, because `null` becomes `0000` which can create non-removable objects.

**2) `gh16592.phpt`**
created a message queue without removing it; now uses a private queue and cleans up after it.