### PR TITLE
Select Windows test workers automatically

### DIFF
--- a/.github/matrix.php
+++ b/.github/matrix.php
@@ -187,6 +187,7 @@ $repository = $argv[5] ?? null;
 foreach ($branches as &$branch) {
     $php_version = $branch['version'][0] . '.' . $branch['version'][1];
     $branch['jobs'] = select_jobs($repository, $trigger, $nightly, $labels, $php_version, $branch['ref'], $all_variations);
+    $branch['config']['default_run_test_jobs'] = version_compare($php_version, '8.6', '>=') ? '' : '-j2';
     $branch['config']['ubuntu_version'] = version_compare($php_version, '8.5', '>=') ? '24.04' : '22.04';
 }
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -857,7 +857,7 @@ jobs:
       PLATFORM: ${{ matrix.x64 && 'x64' || 'x86' }}
       THREAD_SAFE: "${{ matrix.zts && '1' || '0' }}"
       INTRINSICS: "${{ matrix.zts && 'AVX2' || '' }}"
-      PARALLEL: -j2
+      PARALLEL: ${{ matrix.asan && '-j2' || fromJson(inputs.branch).config.default_run_test_jobs }}
       OPCACHE: "${{ matrix.opcache && '1' || '0' }}"
       ASAN: "${{ matrix.asan && '1' || '0' }}"
       CLANG_TOOLSET: "${{ matrix.clang && '1' || '0' }}"

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -857,7 +857,7 @@ jobs:
       PLATFORM: ${{ matrix.x64 && 'x64' || 'x86' }}
       THREAD_SAFE: "${{ matrix.zts && '1' || '0' }}"
       INTRINSICS: "${{ matrix.zts && 'AVX2' || '' }}"
-      PARALLEL: -j2
+      PARALLEL: ${{ matrix.asan && '-j2' || '' }}
       OPCACHE: "${{ matrix.opcache && '1' || '0' }}"
       ASAN: "${{ matrix.asan && '1' || '0' }}"
       CLANG_TOOLSET: "${{ matrix.clang && '1' || '0' }}"


### PR DESCRIPTION
Extracted from https://github.com/php/php-src/pull/22917.

Removes the hard-coded `-j2` from Windows CI so `run-tests.php` selects the worker count automatically. Depends on #22939 for automatic selection and #22957 for reliable concurrent subprocess execution.
