### PR TITLE
ext/curl: hide sensitive parameters to curl_setopt

### DIFF
--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1694,6 +1694,10 @@ ZEND_FUNCTION(get_defined_constants)
 
 static bool backtrace_is_arg_sensitive(const zend_execute_data *call, uint32_t offset)
 {
+	if (call->sensitive_args & (1u << offset)) {
+		return true;
+	}
+
 	const zend_attribute *attribute = zend_get_parameter_attribute_str(
 		call->func->common.attributes,
 		"sensitiveparameter",

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -652,6 +652,7 @@ struct _zend_execute_data {
 	zend_array          *symbol_table;
 	void               **run_time_cache;   /* cache op_array->run_time_cache */
 	zend_array          *extra_named_params;
+	uint32_t             sensitive_args;   /* bitmask for args */
 };
 
 #define ZEND_CALL_HAS_THIS           IS_OBJECT_EX

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -4453,6 +4453,7 @@ static zend_always_inline void i_init_func_execute_data(zend_op_array *op_array,
 #endif
 	EX(call) = NULL;
 	EX(return_value) = return_value;
+	EX(sensitive_args) = 0;
 
 	/* Handle arguments */
 	first_extra_arg = op_array->num_args;
@@ -4540,6 +4541,7 @@ static zend_always_inline void i_init_code_execute_data(zend_execute_data *execu
 	EX(opline) = op_array->opcodes;
 	EX(call) = NULL;
 	EX(return_value) = return_value;
+	EX(sensitive_args) = 0;
 
 	if (op_array->last_var) {
 		zend_attach_symbol_table(execute_data);

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -1637,8 +1637,6 @@ static zend_result _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue
 		case CURLOPT_USERPWD:
 		case CURLOPT_XOAUTH2_BEARER:
 			EG(current_execute_data)->sensitive_args |= (1u << 2);
-		default:
-			// do nothing
 	}
 
 	switch (option) {

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -1626,6 +1626,22 @@ static zend_result _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue
 	zend_long lval;
 
 	switch (option) {
+		case CURLOPT_KEYPASSWD:
+		case CURLOPT_PASSWORD:
+		case CURLOPT_PROXY_KEYPASSWD:
+		case CURLOPT_PROXY_TLSAUTH_PASSWORD:
+		case CURLOPT_PROXYPASSWORD:
+		case CURLOPT_PROXYUSERPWD:
+		case CURLOPT_SSLKEY_BLOB:
+		case CURLOPT_TLSAUTH_PASSWORD:
+		case CURLOPT_USERPWD:
+		case CURLOPT_XOAUTH2_BEARER:
+			EG(current_execute_data)->sensitive_args |= (1u << 2);
+		default:
+			// do nothing
+	}
+
+	switch (option) {
 		/* Callable options */
 		HANDLE_CURL_OPTION_CALLABLE_PHP_CURL_USER(ch, CURLOPT_WRITE, write, PHP_CURL_STDOUT);
 		HANDLE_CURL_OPTION_CALLABLE_PHP_CURL_USER(ch, CURLOPT_HEADER, write_header, PHP_CURL_IGNORE);


### PR DESCRIPTION
This makes it possible to mark parameters as sensitive at runtime.

curl_setopt takes many types of parameters, of which only some are secret. This tries to hide the sensitive values in stack traces, while still showing benign values.

I am not sure this is a good idea, please let me know what you think.

Ping @TimWolla, as the author of https://wiki.php.net/rfc/redact_parameters_in_back_traces.

