### PR TITLE
configuring copy_file_range: linking check instead of compiling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -695,7 +695,7 @@ AS_VAR_IF([php_cv_func_getaddrinfo], [yes],
 dnl on FreeBSD, copy_file_range() works only with the undocumented flag 0x01000000;
 dnl until the problem is fixed properly, copy_file_range() is used only on Linux
 AC_CACHE_CHECK([for copy_file_range], [php_cv_func_copy_file_range],
-[AC_COMPILE_IFELSE([AC_LANG_SOURCE([
+[AC_LINK_IFELSE([AC_LANG_SOURCE([
 #ifndef __linux__
 # error "unsupported platform"
 #endif


### PR DESCRIPTION
For me compiling works but later linking not

 - refs https://github.com/Freetz-NG/freetz-ng/commit/1dd4b9c74a604c5cfa1c4babef12fba4aabcc9fe