### PR TITLE
ext/intl: Reset IntlListFormatter error state in constructor

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,10 @@ PHP                                                                        NEWS
   . Fixed bug GH-22825 (DOMElement::setAttribute() fails silently when the DTD
     declares a default value for the attribute). (iliaal)
 
+- Intl:
+  . Fixed IntlListFormatter::__construct() leaving stale global error state
+    after successful calls. (Weilin Du)
+
 - Opcache:
   . Fixed GH-22693 (DT_TEXTREL in JIT-generated TLS access on x86_64).
     (David Carlier)

--- a/ext/intl/listformatter/listformatter_class.c
+++ b/ext/intl/listformatter/listformatter_class.c
@@ -60,6 +60,9 @@ PHP_METHOD(IntlListFormatter, __construct)
         zend_long type = INTL_LISTFORMATTER_FALLBACK_TYPE_AND;
         zend_long width = INTL_LISTFORMATTER_FALLBACK_WIDTH_WIDE;
     #endif
+
+    intl_errors_reset(LISTFORMATTER_ERROR_P(obj));
+
     ZEND_PARSE_PARAMETERS_START(1, 3)
         Z_PARAM_STRING(locale, locale_len)
         Z_PARAM_OPTIONAL

--- a/ext/intl/tests/listformatter/listformatter_constructor_error_reset.phpt
+++ b/ext/intl/tests/listformatter/listformatter_constructor_error_reset.phpt
@@ -1,0 +1,23 @@
+--TEST--
+IntlListFormatter::__construct() resets stale errors
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+$formatter = new IntlListFormatter('en_US');
+var_dump($formatter->format(["\x80"]));
+var_dump(intl_get_error_code() === U_INVALID_CHAR_FOUND);
+
+$formatter = new IntlListFormatter('en_US');
+var_dump(intl_get_error_code());
+var_dump(intl_get_error_message());
+var_dump($formatter->getErrorCode());
+var_dump($formatter->getErrorMessage());
+?>
+--EXPECT--
+bool(false)
+bool(true)
+int(0)
+string(12) "U_ZERO_ERROR"
+int(0)
+string(12) "U_ZERO_ERROR"


### PR DESCRIPTION
When reading the code base, I found the construct method in IntlListFormatter doesn't reset the error state. 