### PR TITLE
main/io build directory missing from PHP_ADD_BUILD_DIR, breaks out-of-tree (VPATH) builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1834,6 +1834,7 @@ AC_DEFINE([HAVE_BUILD_DEFS_H], [1],
 
 PHP_ADD_BUILD_DIR([
   main
+  main/io
   main/poll
   main/streams
   scripts


### PR DESCRIPTION
Building PHP 8.6.0alpha3 in an out-of-tree build directory (VPATH build, e.g. Debian's separate fpm-build/cli-build dirs) fails while compiling the new main/io/*.c files:

```
main/io/php_io_copy_freebsd.c:1: fatal error: opening dependency file main/io/php_io_copy_freebsd.dep: No such file or directory
compilation terminated.
make[2]: *** [Makefile:1841: main/io/php_io_copy_freebsd.lo] Error 1
```

The same error occurs for php_io.c, php_io_copy_linux.c, php_io_copy_solaris.c, and php_io_copy_macos.c.

configure.ac registers the sources via PHP_ADD_SOURCES([main/io], ...), but the main/io directory was never added to the PHP_ADD_BUILD_DIR([...]) list that configure uses to pre-create build directories for VPATH builds. Every other directory containing sources (main, main/poll, main/streams, TSRM, Zend, etc.) is listed there; main/io was simply omitted when the new I/O subsystem was introduced. As a result, main/io/ never gets created in the build tree, and the compiler can't write the .dep/.o files into it.