### PR TITLE
GH-22905: avoid truncation on null bytes in reflection exceptions

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1772,7 +1772,6 @@ ZEND_API void zend_free_recorded_errors(void)
 ZEND_API ZEND_COLD void zend_throw_error(zend_class_entry *exception_ce, const char *format, ...) /* {{{ */
 {
 	va_list va;
-	char *message = NULL;
 
 	if (!exception_ce) {
 		exception_ce = zend_ce_error;
@@ -1784,16 +1783,20 @@ ZEND_API ZEND_COLD void zend_throw_error(zend_class_entry *exception_ce, const c
 	}
 
 	va_start(va, format);
-	zend_vspprintf(&message, 0, format, va);
+	zend_string *message = zend_vstrpprintf(0, format, va);
 
 	//TODO: we can't convert compile-time errors to exceptions yet???
 	if (EG(current_execute_data) && !CG(in_compilation)) {
-		zend_throw_exception(exception_ce, message, 0);
+		// %S is used for zend_string pointers by smart str printing, but normally
+		// is for wide character strings and so compilers complain if this is inline
+		// Use "%S" so that the message can contain null bytes.
+		const char *format = "%S";
+		zend_throw_exception_ex(exception_ce, 0, format, message);
 	} else {
-		zend_error_noreturn(E_ERROR, "%s", message);
+		zend_error_noreturn(E_ERROR, "%s", ZSTR_VAL(message));
 	}
 
-	efree(message);
+	zend_string_release(message);
 	va_end(va);
 }
 /* }}} */

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -888,14 +888,13 @@ ZEND_API ZEND_COLD zend_object *zend_throw_exception(zend_class_entry *exception
 ZEND_API ZEND_COLD zend_object *zend_throw_exception_ex(zend_class_entry *exception_ce, zend_long code, const char *format, ...) /* {{{ */
 {
 	va_list arg;
-	char *message;
 	zend_object *obj;
 
 	va_start(arg, format);
-	zend_vspprintf(&message, 0, format, arg);
+	zend_string *msg_str = zend_vstrpprintf(0, format, arg);
 	va_end(arg);
-	obj = zend_throw_exception(exception_ce, message, code);
-	efree(message);
+	obj = zend_throw_exception_zstr(exception_ce, msg_str, code);
+	zend_string_release(msg_str);
 	return obj;
 }
 /* }}} */

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -1299,7 +1299,10 @@ static void reflect_attributes(INTERNAL_FUNCTION_PARAMETERS, HashTable *attribut
 	if (name && (flags & REFLECTION_ATTRIBUTE_IS_INSTANCEOF)) {
 		if (NULL == (base = zend_lookup_class(name))) {
 			if (!EG(exception)) {
-				zend_throw_error(NULL, "Class \"%s\" not found", ZSTR_VAL(name));
+				// %S is used for zend_string pointers by smart str printing, but normally
+				// is for wide character strings and so compilers complain if this is inline
+				const char *format = "Class \"%S\" not found";
+				zend_throw_error(NULL, format, name);
 			}
 
 			RETURN_THROWS();
@@ -1705,8 +1708,11 @@ ZEND_METHOD(ReflectionFunction, __construct)
 		}
 
 		if (fptr == NULL) {
+			// %S is used for zend_string pointers by smart str printing, but normally
+			// is for wide character strings and so compilers complain if this is inline
+			const char *format = "Function %S() does not exist";
 			zend_throw_exception_ex(reflection_exception_ptr, 0,
-				"Function %s() does not exist", ZSTR_VAL(fname));
+				format, fname);
 			RETURN_THROWS();
 		}
 	}
@@ -2523,8 +2529,11 @@ ZEND_METHOD(ReflectionParameter, __construct)
 					zend_string_release(lcname);
 				}
 				if (!fptr) {
+					// %S is used for zend_string pointers by smart str printing, but normally
+					// is for wide character strings and so compilers complain if this is inline
+					const char *format = "Function %S() does not exist";
 					zend_throw_exception_ex(reflection_exception_ptr, 0,
-						"Function %s() does not exist", Z_STRVAL_P(reference));
+						format, Z_STR_P(reference));
 					RETURN_THROWS();
 				}
 				ce = fptr->common.scope;
@@ -2551,8 +2560,11 @@ ZEND_METHOD(ReflectionParameter, __construct)
 						return;
 					}
 					if ((ce = zend_lookup_class(name)) == NULL) {
+						// %S is used for zend_string pointers by smart str printing, but normally
+						// is for wide character strings and so compilers complain if this is inline
+						const char *format = "Class \"%S\" does not exist";
 						zend_throw_exception_ex(reflection_exception_ptr, 0,
-								"Class \"%s\" does not exist", ZSTR_VAL(name));
+								format, name);
 						zend_string_release(name);
 						RETURN_THROWS();
 					}
@@ -2571,8 +2583,11 @@ ZEND_METHOD(ReflectionParameter, __construct)
 					/* nothing to do. don't set is_closure since is the invoke handler,
 					   not the closure itself */
 				} else if ((fptr = zend_hash_find_ptr(&ce->function_table, lcname)) == NULL) {
+					// %S is used for zend_string pointers by smart str printing, but normally
+					// is for wide character strings and so compilers complain if this is inline
+					const char *format = "Method %S::%S() does not exist";
 					zend_throw_exception_ex(reflection_exception_ptr, 0,
-						"Method %s::%s() does not exist", ZSTR_VAL(ce->name), ZSTR_VAL(name));
+						format, ce->name, name);
 					zend_string_release(name);
 					zend_string_release(lcname);
 					RETURN_THROWS();
@@ -3389,7 +3404,10 @@ static void instantiate_reflection_method(INTERNAL_FUNCTION_PARAMETERS, bool is_
 	if (class_name) {
 		if ((ce = zend_lookup_class(class_name)) == NULL) {
 			if (!EG(exception)) {
-				zend_throw_exception_ex(reflection_exception_ptr, 0, "Class \"%s\" does not exist", ZSTR_VAL(class_name));
+				// %S is used for zend_string pointers by smart str printing, but normally
+				// is for wide character strings and so compilers complain if this is inline
+				const char *format = "Class \"%S\" does not exist";
+				zend_throw_exception_ex(reflection_exception_ptr, 0, format, class_name);
 			}
 			zend_string_release(class_name);
 			RETURN_THROWS();
@@ -3418,8 +3436,16 @@ static void instantiate_reflection_method(INTERNAL_FUNCTION_PARAMETERS, bool is_
 		/* do nothing, mptr already set */
 	} else if ((mptr = zend_hash_str_find_ptr(&ce->function_table, lcname, method_name_len)) == NULL) {
 		efree(lcname);
+		// %S is used for zend_string pointers by smart str printing, but normally
+		// is for wide character strings and so compilers complain if this is inline
+		const char *format = "Method %S::%S() does not exist";
+		ALLOCA_FLAG(use_heap);
+		zend_string *method_name_zstr;
+		ZSTR_ALLOCA_INIT(method_name_zstr, method_name, method_name_len, use_heap);
 		zend_throw_exception_ex(reflection_exception_ptr, 0,
-			"Method %s::%s() does not exist", ZSTR_VAL(ce->name), method_name);
+			format, ce->name, method_name_zstr);
+		ZSTR_ALLOCA_FREE(method_name_zstr, use_heap);
+
 		RETURN_THROWS();
 	}
 	efree(lcname);
@@ -3930,7 +3956,10 @@ ZEND_METHOD(ReflectionClassConstant, __construct)
 		ce = classname_obj->ce;
 	} else {
 		if ((ce = zend_lookup_class(classname_str)) == NULL) {
-			zend_throw_exception_ex(reflection_exception_ptr, 0, "Class \"%s\" does not exist", ZSTR_VAL(classname_str));
+			// %S is used for zend_string pointers by smart str printing, but normally
+			// is for wide character strings and so compilers complain if this is inline
+			const char *format = "Class \"%S\" does not exist";
+			zend_throw_exception_ex(reflection_exception_ptr, 0, format, classname_str);
 			RETURN_THROWS();
 		}
 	}
@@ -3939,7 +3968,10 @@ ZEND_METHOD(ReflectionClassConstant, __construct)
 	intern = Z_REFLECTION_P(object);
 
 	if ((constant = zend_hash_find_ptr(CE_CONSTANTS_TABLE(ce), constname)) == NULL) {
-		zend_throw_exception_ex(reflection_exception_ptr, 0, "Constant %s::%s does not exist", ZSTR_VAL(ce->name), ZSTR_VAL(constname));
+		// %S is used for zend_string pointers by smart str printing, but normally
+		// is for wide character strings and so compilers complain if this is inline
+		const char *format = "Constant %S::%S does not exist";
+		zend_throw_exception_ex(reflection_exception_ptr, 0, format, ce->name, constname);
 		RETURN_THROWS();
 	}
 
@@ -4224,7 +4256,10 @@ static void reflection_class_object_ctor(INTERNAL_FUNCTION_PARAMETERS, int is_ob
 	} else {
 		if ((ce = zend_lookup_class(arg_class)) == NULL) {
 			if (!EG(exception)) {
-				zend_throw_exception_ex(reflection_exception_ptr, -1, "Class \"%s\" does not exist", ZSTR_VAL(arg_class));
+				// %S is used for zend_string pointers by smart str printing, but normally
+				// is for wide character strings and so compilers complain if this is inline
+				const char *format = "Class \"%S\" does not exist";
+				zend_throw_exception_ex(reflection_exception_ptr, -1, format, arg_class);
 			}
 			RETURN_THROWS();
 		}
@@ -4364,8 +4399,11 @@ ZEND_METHOD(ReflectionClass, getStaticPropertyValue)
 		RETURN_COPY(def_value);
 	}
 
+	// %S is used for zend_string pointers by smart str printing, but normally
+	// is for wide character strings and so compilers complain if this is inline
+	const char *format = "Property %S::$%S does not exist";
 	zend_throw_exception_ex(reflection_exception_ptr, 0,
-		"Property %s::$%s does not exist", ZSTR_VAL(ce->name), ZSTR_VAL(name));
+		format, ce->name, name);
 }
 /* }}} */
 
@@ -4393,8 +4431,11 @@ ZEND_METHOD(ReflectionClass, setStaticPropertyValue)
 	EG(fake_scope) = old_scope;
 	if (!variable_ptr) {
 		zend_clear_exception();
+		// %S is used for zend_string pointers by smart str printing, but normally
+		// is for wide character strings and so compilers complain if this is inline
+		const char *format = "Class %S does not have a property named %S";
 		zend_throw_exception_ex(reflection_exception_ptr, 0,
-				"Class %s does not have a property named %s", ZSTR_VAL(ce->name), ZSTR_VAL(name));
+				format, ce->name, name);
 		RETURN_THROWS();
 	}
 
@@ -4658,8 +4699,11 @@ ZEND_METHOD(ReflectionClass, getMethod)
 	} else if ((mptr = zend_hash_find_ptr(&ce->function_table, lc_name)) != NULL) {
 		reflection_method_factory(ce, mptr, NULL, return_value);
 	} else {
+		// %S is used for zend_string pointers by smart str printing, but normally
+		// is for wide character strings and so compilers complain if this is inline
+		const char *format = "Method %S::%S() does not exist";
 		zend_throw_exception_ex(reflection_exception_ptr, 0,
-				"Method %s::%s() does not exist", ZSTR_VAL(ce->name), ZSTR_VAL(name));
+				format, ce->name, name);
 	}
 	zend_string_release(lc_name);
 }
@@ -4785,7 +4829,9 @@ ZEND_METHOD(ReflectionClass, getProperty)
 		}
 	}
 	str_name = ZSTR_VAL(name);
+	bool fully_qualified = false;
 	if ((tmp = zend_memnstr(ZSTR_VAL(name), "::", 2, ZSTR_VAL(name) + ZSTR_LEN(name))) != NULL) {
+		fully_qualified = true;
 		classname_len = tmp - ZSTR_VAL(name);
 		classname = zend_string_init(ZSTR_VAL(name), classname_len, 0);
 		str_name_len = ZSTR_LEN(name) - (classname_len + 2);
@@ -4802,7 +4848,15 @@ ZEND_METHOD(ReflectionClass, getProperty)
 		zend_string_release_ex(classname, 0);
 
 		if (!instanceof_function(ce, ce2)) {
-			zend_throw_exception_ex(reflection_exception_ptr, -1, "Fully qualified property name %s::$%s does not specify a base class of %s", ZSTR_VAL(ce2->name), str_name, ZSTR_VAL(ce->name));
+			// %S is used for zend_string pointers by smart str printing, but normally
+			// is for wide character strings and so compilers complain if this is inline
+			const char *format = "Fully qualified property name %S::$%S does not specify a base class of %S";
+			ALLOCA_FLAG(use_heap);
+			zend_string *prop_name_zstr;
+			ZSTR_ALLOCA_INIT(prop_name_zstr, str_name, str_name_len, use_heap);
+			zend_throw_exception_ex(reflection_exception_ptr, -1, format, ce2->name, prop_name_zstr, ce->name);
+			ZSTR_ALLOCA_FREE(prop_name_zstr, use_heap);
+
 			RETURN_THROWS();
 		}
 		ce = ce2;
@@ -4815,7 +4869,19 @@ ZEND_METHOD(ReflectionClass, getProperty)
 			return;
 		}
 	}
-	zend_throw_exception_ex(reflection_exception_ptr, 0, "Property %s::$%s does not exist", ZSTR_VAL(ce->name), str_name);
+	// %S is used for zend_string pointers by smart str printing, but normally
+	// is for wide character strings and so compilers complain if this is inline
+	const char *format = "Property %S::$%S does not exist";
+	// Can only use the existing `name` string if it wasn't fully qualified
+	if (fully_qualified) {
+		ALLOCA_FLAG(use_heap);
+		zend_string *prop_name_zstr;
+		ZSTR_ALLOCA_INIT(prop_name_zstr, str_name, str_name_len, use_heap);
+		zend_throw_exception_ex(reflection_exception_ptr, 0, format, ce->name, prop_name_zstr);
+		ZSTR_ALLOCA_FREE(prop_name_zstr, use_heap);
+	} else {
+		zend_throw_exception_ex(reflection_exception_ptr, 0, format, ce->name, name);
+	}
 }
 /* }}} */
 
@@ -5681,7 +5747,10 @@ ZEND_METHOD(ReflectionClass, isSubclassOf)
 		class_ce = argument->ptr;
 	} else {
 		if ((class_ce = zend_lookup_class(class_str)) == NULL) {
-			zend_throw_exception_ex(reflection_exception_ptr, 0, "Class \"%s\" does not exist", ZSTR_VAL(class_str));
+			// %S is used for zend_string pointers by smart str printing, but normally
+			// is for wide character strings and so compilers complain if this is inline
+			const char *format = "Class \"%S\" does not exist";
+			zend_throw_exception_ex(reflection_exception_ptr, 0, format, class_str);
 			RETURN_THROWS();
 		}
 	}
@@ -5714,7 +5783,10 @@ ZEND_METHOD(ReflectionClass, implementsInterface)
 		interface_ce = argument->ptr;
 	} else {
 		if ((interface_ce = zend_lookup_class(interface_str)) == NULL) {
-			zend_throw_exception_ex(reflection_exception_ptr, 0, "Interface \"%s\" does not exist", ZSTR_VAL(interface_str));
+			// %S is used for zend_string pointers by smart str printing, but normally
+			// is for wide character strings and so compilers complain if this is inline
+			const char *format = "Interface \"%S\" does not exist";
+			zend_throw_exception_ex(reflection_exception_ptr, 0, format, interface_str);
 			RETURN_THROWS();
 		}
 	}
@@ -5882,7 +5954,10 @@ ZEND_METHOD(ReflectionProperty, __construct)
 		ce = classname_obj->ce;
 	} else {
 		if ((ce = zend_lookup_class(classname_str)) == NULL) {
-			zend_throw_exception_ex(reflection_exception_ptr, 0, "Class \"%s\" does not exist", ZSTR_VAL(classname_str));
+			// %S is used for zend_string pointers by smart str printing, but normally
+			// is for wide character strings and so compilers complain if this is inline
+			const char *format = "Class \"%S\" does not exist";
+			zend_throw_exception_ex(reflection_exception_ptr, 0, format, classname_str);
 			RETURN_THROWS();
 		}
 	}
@@ -5898,7 +5973,10 @@ ZEND_METHOD(ReflectionProperty, __construct)
 			}
 		}
 		if (dynam_prop == 0) {
-			zend_throw_exception_ex(reflection_exception_ptr, 0, "Property %s::$%s does not exist", ZSTR_VAL(ce->name), ZSTR_VAL(name));
+			// %S is used for zend_string pointers by smart str printing, but normally
+			// is for wide character strings and so compilers complain if this is inline
+			const char *format = "Property %S::$%S does not exist";
+			zend_throw_exception_ex(reflection_exception_ptr, 0, format, ce->name, name);
 			RETURN_THROWS();
 		}
 	}
@@ -6260,13 +6338,17 @@ static zend_result reflection_property_check_lazy_compatible(
 		zend_property_info *prop, zend_string *unmangled_name,
 		reflection_object *intern, zend_object *object, const char *method)
 {
-	if (!prop) {
+	if (!prop) {		
+		// %S is used for zend_string pointers by smart str printing, but normally
+		// is for wide character strings and so compilers complain if this is inline
+		const char *format = "Can not use %s on dynamic property %S::$%S";
 		zend_throw_exception_ex(reflection_exception_ptr, 0,
-				"Can not use %s on dynamic property %s::$%s",
-				method, ZSTR_VAL(intern->ce->name),
-				ZSTR_VAL(unmangled_name));
+				format,
+				method, intern->ce->name,
+				unmangled_name);
 		return FAILURE;
 	}
+	// Non-dynamic properties cannot have null bytes so %s is fine
 
 	if (prop->flags & ZEND_ACC_STATIC) {
 		zend_throw_exception_ex(reflection_exception_ptr, 0,
@@ -6783,22 +6865,24 @@ ZEND_METHOD(ReflectionExtension, __construct)
 	char *lcname;
 	reflection_object *intern;
 	zend_module_entry *module;
-	char *name_str;
-	size_t name_len;
+	zend_string *name_zstr;
 	ALLOCA_FLAG(use_heap)
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &name_str, &name_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S", &name_zstr) == FAILURE) {
 		RETURN_THROWS();
 	}
 
 	object = ZEND_THIS;
 	intern = Z_REFLECTION_P(object);
-	lcname = do_alloca(name_len + 1, use_heap);
-	zend_str_tolower_copy(lcname, name_str, name_len);
-	if ((module = zend_hash_str_find_ptr(&module_registry, lcname, name_len)) == NULL) {
+	lcname = do_alloca(ZSTR_LEN(name_zstr) + 1, use_heap);
+	zend_str_tolower_copy(lcname, ZSTR_VAL(name_zstr), ZSTR_LEN(name_zstr));
+	if ((module = zend_hash_str_find_ptr(&module_registry, lcname, ZSTR_LEN(name_zstr))) == NULL) {
 		free_alloca(lcname, use_heap);
+		// %S is used for zend_string pointers by smart str printing, but normally
+		// is for wide character strings and so compilers complain if this is inline
+		const char *format = "Extension \"%S\" does not exist";
 		zend_throw_exception_ex(reflection_exception_ptr, 0,
-			"Extension \"%s\" does not exist", name_str);
+			format, name_zstr);
 		RETURN_THROWS();
 	}
 	free_alloca(lcname, use_heap);
@@ -7123,20 +7207,22 @@ ZEND_METHOD(ReflectionZendExtension, __construct)
 	zval *object;
 	reflection_object *intern;
 	zend_extension *extension;
-	char *name_str;
-	size_t name_len;
+	zend_string *name_zstr;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &name_str, &name_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S", &name_zstr) == FAILURE) {
 		RETURN_THROWS();
 	}
 
 	object = ZEND_THIS;
 	intern = Z_REFLECTION_P(object);
 
-	extension = zend_get_extension(name_str);
+	extension = zend_get_extension(ZSTR_VAL(name_zstr));
 	if (!extension) {
+		// %S is used for zend_string pointers by smart str printing, but normally
+		// is for wide character strings and so compilers complain if this is inline
+		const char *format = "Zend Extension \"%S\" does not exist";
 		zend_throw_exception_ex(reflection_exception_ptr, 0,
-				"Zend Extension \"%s\" does not exist", name_str);
+				format, name_zstr);
 		RETURN_THROWS();
 	}
 	ZVAL_STRING(reflection_prop_name(object), extension->name);
@@ -7591,7 +7677,10 @@ ZEND_METHOD(ReflectionEnum, getCase)
 
 	zend_class_constant *constant = zend_hash_find_ptr(CE_CONSTANTS_TABLE(ce), name);
 	if (constant == NULL) {
-		zend_throw_exception_ex(reflection_exception_ptr, 0, "Case %s::%s does not exist", ZSTR_VAL(ce->name), ZSTR_VAL(name));
+		// %S is used for zend_string pointers by smart str printing, but normally
+		// is for wide character strings and so compilers complain if this is inline
+		const char *format = "Case %S::%S does not exist";
+		zend_throw_exception_ex(reflection_exception_ptr, 0, format, ce->name, name);
 		RETURN_THROWS();
 	}
 	if (!(ZEND_CLASS_CONST_FLAGS(constant) & ZEND_CLASS_CONST_IS_CASE)) {
@@ -7901,7 +7990,10 @@ ZEND_METHOD(ReflectionConstant, __construct)
 	zend_constant *const_ = zend_get_constant_ptr(lc_name);
 	zend_string_release_ex(lc_name, /* persistent */ false);
 	if (!const_) {
-		zend_throw_exception_ex(reflection_exception_ptr, 0, "Constant \"%s\" does not exist", ZSTR_VAL(name));
+		// %S is used for zend_string pointers by smart str printing, but normally
+		// is for wide character strings and so compilers complain if this is inline
+		const char *format = "Constant \"%S\" does not exist";
+		zend_throw_exception_ex(reflection_exception_ptr, 0, format, name);
 		RETURN_THROWS();
 	}
 

--- a/ext/reflection/tests/gh22905/ReflectionClassConstant_construct_class.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionClassConstant_construct_class.phpt
@@ -7,7 +7,7 @@ new ReflectionClassConstant("foo\0bar", "");
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ReflectionException: Class "foo" does not exist in %s:%d
+Fatal error: Uncaught ReflectionException: Class "foo%0bar" does not exist in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionClassConstant->__construct('foo\x00bar', '')
 #1 {main}

--- a/ext/reflection/tests/gh22905/ReflectionClassConstant_construct_class.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionClassConstant_construct_class.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-22905: null bytes in ReflectionClassConstant::__construct() error messages (class name)
+--FILE--
+<?php
+
+new ReflectionClassConstant("foo\0bar", "");
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ReflectionException: Class "foo" does not exist in %s:%d
+Stack trace:
+#0 %s(%d): ReflectionClassConstant->__construct('foo\x00bar', '')
+#1 {main}
+  thrown in %s on line %d

--- a/ext/reflection/tests/gh22905/ReflectionClassConstant_construct_constant.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionClassConstant_construct_constant.phpt
@@ -8,7 +8,7 @@ new ReflectionClassConstant(Demo::class, "foo\0bar");
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ReflectionException: Constant Demo::foo does not exist in %s:%d
+Fatal error: Uncaught ReflectionException: Constant Demo::foo%0bar does not exist in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionClassConstant->__construct('Demo', 'foo\x00bar')
 #1 {main}

--- a/ext/reflection/tests/gh22905/ReflectionClassConstant_construct_constant.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionClassConstant_construct_constant.phpt
@@ -1,0 +1,15 @@
+--TEST--
+GH-22905: null bytes in ReflectionClassConstant::__construct() error messages (constant name)
+--FILE--
+<?php
+
+class Demo {}
+new ReflectionClassConstant(Demo::class, "foo\0bar");
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ReflectionException: Constant Demo::foo does not exist in %s:%d
+Stack trace:
+#0 %s(%d): ReflectionClassConstant->__construct('Demo', 'foo\x00bar')
+#1 {main}
+  thrown in %s on line %d

--- a/ext/reflection/tests/gh22905/ReflectionClass_construct.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionClass_construct.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-22905: null bytes in ReflectionClass::__construct() error messages
+--FILE--
+<?php
+
+new ReflectionClass("foo\0bar");
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ReflectionException: Class "foo" does not exist in %s:%d
+Stack trace:
+#0 %s(%d): ReflectionClass->__construct('foo\x00bar')
+#1 {main}
+  thrown in %s on line %d

--- a/ext/reflection/tests/gh22905/ReflectionClass_construct.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionClass_construct.phpt
@@ -7,7 +7,7 @@ new ReflectionClass("foo\0bar");
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ReflectionException: Class "foo" does not exist in %s:%d
+Fatal error: Uncaught ReflectionException: Class "foo%0bar" does not exist in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionClass->__construct('foo\x00bar')
 #1 {main}

--- a/ext/reflection/tests/gh22905/ReflectionClass_getMethod.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionClass_getMethod.phpt
@@ -9,7 +9,7 @@ $r->getMethod("foo\0bar");
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ReflectionException: Method Demo::foo() does not exist in %s:%d
+Fatal error: Uncaught ReflectionException: Method Demo::foo%0bar() does not exist in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionClass->getMethod('foo\x00bar')
 #1 {main}

--- a/ext/reflection/tests/gh22905/ReflectionClass_getMethod.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionClass_getMethod.phpt
@@ -1,0 +1,16 @@
+--TEST--
+GH-22905: null bytes in ReflectionClass::getMethod() error messages
+--FILE--
+<?php
+
+class Demo {}
+$r = new ReflectionClass(Demo::class);
+$r->getMethod("foo\0bar");
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ReflectionException: Method Demo::foo() does not exist in %s:%d
+Stack trace:
+#0 %s(%d): ReflectionClass->getMethod('foo\x00bar')
+#1 {main}
+  thrown in %s on line %d

--- a/ext/reflection/tests/gh22905/ReflectionClass_getProperty.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionClass_getProperty.phpt
@@ -1,0 +1,16 @@
+--TEST--
+GH-22905: null bytes in ReflectionClass::getProperty() error messages
+--FILE--
+<?php
+
+class Demo {}
+$r = new ReflectionClass(Demo::class);
+$r->getProperty("foo\0bar");
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ReflectionException: Property Demo::$foo does not exist in %s:%d
+Stack trace:
+#0 %s(%d): ReflectionClass->getProperty('foo\x00bar')
+#1 {main}
+  thrown in %s on line %d

--- a/ext/reflection/tests/gh22905/ReflectionClass_getProperty.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionClass_getProperty.phpt
@@ -9,7 +9,7 @@ $r->getProperty("foo\0bar");
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ReflectionException: Property Demo::$foo does not exist in %s:%d
+Fatal error: Uncaught ReflectionException: Property Demo::$foo%0bar does not exist in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionClass->getProperty('foo\x00bar')
 #1 {main}

--- a/ext/reflection/tests/gh22905/ReflectionClass_getProperty_qualified_base.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionClass_getProperty_qualified_base.phpt
@@ -10,7 +10,7 @@ $r->getProperty("Base::foo\0bar");
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ReflectionException: Property Base::$foo does not exist in %s:%d
+Fatal error: Uncaught ReflectionException: Property Base::$foo%0bar does not exist in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionClass->getProperty('Base::foo\x00bar')
 #1 {main}

--- a/ext/reflection/tests/gh22905/ReflectionClass_getProperty_qualified_base.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionClass_getProperty_qualified_base.phpt
@@ -1,0 +1,17 @@
+--TEST--
+GH-22905: null bytes in ReflectionClass::getProperty() (fully qualified, base class) error messages
+--FILE--
+<?php
+
+class Base {}
+class Demo extends Base {}
+$r = new ReflectionClass(Demo::class);
+$r->getProperty("Base::foo\0bar");
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ReflectionException: Property Base::$foo does not exist in %s:%d
+Stack trace:
+#0 %s(%d): ReflectionClass->getProperty('Base::foo\x00bar')
+#1 {main}
+  thrown in %s on line %d

--- a/ext/reflection/tests/gh22905/ReflectionClass_getProperty_qualified_nobase.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionClass_getProperty_qualified_nobase.phpt
@@ -1,0 +1,17 @@
+--TEST--
+GH-22905: null bytes in ReflectionClass::getProperty() (fully qualified, non-base class) error messages
+--FILE--
+<?php
+
+class Base {}
+class Demo {}
+$r = new ReflectionClass(Demo::class);
+$r->getProperty("Base::foo\0bar");
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ReflectionException: Fully qualified property name Base::$foo does not specify a base class of Demo in %s:%d
+Stack trace:
+#0 %s(%d): ReflectionClass->getProperty('Base::foo\x00bar')
+#1 {main}
+  thrown in %s on line %d

--- a/ext/reflection/tests/gh22905/ReflectionClass_getProperty_qualified_nobase.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionClass_getProperty_qualified_nobase.phpt
@@ -10,7 +10,7 @@ $r->getProperty("Base::foo\0bar");
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ReflectionException: Fully qualified property name Base::$foo does not specify a base class of Demo in %s:%d
+Fatal error: Uncaught ReflectionException: Fully qualified property name Base::$foo%0bar does not specify a base class of Demo in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionClass->getProperty('Base::foo\x00bar')
 #1 {main}

--- a/ext/reflection/tests/gh22905/ReflectionClass_getStaticPropertyValue.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionClass_getStaticPropertyValue.phpt
@@ -9,7 +9,7 @@ $r->getStaticPropertyValue("foo\0bar");
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ReflectionException: Property Demo::$foo does not exist in %s:%d
+Fatal error: Uncaught ReflectionException: Property Demo::$foo%0bar does not exist in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionClass->getStaticPropertyValue('foo\x00bar')
 #1 {main}

--- a/ext/reflection/tests/gh22905/ReflectionClass_getStaticPropertyValue.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionClass_getStaticPropertyValue.phpt
@@ -1,0 +1,16 @@
+--TEST--
+GH-22905: null bytes in ReflectionClass::getStaticPropertyValue() error messages
+--FILE--
+<?php
+
+class Demo {}
+$r = new ReflectionClass(Demo::class);
+$r->getStaticPropertyValue("foo\0bar");
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ReflectionException: Property Demo::$foo does not exist in %s:%d
+Stack trace:
+#0 %s(%d): ReflectionClass->getStaticPropertyValue('foo\x00bar')
+#1 {main}
+  thrown in %s on line %d

--- a/ext/reflection/tests/gh22905/ReflectionClass_implementsInterface.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionClass_implementsInterface.phpt
@@ -1,0 +1,16 @@
+--TEST--
+GH-22905: null bytes in ReflectionClass::implementsInterface() error messages
+--FILE--
+<?php
+
+class Demo {}
+$r = new ReflectionClass(Demo::class);
+$r->implementsInterface("foo\0bar");
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ReflectionException: Interface "foo" does not exist in %s:%d
+Stack trace:
+#0 %s(%d): ReflectionClass->implementsInterface('foo\x00bar')
+#1 {main}
+  thrown in %s on line %d

--- a/ext/reflection/tests/gh22905/ReflectionClass_implementsInterface.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionClass_implementsInterface.phpt
@@ -9,7 +9,7 @@ $r->implementsInterface("foo\0bar");
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ReflectionException: Interface "foo" does not exist in %s:%d
+Fatal error: Uncaught ReflectionException: Interface "foo%0bar" does not exist in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionClass->implementsInterface('foo\x00bar')
 #1 {main}

--- a/ext/reflection/tests/gh22905/ReflectionClass_isSubclassOf.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionClass_isSubclassOf.phpt
@@ -1,0 +1,16 @@
+--TEST--
+GH-22905: null bytes in ReflectionClass::isSubclassOf() error messages
+--FILE--
+<?php
+
+class Demo {}
+$r = new ReflectionClass(Demo::class);
+$r->isSubclassOf("foo\0bar");
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ReflectionException: Class "foo" does not exist in %s:%d
+Stack trace:
+#0 %s(%d): ReflectionClass->isSubclassOf('foo\x00bar')
+#1 {main}
+  thrown in %s on line %d

--- a/ext/reflection/tests/gh22905/ReflectionClass_isSubclassOf.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionClass_isSubclassOf.phpt
@@ -9,7 +9,7 @@ $r->isSubclassOf("foo\0bar");
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ReflectionException: Class "foo" does not exist in %s:%d
+Fatal error: Uncaught ReflectionException: Class "foo%0bar" does not exist in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionClass->isSubclassOf('foo\x00bar')
 #1 {main}

--- a/ext/reflection/tests/gh22905/ReflectionClass_setStaticPropertyValue.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionClass_setStaticPropertyValue.phpt
@@ -9,7 +9,7 @@ $r->setStaticPropertyValue("foo\0bar", 123);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ReflectionException: Class Demo does not have a property named foo in %s:%d
+Fatal error: Uncaught ReflectionException: Class Demo does not have a property named foo%0bar in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionClass->setStaticPropertyValue('foo\x00bar', 123)
 #1 {main}

--- a/ext/reflection/tests/gh22905/ReflectionClass_setStaticPropertyValue.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionClass_setStaticPropertyValue.phpt
@@ -1,0 +1,16 @@
+--TEST--
+GH-22905: null bytes in ReflectionClass::setStaticPropertyValue() error messages
+--FILE--
+<?php
+
+class Demo {}
+$r = new ReflectionClass(Demo::class);
+$r->setStaticPropertyValue("foo\0bar", 123);
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ReflectionException: Class Demo does not have a property named foo in %s:%d
+Stack trace:
+#0 %s(%d): ReflectionClass->setStaticPropertyValue('foo\x00bar', 123)
+#1 {main}
+  thrown in %s on line %d

--- a/ext/reflection/tests/gh22905/ReflectionConstant_construct.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionConstant_construct.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-22905: null bytes in ReflectionConstant::__construct() error messages
+--FILE--
+<?php
+
+new ReflectionConstant("foo\0bar");
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ReflectionException: Constant "foo" does not exist in %s:%d
+Stack trace:
+#0 %s(%d): ReflectionConstant->__construct('foo\x00bar')
+#1 {main}
+  thrown in %s on line %d

--- a/ext/reflection/tests/gh22905/ReflectionConstant_construct.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionConstant_construct.phpt
@@ -7,7 +7,7 @@ new ReflectionConstant("foo\0bar");
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ReflectionException: Constant "foo" does not exist in %s:%d
+Fatal error: Uncaught ReflectionException: Constant "foo%0bar" does not exist in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionConstant->__construct('foo\x00bar')
 #1 {main}

--- a/ext/reflection/tests/gh22905/ReflectionEnum_getCase.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionEnum_getCase.phpt
@@ -1,0 +1,16 @@
+--TEST--
+GH-22905: null bytes in ReflectionEnum::getCase() error messages
+--FILE--
+<?php
+
+enum Demo {}
+$r = new ReflectionEnum(Demo::class);
+$r->getCase("foo\0bar");
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ReflectionException: Case Demo::foo does not exist in %s:%d
+Stack trace:
+#0 %s(%d): ReflectionEnum->getCase('foo\x00bar')
+#1 {main}
+  thrown in %s on line %d

--- a/ext/reflection/tests/gh22905/ReflectionEnum_getCase.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionEnum_getCase.phpt
@@ -9,7 +9,7 @@ $r->getCase("foo\0bar");
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ReflectionException: Case Demo::foo does not exist in %s:%d
+Fatal error: Uncaught ReflectionException: Case Demo::foo%0bar does not exist in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionEnum->getCase('foo\x00bar')
 #1 {main}

--- a/ext/reflection/tests/gh22905/ReflectionExtension_construct.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionExtension_construct.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-22905: null bytes in ReflectionExtension::__construct() error messages
+--FILE--
+<?php
+
+new ReflectionExtension("foo\0bar");
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ReflectionException: Extension "foo" does not exist in %s:%d
+Stack trace:
+#0 %s(%d): ReflectionExtension->__construct('foo\x00bar')
+#1 {main}
+  thrown in %s on line %d

--- a/ext/reflection/tests/gh22905/ReflectionExtension_construct.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionExtension_construct.phpt
@@ -7,7 +7,7 @@ new ReflectionExtension("foo\0bar");
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ReflectionException: Extension "foo" does not exist in %s:%d
+Fatal error: Uncaught ReflectionException: Extension "foo%0bar" does not exist in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionExtension->__construct('foo\x00bar')
 #1 {main}

--- a/ext/reflection/tests/gh22905/ReflectionFunction_construct.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionFunction_construct.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-22905: null bytes in ReflectionFunction::__construct() error messages
+--FILE--
+<?php
+
+new ReflectionFunction("foo\0bar");
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ReflectionException: Function foo() does not exist in %s:%d
+Stack trace:
+#0 %s(%d): ReflectionFunction->__construct('foo\x00bar')
+#1 {main}
+  thrown in %s on line %d

--- a/ext/reflection/tests/gh22905/ReflectionFunction_construct.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionFunction_construct.phpt
@@ -7,7 +7,7 @@ new ReflectionFunction("foo\0bar");
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ReflectionException: Function foo() does not exist in %s:%d
+Fatal error: Uncaught ReflectionException: Function foo%0bar() does not exist in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionFunction->__construct('foo\x00bar')
 #1 {main}

--- a/ext/reflection/tests/gh22905/ReflectionMethod_construct_class.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionMethod_construct_class.phpt
@@ -7,7 +7,7 @@ new ReflectionMethod("foo\0bar", "");
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ReflectionException: Class "foo" does not exist in %s:%d
+Fatal error: Uncaught ReflectionException: Class "foo%0bar" does not exist in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionMethod->__construct('foo\x00bar', '')
 #1 {main}

--- a/ext/reflection/tests/gh22905/ReflectionMethod_construct_class.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionMethod_construct_class.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-22905: null bytes in ReflectionMethod::__construct() error messages (class name)
+--FILE--
+<?php
+
+new ReflectionMethod("foo\0bar", "");
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ReflectionException: Class "foo" does not exist in %s:%d
+Stack trace:
+#0 %s(%d): ReflectionMethod->__construct('foo\x00bar', '')
+#1 {main}
+  thrown in %s on line %d

--- a/ext/reflection/tests/gh22905/ReflectionMethod_construct_method.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionMethod_construct_method.phpt
@@ -8,7 +8,7 @@ new ReflectionMethod(Demo::class, "foo\0bar");
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ReflectionException: Method Demo::foo() does not exist in %s:%d
+Fatal error: Uncaught ReflectionException: Method Demo::foo%0bar() does not exist in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionMethod->__construct('Demo', 'foo\x00bar')
 #1 {main}

--- a/ext/reflection/tests/gh22905/ReflectionMethod_construct_method.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionMethod_construct_method.phpt
@@ -1,0 +1,15 @@
+--TEST--
+GH-22905: null bytes in ReflectionMethod::__construct() error messages (method name)
+--FILE--
+<?php
+
+class Demo {}
+new ReflectionMethod(Demo::class, "foo\0bar");
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ReflectionException: Method Demo::foo() does not exist in %s:%d
+Stack trace:
+#0 %s(%d): ReflectionMethod->__construct('Demo', 'foo\x00bar')
+#1 {main}
+  thrown in %s on line %d

--- a/ext/reflection/tests/gh22905/ReflectionMethod_create_method.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionMethod_create_method.phpt
@@ -1,0 +1,15 @@
+--TEST--
+GH-22905: null bytes in ReflectionMethod::createFromMethodName() error messages (method name)
+--FILE--
+<?php
+
+class Demo {}
+ReflectionMethod::createFromMethodName("Demo::foo\0bar");
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ReflectionException: Method Demo::foo() does not exist in %s:%d
+Stack trace:
+#0 %s(%d): ReflectionMethod::createFromMethodName('Demo::foo\x00bar')
+#1 {main}
+  thrown in %s on line %d

--- a/ext/reflection/tests/gh22905/ReflectionMethod_create_method.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionMethod_create_method.phpt
@@ -8,7 +8,7 @@ ReflectionMethod::createFromMethodName("Demo::foo\0bar");
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ReflectionException: Method Demo::foo() does not exist in %s:%d
+Fatal error: Uncaught ReflectionException: Method Demo::foo%0bar() does not exist in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionMethod::createFromMethodName('Demo::foo\x00bar')
 #1 {main}

--- a/ext/reflection/tests/gh22905/ReflectionParameter_construct_class.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionParameter_construct_class.phpt
@@ -7,7 +7,7 @@ new ReflectionParameter(["foo\0bar", ""], 0);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ReflectionException: Class "foo" does not exist in %s:%d
+Fatal error: Uncaught ReflectionException: Class "foo%0bar" does not exist in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionParameter->__construct(Array, 0)
 #1 {main}

--- a/ext/reflection/tests/gh22905/ReflectionParameter_construct_class.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionParameter_construct_class.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-22905: null bytes in ReflectionParameter::__construct() error messages (array class name)
+--FILE--
+<?php
+
+new ReflectionParameter(["foo\0bar", ""], 0);
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ReflectionException: Class "foo" does not exist in %s:%d
+Stack trace:
+#0 %s(%d): ReflectionParameter->__construct(Array, 0)
+#1 {main}
+  thrown in %s on line %d

--- a/ext/reflection/tests/gh22905/ReflectionParameter_construct_method.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionParameter_construct_method.phpt
@@ -8,7 +8,7 @@ new ReflectionParameter([Demo::class, "foo\0bar"], 0);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ReflectionException: Method Demo::foo() does not exist in %s:%d
+Fatal error: Uncaught ReflectionException: Method Demo::foo%0bar() does not exist in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionParameter->__construct(Array, 0)
 #1 {main}

--- a/ext/reflection/tests/gh22905/ReflectionParameter_construct_method.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionParameter_construct_method.phpt
@@ -1,0 +1,15 @@
+--TEST--
+GH-22905: null bytes in ReflectionParameter::__construct() error messages (array method name)
+--FILE--
+<?php
+
+class Demo {}
+new ReflectionParameter([Demo::class, "foo\0bar"], 0);
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ReflectionException: Method Demo::foo() does not exist in %s:%d
+Stack trace:
+#0 %s(%d): ReflectionParameter->__construct(Array, 0)
+#1 {main}
+  thrown in %s on line %d

--- a/ext/reflection/tests/gh22905/ReflectionParameter_construct_string.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionParameter_construct_string.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-22905: null bytes in ReflectionParameter::__construct() error messages (string function)
+--FILE--
+<?php
+
+new ReflectionParameter("foo\0bar", 0);
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ReflectionException: Function foo() does not exist in %s:%d
+Stack trace:
+#0 %s(%d): ReflectionParameter->__construct('foo\x00bar', 0)
+#1 {main}
+  thrown in %s on line %d

--- a/ext/reflection/tests/gh22905/ReflectionParameter_construct_string.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionParameter_construct_string.phpt
@@ -7,7 +7,7 @@ new ReflectionParameter("foo\0bar", 0);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ReflectionException: Function foo() does not exist in %s:%d
+Fatal error: Uncaught ReflectionException: Function foo%0bar() does not exist in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionParameter->__construct('foo\x00bar', 0)
 #1 {main}

--- a/ext/reflection/tests/gh22905/ReflectionProperty_construct_class.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionProperty_construct_class.phpt
@@ -7,7 +7,7 @@ new ReflectionProperty("foo\0bar", "");
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ReflectionException: Class "foo" does not exist in %s:%d
+Fatal error: Uncaught ReflectionException: Class "foo%0bar" does not exist in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionProperty->__construct('foo\x00bar', '')
 #1 {main}

--- a/ext/reflection/tests/gh22905/ReflectionProperty_construct_class.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionProperty_construct_class.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-22905: null bytes in ReflectionProperty::__construct() error messages (class name)
+--FILE--
+<?php
+
+new ReflectionProperty("foo\0bar", "");
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ReflectionException: Class "foo" does not exist in %s:%d
+Stack trace:
+#0 %s(%d): ReflectionProperty->__construct('foo\x00bar', '')
+#1 {main}
+  thrown in %s on line %d

--- a/ext/reflection/tests/gh22905/ReflectionProperty_construct_property.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionProperty_construct_property.phpt
@@ -8,7 +8,7 @@ new ReflectionProperty(Demo::class, "foo\0bar");
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ReflectionException: Property Demo::$foo does not exist in %s:%d
+Fatal error: Uncaught ReflectionException: Property Demo::$foo%0bar does not exist in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionProperty->__construct('Demo', 'foo\x00bar')
 #1 {main}

--- a/ext/reflection/tests/gh22905/ReflectionProperty_construct_property.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionProperty_construct_property.phpt
@@ -1,0 +1,15 @@
+--TEST--
+GH-22905: null bytes in ReflectionProperty::__construct() error messages (property name)
+--FILE--
+<?php
+
+class Demo {}
+new ReflectionProperty(Demo::class, "foo\0bar");
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ReflectionException: Property Demo::$foo does not exist in %s:%d
+Stack trace:
+#0 %s(%d): ReflectionProperty->__construct('Demo', 'foo\x00bar')
+#1 {main}
+  thrown in %s on line %d

--- a/ext/reflection/tests/gh22905/ReflectionProperty_setRawValueWithoutLazyInitialization.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionProperty_setRawValueWithoutLazyInitialization.phpt
@@ -1,0 +1,16 @@
+--TEST--
+GH-22905: null bytes in ReflectionProperty::setRawValueWithoutLazyInitialization() error messages
+--FILE--
+<?php
+
+$o = (object)["foo\0bar" => "baz"];
+$r = new ReflectionProperty($o, "foo\0bar");
+$r->setRawValueWithoutLazyInitialization($o, 123);
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ReflectionException: Can not use setRawValueWithoutLazyInitialization on dynamic property stdClass::$foo in %s:%d
+Stack trace:
+#0 %s(%d): ReflectionProperty->setRawValueWithoutLazyInitialization(Object(stdClass), 123)
+#1 {main}
+  thrown in %s on line %d

--- a/ext/reflection/tests/gh22905/ReflectionProperty_setRawValueWithoutLazyInitialization.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionProperty_setRawValueWithoutLazyInitialization.phpt
@@ -9,7 +9,7 @@ $r->setRawValueWithoutLazyInitialization($o, 123);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ReflectionException: Can not use setRawValueWithoutLazyInitialization on dynamic property stdClass::$foo in %s:%d
+Fatal error: Uncaught ReflectionException: Can not use setRawValueWithoutLazyInitialization on dynamic property stdClass::$foo%0bar in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionProperty->setRawValueWithoutLazyInitialization(Object(stdClass), 123)
 #1 {main}

--- a/ext/reflection/tests/gh22905/ReflectionProperty_skipLazyInitialization.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionProperty_skipLazyInitialization.phpt
@@ -1,0 +1,16 @@
+--TEST--
+GH-22905: null bytes in ReflectionProperty::skipLazyInitialization() error messages
+--FILE--
+<?php
+
+$o = (object)["foo\0bar" => "baz"];
+$r = new ReflectionProperty($o, "foo\0bar");
+$r->skipLazyInitialization($o);
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ReflectionException: Can not use skipLazyInitialization on dynamic property stdClass::$foo in %s:%d
+Stack trace:
+#0 %s(%d): ReflectionProperty->skipLazyInitialization(Object(stdClass))
+#1 {main}
+  thrown in %s on line %d

--- a/ext/reflection/tests/gh22905/ReflectionProperty_skipLazyInitialization.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionProperty_skipLazyInitialization.phpt
@@ -9,7 +9,7 @@ $r->skipLazyInitialization($o);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ReflectionException: Can not use skipLazyInitialization on dynamic property stdClass::$foo in %s:%d
+Fatal error: Uncaught ReflectionException: Can not use skipLazyInitialization on dynamic property stdClass::$foo%0bar in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionProperty->skipLazyInitialization(Object(stdClass))
 #1 {main}

--- a/ext/reflection/tests/gh22905/ReflectionZendExtension_construct.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionZendExtension_construct.phpt
@@ -7,7 +7,7 @@ new ReflectionZendExtension("foo\0bar");
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ReflectionException: Zend Extension "foo" does not exist in %s:%d
+Fatal error: Uncaught ReflectionException: Zend Extension "foo%0bar" does not exist in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionZendExtension->__construct('foo\x00bar')
 #1 {main}

--- a/ext/reflection/tests/gh22905/ReflectionZendExtension_construct.phpt
+++ b/ext/reflection/tests/gh22905/ReflectionZendExtension_construct.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-22905: null bytes in ReflectionZendExtension::__construct() error messages
+--FILE--
+<?php
+
+new ReflectionZendExtension("foo\0bar");
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ReflectionException: Zend Extension "foo" does not exist in %s:%d
+Stack trace:
+#0 %s(%d): ReflectionZendExtension->__construct('foo\x00bar')
+#1 {main}
+  thrown in %s on line %d

--- a/ext/reflection/tests/gh22905/Reflection_getAttributes.phpt
+++ b/ext/reflection/tests/gh22905/Reflection_getAttributes.phpt
@@ -9,7 +9,7 @@ $r->getAttributes("foo\0bar", ReflectionAttribute::IS_INSTANCEOF);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Class "foo" not found in %s:%d
+Fatal error: Uncaught Error: Class "foo%0bar" not found in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionClass->getAttributes('foo\x00bar', 2)
 #1 {main}

--- a/ext/reflection/tests/gh22905/Reflection_getAttributes.phpt
+++ b/ext/reflection/tests/gh22905/Reflection_getAttributes.phpt
@@ -1,0 +1,16 @@
+--TEST--
+GH-22905: null bytes in Reflection*::getAttributes() error messages
+--FILE--
+<?php
+
+class Demo {}
+$r = new ReflectionClass(Demo::class);
+$r->getAttributes("foo\0bar", ReflectionAttribute::IS_INSTANCEOF);
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Class "foo" not found in %s:%d
+Stack trace:
+#0 %s(%d): ReflectionClass->getAttributes('foo\x00bar', 2)
+#1 {main}
+  thrown in %s on line %d


### PR DESCRIPTION
In addition to the fixes within the reflection extension, support for error strings with null bytes was added to `zend_throw_error()` and `zend_throw_exception_ex()`. The changes to `zend_throw_exception_ex()` are a partial backport of #16684.

Fixes #22905