### PR TITLE
ext/session: report a rejected session cookie header

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -1497,10 +1497,10 @@ static zend_result php_session_send_cookie(void) /* {{{ */
 	php_session_remove_cookie(); /* remove already sent session ID cookie */
 	/*	'replace' must be 0 here, else a previous Set-Cookie
 		header, probably sent with setcookie() will be replaced! */
-	sapi_add_header_ex(estrndup(ZSTR_VAL(ncookie.s), ZSTR_LEN(ncookie.s)), ZSTR_LEN(ncookie.s), 0, 0);
+	zend_result result = sapi_add_header_ex(estrndup(ZSTR_VAL(ncookie.s), ZSTR_LEN(ncookie.s)), ZSTR_LEN(ncookie.s), 0, 0);
 	smart_str_free(&ncookie);
 
-	return SUCCESS;
+	return result;
 }
 /* }}} */
 

--- a/ext/session/tests/session_start_cookie_header_rejected.phpt
+++ b/ext/session/tests/session_start_cookie_header_rejected.phpt
@@ -1,0 +1,28 @@
+--TEST--
+session_start() when the SAPI rejects the session cookie header
+--INI--
+session.save_handler=files
+session.name=PHPSESSID
+session.gc_probability=0
+--EXTENSIONS--
+session
+--FILE--
+<?php
+
+ob_start();
+
+set_error_handler(function (int $errno, string $errstr): bool {
+    echo "handler: ", $errstr, PHP_EOL;
+    return true;
+});
+
+session_set_cookie_params(['path' => "/\r\nX-Injected: yes"]);
+
+var_dump(session_start());
+var_dump(session_status() === PHP_SESSION_NONE);
+
+?>
+--EXPECT--
+handler: Header may not contain more than a single header, new line detected
+bool(false)
+bool(true)

--- a/ext/session/tests/session_start_cookie_header_rejected.phpt
+++ b/ext/session/tests/session_start_cookie_header_rejected.phpt
@@ -1,0 +1,31 @@
+--TEST--
+session_start() when the SAPI rejects the session cookie header
+--INI--
+session.save_handler=files
+session.name=PHPSESSID
+session.gc_probability=0
+--EXTENSIONS--
+session
+--FILE--
+<?php
+
+ob_start();
+
+set_error_handler(function (int $errno, string $errstr): bool {
+    echo "handler: ", $errstr, PHP_EOL;
+    if (session_status() === PHP_SESSION_ACTIVE) {
+        session_destroy();
+    }
+    return true;
+});
+
+session_set_cookie_params(['path' => "/\r\nX-Injected: yes"]);
+
+var_dump(session_start());
+var_dump(session_status() === PHP_SESSION_NONE);
+
+?>
+--EXPECT--
+handler: Header may not contain more than a single header, new line detected
+bool(false)
+bool(true)


### PR DESCRIPTION
`php_session_send_cookie()` dropped the result of `sapi_add_header_ex()` and always returned SUCCESS. When the SAPI refuses a Set-Cookie header containing CR or LF, the warning it emits can reach a userland error handler, and if that handler calls `session_destroy()` then `php_session_reset_id()` carries on and appends the released PS(id).

Reproducer is a `set_error_handler()` that destroys the session, `session_set_cookie_params(['path' => "/\r\nX: y"])`, then `session_start()`: SIGSEGV on 8.4, 8.5 and master, under both CLI and CGI. php_session_reset_id() has handled a FAILURE from the cookie call since 8.4; it just never saw one.
