### PR TITLE
ext/session: do not reuse session state a save handler tore down

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -2408,7 +2408,13 @@ PHP_FUNCTION(session_regenerate_id)
 			RETURN_FALSE;
 		}
 	}
+
 	PS(mod)->s_close(&PS(mod_data));
+
+	if (PS(session_status) != php_session_active) {
+		php_error_docref(NULL, E_WARNING, "Session ID cannot be regenerated because the save handler closed the session");
+		RETURN_FALSE;
+	}
 
 	/* New session data */
 	if (PS(session_vars)) {

--- a/ext/session/tests/user_session_module/session_regenerate_id_handler_closes_session.phpt
+++ b/ext/session/tests/user_session_module/session_regenerate_id_handler_closes_session.phpt
@@ -1,0 +1,67 @@
+--TEST--
+session_regenerate_id() when the close handler destroys the session
+--INI--
+session.save_handler=files
+session.name=PHPSESSID
+session.gc_probability=0
+--EXTENSIONS--
+session
+--FILE--
+<?php
+
+ob_start();
+
+class MySessionHandler implements SessionHandlerInterface
+{
+    private bool $destroyed = false;
+
+    public function open(string $path, string $name): bool
+    {
+        return true;
+    }
+
+    public function close(): bool
+    {
+        if (!$this->destroyed) {
+            $this->destroyed = true;
+            session_destroy();
+        }
+        return true;
+    }
+
+    public function read(string $id): string|false
+    {
+        return '';
+    }
+
+    public function write(string $id, string $data): bool
+    {
+        return true;
+    }
+
+    public function destroy(string $id): bool
+    {
+        return true;
+    }
+
+    public function gc(int $max_lifetime): int|false
+    {
+        return 0;
+    }
+}
+
+session_set_save_handler(new MySessionHandler(), true);
+session_start();
+
+var_dump(session_regenerate_id(false));
+var_dump(session_status() === PHP_SESSION_NONE);
+
+?>
+--EXPECTF--
+Warning: session_destroy(): Cannot call session save handler in a recursive manner in %s on line %d
+
+Warning: session_destroy(): Session object destruction failed in %s on line %d
+
+Warning: session_regenerate_id(): Session ID cannot be regenerated because the save handler closed the session in %s on line %d
+bool(false)
+bool(true)

--- a/ext/session/tests/user_session_module/session_regenerate_id_handler_destroys_session.phpt
+++ b/ext/session/tests/user_session_module/session_regenerate_id_handler_destroys_session.phpt
@@ -1,0 +1,37 @@
+--TEST--
+session_regenerate_id() when the save handler destroys the session
+--INI--
+session.save_handler=files
+session.name=PHPSESSID
+session.gc_probability=0
+--EXTENSIONS--
+session
+--FILE--
+<?php
+
+ob_start();
+
+class MySessionHandler extends SessionHandler
+{
+    public function destroy(string $id): bool
+    {
+        session_destroy();
+        return true;
+    }
+}
+
+session_set_save_handler(new MySessionHandler(), true);
+session_start();
+
+var_dump(session_regenerate_id(true));
+var_dump(session_status() === PHP_SESSION_NONE);
+
+?>
+--EXPECTF--
+Warning: session_destroy(): Cannot call session save handler in a recursive manner in %s on line %d
+
+Warning: session_destroy(): Session object destruction failed in %s on line %d
+
+Warning: session_regenerate_id(): Session ID cannot be regenerated because the save handler closed the session in %s on line %d
+bool(false)
+bool(true)


### PR DESCRIPTION
`session_regenerate_id()` runs the userland write or destroy handler, then the close handler, and keeps operating on `PS(id)` afterwards. Any of the three can call `session_destroy()`, and `php_session_destroy()` reaches `php_rshutdown_session_globals()` even when the recursive call was rejected, so PS(id) is released and set to NULL before control returns and `zend_string_release_ex()` dereferences it.

Smallest reproducer is a SessionHandler subclass whose `destroy()` calls session_destroy(), followed by `session_regenerate_id(true)`: SIGSEGV on 8.4, 8.5 and master. The check now sits after every handler has run, so the function warns and returns false with the session left closed. I swept the nine SessionHandler methods against fourteen session functions, 126 combinations with each method calling session_destroy() once. session_regenerate_id() was the only function that crashed, from the write, destroy and close handlers, and nothing in the sweep crashes after this change. The two tests jorgsowa adds in #22687 cover write() and destroy() returning false and still pass here.
