### PR TITLE
Fix integer overflow in the JSON scanner string length adjustments

### DIFF
--- a/ext/json/json_scanner.re
+++ b/ext/json/json_scanner.re
@@ -295,7 +295,7 @@ std:
 	<STR_P1>ANY              {
 		if (s->options & (PHP_JSON_INVALID_UTF8_IGNORE | PHP_JSON_INVALID_UTF8_SUBSTITUTE)) {
 			if (s->options & PHP_JSON_INVALID_UTF8_SUBSTITUTE) {
-				if (s->utf8_invalid_count > INT_MAX - 2) {
+				if (s->utf8_invalid_count > PTRDIFF_MAX - 2) {
 					s->errcode = PHP_JSON_ERROR_UTF8;
 					return PHP_JSON_T_ERROR;
 				}

--- a/ext/json/php_json_scanner.h
+++ b/ext/json/php_json_scanner.h
@@ -31,12 +31,12 @@ typedef struct _php_json_scanner {
 	php_json_ctype *line_start;     /* start position of the current line */
 	uint64_t line;                  /* current line number (1-based) */
 	zval value;                     /* value */
-	int str_esc;                    /* number of extra characters for escaping */
+	ptrdiff_t str_esc;              /* number of extra characters for escaping */
 	int state;                      /* condition state */
 	int options;                    /* options */
 	php_json_error_code errcode;    /* error type if there is an error */
 	int utf8_invalid;               /* whether utf8 is invalid */
-	int utf8_invalid_count;         /* number of extra character for invalid utf8 */
+	ptrdiff_t utf8_invalid_count;   /* number of extra character for invalid utf8 */
 } php_json_scanner;
 
 void php_json_scanner_init(php_json_scanner *scanner, const char *str, size_t str_len, int options);


### PR DESCRIPTION
php_json_scanner keeps escape shrinkage and invalid-UTF-8 adjustment in int fields. A string carrying more than 2^31 escape sequences or ignored invalid bytes wraps the counter, and the first pass then reserves a result several gigabytes longer than the second pass writes. json_decode() of a 2 GiB run of invalid bytes with JSON_INVALID_UTF8_IGNORE returns a 4 GiB string instead of an empty one, and 2.4 GiB of A escapes returns 4.4 GiB instead of 409 MiB. There is no test because the smallest trigger needs roughly 10 GiB of live memory. This targets master rather than 8.4 since php_json_scanner.h is an installed header whose struct is embedded by value in php_json_parser, so widening the fields changes the layout for anything that embeds it.
