### PR TITLE
ext/mysqli: applied fixers to improve test robustness

### DIFF
--- a/ext/mysqli/tests/bug36802.phpt
+++ b/ext/mysqli/tests/bug36802.phpt
@@ -18,7 +18,7 @@ mysqli
         try {
             $mysql->set_charset('utf8');
         } catch (Error $exception) {
-            echo $exception->getMessage() . "\n";
+            echo $exception::class, ': ', $exception->getMessage(), "\n";
         }
     } else {
         $x[0] = false;
@@ -27,7 +27,7 @@ mysqli
     try {
         $mysql->query("SELECT 'foo' FROM DUAL");
     } catch (Error $exception) {
-        echo $exception->getMessage() . "\n";
+        echo $exception::class, ': ', $exception->getMessage(), "\n";
     }
 
     /* following operations should work */
@@ -39,8 +39,8 @@ mysqli
     var_dump($x);
 ?>
 --EXPECT--
-mysqli object is not fully initialized
-mysqli object is not fully initialized
+Error: mysqli object is not fully initialized
+Error: mysqli object is not fully initialized
 array(2) {
   [1]=>
   string(0) ""

--- a/ext/mysqli/tests/bug62885.phpt
+++ b/ext/mysqli/tests/bug62885.phpt
@@ -13,19 +13,19 @@ $tablica = array();
 try {
     $test1 = mysqli_poll($test2, $test3, $tablica, 0);
 } catch (\ValueError $e) {
-    echo $e->getMessage() . \PHP_EOL;
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
 }
 
 $test2 = array();
 try {
     $test1 = mysqli_poll($test2, $test3, $tablica, 0);
 } catch (\ValueError $e) {
-    echo $e->getMessage() . \PHP_EOL;
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
 }
 echo "okey";
 ?>
 --EXPECTF--
-No stream arrays were passed
+ValueError: No stream arrays were passed
 
 Warning: mysqli_poll(): No stream arrays were passed in %s on line %d
 okey

--- a/ext/mysqli/tests/gh17900.phpt
+++ b/ext/mysqli/tests/gh17900.phpt
@@ -9,8 +9,8 @@ $mysqli = new mysqli();
 try {
     $mysqli->__construct('doesnotexist');
 } catch (Error $e) {
-    echo $e->getMessage(), "\n";
+    echo $e::class, ': ', $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-Cannot call constructor twice
+Error: Cannot call constructor twice

--- a/ext/mysqli/tests/ghsa-h35g-vwh6-m678-auth-message.phpt
+++ b/ext/mysqli/tests/ghsa-h35g-vwh6-m678-auth-message.phpt
@@ -18,7 +18,7 @@ try {
     $info = mysqli_info($conn);
     var_dump($info);
 } catch (Exception $e) {
-    echo $e->getMessage() . PHP_EOL;
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
 }
 
 $process->terminate();
@@ -33,5 +33,5 @@ print "done!";
 [*] Sending - Malicious OK Auth Response [Extract heap through buffer over-read]: 0900000200000002000000fcff
 
 Warning: mysqli::__construct(): OK packet message length is past the packet size in %s on line %d
-Unknown error while trying to connect via tcp://127.0.0.1:%d
+mysqli_sql_exception: Unknown error while trying to connect via tcp://127.0.0.1:%d
 done!

--- a/ext/mysqli/tests/mysqli_driver/write_property.phpt
+++ b/ext/mysqli/tests/mysqli_driver/write_property.phpt
@@ -10,7 +10,7 @@ try {
     /* Read-only property */
     $driver->client_info = 'test';
 } catch (Error $e) {
-    echo $e->getMessage(), "\n";
+    echo $e::class, ': ', $e->getMessage(), "\n";
 }
 
 $driver->report_mode = "1";
@@ -18,11 +18,11 @@ var_dump($driver->report_mode);
 try {
     $driver->report_mode = [];
 } catch (Error $e) {
-    echo $e->getMessage(), "\n";
+    echo $e::class, ': ', $e->getMessage(), "\n";
 }
 
 ?>
 --EXPECT--
-Cannot write read-only property mysqli_driver::$client_info
+Error: Cannot write read-only property mysqli_driver::$client_info
 int(1)
-Cannot assign array to property mysqli_driver::$report_mode of type int
+TypeError: Cannot assign array to property mysqli_driver::$report_mode of type int

--- a/ext/mysqli/tests/mysqli_driver/write_property_strict.phpt
+++ b/ext/mysqli/tests/mysqli_driver/write_property_strict.phpt
@@ -12,16 +12,16 @@ try {
     /* Read-only property */
     $driver->client_info = 42;
 } catch (Error $e) {
-    echo $e->getMessage(), "\n";
+    echo $e::class, ': ', $e->getMessage(), "\n";
 }
 
 try {
     $driver->report_mode = "1";
 } catch (Error $e) {
-    echo $e->getMessage(), "\n";
+    echo $e::class, ': ', $e->getMessage(), "\n";
 }
 
 ?>
 --EXPECT--
-Cannot write read-only property mysqli_driver::$client_info
-Cannot assign string to property mysqli_driver::$report_mode of type int
+Error: Cannot write read-only property mysqli_driver::$client_info
+TypeError: Cannot assign string to property mysqli_driver::$report_mode of type int

--- a/ext/mysqli/tests/mysqli_driver_unclonable.phpt
+++ b/ext/mysqli/tests/mysqli_driver_unclonable.phpt
@@ -9,7 +9,7 @@ try {
     $driver = new mysqli_driver;
     $driver_clone = clone $driver;
 } catch (Throwable $e) {
-    echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
 }
 
 ?>


### PR DESCRIPTION
Thanks for the review in https://github.com/php/php-src/pull/22799#issuecomment-5117207429 @kamil-tekiela. You said you looked at "mysqli and PDO". When matching `.github/CODEOWNERS` to the extensions affected by #22799 then I find only `ext/mysqli`. Both others you are listed for, `/ext/mysqlnd` and `/ext/pdo_mysql`, are not affected.

Are there any other extensions you own that I could cherry-pick to here? I am happy to do that.