### PR TITLE
ext/standard: Fix phpcredits() heading alignment

### DIFF
--- a/ext/standard/credits.c
+++ b/ext/standard/credits.c
@@ -35,7 +35,7 @@ PHPAPI ZEND_COLD void php_print_credits(int flag) /* {{{ */
 		/* Group */
 
 		php_info_print_table_start();
-		php_info_print_table_header(1, "PHP Group");
+		php_info_print_table_colspan_header(1, "PHP Group");
 		php_info_print_table_row(1, "Thies C. Arntzen, Stig Bakken, Shane Caraveo, Andi Gutmans, Rasmus Lerdorf, Sam Ruby, Sascha Schumann, Zeev Suraski, Jim Winstead, Andrei Zmievski");
 		php_info_print_table_end();
 	}
@@ -44,9 +44,9 @@ PHPAPI ZEND_COLD void php_print_credits(int flag) /* {{{ */
 		/* Design & Concept */
 		php_info_print_table_start();
 		if (!sapi_module.phpinfo_as_text) {
-			php_info_print_table_header(1, "Language Design &amp; Concept");
+			php_info_print_table_colspan_header(1, "Language Design &amp; Concept");
 		} else {
-			php_info_print_table_header(1, "Language Design & Concept");
+			php_info_print_table_colspan_header(1, "Language Design & Concept");
 		}
 		php_info_print_table_row(1, "Andi Gutmans, Rasmus Lerdorf, Zeev Suraski, Marcus Boerger");
 		php_info_print_table_end();

--- a/ext/standard/tests/general_functions/phpcredits.phpt
+++ b/ext/standard/tests/general_functions/phpcredits.phpt
@@ -15,10 +15,10 @@ var_dump(phpcredits(CREDITS_GROUP));
 --EXPECTF--
 PHP Credits
 
-PHP Group
+%wPHP Group%w
 %a
 
-Language Design & Concept
+%wLanguage Design & Concept%w
 %a
 
 %wPHP Authors%w
@@ -45,6 +45,6 @@ bool(true)
 --
 PHP Credits
 
-PHP Group
+%wPHP Group%w
 %a
 bool(true)


### PR DESCRIPTION
```
PHP Group
Thies C. Arntzen, Stig Bakken, Shane Caraveo, Andi Gutmans, Rasmus Lerdorf, Sam Ruby, Sascha Schumann, Zeev Suraski, Jim Winstead, Andrei Zmievski

Language Design & Concept
Andi Gutmans, Rasmus Lerdorf, Zeev Suraski, Marcus Boerger

                               PHP Authors                               
Contribution => Authors
Zend Scripting Language Engine => Andi Gutmans, Zeev Suraski, Stanislav Malyshev, Marcus Boerger, Dmitry Stogov, Xinchen Hui, Nikita Popov
Extension Module API => Andi Gutmans, Zeev Suraski, Andrei Zmievski
UNIX Build and Modularization => Stig Bakken, Sascha Schumann, Jani Taskinen, Peter Kokot
Windows Support => Shane Caraveo, Zeev Suraski, Wez Furlong, Pierre-Alain Joye, Anatol Belski, Kalle Sommer Nielsen
Server API (SAPI) Abstraction Layer => Andi Gutmans, Shane Caraveo, Zeev Suraski
Streams Abstraction Layer => Wez Furlong, Sara Golemon
PHP Data Objects Layer => Wez Furlong, Marcus Boerger, Sterling Hughes, George Schlossnagle, Ilia Alshanetsky
Output Handler => Zeev Suraski, Thies C. Arntzen, Marcus Boerger, Michael Wallner
Consistent 64 bit support => Anthony Ferrara, Anatol Belski

                               SAPI Modules                               
Contribution => Authors
Apache 2 Handler => Ian Holsman, Justin Erenkrantz (based on Apache 2 Filter code)
CGI / FastCGI => Rasmus Lerdorf, Stig Bakken, Shane Caraveo, Dmitry Stogov
CLI => Edin Kadribasic, Marcus Boerger, Johannes Schlueter, Moriyoshi Koizumi, Xinchen Hui
Embed => Edin Kadribasic
FastCGI Process Manager => Andrei Nigmatulin, dreamcat4, Antony Dovgal, Jerome Loyet
litespeed => George Wang
phpdbg => Felipe Pena, Joe Watkins, Bob Weinand
```

The first two title is wrongly aligned.