### PR TITLE
Fix error: static declaration of copy_file_range follows non-static d…

### DIFF
--- a/main/io/php_io_copy_linux.c
+++ b/main/io/php_io_copy_linux.c
@@ -21,11 +21,12 @@
 
 #if !defined(HAVE_COPY_FILE_RANGE) && defined(__NR_copy_file_range)
 #define HAVE_COPY_FILE_RANGE 1
-static inline ssize_t copy_file_range(
+static inline ssize_t php_copy_file_range(
 		int fd_in, off_t *off_in, int fd_out, off_t *off_out, size_t len, unsigned int flags)
 {
 	return syscall(__NR_copy_file_range, fd_in, off_in, fd_out, off_out, len, flags);
 }
+#define copy_file_range php_copy_file_range
 #endif
 
 #ifdef HAVE_SENDFILE


### PR DESCRIPTION
On RHEL-8 where copy_file_range exists but kernel is too old

```
/builddir/build/BUILD/php-8.6.0alpha3/main/io/php_io_copy_linux.c:24:23: error: static declaration of 'copy_file_range' follows non-static declaration
 static inline ssize_t copy_file_range(
                       ^~~~~~~~~~~~~~~
In file included from /builddir/build/BUILD/php-8.6.0alpha3/Zend/zend_hrtime.h:23,
                 from /builddir/build/BUILD/php-8.6.0alpha3/Zend/zend_gc.h:22,
                 from /builddir/build/BUILD/php-8.6.0alpha3/Zend/zend_string.h:22,
                 from /builddir/build/BUILD/php-8.6.0alpha3/Zend/zend.h:31,
                 from /builddir/build/BUILD/php-8.6.0alpha3/main/php.h:28,
                 from /builddir/build/BUILD/php-8.6.0alpha3/main/php_io.h:20,
                 from /builddir/build/BUILD/php-8.6.0alpha3/main/io/php_io_internal.h:18,
                 from /builddir/build/BUILD/php-8.6.0alpha3/main/io/php_io_copy_linux.c:17:
/usr/include/unistd.h:1107:9: note: previous declaration of 'copy_file_range' was here
 ssize_t copy_file_range (int __infd, __off64_t *__pinoff,
         ^~~~~~~~~~~~~~~

```