### PR TITLE
Free the hooked property value when json_encode() sees an exception

### DIFF
--- a/ext/json/json_encoder.c
+++ b/ext/json/json_encoder.c
@@ -287,6 +287,7 @@ static zend_result php_json_encode_array(smart_str *buf, zval *val, int options,
 						if (EG(exception)) {
 							PHP_JSON_HASH_UNPROTECT_RECURSION(recursion_rc);
 							zend_release_properties(prop_ht);
+							zval_ptr_dtor(&tmp);
 							return FAILURE;
 						}
 					}

--- a/ext/json/tests/json_encode_hooked_property_throwing_getter.phpt
+++ b/ext/json/tests/json_encode_hooked_property_throwing_getter.phpt
@@ -1,0 +1,44 @@
+--TEST--
+json_encode() releases the hooked property value when the get hook throws
+--FILE--
+<?php
+
+class Value
+{
+    public function __destruct()
+    {
+        echo "Value::__destruct\n";
+    }
+}
+
+class ThrowOnFree
+{
+    public function __destruct()
+    {
+        throw new Exception('thrown while freeing the get hook frame');
+    }
+}
+
+class Container
+{
+    public $hooked {
+        get {
+            $local = new ThrowOnFree();
+            return new Value();
+        }
+    }
+}
+
+try {
+    json_encode(new Container());
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
+}
+
+echo "done\n";
+
+?>
+--EXPECT--
+Value::__destruct
+Exception: thrown while freeing the get hook frame
+done


### PR DESCRIPTION
A get hook can publish its return value into the zval json_encode() handed to zend_read_property_ex(), then throw while the engine tears the hook's frame down, for instance from the destructor of one of its locals. php_json_encode_array() returns on EG(exception) without destroying that zval, so the value survives to request shutdown. Twenty encodes of a hook returning a 1 MiB string retain 21 MB before the patch, 1.5 KB after.
