### PR TITLE
Convert usage of `php_error`/`zend_error` to `php_error_docref`

### DIFF
--- a/Zend/tests/zend_ini/gh16886.phpt
+++ b/Zend/tests/zend_ini/gh16886.phpt
@@ -13,29 +13,29 @@ echo ini_parse_quantity('0o+0'), "\n";
 echo ini_parse_quantity('0o-0'), "\n";
 ?>
 --EXPECTF--
-Warning: Invalid quantity "0x 0": no digits after base prefix, interpreting as "0" for backwards compatibility in %s on line %d
+Warning: ini_parse_quantity(): Invalid quantity "0x 0": no digits after base prefix, interpreting as "0" for backwards compatibility in %s on line %d
 0
 
-Warning: Invalid quantity "0x+0": no digits after base prefix, interpreting as "0" for backwards compatibility in %s on line %d
+Warning: ini_parse_quantity(): Invalid quantity "0x+0": no digits after base prefix, interpreting as "0" for backwards compatibility in %s on line %d
 0
 
-Warning: Invalid quantity "0x-0": no digits after base prefix, interpreting as "0" for backwards compatibility in %s on line %d
+Warning: ini_parse_quantity(): Invalid quantity "0x-0": no digits after base prefix, interpreting as "0" for backwards compatibility in %s on line %d
 0
 
-Warning: Invalid quantity "0b 0": no digits after base prefix, interpreting as "0" for backwards compatibility in %s on line %d
+Warning: ini_parse_quantity(): Invalid quantity "0b 0": no digits after base prefix, interpreting as "0" for backwards compatibility in %s on line %d
 0
 
-Warning: Invalid quantity "0b+0": no digits after base prefix, interpreting as "0" for backwards compatibility in %s on line %d
+Warning: ini_parse_quantity(): Invalid quantity "0b+0": no digits after base prefix, interpreting as "0" for backwards compatibility in %s on line %d
 0
 
-Warning: Invalid quantity "0b-0": no digits after base prefix, interpreting as "0" for backwards compatibility in %s on line %d
+Warning: ini_parse_quantity(): Invalid quantity "0b-0": no digits after base prefix, interpreting as "0" for backwards compatibility in %s on line %d
 0
 
-Warning: Invalid quantity "0o 0": no digits after base prefix, interpreting as "0" for backwards compatibility in %s on line %d
+Warning: ini_parse_quantity(): Invalid quantity "0o 0": no digits after base prefix, interpreting as "0" for backwards compatibility in %s on line %d
 0
 
-Warning: Invalid quantity "0o+0": no digits after base prefix, interpreting as "0" for backwards compatibility in %s on line %d
+Warning: ini_parse_quantity(): Invalid quantity "0o+0": no digits after base prefix, interpreting as "0" for backwards compatibility in %s on line %d
 0
 
-Warning: Invalid quantity "0o-0": no digits after base prefix, interpreting as "0" for backwards compatibility in %s on line %d
+Warning: ini_parse_quantity(): Invalid quantity "0o-0": no digits after base prefix, interpreting as "0" for backwards compatibility in %s on line %d
 0

--- a/ext/exif/exif.c
+++ b/ext/exif/exif.c
@@ -1337,7 +1337,7 @@ static HashTable *exif_make_tag_ht(tag_info_type *tag_table)
 	zend_hash_init(ht, 0, NULL, NULL, 1);
 	while (tag_table->Tag != TAG_END_OF_LIST) {
 		if (!zend_hash_index_add_ptr(ht, tag_table->Tag, tag_table->Desc)) {
-			zend_error(E_CORE_ERROR, "Duplicate tag %x", tag_table->Tag);
+			php_error_docref(NULL, E_CORE_ERROR, "Duplicate tag %x", tag_table->Tag);
 		}
 		tag_table++;
 	}

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -345,7 +345,7 @@ PDO_API void php_pdo_internal_construct_driver(INTERNAL_FUNCTION_PARAMETERS, zen
 	}
 
 	if (!strncmp(data_source, "uri:", sizeof("uri:")-1)) {
-		zend_error(E_DEPRECATED, "Looking up the DSN from a URI is deprecated due to possible security concerns with DSNs coming from remote URIs");
+		php_error_docref(NULL, E_DEPRECATED, "Looking up the DSN from a URI is deprecated due to possible security concerns with DSNs coming from remote URIs");
 		if (EG(exception)) {
 			RETURN_THROWS();
 		}

--- a/ext/pdo_mysql/tests/pdo_mysql___construct_uri.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql___construct_uri.phpt
@@ -64,7 +64,7 @@ MySQLPDOTest::skip();
     print "done!";
 ?>
 --EXPECTF--
-Deprecated: Looking up the DSN from a URI is deprecated due to possible security concerns with DSNs coming from remote URIs in %s on line %d
+Deprecated: PDO::__construct(): Looking up the DSN from a URI is deprecated due to possible security concerns with DSNs coming from remote URIs in %s on line %d
 
-Deprecated: Looking up the DSN from a URI is deprecated due to possible security concerns with DSNs coming from remote URIs in %s on line %d
+Deprecated: PDO::__construct(): Looking up the DSN from a URI is deprecated due to possible security concerns with DSNs coming from remote URIs in %s on line %d
 done!

--- a/ext/pdo_sqlite/pdo_sqlite.c
+++ b/ext/pdo_sqlite/pdo_sqlite.c
@@ -307,7 +307,7 @@ PHP_METHOD(Pdo_Sqlite, openBlob)
 	sqlite_flags = (flags & SQLITE_OPEN_READWRITE) ? 1 : 0;
 
 	if (sqlite3_blob_open(sqlite_handle, dbname, table, column, rowid, sqlite_flags, &blob) != SQLITE_OK) {
-		zend_error(E_WARNING, "Unable to open blob: %s", sqlite3_errmsg(sqlite_handle));
+		php_error_docref(NULL, E_WARNING, "Unable to open blob: %s", sqlite3_errmsg(sqlite_handle));
 		RETURN_FALSE;
 	}
 

--- a/ext/pdo_sqlite/tests/pdo_sqlite___construct_uri.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite___construct_uri.phpt
@@ -41,8 +41,8 @@ var_dump(file_exists($dbFile));
 --EXPECTF--
 bool(false)
 
-Deprecated: Looking up the DSN from a URI is deprecated due to possible security concerns with DSNs coming from remote URIs in %s on line %d
+Deprecated: PDO::__construct(): Looking up the DSN from a URI is deprecated due to possible security concerns with DSNs coming from remote URIs in %s on line %d
 bool(true)
 bool(false)
-ErrorException: Looking up the DSN from a URI is deprecated due to possible security concerns with DSNs coming from remote URIs
+ErrorException: PDO::__construct(): Looking up the DSN from a URI is deprecated due to possible security concerns with DSNs coming from remote URIs
 bool(false)

--- a/ext/sodium/libsodium.c
+++ b/ext/sodium/libsodium.c
@@ -1462,7 +1462,7 @@ PHP_FUNCTION(sodium_crypto_pwhash)
 		RETURN_THROWS();
 	}
 	if (passwd_len <= 0) {
-		zend_error(E_WARNING, "empty password");
+		php_error_docref(NULL, E_WARNING, "empty password");
 	}
 	if (salt_len != crypto_pwhash_SALTBYTES) {
 		zend_argument_value_error(3, "must be SODIUM_CRYPTO_PWHASH_SALTBYTES bytes long");
@@ -1536,7 +1536,7 @@ PHP_FUNCTION(sodium_crypto_pwhash_str)
 		RETURN_THROWS();
 	}
 	if (passwd_len <= 0) {
-		zend_error(E_WARNING, "empty password");
+		php_error_docref(NULL, E_WARNING, "empty password");
 	}
 	if (opslimit < crypto_pwhash_OPSLIMIT_MIN) {
 		zend_argument_value_error(2, "must be greater than or equal to %d", crypto_pwhash_OPSLIMIT_MIN);
@@ -1601,7 +1601,7 @@ PHP_FUNCTION(sodium_crypto_pwhash_str_verify)
 		RETURN_THROWS();
 	}
 	if (passwd_len <= 0) {
-		zend_error(E_WARNING, "empty password");
+		php_error_docref(NULL, E_WARNING, "empty password");
 	}
 	if (crypto_pwhash_str_verify
 		(hash_str, passwd, (unsigned long long) passwd_len) == 0) {
@@ -1647,7 +1647,7 @@ PHP_FUNCTION(sodium_crypto_pwhash_scryptsalsa208sha256)
 		RETURN_THROWS();
 	}
 	if (passwd_len <= 0) {
-		zend_error(E_WARNING, "empty password");
+		php_error_docref(NULL, E_WARNING, "empty password");
 	}
 	if (salt_len != crypto_pwhash_scryptsalsa208sha256_SALTBYTES) {
 		zend_argument_value_error(3, "must be SODIUM_CRYPTO_PWHASH_SCRYPTSALSA208SHA256_SALTBYTES bytes long");
@@ -1703,7 +1703,7 @@ PHP_FUNCTION(sodium_crypto_pwhash_scryptsalsa208sha256_str)
 		RETURN_THROWS();
 	}
 	if (passwd_len <= 0) {
-		zend_error(E_WARNING, "empty password");
+		php_error_docref(NULL, E_WARNING, "empty password");
 	}
 	if (opslimit < crypto_pwhash_scryptsalsa208sha256_OPSLIMIT_INTERACTIVE) {
 		zend_argument_value_error(2, "must be greater than or equal to %d", crypto_pwhash_scryptsalsa208sha256_OPSLIMIT_INTERACTIVE);
@@ -1743,10 +1743,10 @@ PHP_FUNCTION(sodium_crypto_pwhash_scryptsalsa208sha256_str_verify)
 		RETURN_THROWS();
 	}
 	if (passwd_len <= 0) {
-		zend_error(E_WARNING, "empty password");
+		php_error_docref(NULL, E_WARNING, "empty password");
 	}
 	if (hash_str_len != crypto_pwhash_scryptsalsa208sha256_STRBYTES - 1) {
-		zend_error(E_WARNING, "wrong size for the hashed password");
+		php_error_docref(NULL, E_WARNING, "wrong size for the hashed password");
 		RETURN_FALSE;
 	}
 	if (crypto_pwhash_scryptsalsa208sha256_str_verify

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -1884,7 +1884,7 @@ PHP_FUNCTION(ini_parse_quantity)
 	RETVAL_LONG(zend_ini_parse_quantity(shorthand, &errstr));
 
 	if (errstr) {
-		zend_error(E_WARNING, "%s", ZSTR_VAL(errstr));
+		php_error_docref(NULL, E_WARNING, "%s", ZSTR_VAL(errstr));
 		zend_string_release(errstr);
 	}
 }

--- a/ext/standard/browscap.c
+++ b/ext/standard/browscap.c
@@ -333,7 +333,7 @@ static void php_browscap_parser_cb(zval *arg1, zval *arg2, zval *arg3, int callb
 					if (ctx->current_section_name != NULL &&
 						zend_string_equals_ci(ctx->current_section_name, Z_STR_P(arg2))
 					) {
-						zend_error(E_CORE_ERROR, "Invalid browscap ini file: "
+						php_error_docref(NULL, E_CORE_ERROR, "Invalid browscap ini file: "
 							"'Parent' value cannot be same as the section name: %s "
 							"(in file %s)", ZSTR_VAL(ctx->current_section_name), zend_ini_string_literal("browscap"));
 						return;
@@ -409,7 +409,7 @@ static zend_result browscap_read_file(const char *filename, browser_data *browda
 
 	fp = VCWD_FOPEN(filename, "r");
 	if (!fp) {
-		zend_error(E_CORE_WARNING, "Cannot open \"%s\" for reading", filename);
+		php_error_docref(NULL, E_CORE_WARNING, "Cannot open \"%s\" for reading", filename);
 		return FAILURE;
 	}
 	zend_stream_init_fp(&fh, fp, filename);

--- a/ext/standard/browscap.c
+++ b/ext/standard/browscap.c
@@ -333,7 +333,7 @@ static void php_browscap_parser_cb(zval *arg1, zval *arg2, zval *arg3, int callb
 					if (ctx->current_section_name != NULL &&
 						zend_string_equals_ci(ctx->current_section_name, Z_STR_P(arg2))
 					) {
-						php_error_docref(NULL, E_CORE_ERROR, "Invalid browscap ini file: "
+						php_error_docref("misc.configuration.php#ini.browscap", E_CORE_ERROR, "Invalid browscap ini file: "
 							"'Parent' value cannot be same as the section name: %s "
 							"(in file %s)", ZSTR_VAL(ctx->current_section_name), zend_ini_string_literal("browscap"));
 						return;

--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -137,7 +137,7 @@ static void file_globals_dtor(php_file_globals *file_globals_p)
 static PHP_INI_MH(OnUpdateAutoDetectLineEndings)
 {
 	if (zend_ini_parse_bool(new_value)) {
-		zend_error(E_DEPRECATED, "auto_detect_line_endings is deprecated");
+		php_error_docref(NULL, E_DEPRECATED, "auto_detect_line_endings is deprecated");
 	}
 	return OnUpdateBool(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
 }

--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -910,7 +910,7 @@ PHPAPI void _php_math_basetozval(zend_string *str, int base, zval *ret)
 	}
 
 	if (invalidchars > 0) {
-		zend_error(E_DEPRECATED, "Invalid characters passed for attempted conversion, these have been ignored");
+		php_error_docref(NULL, E_DEPRECATED, "Invalid characters passed for attempted conversion, these have been ignored");
 	}
 
 	if (mode == 1) {

--- a/ext/standard/net.c
+++ b/ext/standard/net.c
@@ -167,7 +167,7 @@ PHP_FUNCTION(net_get_interfaces) {
 	}
 
 	if (pAddresses == NULL) {
-		zend_error(E_WARNING, "Memory allocation failed for IP_ADAPTER_ADDRESSES struct");
+		php_error_docref(NULL, E_WARNING, "Memory allocation failed for IP_ADAPTER_ADDRESSES struct");
 		RETURN_FALSE;
 	}
 
@@ -175,7 +175,7 @@ PHP_FUNCTION(net_get_interfaces) {
 
 	if (NO_ERROR != dwRetVal) {
 		char *buf = php_win32_error_to_msg(GetLastError());
-		zend_error(E_WARNING, "GetAdaptersAddresses failed: %s", buf);
+		php_error_docref(NULL, E_WARNING, "GetAdaptersAddresses failed: %s", buf);
 		php_win32_error_msg_free(buf);
 		FREE(pAddresses);
 		RETURN_FALSE;
@@ -265,7 +265,7 @@ PHP_FUNCTION(net_get_interfaces) {
 	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (getifaddrs(&addrs)) {
-		php_error(E_WARNING, "getifaddrs() failed %d: %s", errno, strerror(errno));
+		php_error_docref(NULL, E_WARNING, "getifaddrs() failed %d: %s", errno, strerror(errno));
 		RETURN_FALSE;
 	}
 

--- a/ext/standard/tests/file/auto_detect_line_endings_1.phpt
+++ b/ext/standard/tests/file/auto_detect_line_endings_1.phpt
@@ -16,7 +16,7 @@ var_dump(fgets(STDIN));
 echo "Done\n";
 ?>
 --EXPECT--
-Deprecated: auto_detect_line_endings is deprecated in Unknown on line 0
+Deprecated: PHP Startup: auto_detect_line_endings is deprecated in Unknown on line 0
 string(1) "1"
 string(8) "fooBar1"
 string(8) "fooBar2"

--- a/ext/standard/tests/file/auto_detect_line_endings_2.phpt
+++ b/ext/standard/tests/file/auto_detect_line_endings_2.phpt
@@ -17,7 +17,7 @@ var_dump(fgets($stdin));
 echo "Done\n";
 ?>
 --EXPECTF--
-Deprecated: auto_detect_line_endings is deprecated in %s on line %d
+Deprecated: ini_set(): auto_detect_line_endings is deprecated in %s on line %d
 string(2) "on"
 string(8) "fooBar1"
 string(8) "fooBar2"

--- a/ext/standard/tests/math/base_convert_basic.phpt
+++ b/ext/standard/tests/math/base_convert_basic.phpt
@@ -33,137 +33,137 @@ for ($f= 0; $f < count($frombase); $f++) {
 ......to base is 2
 .........value= 10 res = 10
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 27 res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3 res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 95 res = 0
 .........value= 10 res = 10
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 27 res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 0
 ......to base is 8
 .........value= 10 res = 2
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 27 res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3 res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 95 res = 0
 .........value= 10 res = 2
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 27 res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 0
 ......to base is 10
 .........value= 10 res = 2
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 27 res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3 res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 95 res = 0
 .........value= 10 res = 2
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 27 res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 0
 ......to base is 16
 .........value= 10 res = 2
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 27 res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3 res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 95 res = 0
 .........value= 10 res = 2
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 27 res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 0
 ......to base is 36
 .........value= 10 res = 2
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 27 res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3 res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 95 res = 0
 .........value= 10 res = 2
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 27 res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 0
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 0
 
 ...from base is 8
@@ -171,106 +171,106 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 10 res = 1000
 .........value= 27 res = 10111
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 11
 .........value= 3 res = 11
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 95 res = 101
 .........value= 10 res = 1000
 .........value= 27 res = 10111
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 11
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 101
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 11
 ......to base is 8
 .........value= 10 res = 10
 .........value= 27 res = 27
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 3
 .........value= 3 res = 3
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 95 res = 5
 .........value= 10 res = 10
 .........value= 27 res = 27
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 3
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 5
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 3
 ......to base is 10
 .........value= 10 res = 8
 .........value= 27 res = 23
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 3
 .........value= 3 res = 3
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 95 res = 5
 .........value= 10 res = 8
 .........value= 27 res = 23
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 3
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 5
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 3
 ......to base is 16
 .........value= 10 res = 8
 .........value= 27 res = 17
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 3
 .........value= 3 res = 3
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 95 res = 5
 .........value= 10 res = 8
 .........value= 27 res = 17
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 3
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 5
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 3
 ......to base is 36
 .........value= 10 res = 8
 .........value= 27 res = n
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 3
 .........value= 3 res = 3
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 95 res = 5
 .........value= 10 res = 8
 .........value= 27 res = n
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 3
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 5
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 3
 
 ...from base is 10
@@ -284,10 +284,10 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 27 res = 11011
 .........value= 39 res = 100111
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 101
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 11
 ......to base is 8
 .........value= 10 res = 12
@@ -299,10 +299,10 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 27 res = 33
 .........value= 39 res = 47
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 5
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 3
 ......to base is 10
 .........value= 10 res = 10
@@ -314,10 +314,10 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 27 res = 27
 .........value= 39 res = 39
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 5
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 3
 ......to base is 16
 .........value= 10 res = a
@@ -329,10 +329,10 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 27 res = 1b
 .........value= 39 res = 27
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 5
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 3
 ......to base is 36
 .........value= 10 res = a
@@ -344,10 +344,10 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 27 res = r
 .........value= 39 res = 13
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 5
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 3
 
 ...from base is 16
@@ -362,7 +362,7 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 39 res = 111001
 .........value= 5F res = 1011111
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 11
 ......to base is 8
 .........value= 10 res = 20
@@ -375,7 +375,7 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 39 res = 71
 .........value= 5F res = 137
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 3
 ......to base is 10
 .........value= 10 res = 16
@@ -388,7 +388,7 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 39 res = 57
 .........value= 5F res = 95
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 3
 ......to base is 16
 .........value= 10 res = 10
@@ -401,7 +401,7 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 39 res = 39
 .........value= 5F res = 5f
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 3
 ......to base is 36
 .........value= 10 res = g
@@ -414,7 +414,7 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 39 res = 1l
 .........value= 5F res = 2n
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 3
 
 ...from base is 36

--- a/ext/standard/tests/math/base_convert_improvements.phpt
+++ b/ext/standard/tests/math/base_convert_improvements.phpt
@@ -33,15 +33,15 @@ echo base_convert("0 0" , 9, 10) . "\n";
 7
 10
 =======================================
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 15
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 61695
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 511
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 0
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 7
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 0

--- a/ext/standard/tests/math/base_convert_variation1.phpt
+++ b/ext/standard/tests/math/base_convert_variation1.phpt
@@ -75,7 +75,7 @@ string(2) "14"
 
 -- Iteration 4 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 string(2) "14"
 
 -- Iteration 5 --
@@ -83,27 +83,27 @@ string(11) "17777777777"
 
 -- Iteration 6 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 string(3) "151"
 
 -- Iteration 7 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 string(3) "151"
 
 -- Iteration 8 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 string(7) "4553207"
 
 -- Iteration 9 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 string(7) "4553207"
 
 -- Iteration 10 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 string(1) "5"
 
 -- Iteration 11 --
@@ -129,17 +129,17 @@ base_convert(): Argument #1 ($num) must be of type string, array given
 
 -- Iteration 18 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 string(1) "0"
 
 -- Iteration 19 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 string(1) "0"
 
 -- Iteration 20 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: base_convert(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 string(1) "0"
 
 -- Iteration 21 --

--- a/ext/standard/tests/math/bindec_basic_64bit.phpt
+++ b/ext/standard/tests/math/bindec_basic_64bit.phpt
@@ -36,41 +36,41 @@ for ($i = 0; $i < count($values); $i++) {
 --EXPECTF--
 int(455)
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: bindec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: bindec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(32766)
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: bindec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(5)
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: bindec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(129)
 int(455)
 int(224)
 int(2147483647)
 int(2147483648)
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: bindec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(129)
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: bindec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: bindec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(13)
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: bindec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(13)
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: bindec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(26)
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: bindec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(6)
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: bindec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 int(1)
 int(0)

--- a/ext/standard/tests/math/bindec_variation1_64bit.phpt
+++ b/ext/standard/tests/math/bindec_variation1_64bit.phpt
@@ -75,37 +75,37 @@ int(1)
 
 -- Iteration 3 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: bindec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(1)
 
 -- Iteration 4 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: bindec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 
 -- Iteration 5 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: bindec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(2)
 
 -- Iteration 6 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: bindec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(2)
 
 -- Iteration 7 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: bindec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(8)
 
 -- Iteration 8 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: bindec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(1)
 
 -- Iteration 9 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: bindec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 
 -- Iteration 10 --
@@ -131,17 +131,17 @@ bindec(): Argument #1 ($binary_string) must be of type string, array given
 
 -- Iteration 17 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: bindec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 
 -- Iteration 18 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: bindec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 
 -- Iteration 19 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: bindec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 
 -- Iteration 20 --

--- a/ext/standard/tests/math/hexdec.phpt
+++ b/ext/standard/tests/math/hexdec.phpt
@@ -18,13 +18,13 @@ var_dump(hexdec("17fffffffffffffff"));
 int(74565)
 int(74565)
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: hexdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(74565)
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: hexdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(74565)
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: hexdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(74565)
 
 Notice: Input number is larger than PHP_INT_MAX, precision has been lost in conversion in %s on line %d

--- a/ext/standard/tests/math/hexdec_basic_64bit.phpt
+++ b/ext/standard/tests/math/hexdec_basic_64bit.phpt
@@ -62,7 +62,7 @@ int(2147483648)
 
 -- hexdec 0x123XYZABC --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: hexdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(1194684)
 
 -- hexdec 311015 --
@@ -73,7 +73,7 @@ int(3215381)
 
 -- hexdec 31101.3 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: hexdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(3215379)
 
 -- hexdec 3110130 --

--- a/ext/standard/tests/math/hexdec_variation1_64bit.phpt
+++ b/ext/standard/tests/math/hexdec_variation1_64bit.phpt
@@ -82,7 +82,7 @@ int(74565)
 
 -- Iteration 4 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: hexdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(9029)
 
 -- Iteration 5 --
@@ -93,12 +93,12 @@ int(285960729238)
 
 -- Iteration 7 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: hexdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(261)
 
 -- Iteration 8 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: hexdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(261)
 
 -- Iteration 9 --
@@ -106,12 +106,12 @@ int(20015998341120)
 
 -- Iteration 10 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: hexdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(1250999896553)
 
 -- Iteration 11 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: hexdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(5)
 
 -- Iteration 12 --
@@ -137,17 +137,17 @@ hexdec(): Argument #1 ($hex_string) must be of type string, array given
 
 -- Iteration 19 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: hexdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(2748)
 
 -- Iteration 20 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: hexdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(2748)
 
 -- Iteration 21 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: hexdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(2748)
 
 -- Iteration 22 --

--- a/ext/standard/tests/math/octdec_basic_64bit.phpt
+++ b/ext/standard/tests/math/octdec_basic_64bit.phpt
@@ -35,17 +35,17 @@ for ($i = 0; $i < count($values); $i++) {
 --EXPECTF--
 *** Testing octdec() : basic functionality ***
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: octdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(14489)
 int(253)
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: octdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(36947879)
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: octdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(4618484)
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: octdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(4104)
 int(5349)
 int(342391)
@@ -53,11 +53,11 @@ int(375)
 int(2147483647)
 int(2147483648)
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: octdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(668)
 int(5349)
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: octdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(102923)
 int(823384)
 int(1)

--- a/ext/standard/tests/math/octdec_variation1.phpt
+++ b/ext/standard/tests/math/octdec_variation1.phpt
@@ -79,42 +79,42 @@ int(5349)
 
 -- Iteration 4 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: octdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(1253)
 
 -- Iteration 5 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: octdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(1134037)
 
 -- Iteration 6 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: octdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(1134038)
 
 -- Iteration 7 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: octdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(69)
 
 -- Iteration 8 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: octdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(69)
 
 -- Iteration 9 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: octdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(175304192)
 
 -- Iteration 10 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: octdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(342391)
 
 -- Iteration 11 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: octdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(5)
 
 -- Iteration 12 --
@@ -140,17 +140,17 @@ octdec(): Argument #1 ($octal_string) must be of type string, array given
 
 -- Iteration 19 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: octdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 
 -- Iteration 20 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: octdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 
 -- Iteration 21 --
 
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+Deprecated: octdec(): Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 
 -- Iteration 22 --

--- a/tests/basic/ini_parse_quantity_warnings.phpt
+++ b/tests/basic/ini_parse_quantity_warnings.phpt
@@ -9,6 +9,6 @@ ini_parse_quantity('1mb');
 ini_parse_quantity('256 then skip a few then g')
 ?>
 --EXPECTF--
-Warning: Invalid quantity "1mb": unknown multiplier "b", interpreting as "1" for backwards compatibility in %sini_parse_quantity_warnings.php on line 3
+Warning: ini_parse_quantity(): Invalid quantity "1mb": unknown multiplier "b", interpreting as "1" for backwards compatibility in %s on line %d
 
-Warning: Invalid quantity "256 then skip a few then g", interpreting as "256 g" for backwards compatibility in %sini_parse_quantity_warnings.php on line 4
+Warning: ini_parse_quantity(): Invalid quantity "256 then skip a few then g", interpreting as "256 g" for backwards compatibility in %s on line %d


### PR DESCRIPTION
Not yet complete, likely adding more. Some notes so far:

* The goal is to eventually eliminate `php_error` as an alias for `zend_error`, make error reporting more consistent, and eventually figure out some symmetry between `php_verror` and `php_error_docref` naming wise. `zend_error` should remain, but there may be quite a bit of overlap anyways.
* I'm starting with `ext` since this usually is for functions where the `php_error_docref` output makes sense when prefixing with a function name and optionally arguments (or indicating phase of startup/shutdown). There are some notable exceptions (some stuff related to arrays and comparisons) that do not work in that context.
  * There may be some stuff in `Zend` and `sapi` too.
* Deprecation messages tend to repeat the function name, so I haven't changed those. Perhaps there should be some kind of function for consistent deprecation messages?
* soap has been broken out into a separate PR (GH-22951)
* A lot are in hard to reach areas without tests to validate. Some of these may make more sense as exceptions, for instance.
* There's also some fprintf with stderr; usually in `#if DEBUG` type code. Worth changing?