### PR TITLE
Fix use-after-free when json_encode() re-enters an ArrayObject

### DIFF
--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -60,16 +60,28 @@ static inline spl_array_object *spl_array_from_obj(zend_object *obj) /* {{{ */ {
 
 #define Z_SPLARRAY_P(zv)  spl_array_from_obj(Z_OBJ_P((zv)))
 
+static zend_always_inline void spl_array_separate_properties(zend_object *obj)
+{
+	if (GC_REFCOUNT(obj->properties) > 1) {
+		if (EXPECTED(!(GC_FLAGS(obj->properties) & IS_ARRAY_IMMUTABLE))) {
+			GC_DELREF(obj->properties);
+		}
+		obj->properties = zend_array_dup(obj->properties);
+	}
+}
+
 static inline HashTable **spl_array_get_hash_table_ptr(spl_array_object* intern) { /* {{{ */
 	//??? TODO: Delay duplication for arrays; only duplicate for write operations
 	if (intern->ar_flags & SPL_ARRAY_IS_SELF) {
 		/* rebuild properties */
 		zend_std_get_properties_ex(&intern->std);
+		spl_array_separate_properties(&intern->std);
 		return &intern->std.properties;
 	} else if (intern->ar_flags & SPL_ARRAY_USE_OTHER) {
 		spl_array_object *other = Z_SPLARRAY_P(&intern->array);
 		return spl_array_get_hash_table_ptr(other);
 	} else if (Z_TYPE(intern->array) == IS_ARRAY) {
+		SEPARATE_ARRAY(&intern->array);
 		return &Z_ARRVAL(intern->array);
 	} else {
 		zend_object *obj = Z_OBJ(intern->array);
@@ -88,12 +100,7 @@ static inline HashTable **spl_array_get_hash_table_ptr(spl_array_object* intern)
 		ZEND_ASSERT(!zend_lazy_object_must_init(obj));
 		/* rebuild properties */
 		zend_std_get_properties_ex(obj);
-		if (GC_REFCOUNT(obj->properties) > 1) {
-			if (EXPECTED(!(GC_FLAGS(obj->properties) & IS_ARRAY_IMMUTABLE))) {
-				GC_DELREF(obj->properties);
-			}
-			obj->properties = zend_array_dup(obj->properties);
-		}
+		spl_array_separate_properties(obj);
 		return &obj->properties;
 	}
 }

--- a/ext/spl/tests/ArrayObject_modified_during_json_encode.phpt
+++ b/ext/spl/tests/ArrayObject_modified_during_json_encode.phpt
@@ -1,0 +1,51 @@
+--TEST--
+Modifying an ArrayObject or ArrayIterator from within json_encode()
+--FILE--
+<?php
+
+class Mutator implements JsonSerializable
+{
+    public function __construct(private object $target) {}
+
+    public function jsonSerialize(): mixed
+    {
+        $this->target['b'] = 'mutated';
+        for ($i = 0; $i < 64; $i++) {
+            $this->target["appended$i"] = 'appended';
+        }
+        $ref = &$this->target['by-reference'];
+        $ref = 'by-reference';
+        return 'serialized';
+    }
+}
+
+$self = new ArrayObject();
+$self->exchangeArray($self);
+
+$containers = [
+    'array-backed ArrayObject' => new ArrayObject(),
+    'array-backed ArrayIterator' => new ArrayIterator(),
+    'self-backed ArrayObject' => $self,
+    'object-backed ArrayObject' => new ArrayObject(new stdClass()),
+];
+
+foreach ($containers as $label => $container) {
+    $container['a'] = null;
+    $container['b'] = 'second';
+    $container['c'] = 'third';
+    $container['a'] = new Mutator($container);
+
+    echo $label, ': ', json_encode($container), "\n";
+    echo 'count: ', count($container), "\n";
+}
+
+?>
+--EXPECT--
+array-backed ArrayObject: {"a":"serialized","b":"second","c":"third"}
+count: 68
+array-backed ArrayIterator: {"a":"serialized","b":"second","c":"third"}
+count: 68
+self-backed ArrayObject: {"a":"serialized","b":"second","c":"third"}
+count: 68
+object-backed ArrayObject: {"a":"serialized","b":"second","c":"third"}
+count: 68


### PR DESCRIPTION
json_encode() borrows an ArrayObject's storage table for the length of the encode and then runs userland through JsonSerializable::jsonSerialize() and property hooks. spl_array_get_hash_table_ptr() hands that same table back to the write paths, so an insert from the callback grows it and frees the buckets the encoder is iterating; valgrind reports invalid reads in php_json_encode_array() for the array-backed ArrayObject, ArrayIterator and self-backed cases in the test. The object-backed branch of that function already separates when the table is borrowed, so this gives the other two branches the same treatment. Encoding cost is unchanged: the separation only fires while a borrow is outstanding, and the refcount is 1 the rest of the time.

#20725 proposes the same SEPARATE_ARRAY call at the write sites instead. That placement leaves the by-reference auto-vivify path through spl_array_get_dimension_ptr() unprotected, which valgrind still reports as an invalid read, and it does not reach the self-backed case.
