### PR TITLE
Make socket tests robust in restricted environments

### DIFF
--- a/ext/sockets/tests/bug76839.phpt
+++ b/ext/sockets/tests/bug76839.phpt
@@ -7,6 +7,7 @@ sockets
 if (strtolower(substr(PHP_OS, 0, 3)) === 'win') {
     die('skip not valid for Windows.');
 }
+require __DIR__ . '/unix_dgram_skipif.inc';
 ?>
 --FILE--
 <?php
@@ -16,11 +17,11 @@ if (strtolower(substr(PHP_OS, 0, 3)) === 'win') {
 // best way I could manage to reproduce this problem without modifying php itself :-/
 
 for ($i = 0; $i < 10; $i++) {
-    $senderSocketPath = '/tmp/' . substr(md5(rand()), 0, rand(8, 16)) . '.sock';
+    $senderSocketPath = sys_get_temp_dir() . '/' . substr(md5(rand()), 0, rand(8, 16)) . '.sock';
     $senderSocket = socket_create(AF_UNIX, SOCK_DGRAM, 0);
     socket_bind($senderSocket, $senderSocketPath);
 
-    $receiverSocketPath = '/tmp/' . substr(md5(rand()), 0, rand(8, 16)) . '.sock';
+    $receiverSocketPath = sys_get_temp_dir() . '/' . substr(md5(rand()), 0, rand(8, 16)) . '.sock';
     $receiverSocket = socket_create(AF_UNIX, SOCK_DGRAM, 0);
     socket_bind($receiverSocket, $receiverSocketPath);
 

--- a/ext/sockets/tests/gh20532.phpt
+++ b/ext/sockets/tests/gh20532.phpt
@@ -7,7 +7,7 @@ sockets
 $error_code = 0;
 var_dump(socket_addrinfo_lookup(".whynot", null, [], $error_code) === false && in_array($error_code, [EAI_NONAME, EAI_FAIL], true));
 var_dump(socket_addrinfo_lookup("2001:db8::1", null, ['ai_family' => AF_INET], $error_code) === false && in_array($error_code, [EAI_FAMILY, EAI_ADDRFAMILY, EAI_NONAME, EAI_NODATA]));
-var_dump(socket_addrinfo_lookup("example.com", "http", ['ai_socktype' => SOCK_RAW, 'ai_flags' => 2147483647], $error_code) === false && in_array($error_code, [EAI_SOCKTYPE, EAI_SERVICE, EAI_BADFLAGS, EAI_NONAME]));
+var_dump(socket_addrinfo_lookup("localhost", "http", ['ai_socktype' => SOCK_RAW, 'ai_flags' => 2147483647], $error_code) === false && in_array($error_code, [EAI_SOCKTYPE, EAI_SERVICE, EAI_BADFLAGS, EAI_NONAME]));
 ?>
 --EXPECT--
 bool(true)

--- a/ext/sockets/tests/socket_sendmsg_scm_rights_object.phpt
+++ b/ext/sockets/tests/socket_sendmsg_scm_rights_object.phpt
@@ -13,6 +13,7 @@ if (strtolower(substr(PHP_OS, 0, 3)) == 'aix') {
 if (!defined('SCM_RIGHTS')) {
     die('skip SCM_RIGHTS not available');
 }
+require __DIR__ . '/unix_dgram_skipif.inc';
 ?>
 --FILE--
 <?php

--- a/ext/sockets/tests/unix_dgram_skipif.inc
+++ b/ext/sockets/tests/unix_dgram_skipif.inc
@@ -1,0 +1,31 @@
+<?php
+
+$socketPath = tempnam(sys_get_temp_dir(), 'php_socket_');
+if ($socketPath === false) {
+    die('skip unable to create a temporary socket path');
+}
+unlink($socketPath);
+
+$socket = socket_create(AF_UNIX, SOCK_DGRAM, 0);
+if ($socket === false || !@socket_bind($socket, $socketPath)) {
+    $error = socket_last_error($socket !== false ? $socket : null);
+    if ($socket !== false) {
+        socket_close($socket);
+    }
+    @unlink($socketPath);
+
+    $unavailableErrors = array_filter([
+        defined('SOCKET_EPERM') ? SOCKET_EPERM : null,
+        defined('SOCKET_EACCES') ? SOCKET_EACCES : null,
+        defined('SOCKET_EAFNOSUPPORT') ? SOCKET_EAFNOSUPPORT : null,
+        defined('SOCKET_EPROTONOSUPPORT') ? SOCKET_EPROTONOSUPPORT : null,
+        defined('SOCKET_ESOCKTNOSUPPORT') ? SOCKET_ESOCKTNOSUPPORT : null,
+        defined('SOCKET_EOPNOTSUPP') ? SOCKET_EOPNOTSUPP : null,
+    ], static fn(?int $error): bool => $error !== null);
+    if (in_array($error, $unavailableErrors, true)) {
+        die('skip unable to bind an AF_UNIX datagram socket');
+    }
+    die('unexpected AF_UNIX datagram bind failure: ' . socket_strerror($error));
+}
+socket_close($socket);
+unlink($socketPath);


### PR DESCRIPTION
Extracted from https://github.com/php/php-src/pull/22917.

Makes socket tests independent of external DNS and hard-coded temporary paths, and skips Unix datagram tests --only when the environment does not support them; otherwise original test coverage applies.