### PR TITLE
Improve performance of json_encode() for long ASCII strings

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -640,6 +640,7 @@ PHP 8.6 UPGRADE NOTES
 
 - JSON:
   . Improve performance of encoding arrays and objects.
+  . Improved performance of json_encode() for long ASCII strings.
   . Improved performance of indentation generation in json_encode()
     when using PHP_JSON_PRETTY_PRINT.
 

--- a/ext/json/json_encoder.c
+++ b/ext/json/json_encoder.c
@@ -27,8 +27,54 @@
 #include "zend_enum.h"
 #include "zend_property_hooks.h"
 #include "zend_lazy_objects.h"
+#include "zend_simd.h"
+#include "zend_bitset.h"
 
 static const char digits[] = "0123456789abcdef";
+
+static const uint32_t php_json_encode_charmap[8] = {
+	0xffffffff, 0x500080c4, 0x10000000, 0x00000000,
+	0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+};
+
+#ifdef XSSE2
+static zend_never_inline size_t php_json_safe_prefix(const char *s, size_t len)
+{
+	size_t pos = 0;
+
+	while (pos < len && pos < sizeof(__m128i)
+			&& !ZEND_BIT_TEST(php_json_encode_charmap, (unsigned char) s[pos])) {
+		pos++;
+	}
+	if (pos < len && pos < sizeof(__m128i)) {
+		return pos;
+	}
+	while (len - pos >= sizeof(__m128i)) {
+		__m128i in = _mm_loadu_si128((const __m128i *) (s + pos));
+		/* A signed comparison treats non-ASCII bytes as special as well. */
+		__m128i special = _mm_cmplt_epi8(in, _mm_set1_epi8(' '));
+		uint32_t mask;
+
+		special = _mm_or_si128(special, _mm_cmpeq_epi8(in, _mm_set1_epi8('"')));
+		special = _mm_or_si128(special, _mm_cmpeq_epi8(in, _mm_set1_epi8('&')));
+		special = _mm_or_si128(special, _mm_cmpeq_epi8(in, _mm_set1_epi8('\'')));
+		special = _mm_or_si128(special, _mm_cmpeq_epi8(in, _mm_set1_epi8('/')));
+		special = _mm_or_si128(special, _mm_cmpeq_epi8(in, _mm_set1_epi8('<')));
+		special = _mm_or_si128(special, _mm_cmpeq_epi8(in, _mm_set1_epi8('>')));
+		special = _mm_or_si128(special, _mm_cmpeq_epi8(in, _mm_set1_epi8('\\')));
+		mask = _mm_movemask_epi8(special);
+		if (mask) {
+			return pos + zend_ulong_ntz(mask);
+		}
+		pos += sizeof(__m128i);
+	}
+
+	while (pos < len && !ZEND_BIT_TEST(php_json_encode_charmap, (unsigned char) s[pos])) {
+		pos++;
+	}
+	return pos;
+}
+#endif
 
 static zend_always_inline bool php_json_check_stack_limit(void)
 {
@@ -380,15 +426,27 @@ zend_result php_json_escape_string(
 	smart_str_alloc(buf, len+2, 0);
 	smart_str_appendc(buf, '"');
 
+#ifdef XSSE2
+	if (len >= 2 * sizeof(__m128i) && !(options & PHP_JSON_UNESCAPED_UNICODE)) {
+		size_t safe_prefix = php_json_safe_prefix(s, len);
+
+		if (safe_prefix) {
+			smart_str_appendl(buf, s, safe_prefix);
+			s += safe_prefix;
+			len -= safe_prefix;
+			if (len == 0) {
+				smart_str_appendc(buf, '"');
+				return SUCCESS;
+			}
+		}
+	}
+#endif
+
 	pos = 0;
 
 	do {
-		static const uint32_t charmap[8] = {
-			0xffffffff, 0x500080c4, 0x10000000, 0x00000000,
-			0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff};
-
 		unsigned int us = (unsigned char)s[pos];
-		if (EXPECTED(!ZEND_BIT_TEST(charmap, us))) {
+		if (EXPECTED(!ZEND_BIT_TEST(php_json_encode_charmap, us))) {
 			pos++;
 			len--;
 			if (len == 0) {

--- a/ext/json/tests/json_encode_simd_boundaries.phpt
+++ b/ext/json/tests/json_encode_simd_boundaries.phpt
@@ -1,0 +1,89 @@
+--TEST--
+json_encode() SIMD scanner boundaries
+--FILE--
+<?php
+
+function check(string $input, int $flags, string|false $expected, string $label): void
+{
+    $actual = json_encode($input, $flags);
+    if ($actual !== $expected) {
+        printf(
+            "FAIL %s\nExpected: %s\nActual:   %s\n",
+            $label,
+            var_export($expected, true),
+            var_export($actual, true),
+        );
+    }
+}
+
+foreach ([31, 32, 33, 47, 48, 63, 64, 65] as $length) {
+    $input = str_repeat('a', $length);
+    check($input, 0, '"' . $input . '"', "safe input of length $length");
+}
+
+$escapes = [
+    "\x00" => '\u0000',
+    "\x08" => '\b',
+    "\x09" => '\t',
+    "\x0a" => '\n',
+    "\x0c" => '\f',
+    "\x0d" => '\r',
+    "\x1f" => '\u001f',
+    '"' => '\"',
+    '&' => '&',
+    "'" => "'",
+    '/' => '\/',
+    '<' => '<',
+    '>' => '>',
+    '\\' => '\\\\',
+    "\u{100}" => '\u0100',
+];
+
+foreach ([15, 16, 31, 32, 47, 48] as $position) {
+    $prefix = str_repeat('a', $position);
+    $suffix = str_repeat('b', 64 - $position);
+    foreach ($escapes as $character => $escape) {
+        check(
+            $prefix . $character . $suffix,
+            0,
+            '"' . $prefix . $escape . $suffix . '"',
+            sprintf("character %s at position %d", bin2hex($character), $position),
+        );
+    }
+}
+
+check(
+    str_repeat('a', 32) . '<>&\'"',
+    JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT,
+    '"' . str_repeat('a', 32) . '\u003C\u003E\u0026\u0027\u0022"',
+    'JSON_HEX_* flags',
+);
+check(
+    str_repeat('a', 32) . '/',
+    JSON_UNESCAPED_SLASHES,
+    '"' . str_repeat('a', 32) . '/"',
+    'JSON_UNESCAPED_SLASHES',
+);
+check(
+    str_repeat('a', 32) . "\xff",
+    JSON_INVALID_UTF8_SUBSTITUTE,
+    '"' . str_repeat('a', 32) . '\ufffd"',
+    'JSON_INVALID_UTF8_SUBSTITUTE',
+);
+check(
+    str_repeat('a', 32) . "\xff",
+    JSON_INVALID_UTF8_IGNORE,
+    '"' . str_repeat('a', 32) . '"',
+    'JSON_INVALID_UTF8_IGNORE',
+);
+check(
+    str_repeat('a', 32) . "\xff",
+    0,
+    false,
+    'invalid UTF-8',
+);
+
+echo "Done\n";
+?>
+--EXPECT--
+Done


### PR DESCRIPTION
## Summary

Speed up `json_encode()` for long ASCII strings using `zend_simd.h`.

The SIMD scanner finds the first byte requiring special handling. The safe prefix
is appended in one operation, then the existing scalar encoder resumes at the
special byte. Short strings, unsupported architectures, and
`JSON_UNESCAPED_UNICODE` keep the existing path.

No API or behavior changes.

## Benchmarks

Ryzen 9 5900X, GCC 13.3, `-O2`, CPU-pinned. Median of three alternating runs;
each run uses seven samples.

| Workload | Before | After | Change |
|---|---:|---:|---:|
| ASCII, 256 B | 177.9 ns | 77.9 ns | 2.28× faster |
| ASCII, 4 KiB | 3098.5 ns | 1457.8 ns | 2.13× faster |
| ASCII, 64 KiB | 49191.9 ns | 22270.8 ns | 2.21× faster |
| Long-ASCII record payload | 28171.8 ns | 22217.4 ns | 1.27× faster |
| Sparse-escape record payload | 28483.7 ns | 22551.4 ns | 1.26× faster |
| UTF-8 record payload | 78133.0 ns | 78578.1 ns | Flat |

The reproducible harness is included as `ext/json/bench.php`.

## Validation

- Debug suite: 13,444 passed, 0 failed.
- Debug+ZTS JSON suite: 101 passed, 0 failed.
- Added SIMD-boundary, escaping-option, Unicode, and invalid UTF-8 coverage.

## Benchmark file
```
#!/usr/bin/env php
<?php

error_reporting(E_ALL);

function make_records(string $description): array
{
    $records = [];
    for ($i = 0; $i < 100; $i++) {
        $records[] = [
            'id' => sprintf('item-%08d', $i),
            'url' => 'https://example.com/api/items/' . str_repeat('a', 96),
            'description' => $description,
            'active' => true,
            'count' => $i,
        ];
    }
    return $records;
}

$cases = [
    'ascii_16' => ['abcdefghijklmnop', 0],
    'ascii_256' => [str_repeat('abcdefghijklmnop', 16), 0],
    'ascii_4k' => [str_repeat('abcdefghijklmnop', 256), 0],
    'ascii_64k' => [str_repeat('abcdefghijklmnop', 4096), 0],
    'sparse_escapes' => [str_repeat(str_repeat('a', 255) . '"', 16), 0],
    'dense_escapes' => [str_repeat("a\"b\\c\nd/e\t", 342), 0],
    'utf8_default' => [str_repeat('Zażółć gęślą jaźń. ', 195), 0],
    'utf8_unescaped' => [
        str_repeat('Zażółć gęślą jaźń. ', 195),
        JSON_UNESCAPED_UNICODE,
    ],
    'html_options' => [
        str_repeat("<tag attr='value'>&\"/", 186),
        JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT,
    ],
    'invalid_utf8' => [
        str_repeat(str_repeat('a', 255) . "\xff", 16),
        JSON_INVALID_UTF8_SUBSTITUTE,
    ],
    'records_long_ascii' => [
        make_records(str_repeat('abcdefghijklmnop', 16)),
        0,
    ],
    'records_sparse_escapes' => [
        make_records(str_repeat('a', 255) . '"'),
        0,
    ],
    'records_utf8' => [
        make_records(str_repeat('Zażółć gęślą jaźń. ', 12)),
        0,
    ],
];

if (count($argv) > 1) {
    $selectedCases = [];
    foreach (array_slice($argv, 1) as $name) {
        if (!isset($cases[$name])) {
            fprintf(STDERR, "Unknown case: %s\n", $name);
            fprintf(
                STDERR,
                "Available cases: %s\n",
                implode(', ', array_keys($cases)),
            );
            exit(1);
        }
        $selectedCases[$name] = $cases[$name];
    }
    $cases = $selectedCases;
}

printf("case,workload_bytes,iterations,median_ns_per_call,mib_per_second,checksum\n");

foreach ($cases as $name => [$value, $options]) {
    if (is_string($value)) {
        $workloadBytes = strlen($value);
    } else {
        $encoded = json_encode($value, $options);
        if ($encoded === false) {
            fprintf(STDERR, "Failed to encode benchmark case: %s\n", $name);
            exit(1);
        }
        $workloadBytes = strlen($encoded);
    }

    $iterations = max(100, intdiv(128 * 1024 * 1024, $workloadBytes));
    $samples = [];
    $checksum = 0;

    for ($run = 0; $run < 7; $run++) {
        $start = hrtime(true);
        for ($i = 0; $i < $iterations; $i++) {
            $encoded = json_encode($value, $options);
            $checksum += strlen($encoded);
        }
        $samples[] = (hrtime(true) - $start) / $iterations;
    }

    sort($samples);
    $median = $samples[intdiv(count($samples), 2)];
    $mibPerSecond = $workloadBytes / $median * 1_000_000_000 / (1024 * 1024);
    printf(
        "%s,%d,%d,%.1f,%.1f,%d\n",
        $name,
        $workloadBytes,
        $iterations,
        $median,
        $mibPerSecond,
        $checksum,
    );
}

```

> Disclosure: This PR was created with LLM assistance and reviewed by
> the contributor.
