### PR TITLE
Run scandir overflow test on Windows only

### DIFF
--- a/ext/standard/tests/file/bug36365.phpt
+++ b/ext/standard/tests/file/bug36365.phpt
@@ -2,6 +2,7 @@
 Bug #36365 (scandir duplicates file name at every 65535th file)
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY !== 'Windows') die('skip Windows only');
 if (getenv("SKIP_SLOW_TESTS")) die('skip slow test');
 ?>
 --FILE--


### PR DESCRIPTION
Extracted from https://github.com/php/php-src/pull/22917.

Avoids creating 70,000 files on platforms unaffected by the Win32 DIR_W32.offset regression. Shaves ~9s off non-Windows test runs.

Ref: https://github.com/php/php-src/commit/d3cc9e2dd542338bd650ac476247009d1a47849b#commitcomment-194333406 
cc @arnaud-lb 