### PR TITLE
soap: use `php_error_docref` consistently

### DIFF
--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -376,7 +376,7 @@ static xmlNodePtr master_to_xml_int(encodePtr encode, zval *data, int style, xml
 
 		zval *ztype = Z_VAR_ENC_TYPE_P(data);
 		if (Z_TYPE_P(ztype) != IS_LONG) {
-			soap_error(E_ERROR, "Encoding: SoapVar has no 'enc_type' property");
+			php_error_docref(NULL, E_ERROR, "Encoding: SoapVar has no 'enc_type' property");
 		}
 
 		zval *zstype = Z_VAR_ENC_STYPE_P(data);
@@ -591,7 +591,7 @@ xmlNodePtr to_xml_user(encodeTypePtr type, zval *data, int style, xmlNodePtr par
 		ZVAL_NULL(&return_value);
 
 		if (call_user_function(NULL, NULL, &type->map->to_xml, &return_value, 1, data) == FAILURE) {
-			soap_error(E_ERROR, "Encoding: Error calling to_xml callback");
+			php_error_docref(NULL, E_ERROR, "Encoding: Error calling to_xml callback");
 		}
 		if (Z_TYPE(return_value) == IS_STRING) {
 			xmlDocPtr doc = soap_xmlParseMemory(Z_STRVAL(return_value), Z_STRLEN(return_value));
@@ -628,7 +628,7 @@ zval *to_zval_user(zval *ret, encodeTypePtr type, xmlNodePtr node)
 		xmlFreeNode(copy);
 
 		if (call_user_function(NULL, NULL, &type->map->to_zval, ret, 1, &data) == FAILURE) {
-			soap_error(E_ERROR, "Encoding: Error calling from_xml callback");
+			php_error_docref(NULL, E_ERROR, "Encoding: Error calling from_xml callback");
 		} else if (EG(exception)) {
 			ZVAL_NULL(ret);
 		}
@@ -665,7 +665,7 @@ static zval *to_zval_string(zval *ret, encodeTypePtr type, xmlNodePtr data)
 		} else if (data->children->type == XML_CDATA_SECTION_NODE && data->children->next == NULL) {
 			ZVAL_STRING(ret, (char*)data->children->content);
 		} else {
-			soap_error(E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
+			php_error_docref(NULL, E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
 		}
 	} else {
 		ZVAL_EMPTY_STRING(ret);
@@ -698,7 +698,7 @@ static zval *to_zval_stringr(zval *ret, encodeTypePtr type, xmlNodePtr data)
 		} else if (data->children->type == XML_CDATA_SECTION_NODE && data->children->next == NULL) {
 			ZVAL_STRING(ret, (char*)data->children->content);
 		} else {
-			soap_error(E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
+			php_error_docref(NULL, E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
 		}
 	} else {
 		ZVAL_EMPTY_STRING(ret);
@@ -731,7 +731,7 @@ static zval *to_zval_stringc(zval *ret, encodeTypePtr type, xmlNodePtr data)
 		} else if (data->children->type == XML_CDATA_SECTION_NODE && data->children->next == NULL) {
 			ZVAL_STRING(ret, (char*)data->children->content);
 		} else {
-			soap_error(E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
+			php_error_docref(NULL, E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
 		}
 	} else {
 		ZVAL_EMPTY_STRING(ret);
@@ -750,17 +750,17 @@ static zval *to_zval_base64(zval *ret, encodeTypePtr type, xmlNodePtr data)
 			whiteSpace_collapse(data->children->content);
 			str = php_base64_decode(data->children->content, strlen((char*)data->children->content));
 			if (!str) {
-				soap_error(E_ERROR, "Encoding: Invalid value for type '%s'", soap_type_name(type));
+				php_error_docref(NULL, E_ERROR, "Encoding: Invalid value for type '%s'", soap_type_name(type));
 			}
 			ZVAL_STR(ret, str);
 		} else if (data->children->type == XML_CDATA_SECTION_NODE && data->children->next == NULL) {
 			str = php_base64_decode(data->children->content, strlen((char*)data->children->content));
 			if (!str) {
-				soap_error(E_ERROR, "Encoding: Invalid value for type '%s'", soap_type_name(type));
+				php_error_docref(NULL, E_ERROR, "Encoding: Invalid value for type '%s'", soap_type_name(type));
 			}
 			ZVAL_STR(ret, str);
 		} else {
-			soap_error(E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
+			php_error_docref(NULL, E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
 		}
 	} else {
 		ZVAL_EMPTY_STRING(ret);
@@ -781,12 +781,12 @@ static zval *to_zval_hexbin(zval *ret, encodeTypePtr type, xmlNodePtr data)
 		if (data->children->type == XML_TEXT_NODE && data->children->next == NULL) {
 			whiteSpace_collapse(data->children->content);
 		} else if (data->children->type != XML_CDATA_SECTION_NODE || data->children->next != NULL) {
-			soap_error(E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
+			php_error_docref(NULL, E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
 			return ret;
 		}
 		content_len = strlen((char*) data->children->content);
 		if (content_len % 2 != 0) {
-			soap_error(E_ERROR, "Encoding: Type '%s' value must contain an even number of hexadecimal digits", soap_type_name(type));
+			php_error_docref(NULL, E_ERROR, "Encoding: Type '%s' value must contain an even number of hexadecimal digits", soap_type_name(type));
 			return ret;
 		}
 		str = zend_string_alloc(content_len / 2, 0);
@@ -799,7 +799,7 @@ static zval *to_zval_hexbin(zval *ret, encodeTypePtr type, xmlNodePtr data)
 			} else if (c >= 'A' && c <= 'F') {
 				ZSTR_VAL(str)[i] = (c - 'A' + 10) << 4;
 			} else {
-				soap_error(E_ERROR, "Encoding: Invalid value for type '%s'", soap_type_name(type));
+				php_error_docref(NULL, E_ERROR, "Encoding: Invalid value for type '%s'", soap_type_name(type));
 			}
 			c = data->children->content[j++];
 			if (c >= '0' && c <= '9') {
@@ -809,7 +809,7 @@ static zval *to_zval_hexbin(zval *ret, encodeTypePtr type, xmlNodePtr data)
 			} else if (c >= 'A' && c <= 'F') {
 				ZSTR_VAL(str)[i] |= c - 'A' + 10;
 			} else {
-				soap_error(E_ERROR, "Encoding: Invalid value for type '%s'", soap_type_name(type));
+				php_error_docref(NULL, E_ERROR, "Encoding: Invalid value for type '%s'", soap_type_name(type));
 			}
 		}
 		ZSTR_VAL(str)[ZSTR_LEN(str)] = '\0';
@@ -928,7 +928,7 @@ static xmlNodePtr to_xml_string(encodeTypePtr type, zval *data, int style, xmlNo
 			err[i++] = 0;
 		}
 
-		soap_error(E_ERROR,  "Encoding: string '%s' is not a valid utf-8 string", err);
+		php_error_docref(NULL, E_ERROR,  "Encoding: string '%s' is not a valid utf-8 string", err);
 	}
 
 	text = xmlNewTextLen(BAD_CAST(str), new_len);
@@ -1030,11 +1030,11 @@ static zval *to_zval_double(zval *ret, encodeTypePtr type, xmlNodePtr data)
 					} else if (strncasecmp((char*)data->children->content, "-INF", sizeof("-INF")-1) == 0) {
 						ZVAL_DOUBLE(ret, -php_get_inf());
 					} else {
-						soap_error(E_ERROR, "Encoding: Invalid value for type '%s'", soap_type_name(type));
+						php_error_docref(NULL, E_ERROR, "Encoding: Invalid value for type '%s'", soap_type_name(type));
 					}
 			}
 		} else {
-			soap_error(E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
+			php_error_docref(NULL, E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
 		}
 	} else {
 		ZVAL_NULL(ret);
@@ -1063,10 +1063,10 @@ static zval *to_zval_long(zval *ret, encodeTypePtr type, xmlNodePtr data)
 					ZVAL_DOUBLE(ret, dval);
 					break;
 				default:
-					soap_error(E_ERROR, "Encoding: Invalid value for type '%s'", soap_type_name(type));
+					php_error_docref(NULL, E_ERROR, "Encoding: Invalid value for type '%s'", soap_type_name(type));
 			}
 		} else {
-			soap_error(E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
+			php_error_docref(NULL, E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
 		}
 	} else {
 		ZVAL_NULL(ret);
@@ -1132,7 +1132,7 @@ static zval *to_zval_bool(zval *ret, encodeTypePtr type, xmlNodePtr data)
 	}
 	if (data->children->type != XML_TEXT_NODE || data->children->next != NULL) {
 		// TODO Convert to exception?
-		soap_error(E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
+		php_error_docref(NULL, E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
 	}
 
 	whiteSpace_collapse(data->children->content);
@@ -1314,7 +1314,7 @@ static void model_to_zval_object(zval *ret, sdlContentModelPtr model, xmlNodePtr
 					r_node = check_and_resolve_href(node);
 					if (r_node && r_node->children && r_node->children->content) {
 						if (model->u.element->fixed && strcmp(model->u.element->fixed, (char*)r_node->children->content) != 0) {
-							soap_error(E_ERROR, "Encoding: Element '%s' has fixed value '%s' (value '%s' is not allowed)", model->u.element->name, model->u.element->fixed, r_node->children->content);
+							php_error_docref(NULL, E_ERROR, "Encoding: Element '%s' has fixed value '%s' (value '%s' is not allowed)", model->u.element->name, model->u.element->fixed, r_node->children->content);
 						}
 						master_to_zval(&val, model->u.element->encode, r_node);
 					} else if (model->u.element->fixed) {
@@ -1339,7 +1339,7 @@ static void model_to_zval_object(zval *ret, sdlContentModelPtr model, xmlNodePtr
 							ZVAL_NULL(&val);
 							if (node && node->children && node->children->content) {
 								if (model->u.element->fixed && strcmp(model->u.element->fixed, (char*)node->children->content) != 0) {
-									soap_error(E_ERROR, "Encoding: Element '%s' has fixed value '%s' (value '%s' is not allowed)", model->u.element->name, model->u.element->fixed, node->children->content);
+									php_error_docref(NULL, E_ERROR, "Encoding: Element '%s' has fixed value '%s' (value '%s' is not allowed)", model->u.element->name, model->u.element->fixed, node->children->content);
 								}
 								master_to_zval(&val, model->u.element->encode, node);
 							} else if (model->u.element->fixed) {
@@ -1542,7 +1542,7 @@ static zval *to_zval_object_ex(zval *ret, encodeTypePtr type, xmlNodePtr data, z
 					if (val && val->children && val->children->content) {
 						str_val = (char*)val->children->content;
 						if (attr->fixed && strcmp(attr->fixed, str_val) != 0) {
-							soap_error(E_ERROR, "Encoding: Attribute '%s' has fixed value '%s' (value '%s' is not allowed)", attr->name, attr->fixed, str_val);
+							php_error_docref(NULL, E_ERROR, "Encoding: Attribute '%s' has fixed value '%s' (value '%s' is not allowed)", attr->name, attr->fixed, str_val);
 						}
 					} else if (attr->fixed) {
 						str_val = attr->fixed;
@@ -1665,7 +1665,7 @@ static int model_to_xml_object(xmlNodePtr node, sdlContentModelPtr model, zval *
 							property = master_to_xml(enc, val, style, node);
 							if (property->children && property->children->content &&
 							    model->u.element->fixed && strcmp(model->u.element->fixed, (char*)property->children->content) != 0) {
-								soap_error(E_ERROR, "Encoding: Element '%s' has fixed value '%s' (value '%s' is not allowed)", model->u.element->name, model->u.element->fixed, property->children->content);
+								php_error_docref(NULL, E_ERROR, "Encoding: Element '%s' has fixed value '%s' (value '%s' is not allowed)", model->u.element->name, model->u.element->fixed, property->children->content);
 							}
 						}
 						xmlNodeSetName(property, BAD_CAST(model->u.element->name));
@@ -1687,7 +1687,7 @@ static int model_to_xml_object(xmlNodePtr node, sdlContentModelPtr model, zval *
 						property = master_to_xml(enc, data, style, node);
 						if (property->children && property->children->content &&
 						    model->u.element->fixed && strcmp(model->u.element->fixed, (char*)property->children->content) != 0) {
-							soap_error(E_ERROR, "Encoding: Element '%s' has fixed value '%s' (value '%s' is not allowed)", model->u.element->name, model->u.element->fixed, property->children->content);
+							php_error_docref(NULL, E_ERROR, "Encoding: Element '%s' has fixed value '%s' (value '%s' is not allowed)", model->u.element->name, model->u.element->fixed, property->children->content);
 						}
 					}
 					xmlNodeSetName(property, BAD_CAST(model->u.element->name));
@@ -1714,7 +1714,7 @@ static int model_to_xml_object(xmlNodePtr node, sdlContentModelPtr model, zval *
 				return 2;
 			} else {
 				if (strict) {
-					soap_error(E_ERROR,  "Encoding: object has no '%s' property", model->u.element->name);
+					php_error_docref(NULL, E_ERROR,  "Encoding: object has no '%s' property", model->u.element->name);
 				}
 				return 0;
 			}
@@ -1745,7 +1745,7 @@ static int model_to_xml_object(xmlNodePtr node, sdlContentModelPtr model, zval *
 				return 2;
 			} else {
 				if (strict) {
-					soap_error(E_ERROR,  "Encoding: object has no 'any' property");
+					php_error_docref(NULL, E_ERROR,  "Encoding: object has no 'any' property");
 				}
 				return 0;
 			}
@@ -1950,7 +1950,7 @@ static xmlNodePtr to_xml_object(encodeTypePtr type, zval *data, int style, xmlNo
 							dummy = master_to_xml(attr->encode, zattr, SOAP_LITERAL, xmlParam);
 							if (dummy->children && dummy->children->content) {
 								if (attr->fixed && strcmp(attr->fixed, (char*)dummy->children->content) != 0) {
-									soap_error(E_ERROR, "Encoding: Attribute '%s' has fixed value '%s' (value '%s' is not allowed)", attr->name, attr->fixed, dummy->children->content);
+									php_error_docref(NULL, E_ERROR, "Encoding: Attribute '%s' has fixed value '%s' (value '%s' is not allowed)", attr->name, attr->fixed, dummy->children->content);
 								}
 								/* we need to handle xml: namespace specially, since it is
 								   an implicit schema. Otherwise, use form.
@@ -2052,7 +2052,7 @@ static int calc_dimension_12(const char* str)
 			flag = 1;
 		}
 	  } else if (*str == '*') {
-			soap_error(E_ERROR, "Encoding: '*' may only be first arraySize value in list");
+			php_error_docref(NULL, E_ERROR, "Encoding: '*' may only be first arraySize value in list");
 		} else {
 			flag = 0;
 		}
@@ -2064,7 +2064,7 @@ static int calc_dimension_12(const char* str)
 static void soap_array_position_add_digit(int *position, int digit)
 {
 	if (UNEXPECTED(*position > (INT_MAX - digit) / 10)) {
-		soap_error(E_ERROR, "Encoding: array index out of range");
+		php_error_docref(NULL, E_ERROR, "Encoding: array index out of range");
 	}
 
 	*position = (*position * 10) + digit;
@@ -2092,7 +2092,7 @@ static int* get_position_12(int dimension, const char* str)
 			}
 			soap_array_position_add_digit(&pos[i], *str - '0');
 		} else if (*str == '*') {
-			soap_error(E_ERROR, "Encoding: '*' may only be first arraySize value in list");
+			php_error_docref(NULL, E_ERROR, "Encoding: '*' may only be first arraySize value in list");
 		} else {
 		  flag = 0;
 		}
@@ -2713,7 +2713,7 @@ static zval *to_zval_array(zval *ret, encodeTypePtr type, xmlNodePtr data)
 					efree(pos);
 					zval_ptr_dtor(ret);
 					ZVAL_UNDEF(ret);
-					soap_error(E_ERROR, "Encoding: array index out of range");
+					php_error_docref(NULL, E_ERROR, "Encoding: array index out of range");
 				}
 				pos[i]++;
 				if (pos[i] < dims[i]) {
@@ -2806,12 +2806,12 @@ static zval *to_zval_map(zval *ret, encodeTypePtr type, xmlNodePtr data)
 		FOREACHNODE(trav, "item", item) {
 			xmlKey = get_node(item->children, "key");
 			if (!xmlKey) {
-				soap_error(E_ERROR,  "Encoding: Can't decode apache map, missing key");
+				php_error_docref(NULL, E_ERROR,  "Encoding: Can't decode apache map, missing key");
 			}
 
 			xmlValue = get_node(item->children, "value");
 			if (!xmlValue) {
-				soap_error(E_ERROR,  "Encoding: Can't decode apache map, missing value");
+				php_error_docref(NULL, E_ERROR,  "Encoding: Can't decode apache map, missing value");
 			}
 
 			ZVAL_NULL(&key);
@@ -2824,7 +2824,7 @@ static zval *to_zval_map(zval *ret, encodeTypePtr type, xmlNodePtr data)
 			} else if (Z_TYPE(key) == IS_LONG) {
 				zend_hash_index_update(Z_ARRVAL_P(ret), Z_LVAL(key), &value);
 			} else {
-				soap_error(E_ERROR,  "Encoding: Can't decode apache map, only Strings or Longs are allowed as keys");
+				php_error_docref(NULL, E_ERROR,  "Encoding: Can't decode apache map, only Strings or Longs are allowed as keys");
 			}
 			zval_ptr_dtor(&key);
 		}
@@ -2956,7 +2956,7 @@ static xmlNodePtr to_xml_datetime_ex(encodeTypePtr type, zval *data, char *forma
 		ta = php_localtime_r(&timestamp, &tmbuf);
 		/*ta = php_gmtime_r(&timestamp, &tmbuf);*/
 		if (!ta) {
-			soap_error(E_ERROR, "Encoding: Invalid timestamp " ZEND_LONG_FMT, Z_LVAL_P(data));
+			php_error_docref(NULL, E_ERROR, "Encoding: Invalid timestamp " ZEND_LONG_FMT, Z_LVAL_P(data));
 		}
 
 		buf = (char *) emalloc(buf_len);
@@ -3001,7 +3001,7 @@ static xmlNodePtr to_xml_datetime_ex(encodeTypePtr type, zval *data, char *forma
 				xmlNodeSetContentLen(xmlParam, BAD_CAST(ZSTR_VAL(formatted_date_string)), ZSTR_LEN(formatted_date_string));
 				zend_string_release_ex(formatted_date_string, false);
 			} else {
-				soap_error(E_ERROR, "Encoding: Invalid DateTimeInterface");
+				php_error_docref(NULL, E_ERROR, "Encoding: Invalid DateTimeInterface");
 			}
 		}
 	}
@@ -3101,7 +3101,7 @@ static xmlNodePtr to_xml_list(encodeTypePtr enc, zval *data, int style, xmlNodeP
 				}
 				smart_str_appends(&list, (char*)dummy->children->content);
 			} else {
-				soap_error(E_ERROR,
+				php_error_docref(NULL, E_ERROR,
 					"Encoding: Failed to encode list item of type '%s' for list type '%s'",
 					soap_type_name(&list_enc->details), soap_type_name(enc));
 			}
@@ -3145,7 +3145,7 @@ static xmlNodePtr to_xml_list(encodeTypePtr enc, zval *data, int style, xmlNodeP
 				}
 				smart_str_appends(&list, (char*)dummy->children->content);
 			} else {
-				soap_error(E_ERROR,
+				php_error_docref(NULL, E_ERROR,
 					"Encoding: Failed to encode list item of type '%s' for list type '%s'",
 					soap_type_name(&list_enc->details), soap_type_name(enc));
 			}
@@ -3273,20 +3273,20 @@ zval *sdl_guess_convert_zval(zval *ret, encodeTypePtr enc, xmlNodePtr data)
 		}
 		if (type->restrictions->enumeration) {
 			if (!zend_hash_exists(type->restrictions->enumeration,data->children->content,strlen(data->children->content)+1)) {
-				soap_error(E_WARNING, "Encoding: Restriction: invalid enumeration value \"%s\"", data->children->content);
+				php_error_docref(NULL, E_WARNING, "Encoding: Restriction: invalid enumeration value \"%s\"", data->children->content);
 			}
 		}
 		if (type->restrictions->minLength &&
 		    strlen(data->children->content) < type->restrictions->minLength->value) {
-		  soap_error(E_WARNING, "Encoding: Restriction: length less than 'minLength'");
+		  php_error_docref(NULL, E_WARNING, "Encoding: Restriction: length less than 'minLength'");
 		}
 		if (type->restrictions->maxLength &&
 		    strlen(data->children->content) > type->restrictions->maxLength->value) {
-		  soap_error(E_WARNING, "Encoding: Restriction: length greater than 'maxLength'");
+		  php_error_docref(NULL, E_WARNING, "Encoding: Restriction: length greater than 'maxLength'");
 		}
 		if (type->restrictions->length &&
 		    strlen(data->children->content) != type->restrictions->length->value) {
-		  soap_error(E_WARNING, "Encoding: Restriction: length is not equal to 'length'");
+		  php_error_docref(NULL, E_WARNING, "Encoding: Restriction: length is not equal to 'length'");
 		}
 	}
 */
@@ -3312,7 +3312,7 @@ zval *sdl_guess_convert_zval(zval *ret, encodeTypePtr enc, xmlNodePtr data)
 			}
 			return to_zval_object(ret, enc, data);
 		default:
-			soap_error(E_ERROR, "Encoding: Internal Error");
+			php_error_docref(NULL, E_ERROR, "Encoding: Internal Error");
 			return guess_zval_convert(ret, enc, data);
 	}
 }
@@ -3336,20 +3336,20 @@ xmlNodePtr sdl_guess_convert_xml(encodeTypePtr enc, zval *data, int style, xmlNo
 		if (type->restrictions && Z_TYPE_P(data) == IS_STRING) {
 			if (type->restrictions->enumeration) {
 				if (!zend_hash_exists(type->restrictions->enumeration,Z_STRVAL_P(data),Z_STRLEN_P(data)+1)) {
-					soap_error(E_WARNING, "Encoding: Restriction: invalid enumeration value \"%s\".", Z_STRVAL_P(data));
+					php_error_docref(NULL, E_WARNING, "Encoding: Restriction: invalid enumeration value \"%s\".", Z_STRVAL_P(data));
 				}
 			}
 			if (type->restrictions->minLength &&
 			    Z_STRLEN_P(data) < type->restrictions->minLength->value) {
-			soap_error(E_WARNING, "Encoding: Restriction: length less than 'minLength'");
+			php_error_docref(NULL, E_WARNING, "Encoding: Restriction: length less than 'minLength'");
 			}
 			if (type->restrictions->maxLength &&
 			    Z_STRLEN_P(data) > type->restrictions->maxLength->value) {
-			soap_error(E_WARNING, "Encoding: Restriction: length greater than 'maxLength'");
+			php_error_docref(NULL, E_WARNING, "Encoding: Restriction: length greater than 'maxLength'");
 			}
 			if (type->restrictions->length &&
 			    Z_STRLEN_P(data) != type->restrictions->length->value) {
-			soap_error(E_WARNING, "Encoding: Restriction: length is not equal to 'length'");
+			php_error_docref(NULL, E_WARNING, "Encoding: Restriction: length is not equal to 'length'");
 			}
 		}
 	}
@@ -3380,7 +3380,7 @@ xmlNodePtr sdl_guess_convert_xml(encodeTypePtr enc, zval *data, int style, xmlNo
 			}
 			break;
 		default:
-		soap_error(E_ERROR, "Encoding: Internal Error");
+		php_error_docref(NULL, E_ERROR, "Encoding: Internal Error");
 			break;
 	}
 	if (style == SOAP_ENCODED) {
@@ -3398,12 +3398,12 @@ static xmlNodePtr check_and_resolve_href(xmlNodePtr data)
 			if (href->children->content[0] == '#') {
 				xmlNodePtr ret = get_node_with_attribute_recursive(data->doc->children, NULL, "id", (char*)&href->children->content[1]);
 				if (!ret) {
-					soap_error(E_ERROR, "Encoding: Unresolved reference '%s'", href->children->content);
+					php_error_docref(NULL, E_ERROR, "Encoding: Unresolved reference '%s'", href->children->content);
 				}
 				return ret;
 			} else {
 				/*  TODO: External href....? */
-				soap_error(E_ERROR, "Encoding: External reference '%s'", href->children->content);
+				php_error_docref(NULL, E_ERROR, "Encoding: External reference '%s'", href->children->content);
 			}
 		}
 		/* SOAP 1.2 enc:id enc:ref */
@@ -3419,9 +3419,9 @@ static xmlNodePtr check_and_resolve_href(xmlNodePtr data)
 			}
 			ret = get_node_with_attribute_recursive_ex(data->doc->children, NULL, NULL, "id", (char*)id, SOAP_1_2_ENC_NAMESPACE);
 			if (!ret) {
-				soap_error(E_ERROR, "Encoding: Unresolved reference '%s'", href->children->content);
+				php_error_docref(NULL, E_ERROR, "Encoding: Unresolved reference '%s'", href->children->content);
 			} else if (ret == data) {
-				soap_error(E_ERROR, "Encoding: Violation of id and ref information items '%s'", href->children->content);
+				php_error_docref(NULL, E_ERROR, "Encoding: Violation of id and ref information items '%s'", href->children->content);
 			}
 			return ret;
 		}
@@ -3570,7 +3570,7 @@ encodePtr get_conversion(int encode)
 	encodePtr enc;
 
 	if ((enc = zend_hash_index_find_ptr(&php_soap_defEncIndex, encode)) == NULL) {
-		soap_error(E_ERROR,  "Encoding: Cannot find encoding");
+		php_error_docref(NULL, E_ERROR,  "Encoding: Cannot find encoding");
 		return NULL;
 	} else {
 		return enc;
@@ -3600,7 +3600,7 @@ static encodePtr get_array_type(xmlNodePtr node, zval *array, smart_str *type)
 		    Z_OBJCE_P(tmp) == soap_var_class_entry) {
 			zval *ztype = Z_VAR_ENC_TYPE_P(tmp);
 			if (Z_TYPE_P(ztype) != IS_LONG) {
-				soap_error(E_ERROR,  "Encoding: SoapVar has no 'enc_type' property");
+				php_error_docref(NULL, E_ERROR,  "Encoding: SoapVar has no 'enc_type' property");
 			}
 			cur_type = Z_LVAL_P(ztype);
 			if (cur_type == UNKNOWN_TYPE) {

--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -249,7 +249,7 @@ void whiteSpace_collapse(xmlChar* str)
 		str++;
 	}
 	if (old == ' ') {
-	 	--pos;
+		--pos;
 	}
 	*pos = '\0';
 }
@@ -568,8 +568,8 @@ zval *master_to_zval(zval *ret, encodePtr encode, xmlNodePtr data)
 			         tmp->details.sdl_type->kind != XSD_TYPEKIND_COMPLEX) {
 			    if (enc == tmp->details.sdl_type->encode ||
 			        tmp == tmp->details.sdl_type->encode) {
-			    	enc = NULL;
-			    	break;
+				enc = NULL;
+				break;
 			    }
 			    tmp = tmp->details.sdl_type->encode;
 			  }
@@ -2048,9 +2048,9 @@ static int calc_dimension_12(const char* str)
 	while (*str != '\0') {
 		if (*str >= '0' && *str <= '9') {
 			if (flag == 0) {
-	   		i++;
-	   		flag = 1;
-	   	}
+			i++;
+			flag = 1;
+		}
 	  } else if (*str == '*') {
 			soap_error(E_ERROR, "Encoding: '*' may only be first arraySize value in list");
 		} else {
@@ -2160,18 +2160,18 @@ static void add_xml_array_elements(xmlNodePtr xmlParam,
 		GC_TRY_PROTECT_RECURSION(Z_ARRVAL_P(data));
 
 		ZEND_HASH_FOREACH_VAL_IND(Z_ARRVAL_P(data), zdata) {
-	 		if (j >= dims[0]) {
-	 			break;
-	 		}
+			if (j >= dims[0]) {
+				break;
+			}
 			ZVAL_DEREF(zdata);
 			if (dimension == 1) {
 				if (enc == NULL) {
 					xparam = master_to_xml(get_conversion(Z_TYPE_P(zdata)), zdata, style, xmlParam);
 				} else {
 					xparam = master_to_xml(enc, zdata, style, xmlParam);
-	 			}
+				}
 
-	 			if (type) {
+				if (type) {
 					xmlNodeSetName(xparam, BAD_CAST(type->name));
 				} else if (style == SOAP_LITERAL && enc && enc->details.type_str) {
 					xmlNodeSetName(xparam, BAD_CAST(enc->details.type_str));
@@ -2186,11 +2186,11 @@ static void add_xml_array_elements(xmlNodePtr xmlParam,
 		} ZEND_HASH_FOREACH_END();
 
 		if (dimension == 1) {
-	 		while (j < dims[0]) {
+			while (j < dims[0]) {
 				xparam = xmlNewDocNode(xmlParam->doc, NULL, BAD_CAST("BOGUS"), NULL);
 				xmlAddChild(xmlParam, xparam);
 
-	 			if (type) {
+				if (type) {
 					xmlNodeSetName(xparam, BAD_CAST(type->name));
 				} else if (style == SOAP_LITERAL && enc && enc->details.type_str) {
 					xmlNodeSetName(xparam, BAD_CAST(enc->details.type_str));
@@ -2202,7 +2202,7 @@ static void add_xml_array_elements(xmlNodePtr xmlParam,
 				j++;
 			}
 		} else {
-	 		while (j < dims[0]) {
+			while (j < dims[0]) {
 				add_xml_array_elements(xmlParam, type, enc, ns, dimension-1, dims+1, NULL, style);
 				j++;
 			}
@@ -2212,11 +2212,11 @@ static void add_xml_array_elements(xmlNodePtr xmlParam,
 	} else {
 		for (j=0; j<dims[0]; j++) {
 			if (dimension == 1) {
-	 			xmlNodePtr xparam;
+				xmlNodePtr xparam;
 
 				xparam = xmlNewDocNode(xmlParam->doc, NULL, BAD_CAST("BOGUS"), NULL);
 				xmlAddChild(xmlParam, xparam);
-	 			if (type) {
+				if (type) {
 					xmlNodeSetName(xparam, BAD_CAST(type->name));
 				} else if (style == SOAP_LITERAL && enc && enc->details.type_str) {
 					xmlNodeSetName(xparam, BAD_CAST(enc->details.type_str));
@@ -2359,7 +2359,7 @@ iterator_failed_to_get:
 				if (el != NULL && Z_TYPE_P(el) == IS_ARRAY &&
 				    zend_hash_num_elements(Z_ARRVAL_P(el)) > 0) {
 				    ZEND_HASH_FOREACH_VAL_IND(Z_ARRVAL_P(el), el) {
-				    	break;
+					break;
 				    } ZEND_HASH_FOREACH_END();
 					ZVAL_DEREF(el);
 					if (Z_TYPE_P(el) == IS_ARRAY) {
@@ -2882,8 +2882,8 @@ static zval *guess_zval_convert(zval *ret, encodeTypePtr type, xmlNodePtr data)
 			         tmp->details.sdl_type->kind != XSD_TYPEKIND_COMPLEX) {
 			    if (enc == tmp->details.sdl_type->encode ||
 			        tmp == tmp->details.sdl_type->encode) {
-			    	enc = NULL;
-			    	break;
+				enc = NULL;
+				break;
 			    }
 			    tmp = tmp->details.sdl_type->encode;
 			  }
@@ -3312,7 +3312,7 @@ zval *sdl_guess_convert_zval(zval *ret, encodeTypePtr enc, xmlNodePtr data)
 			}
 			return to_zval_object(ret, enc, data);
 		default:
-	  	soap_error(E_ERROR, "Encoding: Internal Error");
+			soap_error(E_ERROR, "Encoding: Internal Error");
 			return guess_zval_convert(ret, enc, data);
 	}
 }
@@ -3341,15 +3341,15 @@ xmlNodePtr sdl_guess_convert_xml(encodeTypePtr enc, zval *data, int style, xmlNo
 			}
 			if (type->restrictions->minLength &&
 			    Z_STRLEN_P(data) < type->restrictions->minLength->value) {
-		  	soap_error(E_WARNING, "Encoding: Restriction: length less than 'minLength'");
+			soap_error(E_WARNING, "Encoding: Restriction: length less than 'minLength'");
 			}
 			if (type->restrictions->maxLength &&
 			    Z_STRLEN_P(data) > type->restrictions->maxLength->value) {
-		  	soap_error(E_WARNING, "Encoding: Restriction: length greater than 'maxLength'");
+			soap_error(E_WARNING, "Encoding: Restriction: length greater than 'maxLength'");
 			}
 			if (type->restrictions->length &&
 			    Z_STRLEN_P(data) != type->restrictions->length->value) {
-		  	soap_error(E_WARNING, "Encoding: Restriction: length is not equal to 'length'");
+			soap_error(E_WARNING, "Encoding: Restriction: length is not equal to 'length'");
 			}
 		}
 	}
@@ -3380,7 +3380,7 @@ xmlNodePtr sdl_guess_convert_xml(encodeTypePtr enc, zval *data, int style, xmlNo
 			}
 			break;
 		default:
-	  	soap_error(E_ERROR, "Encoding: Internal Error");
+		soap_error(E_ERROR, "Encoding: Internal Error");
 			break;
 	}
 	if (style == SOAP_ENCODED) {

--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -376,7 +376,7 @@ static xmlNodePtr master_to_xml_int(encodePtr encode, zval *data, int style, xml
 
 		zval *ztype = Z_VAR_ENC_TYPE_P(data);
 		if (Z_TYPE_P(ztype) != IS_LONG) {
-			soap_error0(E_ERROR, "Encoding: SoapVar has no 'enc_type' property");
+			soap_error(E_ERROR, "Encoding: SoapVar has no 'enc_type' property");
 		}
 
 		zval *zstype = Z_VAR_ENC_STYPE_P(data);
@@ -591,7 +591,7 @@ xmlNodePtr to_xml_user(encodeTypePtr type, zval *data, int style, xmlNodePtr par
 		ZVAL_NULL(&return_value);
 
 		if (call_user_function(NULL, NULL, &type->map->to_xml, &return_value, 1, data) == FAILURE) {
-			soap_error0(E_ERROR, "Encoding: Error calling to_xml callback");
+			soap_error(E_ERROR, "Encoding: Error calling to_xml callback");
 		}
 		if (Z_TYPE(return_value) == IS_STRING) {
 			xmlDocPtr doc = soap_xmlParseMemory(Z_STRVAL(return_value), Z_STRLEN(return_value));
@@ -628,7 +628,7 @@ zval *to_zval_user(zval *ret, encodeTypePtr type, xmlNodePtr node)
 		xmlFreeNode(copy);
 
 		if (call_user_function(NULL, NULL, &type->map->to_zval, ret, 1, &data) == FAILURE) {
-			soap_error0(E_ERROR, "Encoding: Error calling from_xml callback");
+			soap_error(E_ERROR, "Encoding: Error calling from_xml callback");
 		} else if (EG(exception)) {
 			ZVAL_NULL(ret);
 		}
@@ -665,7 +665,7 @@ static zval *to_zval_string(zval *ret, encodeTypePtr type, xmlNodePtr data)
 		} else if (data->children->type == XML_CDATA_SECTION_NODE && data->children->next == NULL) {
 			ZVAL_STRING(ret, (char*)data->children->content);
 		} else {
-			soap_error1(E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
+			soap_error(E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
 		}
 	} else {
 		ZVAL_EMPTY_STRING(ret);
@@ -698,7 +698,7 @@ static zval *to_zval_stringr(zval *ret, encodeTypePtr type, xmlNodePtr data)
 		} else if (data->children->type == XML_CDATA_SECTION_NODE && data->children->next == NULL) {
 			ZVAL_STRING(ret, (char*)data->children->content);
 		} else {
-			soap_error1(E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
+			soap_error(E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
 		}
 	} else {
 		ZVAL_EMPTY_STRING(ret);
@@ -731,7 +731,7 @@ static zval *to_zval_stringc(zval *ret, encodeTypePtr type, xmlNodePtr data)
 		} else if (data->children->type == XML_CDATA_SECTION_NODE && data->children->next == NULL) {
 			ZVAL_STRING(ret, (char*)data->children->content);
 		} else {
-			soap_error1(E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
+			soap_error(E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
 		}
 	} else {
 		ZVAL_EMPTY_STRING(ret);
@@ -750,17 +750,17 @@ static zval *to_zval_base64(zval *ret, encodeTypePtr type, xmlNodePtr data)
 			whiteSpace_collapse(data->children->content);
 			str = php_base64_decode(data->children->content, strlen((char*)data->children->content));
 			if (!str) {
-				soap_error1(E_ERROR, "Encoding: Invalid value for type '%s'", soap_type_name(type));
+				soap_error(E_ERROR, "Encoding: Invalid value for type '%s'", soap_type_name(type));
 			}
 			ZVAL_STR(ret, str);
 		} else if (data->children->type == XML_CDATA_SECTION_NODE && data->children->next == NULL) {
 			str = php_base64_decode(data->children->content, strlen((char*)data->children->content));
 			if (!str) {
-				soap_error1(E_ERROR, "Encoding: Invalid value for type '%s'", soap_type_name(type));
+				soap_error(E_ERROR, "Encoding: Invalid value for type '%s'", soap_type_name(type));
 			}
 			ZVAL_STR(ret, str);
 		} else {
-			soap_error1(E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
+			soap_error(E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
 		}
 	} else {
 		ZVAL_EMPTY_STRING(ret);
@@ -781,12 +781,12 @@ static zval *to_zval_hexbin(zval *ret, encodeTypePtr type, xmlNodePtr data)
 		if (data->children->type == XML_TEXT_NODE && data->children->next == NULL) {
 			whiteSpace_collapse(data->children->content);
 		} else if (data->children->type != XML_CDATA_SECTION_NODE || data->children->next != NULL) {
-			soap_error1(E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
+			soap_error(E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
 			return ret;
 		}
 		content_len = strlen((char*) data->children->content);
 		if (content_len % 2 != 0) {
-			soap_error1(E_ERROR, "Encoding: Type '%s' value must contain an even number of hexadecimal digits", soap_type_name(type));
+			soap_error(E_ERROR, "Encoding: Type '%s' value must contain an even number of hexadecimal digits", soap_type_name(type));
 			return ret;
 		}
 		str = zend_string_alloc(content_len / 2, 0);
@@ -799,7 +799,7 @@ static zval *to_zval_hexbin(zval *ret, encodeTypePtr type, xmlNodePtr data)
 			} else if (c >= 'A' && c <= 'F') {
 				ZSTR_VAL(str)[i] = (c - 'A' + 10) << 4;
 			} else {
-				soap_error1(E_ERROR, "Encoding: Invalid value for type '%s'", soap_type_name(type));
+				soap_error(E_ERROR, "Encoding: Invalid value for type '%s'", soap_type_name(type));
 			}
 			c = data->children->content[j++];
 			if (c >= '0' && c <= '9') {
@@ -809,7 +809,7 @@ static zval *to_zval_hexbin(zval *ret, encodeTypePtr type, xmlNodePtr data)
 			} else if (c >= 'A' && c <= 'F') {
 				ZSTR_VAL(str)[i] |= c - 'A' + 10;
 			} else {
-				soap_error1(E_ERROR, "Encoding: Invalid value for type '%s'", soap_type_name(type));
+				soap_error(E_ERROR, "Encoding: Invalid value for type '%s'", soap_type_name(type));
 			}
 		}
 		ZSTR_VAL(str)[ZSTR_LEN(str)] = '\0';
@@ -928,7 +928,7 @@ static xmlNodePtr to_xml_string(encodeTypePtr type, zval *data, int style, xmlNo
 			err[i++] = 0;
 		}
 
-		soap_error1(E_ERROR,  "Encoding: string '%s' is not a valid utf-8 string", err);
+		soap_error(E_ERROR,  "Encoding: string '%s' is not a valid utf-8 string", err);
 	}
 
 	text = xmlNewTextLen(BAD_CAST(str), new_len);
@@ -1030,11 +1030,11 @@ static zval *to_zval_double(zval *ret, encodeTypePtr type, xmlNodePtr data)
 					} else if (strncasecmp((char*)data->children->content, "-INF", sizeof("-INF")-1) == 0) {
 						ZVAL_DOUBLE(ret, -php_get_inf());
 					} else {
-						soap_error1(E_ERROR, "Encoding: Invalid value for type '%s'", soap_type_name(type));
+						soap_error(E_ERROR, "Encoding: Invalid value for type '%s'", soap_type_name(type));
 					}
 			}
 		} else {
-			soap_error1(E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
+			soap_error(E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
 		}
 	} else {
 		ZVAL_NULL(ret);
@@ -1063,10 +1063,10 @@ static zval *to_zval_long(zval *ret, encodeTypePtr type, xmlNodePtr data)
 					ZVAL_DOUBLE(ret, dval);
 					break;
 				default:
-					soap_error1(E_ERROR, "Encoding: Invalid value for type '%s'", soap_type_name(type));
+					soap_error(E_ERROR, "Encoding: Invalid value for type '%s'", soap_type_name(type));
 			}
 		} else {
-			soap_error1(E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
+			soap_error(E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
 		}
 	} else {
 		ZVAL_NULL(ret);
@@ -1132,7 +1132,7 @@ static zval *to_zval_bool(zval *ret, encodeTypePtr type, xmlNodePtr data)
 	}
 	if (data->children->type != XML_TEXT_NODE || data->children->next != NULL) {
 		// TODO Convert to exception?
-		soap_error1(E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
+		soap_error(E_ERROR, "Encoding: Type '%s' value must contain a single text or CDATA node", soap_type_name(type));
 	}
 
 	whiteSpace_collapse(data->children->content);
@@ -1314,7 +1314,7 @@ static void model_to_zval_object(zval *ret, sdlContentModelPtr model, xmlNodePtr
 					r_node = check_and_resolve_href(node);
 					if (r_node && r_node->children && r_node->children->content) {
 						if (model->u.element->fixed && strcmp(model->u.element->fixed, (char*)r_node->children->content) != 0) {
-							soap_error3(E_ERROR, "Encoding: Element '%s' has fixed value '%s' (value '%s' is not allowed)", model->u.element->name, model->u.element->fixed, r_node->children->content);
+							soap_error(E_ERROR, "Encoding: Element '%s' has fixed value '%s' (value '%s' is not allowed)", model->u.element->name, model->u.element->fixed, r_node->children->content);
 						}
 						master_to_zval(&val, model->u.element->encode, r_node);
 					} else if (model->u.element->fixed) {
@@ -1339,7 +1339,7 @@ static void model_to_zval_object(zval *ret, sdlContentModelPtr model, xmlNodePtr
 							ZVAL_NULL(&val);
 							if (node && node->children && node->children->content) {
 								if (model->u.element->fixed && strcmp(model->u.element->fixed, (char*)node->children->content) != 0) {
-									soap_error3(E_ERROR, "Encoding: Element '%s' has fixed value '%s' (value '%s' is not allowed)", model->u.element->name, model->u.element->fixed, node->children->content);
+									soap_error(E_ERROR, "Encoding: Element '%s' has fixed value '%s' (value '%s' is not allowed)", model->u.element->name, model->u.element->fixed, node->children->content);
 								}
 								master_to_zval(&val, model->u.element->encode, node);
 							} else if (model->u.element->fixed) {
@@ -1542,7 +1542,7 @@ static zval *to_zval_object_ex(zval *ret, encodeTypePtr type, xmlNodePtr data, z
 					if (val && val->children && val->children->content) {
 						str_val = (char*)val->children->content;
 						if (attr->fixed && strcmp(attr->fixed, str_val) != 0) {
-							soap_error3(E_ERROR, "Encoding: Attribute '%s' has fixed value '%s' (value '%s' is not allowed)", attr->name, attr->fixed, str_val);
+							soap_error(E_ERROR, "Encoding: Attribute '%s' has fixed value '%s' (value '%s' is not allowed)", attr->name, attr->fixed, str_val);
 						}
 					} else if (attr->fixed) {
 						str_val = attr->fixed;
@@ -1665,7 +1665,7 @@ static int model_to_xml_object(xmlNodePtr node, sdlContentModelPtr model, zval *
 							property = master_to_xml(enc, val, style, node);
 							if (property->children && property->children->content &&
 							    model->u.element->fixed && strcmp(model->u.element->fixed, (char*)property->children->content) != 0) {
-								soap_error3(E_ERROR, "Encoding: Element '%s' has fixed value '%s' (value '%s' is not allowed)", model->u.element->name, model->u.element->fixed, property->children->content);
+								soap_error(E_ERROR, "Encoding: Element '%s' has fixed value '%s' (value '%s' is not allowed)", model->u.element->name, model->u.element->fixed, property->children->content);
 							}
 						}
 						xmlNodeSetName(property, BAD_CAST(model->u.element->name));
@@ -1687,7 +1687,7 @@ static int model_to_xml_object(xmlNodePtr node, sdlContentModelPtr model, zval *
 						property = master_to_xml(enc, data, style, node);
 						if (property->children && property->children->content &&
 						    model->u.element->fixed && strcmp(model->u.element->fixed, (char*)property->children->content) != 0) {
-							soap_error3(E_ERROR, "Encoding: Element '%s' has fixed value '%s' (value '%s' is not allowed)", model->u.element->name, model->u.element->fixed, property->children->content);
+							soap_error(E_ERROR, "Encoding: Element '%s' has fixed value '%s' (value '%s' is not allowed)", model->u.element->name, model->u.element->fixed, property->children->content);
 						}
 					}
 					xmlNodeSetName(property, BAD_CAST(model->u.element->name));
@@ -1714,7 +1714,7 @@ static int model_to_xml_object(xmlNodePtr node, sdlContentModelPtr model, zval *
 				return 2;
 			} else {
 				if (strict) {
-					soap_error1(E_ERROR,  "Encoding: object has no '%s' property", model->u.element->name);
+					soap_error(E_ERROR,  "Encoding: object has no '%s' property", model->u.element->name);
 				}
 				return 0;
 			}
@@ -1745,7 +1745,7 @@ static int model_to_xml_object(xmlNodePtr node, sdlContentModelPtr model, zval *
 				return 2;
 			} else {
 				if (strict) {
-					soap_error0(E_ERROR,  "Encoding: object has no 'any' property");
+					soap_error(E_ERROR,  "Encoding: object has no 'any' property");
 				}
 				return 0;
 			}
@@ -1950,7 +1950,7 @@ static xmlNodePtr to_xml_object(encodeTypePtr type, zval *data, int style, xmlNo
 							dummy = master_to_xml(attr->encode, zattr, SOAP_LITERAL, xmlParam);
 							if (dummy->children && dummy->children->content) {
 								if (attr->fixed && strcmp(attr->fixed, (char*)dummy->children->content) != 0) {
-									soap_error3(E_ERROR, "Encoding: Attribute '%s' has fixed value '%s' (value '%s' is not allowed)", attr->name, attr->fixed, dummy->children->content);
+									soap_error(E_ERROR, "Encoding: Attribute '%s' has fixed value '%s' (value '%s' is not allowed)", attr->name, attr->fixed, dummy->children->content);
 								}
 								/* we need to handle xml: namespace specially, since it is
 								   an implicit schema. Otherwise, use form.
@@ -2052,7 +2052,7 @@ static int calc_dimension_12(const char* str)
 	   		flag = 1;
 	   	}
 	  } else if (*str == '*') {
-			soap_error0(E_ERROR, "Encoding: '*' may only be first arraySize value in list");
+			soap_error(E_ERROR, "Encoding: '*' may only be first arraySize value in list");
 		} else {
 			flag = 0;
 		}
@@ -2064,7 +2064,7 @@ static int calc_dimension_12(const char* str)
 static void soap_array_position_add_digit(int *position, int digit)
 {
 	if (UNEXPECTED(*position > (INT_MAX - digit) / 10)) {
-		soap_error0(E_ERROR, "Encoding: array index out of range");
+		soap_error(E_ERROR, "Encoding: array index out of range");
 	}
 
 	*position = (*position * 10) + digit;
@@ -2092,7 +2092,7 @@ static int* get_position_12(int dimension, const char* str)
 			}
 			soap_array_position_add_digit(&pos[i], *str - '0');
 		} else if (*str == '*') {
-			soap_error0(E_ERROR, "Encoding: '*' may only be first arraySize value in list");
+			soap_error(E_ERROR, "Encoding: '*' may only be first arraySize value in list");
 		} else {
 		  flag = 0;
 		}
@@ -2713,7 +2713,7 @@ static zval *to_zval_array(zval *ret, encodeTypePtr type, xmlNodePtr data)
 					efree(pos);
 					zval_ptr_dtor(ret);
 					ZVAL_UNDEF(ret);
-					soap_error0(E_ERROR, "Encoding: array index out of range");
+					soap_error(E_ERROR, "Encoding: array index out of range");
 				}
 				pos[i]++;
 				if (pos[i] < dims[i]) {
@@ -2806,12 +2806,12 @@ static zval *to_zval_map(zval *ret, encodeTypePtr type, xmlNodePtr data)
 		FOREACHNODE(trav, "item", item) {
 			xmlKey = get_node(item->children, "key");
 			if (!xmlKey) {
-				soap_error0(E_ERROR,  "Encoding: Can't decode apache map, missing key");
+				soap_error(E_ERROR,  "Encoding: Can't decode apache map, missing key");
 			}
 
 			xmlValue = get_node(item->children, "value");
 			if (!xmlValue) {
-				soap_error0(E_ERROR,  "Encoding: Can't decode apache map, missing value");
+				soap_error(E_ERROR,  "Encoding: Can't decode apache map, missing value");
 			}
 
 			ZVAL_NULL(&key);
@@ -2824,7 +2824,7 @@ static zval *to_zval_map(zval *ret, encodeTypePtr type, xmlNodePtr data)
 			} else if (Z_TYPE(key) == IS_LONG) {
 				zend_hash_index_update(Z_ARRVAL_P(ret), Z_LVAL(key), &value);
 			} else {
-				soap_error0(E_ERROR,  "Encoding: Can't decode apache map, only Strings or Longs are allowed as keys");
+				soap_error(E_ERROR,  "Encoding: Can't decode apache map, only Strings or Longs are allowed as keys");
 			}
 			zval_ptr_dtor(&key);
 		}
@@ -2956,7 +2956,7 @@ static xmlNodePtr to_xml_datetime_ex(encodeTypePtr type, zval *data, char *forma
 		ta = php_localtime_r(&timestamp, &tmbuf);
 		/*ta = php_gmtime_r(&timestamp, &tmbuf);*/
 		if (!ta) {
-			soap_error1(E_ERROR, "Encoding: Invalid timestamp " ZEND_LONG_FMT, Z_LVAL_P(data));
+			soap_error(E_ERROR, "Encoding: Invalid timestamp " ZEND_LONG_FMT, Z_LVAL_P(data));
 		}
 
 		buf = (char *) emalloc(buf_len);
@@ -3001,7 +3001,7 @@ static xmlNodePtr to_xml_datetime_ex(encodeTypePtr type, zval *data, char *forma
 				xmlNodeSetContentLen(xmlParam, BAD_CAST(ZSTR_VAL(formatted_date_string)), ZSTR_LEN(formatted_date_string));
 				zend_string_release_ex(formatted_date_string, false);
 			} else {
-				soap_error0(E_ERROR, "Encoding: Invalid DateTimeInterface");
+				soap_error(E_ERROR, "Encoding: Invalid DateTimeInterface");
 			}
 		}
 	}
@@ -3101,7 +3101,7 @@ static xmlNodePtr to_xml_list(encodeTypePtr enc, zval *data, int style, xmlNodeP
 				}
 				smart_str_appends(&list, (char*)dummy->children->content);
 			} else {
-				soap_error2(E_ERROR,
+				soap_error(E_ERROR,
 					"Encoding: Failed to encode list item of type '%s' for list type '%s'",
 					soap_type_name(&list_enc->details), soap_type_name(enc));
 			}
@@ -3145,7 +3145,7 @@ static xmlNodePtr to_xml_list(encodeTypePtr enc, zval *data, int style, xmlNodeP
 				}
 				smart_str_appends(&list, (char*)dummy->children->content);
 			} else {
-				soap_error2(E_ERROR,
+				soap_error(E_ERROR,
 					"Encoding: Failed to encode list item of type '%s' for list type '%s'",
 					soap_type_name(&list_enc->details), soap_type_name(enc));
 			}
@@ -3273,20 +3273,20 @@ zval *sdl_guess_convert_zval(zval *ret, encodeTypePtr enc, xmlNodePtr data)
 		}
 		if (type->restrictions->enumeration) {
 			if (!zend_hash_exists(type->restrictions->enumeration,data->children->content,strlen(data->children->content)+1)) {
-				soap_error1(E_WARNING, "Encoding: Restriction: invalid enumeration value \"%s\"", data->children->content);
+				soap_error(E_WARNING, "Encoding: Restriction: invalid enumeration value \"%s\"", data->children->content);
 			}
 		}
 		if (type->restrictions->minLength &&
 		    strlen(data->children->content) < type->restrictions->minLength->value) {
-		  soap_error0(E_WARNING, "Encoding: Restriction: length less than 'minLength'");
+		  soap_error(E_WARNING, "Encoding: Restriction: length less than 'minLength'");
 		}
 		if (type->restrictions->maxLength &&
 		    strlen(data->children->content) > type->restrictions->maxLength->value) {
-		  soap_error0(E_WARNING, "Encoding: Restriction: length greater than 'maxLength'");
+		  soap_error(E_WARNING, "Encoding: Restriction: length greater than 'maxLength'");
 		}
 		if (type->restrictions->length &&
 		    strlen(data->children->content) != type->restrictions->length->value) {
-		  soap_error0(E_WARNING, "Encoding: Restriction: length is not equal to 'length'");
+		  soap_error(E_WARNING, "Encoding: Restriction: length is not equal to 'length'");
 		}
 	}
 */
@@ -3312,7 +3312,7 @@ zval *sdl_guess_convert_zval(zval *ret, encodeTypePtr enc, xmlNodePtr data)
 			}
 			return to_zval_object(ret, enc, data);
 		default:
-	  	soap_error0(E_ERROR, "Encoding: Internal Error");
+	  	soap_error(E_ERROR, "Encoding: Internal Error");
 			return guess_zval_convert(ret, enc, data);
 	}
 }
@@ -3336,20 +3336,20 @@ xmlNodePtr sdl_guess_convert_xml(encodeTypePtr enc, zval *data, int style, xmlNo
 		if (type->restrictions && Z_TYPE_P(data) == IS_STRING) {
 			if (type->restrictions->enumeration) {
 				if (!zend_hash_exists(type->restrictions->enumeration,Z_STRVAL_P(data),Z_STRLEN_P(data)+1)) {
-					soap_error1(E_WARNING, "Encoding: Restriction: invalid enumeration value \"%s\".", Z_STRVAL_P(data));
+					soap_error(E_WARNING, "Encoding: Restriction: invalid enumeration value \"%s\".", Z_STRVAL_P(data));
 				}
 			}
 			if (type->restrictions->minLength &&
 			    Z_STRLEN_P(data) < type->restrictions->minLength->value) {
-		  	soap_error0(E_WARNING, "Encoding: Restriction: length less than 'minLength'");
+		  	soap_error(E_WARNING, "Encoding: Restriction: length less than 'minLength'");
 			}
 			if (type->restrictions->maxLength &&
 			    Z_STRLEN_P(data) > type->restrictions->maxLength->value) {
-		  	soap_error0(E_WARNING, "Encoding: Restriction: length greater than 'maxLength'");
+		  	soap_error(E_WARNING, "Encoding: Restriction: length greater than 'maxLength'");
 			}
 			if (type->restrictions->length &&
 			    Z_STRLEN_P(data) != type->restrictions->length->value) {
-		  	soap_error0(E_WARNING, "Encoding: Restriction: length is not equal to 'length'");
+		  	soap_error(E_WARNING, "Encoding: Restriction: length is not equal to 'length'");
 			}
 		}
 	}
@@ -3380,7 +3380,7 @@ xmlNodePtr sdl_guess_convert_xml(encodeTypePtr enc, zval *data, int style, xmlNo
 			}
 			break;
 		default:
-	  	soap_error0(E_ERROR, "Encoding: Internal Error");
+	  	soap_error(E_ERROR, "Encoding: Internal Error");
 			break;
 	}
 	if (style == SOAP_ENCODED) {
@@ -3398,12 +3398,12 @@ static xmlNodePtr check_and_resolve_href(xmlNodePtr data)
 			if (href->children->content[0] == '#') {
 				xmlNodePtr ret = get_node_with_attribute_recursive(data->doc->children, NULL, "id", (char*)&href->children->content[1]);
 				if (!ret) {
-					soap_error1(E_ERROR, "Encoding: Unresolved reference '%s'", href->children->content);
+					soap_error(E_ERROR, "Encoding: Unresolved reference '%s'", href->children->content);
 				}
 				return ret;
 			} else {
 				/*  TODO: External href....? */
-				soap_error1(E_ERROR, "Encoding: External reference '%s'", href->children->content);
+				soap_error(E_ERROR, "Encoding: External reference '%s'", href->children->content);
 			}
 		}
 		/* SOAP 1.2 enc:id enc:ref */
@@ -3419,9 +3419,9 @@ static xmlNodePtr check_and_resolve_href(xmlNodePtr data)
 			}
 			ret = get_node_with_attribute_recursive_ex(data->doc->children, NULL, NULL, "id", (char*)id, SOAP_1_2_ENC_NAMESPACE);
 			if (!ret) {
-				soap_error1(E_ERROR, "Encoding: Unresolved reference '%s'", href->children->content);
+				soap_error(E_ERROR, "Encoding: Unresolved reference '%s'", href->children->content);
 			} else if (ret == data) {
-				soap_error1(E_ERROR, "Encoding: Violation of id and ref information items '%s'", href->children->content);
+				soap_error(E_ERROR, "Encoding: Violation of id and ref information items '%s'", href->children->content);
 			}
 			return ret;
 		}
@@ -3570,7 +3570,7 @@ encodePtr get_conversion(int encode)
 	encodePtr enc;
 
 	if ((enc = zend_hash_index_find_ptr(&php_soap_defEncIndex, encode)) == NULL) {
-		soap_error0(E_ERROR,  "Encoding: Cannot find encoding");
+		soap_error(E_ERROR,  "Encoding: Cannot find encoding");
 		return NULL;
 	} else {
 		return enc;
@@ -3600,7 +3600,7 @@ static encodePtr get_array_type(xmlNodePtr node, zval *array, smart_str *type)
 		    Z_OBJCE_P(tmp) == soap_var_class_entry) {
 			zval *ztype = Z_VAR_ENC_TYPE_P(tmp);
 			if (Z_TYPE_P(ztype) != IS_LONG) {
-				soap_error0(E_ERROR,  "Encoding: SoapVar has no 'enc_type' property");
+				soap_error(E_ERROR,  "Encoding: SoapVar has no 'enc_type' property");
 			}
 			cur_type = Z_LVAL_P(ztype);
 			if (cur_type == UNKNOWN_TYPE) {

--- a/ext/soap/php_http.c
+++ b/ext/soap/php_http.c
@@ -1526,7 +1526,7 @@ static zend_string* get_http_body(php_stream *stream, bool close, zend_string *h
 						  break;
 						}
 						len_size += len_read;
-	 					http_buf_size += len_read;
+						http_buf_size += len_read;
 					}
 
 					/* Eat up '\r' '\n' */

--- a/ext/soap/php_http.c
+++ b/ext/soap/php_http.c
@@ -1522,7 +1522,7 @@ static zend_string* get_http_body(php_stream *stream, bool close, zend_string *h
 						  break;
 						}
 						len_size += len_read;
-	 					http_buf_size += len_read;
+						http_buf_size += len_read;
 					}
 
 					/* Eat up '\r' '\n' */

--- a/ext/soap/php_schema.c
+++ b/ext/soap/php_schema.c
@@ -64,12 +64,12 @@ static int schema_parse_int(const xmlChar *value, const char *name, bool allow_n
 		errno = 0;
 		lval = ZEND_STRTOL(str, NULL, 10);
 		if (UNEXPECTED(oflow_info || (errno == ERANGE && lval != 0))) {
-			soap_error(E_ERROR, "Parsing Schema: %s value is out of range", name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: %s value is out of range", name);
 		}
 	}
 
 	if (UNEXPECTED(ZEND_LONG_EXCEEDS_INT(lval) || (!allow_negative && lval < 0))) {
-		soap_error(E_ERROR, "Parsing Schema: %s value is out of range", name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: %s value is out of range", name);
 	}
 
 	return (int) lval;
@@ -150,13 +150,13 @@ static void schema_load_file(sdlCtx *ctx, xmlAttrPtr ns, xmlChar *location, xmlA
 
 		if (doc == NULL) {
 			requestify_string(&location);
-			soap_error(E_ERROR, "Parsing Schema: can't import schema from '%s'", location);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: can't import schema from '%s'", location);
 		}
 		schema = get_node(doc->children, "schema");
 		if (schema == NULL) {
 			requestify_string(&location);
 			xmlFreeDoc(doc);
-			soap_error(E_ERROR, "Parsing Schema: can't import schema from '%s'", location);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: can't import schema from '%s'", location);
 		}
 		new_tns = get_attribute(schema->properties, "targetNamespace");
 		if (import) {
@@ -164,12 +164,12 @@ static void schema_load_file(sdlCtx *ctx, xmlAttrPtr ns, xmlChar *location, xmlA
 				requestify_string(&location);
 				if (new_tns == NULL) {
 					xmlFreeDoc(doc);
-					soap_error(E_ERROR, "Parsing Schema: can't import schema from '%s', missing 'targetNamespace', expected '%s'", location, ns->children->content);
+					php_error_docref(NULL, E_ERROR, "Parsing Schema: can't import schema from '%s', missing 'targetNamespace', expected '%s'", location, ns->children->content);
 				} else {
 					/* Have to make a copy to avoid a UAF after freeing `doc` */
 					const char *target_ns_copy = estrdup((const char *) new_tns->children->content);
 					xmlFreeDoc(doc);
-					soap_error(E_ERROR, "Parsing Schema: can't import schema from '%s', unexpected 'targetNamespace'='%s', expected '%s'", location, target_ns_copy, ns->children->content);
+					php_error_docref(NULL, E_ERROR, "Parsing Schema: can't import schema from '%s', unexpected 'targetNamespace'='%s', expected '%s'", location, target_ns_copy, ns->children->content);
 				}
 			}
 			if (ns == NULL && new_tns != NULL) {
@@ -177,7 +177,7 @@ static void schema_load_file(sdlCtx *ctx, xmlAttrPtr ns, xmlChar *location, xmlA
 				/* Have to make a copy to avoid a UAF after freeing `doc` */
 				const char *target_ns_copy = estrdup((const char *) new_tns->children->content);
 				xmlFreeDoc(doc);
-				soap_error(E_ERROR, "Parsing Schema: can't import schema from '%s', unexpected 'targetNamespace'='%s', expected no 'targetNamespace'", location, target_ns_copy);
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: can't import schema from '%s', unexpected 'targetNamespace'='%s', expected no 'targetNamespace'", location, target_ns_copy);
 			}
 		} else {
 			new_tns = get_attribute(schema->properties, "targetNamespace");
@@ -188,7 +188,7 @@ static void schema_load_file(sdlCtx *ctx, xmlAttrPtr ns, xmlChar *location, xmlA
 			} else if (tns != NULL && xmlStrcmp(tns->children->content, new_tns->children->content) != 0) {
 				requestify_string(&location);
 				xmlFreeDoc(doc);
-				soap_error(E_ERROR, "Parsing Schema: can't include schema from '%s', different 'targetNamespace'", location);
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: can't include schema from '%s', different 'targetNamespace'", location);
 			}
 		}
 		zend_hash_str_add_ptr(&ctx->docs, (char*)location, xmlStrlen(location), doc);
@@ -263,7 +263,7 @@ int load_schema(sdlCtx *ctx, xmlNodePtr schema)
 
 			location = get_attribute(trav->properties, "schemaLocation");
 			if (location == NULL) {
-				soap_error(E_ERROR, "Parsing Schema: include has no 'schemaLocation' attribute");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: include has no 'schemaLocation' attribute");
 			} else {
 				xmlChar *uri = schema_location_construct_uri(location);
 				schema_load_file(ctx, NULL, uri, tns, 0);
@@ -275,7 +275,7 @@ int load_schema(sdlCtx *ctx, xmlNodePtr schema)
 
 			location = get_attribute(trav->properties, "schemaLocation");
 			if (location == NULL) {
-				soap_error(E_ERROR, "Parsing Schema: redefine has no 'schemaLocation' attribute");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: redefine has no 'schemaLocation' attribute");
 			} else {
 				xmlChar *uri = schema_location_construct_uri(location);
 				schema_load_file(ctx, NULL, uri, tns, 0);
@@ -292,9 +292,9 @@ int load_schema(sdlCtx *ctx, xmlNodePtr schema)
 
 			if (ns != NULL && tns != NULL && xmlStrcmp(ns->children->content, tns->children->content) == 0) {
 				if (location) {
-					soap_error(E_ERROR, "Parsing Schema: can't import schema from '%s', namespace must not match the enclosing schema 'targetNamespace'", location->children->content);
+					php_error_docref(NULL, E_ERROR, "Parsing Schema: can't import schema from '%s', namespace must not match the enclosing schema 'targetNamespace'", location->children->content);
 				} else {
-					soap_error(E_ERROR, "Parsing Schema: can't import schema. Namespace must not match the enclosing schema 'targetNamespace'");
+					php_error_docref(NULL, E_ERROR, "Parsing Schema: can't import schema. Namespace must not match the enclosing schema 'targetNamespace'");
 				}
 			}
 			if (location) {
@@ -335,7 +335,7 @@ int load_schema(sdlCtx *ctx, xmlNodePtr schema)
 		} else if (node_is_equal_xsd(trav,"annotation")) {
 			/* TODO: <annotation> support */
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in schema", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in schema", trav->name);
 		}
 		trav = trav->next;
 	}
@@ -419,7 +419,7 @@ static int schema_simpleType(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr simpleType, 
 
 		create_encoder(sdl, cur_type, ns->children->content, name->children->content);
 	} else {
-		soap_error(E_ERROR, "Parsing Schema: simpleType has no 'name' attribute");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: simpleType has no 'name' attribute");
 	}
 
 	trav = simpleType->children;
@@ -440,13 +440,13 @@ static int schema_simpleType(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr simpleType, 
 			schema_union(sdl, tns, trav, cur_type);
 			trav = trav->next;
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in simpleType", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in simpleType", trav->name);
 		}
 	} else {
-		soap_error(E_ERROR, "Parsing Schema: expected <restriction>, <list> or <union> in simpleType");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: expected <restriction>, <list> or <union> in simpleType");
 	}
 	if (trav != NULL) {
-		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in simpleType", trav->name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in simpleType", trav->name);
 	}
 
 	return TRUE;
@@ -502,7 +502,7 @@ static int schema_list(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr listType, sdlTypeP
 		sdlTypePtr newType;
 
 		if (itemType != NULL) {
-			soap_error(E_ERROR, "Parsing Schema: element has both 'itemType' attribute and subtype");
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: element has both 'itemType' attribute and subtype");
 		}
 
 		newType = emalloc(sizeof(sdlType));
@@ -530,7 +530,7 @@ static int schema_list(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr listType, sdlTypeP
 		trav = trav->next;
 	}
 	if (trav != NULL) {
-		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in list", trav->name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in list", trav->name);
 	}
 	return TRUE;
 }
@@ -625,12 +625,12 @@ static int schema_union(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr unionType, sdlTyp
 			schema_simpleType(sdl, tns, trav, newType);
 
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in union", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in union", trav->name);
 		}
 		trav = trav->next;
 	}
 	if (trav != NULL) {
-		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in union", trav->name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in union", trav->name);
 	}
 	return TRUE;
 }
@@ -661,13 +661,13 @@ static int schema_simpleContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr simpCompT
 			schema_extension_simpleContent(sdl, tns, trav, cur_type);
 			trav = trav->next;
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in simpleContent", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in simpleContent", trav->name);
 		}
 	} else {
-		soap_error(E_ERROR, "Parsing Schema: expected <restriction> or <extension> in simpleContent");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: expected <restriction> or <extension> in simpleContent");
 	}
 	if (trav != NULL) {
-		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in simpleContent", trav->name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in simpleContent", trav->name);
 	}
 
 	return TRUE;
@@ -705,7 +705,7 @@ static int schema_restriction_simpleContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodeP
 		}
 		if (ns) {efree(ns);}
 	} else if (!simpleType) {
-		soap_error(E_ERROR, "Parsing Schema: restriction has no 'base' attribute");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: restriction has no 'base' attribute");
 	}
 
 	if (cur_type->restrictions == NULL) {
@@ -772,13 +772,13 @@ static int schema_restriction_simpleContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodeP
 				trav = trav->next;
 				break;
 			} else {
-				soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
 			}
 			trav = trav->next;
 		}
 	}
 	if (trav != NULL) {
-		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
 	}
 
 	return TRUE;
@@ -810,7 +810,7 @@ static int schema_restriction_complexContent(sdlPtr sdl, xmlAttrPtr tns, xmlNode
 		}
 		if (ns) {efree(ns);}
 	} else {
-		soap_error(E_ERROR, "Parsing Schema: restriction has no 'base' attribute");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: restriction has no 'base' attribute");
 	}
 
 	trav = restType->children;
@@ -843,12 +843,12 @@ static int schema_restriction_complexContent(sdlPtr sdl, xmlAttrPtr tns, xmlNode
 			trav = trav->next;
 			break;
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
 		}
 		trav = trav->next;
 	}
 	if (trav != NULL) {
-		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
 	}
 
 	return TRUE;
@@ -873,7 +873,7 @@ static int schema_restriction_var_int(xmlNodePtr val, sdlRestrictionIntPtr *valp
 
 	value = get_attribute(val->properties, "value");
 	if (value == NULL) {
-		soap_error(E_ERROR, "Parsing Schema: missing restriction value");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: missing restriction value");
 	}
 
 	(*valptr)->value = schema_parse_int(value->children->content, (const char *) val->name, true);
@@ -901,7 +901,7 @@ static int schema_restriction_var_char(xmlNodePtr val, sdlRestrictionCharPtr *va
 
 	value = get_attribute(val->properties, "value");
 	if (value == NULL) {
-		soap_error(E_ERROR, "Parsing Schema: missing restriction value");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: missing restriction value");
 	}
 
 	(*valptr)->value = estrdup((char*)value->children->content);
@@ -935,7 +935,7 @@ static int schema_extension_simpleContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr
 		}
 		if (ns) {efree(ns);}
 	} else {
-		soap_error(E_ERROR, "Parsing Schema: extension has no 'base' attribute");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: extension has no 'base' attribute");
 	}
 
 	trav = extType->children;
@@ -953,12 +953,12 @@ static int schema_extension_simpleContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr
 			trav = trav->next;
 			break;
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
 		}
 		trav = trav->next;
 	}
 	if (trav != NULL) {
-		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
 	}
 	return TRUE;
 }
@@ -990,7 +990,7 @@ static int schema_extension_complexContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePt
 		}
 		if (ns) {efree(ns);}
 	} else {
-		soap_error(E_ERROR, "Parsing Schema: extension has no 'base' attribute");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: extension has no 'base' attribute");
 	}
 
 	trav = extType->children;
@@ -1023,12 +1023,12 @@ static int schema_extension_complexContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePt
 			trav = trav->next;
 			break;
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
 		}
 		trav = trav->next;
 	}
 	if (trav != NULL) {
-		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
 	}
 	return TRUE;
 }
@@ -1090,7 +1090,7 @@ static int schema_all(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr all, sdlTypePtr cur
 		if (node_is_equal_xsd(trav,"element")) {
 			schema_element(sdl, tns, trav, cur_type, newModel);
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in all", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in all", trav->name);
 		}
 		trav = trav->next;
 	}
@@ -1177,7 +1177,7 @@ static int schema_group(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr groupType, sdlTyp
 				zend_hash_init(sdl->groups, 0, NULL, delete_type, 0);
 			}
 			if (zend_hash_add_ptr(sdl->groups, key.s, newType) == NULL) {
-				soap_error(E_ERROR, "Parsing Schema: group '%s' already defined", ZSTR_VAL(key.s));
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: group '%s' already defined", ZSTR_VAL(key.s));
 			}
 
 			cur_type = newType;
@@ -1190,7 +1190,7 @@ static int schema_group(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr groupType, sdlTyp
 			zend_hash_next_index_insert_ptr(model->u.content, newModel);
 		}
 	} else {
-		soap_error(E_ERROR, "Parsing Schema: group has no 'name' nor 'ref' attributes");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: group has no 'name' nor 'ref' attributes");
 	}
 
 	schema_min_max(groupType, newModel);
@@ -1203,31 +1203,31 @@ static int schema_group(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr groupType, sdlTyp
 	if (trav != NULL) {
 		if (node_is_equal_xsd(trav,"choice")) {
 			if (ref != NULL) {
-				soap_error(E_ERROR, "Parsing Schema: group has both 'ref' attribute and subcontent");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: group has both 'ref' attribute and subcontent");
 			}
 			newModel->kind = XSD_CONTENT_CHOICE;
 			schema_choice(sdl, tns, trav, cur_type, newModel);
 			trav = trav->next;
 		} else if (node_is_equal_xsd(trav,"sequence")) {
 			if (ref != NULL) {
-				soap_error(E_ERROR, "Parsing Schema: group has both 'ref' attribute and subcontent");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: group has both 'ref' attribute and subcontent");
 			}
 			newModel->kind = XSD_CONTENT_SEQUENCE;
 			schema_sequence(sdl, tns, trav, cur_type, newModel);
 			trav = trav->next;
 		} else if (node_is_equal_xsd(trav,"all")) {
 			if (ref != NULL) {
-				soap_error(E_ERROR, "Parsing Schema: group has both 'ref' attribute and subcontent");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: group has both 'ref' attribute and subcontent");
 			}
 			newModel->kind = XSD_CONTENT_ALL;
 			schema_all(sdl, tns, trav, cur_type, newModel);
 			trav = trav->next;
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in group", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in group", trav->name);
 		}
 	}
 	if (trav != NULL) {
-		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in group", trav->name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in group", trav->name);
 	}
 	return TRUE;
 }
@@ -1274,7 +1274,7 @@ static int schema_choice(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr choiceType, sdlT
 		} else if (node_is_equal_xsd(trav,"any")) {
 			schema_any(sdl, tns, trav, cur_type, newModel);
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in choice", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in choice", trav->name);
 		}
 		trav = trav->next;
 	}
@@ -1324,7 +1324,7 @@ static int schema_sequence(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr seqType, sdlTy
 		} else if (node_is_equal_xsd(trav,"any")) {
 			schema_any(sdl, tns, trav, cur_type, newModel);
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in sequence", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in sequence", trav->name);
 		}
 		trav = trav->next;
 	}
@@ -1384,13 +1384,13 @@ static int schema_complexContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr compCont
 			schema_extension_complexContent(sdl, tns, trav, cur_type);
 			trav = trav->next;
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in complexContent", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in complexContent", trav->name);
 		}
 	} else {
-		soap_error(E_ERROR, "Parsing Schema: <restriction> or <extension> expected in complexContent");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: <restriction> or <extension> expected in complexContent");
 	}
 	if (trav != NULL) {
-		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in complexContent", trav->name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in complexContent", trav->name);
 	}
 
 	return TRUE;
@@ -1469,7 +1469,7 @@ static int schema_complexType(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr compType, s
 		cur_type = ptr;
 		create_encoder(sdl, cur_type, ns->children->content, name->children->content);
 	} else {
-		soap_error(E_ERROR, "Parsing Schema: complexType has no 'name' attribute");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: complexType has no 'name' attribute");
 		return FALSE;
 	}
 
@@ -1509,14 +1509,14 @@ static int schema_complexType(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr compType, s
 					trav = trav->next;
 					break;
 				} else {
-					soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in complexType", trav->name);
+					php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in complexType", trav->name);
 				}
 				trav = trav->next;
 			}
 		}
 	}
 	if (trav != NULL) {
-		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in complexType", trav->name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in complexType", trav->name);
 	}
 	return TRUE;
 }
@@ -1619,7 +1619,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 		smart_str_0(&key);
 		if (zend_hash_add_ptr(addHash, key.s, newType) == NULL) {
 			if (cur_type == NULL) {
-				soap_error(E_ERROR, "Parsing Schema: element '%s' already defined", ZSTR_VAL(key.s));
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: element '%s' already defined", ZSTR_VAL(key.s));
 			} else {
 				zend_hash_next_index_insert_ptr(addHash, newType);
 			}
@@ -1639,7 +1639,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 		}
 		cur_type = newType;
 	} else {
-		soap_error(E_ERROR, "Parsing Schema: element has no 'name' nor 'ref' attributes");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: element has no 'name' nor 'ref' attributes");
 	}
 
 	/* nillable = boolean : false */
@@ -1647,7 +1647,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 	attr = get_attribute(attrs, "nillable");
 	if (attr) {
 		if (ref != NULL) {
-			soap_error(E_ERROR, "Parsing Schema: element has both 'ref' and 'nillable' attributes");
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: element has both 'ref' and 'nillable' attributes");
 		}
 		if (!stricmp((char*)attr->children->content, "true") ||
 			!stricmp((char*)attr->children->content, "1")) {
@@ -1662,7 +1662,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 	attr = get_attribute(attrs, "fixed");
 	if (attr) {
 		if (ref != NULL) {
-			soap_error(E_ERROR, "Parsing Schema: element has both 'ref' and 'fixed' attributes");
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: element has both 'ref' and 'fixed' attributes");
 		}
 		cur_type->fixed = estrdup((char*)attr->children->content);
 	}
@@ -1670,7 +1670,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 	attr = get_attribute(attrs, "default");
 	if (attr) {
 		if (ref != NULL) {
-			soap_error(E_ERROR, "Parsing Schema: element has both 'default' and 'fixed' attributes");
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: element has both 'default' and 'fixed' attributes");
 		}
 		cur_type->def = estrdup((char*)attr->children->content);
 	}
@@ -1716,7 +1716,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 		xmlNsPtr nsptr;
 
 		if (ref != NULL) {
-			soap_error(E_ERROR, "Parsing Schema: element has both 'ref' and 'type' attributes");
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: element has both 'ref' and 'type' attributes");
 		}
 		parse_namespace(type->children->content, &cptype, &str_ns);
 		nsptr = xmlSearchNs(element->doc, element, BAD_CAST(str_ns));
@@ -1734,17 +1734,17 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 	if (trav != NULL) {
 		if (node_is_equal_xsd(trav,"simpleType")) {
 			if (ref != NULL) {
-				soap_error(E_ERROR, "Parsing Schema: element has both 'ref' attribute and subtype");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: element has both 'ref' attribute and subtype");
 			} else if (type != NULL) {
-				soap_error(E_ERROR, "Parsing Schema: element has both 'type' attribute and subtype");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: element has both 'type' attribute and subtype");
 			}
 			schema_simpleType(sdl, tns, trav, cur_type);
 			trav = trav->next;
 		} else if (node_is_equal_xsd(trav,"complexType")) {
 			if (ref != NULL) {
-				soap_error(E_ERROR, "Parsing Schema: element has both 'ref' attribute and subtype");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: element has both 'ref' attribute and subtype");
 			} else if (type != NULL) {
-				soap_error(E_ERROR, "Parsing Schema: element has both 'type' attribute and subtype");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: element has both 'type' attribute and subtype");
 			}
 			schema_complexType(sdl, tns, trav, cur_type);
 			trav = trav->next;
@@ -1758,7 +1758,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 		} else if (node_is_equal_xsd(trav,"keyref")) {
 			/* TODO: <keyref> support */
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in element", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in element", trav->name);
 		}
 		trav = trav->next;
 	}
@@ -1848,11 +1848,11 @@ static int schema_attribute(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrType, sdl
 		}
 
 		if (zend_hash_add_ptr(addHash, key.s, newAttr) == NULL) {
-			soap_error(E_ERROR, "Parsing Schema: attribute '%s' already defined", ZSTR_VAL(key.s));
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: attribute '%s' already defined", ZSTR_VAL(key.s));
 		}
 		smart_str_free(&key);
 	} else{
-		soap_error(E_ERROR, "Parsing Schema: attribute has no 'name' nor 'ref' attributes");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: attribute has no 'name' nor 'ref' attributes");
 		return FALSE; /* the above call is noreturn, but not marked as such */
 	}
 
@@ -1864,7 +1864,7 @@ static int schema_attribute(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrType, sdl
 		xmlNsPtr nsptr;
 
 		if (ref != NULL) {
-			soap_error(E_ERROR, "Parsing Schema: attribute has both 'ref' and 'type' attributes");
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: attribute has both 'ref' and 'type' attributes");
 		}
 		parse_namespace(type->children->content, &cptype, &str_ns);
 		nsptr = xmlSearchNs(attrType->doc, attrType, BAD_CAST(str_ns));
@@ -1973,9 +1973,9 @@ static int schema_attribute(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrType, sdl
 			zval zv;
 
 			if (ref != NULL) {
-				soap_error(E_ERROR, "Parsing Schema: attribute has both 'ref' attribute and subtype");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: attribute has both 'ref' attribute and subtype");
 			} else if (type != NULL) {
-				soap_error(E_ERROR, "Parsing Schema: attribute has both 'type' attribute and subtype");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: attribute has both 'type' attribute and subtype");
 			}
 			dummy_type = emalloc(sizeof(sdlType));
 			memset(dummy_type, 0, sizeof(sdlType));
@@ -1997,7 +1997,7 @@ static int schema_attribute(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrType, sdl
 		}
 	}
 	if (trav != NULL) {
-		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in attribute", trav->name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in attribute", trav->name);
 	}
 	return TRUE;
 }
@@ -2033,7 +2033,7 @@ static int schema_attributeGroup(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrGrou
 			smart_str_0(&key);
 
 			if (zend_hash_add_ptr(ctx->attributeGroups, key.s, newType) == NULL) {
-				soap_error(E_ERROR, "Parsing Schema: attributeGroup '%s' already defined", ZSTR_VAL(key.s));
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: attributeGroup '%s' already defined", ZSTR_VAL(key.s));
 			}
 			cur_type = newType;
 			smart_str_free(&key);
@@ -2067,7 +2067,7 @@ static int schema_attributeGroup(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrGrou
 			cur_type = NULL;
 		}
 	} else{
-		soap_error(E_ERROR, "Parsing Schema: attributeGroup has no 'name' nor 'ref' attributes");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: attributeGroup has no 'name' nor 'ref' attributes");
 	}
 
 	trav = attrGroup->children;
@@ -2078,28 +2078,28 @@ static int schema_attributeGroup(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrGrou
 	while (trav != NULL) {
 		if (node_is_equal_xsd(trav,"attribute")) {
 			if (ref != NULL) {
-				soap_error(E_ERROR, "Parsing Schema: attributeGroup has both 'ref' attribute and subattribute");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: attributeGroup has both 'ref' attribute and subattribute");
 			}
 			schema_attribute(sdl, tns, trav, cur_type, NULL);
 		} else if (node_is_equal_xsd(trav,"attributeGroup")) {
 			if (ref != NULL) {
-				soap_error(E_ERROR, "Parsing Schema: attributeGroup has both 'ref' attribute and subattribute");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: attributeGroup has both 'ref' attribute and subattribute");
 			}
 			schema_attributeGroup(sdl, tns, trav, cur_type, NULL);
 		} else if (node_is_equal_xsd(trav,"anyAttribute")) {
 			if (ref != NULL) {
-				soap_error(E_ERROR, "Parsing Schema: attributeGroup has both 'ref' attribute and subattribute");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: attributeGroup has both 'ref' attribute and subattribute");
 			}
 			/* TODO: <anyAttribute> support */
 			trav = trav->next;
 			break;
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in attributeGroup", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in attributeGroup", trav->name);
 		}
 		trav = trav->next;
 	}
 	if (trav != NULL) {
-		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in attributeGroup", trav->name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in attributeGroup", trav->name);
 	}
 	return TRUE;
 }
@@ -2247,7 +2247,7 @@ static void schema_content_model_fixup(sdlCtx *ctx, sdlContentModelPtr model)
 				model->kind = XSD_CONTENT_GROUP;
 				model->u.group = tmp;
 			} else {
-				soap_error(E_ERROR, "Parsing Schema: unresolved group 'ref' attribute '%s'", model->u.group_ref);
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: unresolved group 'ref' attribute '%s'", model->u.group_ref);
 			}
 			break;
 		}
@@ -2304,7 +2304,7 @@ static void schema_type_fixup(sdlCtx *ctx, sdlTypePtr type)
 			} else if (strcmp(type->ref, XSD_NAMESPACE ":schema") == 0) {
 				type->encode = get_conversion(XSD_ANYXML);
 			} else {
-				soap_error(E_ERROR, "Parsing Schema: unresolved element 'ref' attribute '%s'", type->ref);
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: unresolved element 'ref' attribute '%s'", type->ref);
 			}
 		}
 		efree(type->ref);

--- a/ext/soap/php_schema.c
+++ b/ext/soap/php_schema.c
@@ -64,12 +64,12 @@ static int schema_parse_int(const xmlChar *value, const char *name, bool allow_n
 		errno = 0;
 		lval = ZEND_STRTOL(str, NULL, 10);
 		if (UNEXPECTED(oflow_info || (errno == ERANGE && lval != 0))) {
-			soap_error1(E_ERROR, "Parsing Schema: %s value is out of range", name);
+			soap_error(E_ERROR, "Parsing Schema: %s value is out of range", name);
 		}
 	}
 
 	if (UNEXPECTED(ZEND_LONG_EXCEEDS_INT(lval) || (!allow_negative && lval < 0))) {
-		soap_error1(E_ERROR, "Parsing Schema: %s value is out of range", name);
+		soap_error(E_ERROR, "Parsing Schema: %s value is out of range", name);
 	}
 
 	return (int) lval;
@@ -150,13 +150,13 @@ static void schema_load_file(sdlCtx *ctx, xmlAttrPtr ns, xmlChar *location, xmlA
 
 		if (doc == NULL) {
 			requestify_string(&location);
-			soap_error1(E_ERROR, "Parsing Schema: can't import schema from '%s'", location);
+			soap_error(E_ERROR, "Parsing Schema: can't import schema from '%s'", location);
 		}
 		schema = get_node(doc->children, "schema");
 		if (schema == NULL) {
 			requestify_string(&location);
 			xmlFreeDoc(doc);
-			soap_error1(E_ERROR, "Parsing Schema: can't import schema from '%s'", location);
+			soap_error(E_ERROR, "Parsing Schema: can't import schema from '%s'", location);
 		}
 		new_tns = get_attribute(schema->properties, "targetNamespace");
 		if (import) {
@@ -164,12 +164,12 @@ static void schema_load_file(sdlCtx *ctx, xmlAttrPtr ns, xmlChar *location, xmlA
 				requestify_string(&location);
 				if (new_tns == NULL) {
 					xmlFreeDoc(doc);
-					soap_error2(E_ERROR, "Parsing Schema: can't import schema from '%s', missing 'targetNamespace', expected '%s'", location, ns->children->content);
+					soap_error(E_ERROR, "Parsing Schema: can't import schema from '%s', missing 'targetNamespace', expected '%s'", location, ns->children->content);
 				} else {
 					/* Have to make a copy to avoid a UAF after freeing `doc` */
 					const char *target_ns_copy = estrdup((const char *) new_tns->children->content);
 					xmlFreeDoc(doc);
-					soap_error3(E_ERROR, "Parsing Schema: can't import schema from '%s', unexpected 'targetNamespace'='%s', expected '%s'", location, target_ns_copy, ns->children->content);
+					soap_error(E_ERROR, "Parsing Schema: can't import schema from '%s', unexpected 'targetNamespace'='%s', expected '%s'", location, target_ns_copy, ns->children->content);
 				}
 			}
 			if (ns == NULL && new_tns != NULL) {
@@ -177,7 +177,7 @@ static void schema_load_file(sdlCtx *ctx, xmlAttrPtr ns, xmlChar *location, xmlA
 				/* Have to make a copy to avoid a UAF after freeing `doc` */
 				const char *target_ns_copy = estrdup((const char *) new_tns->children->content);
 				xmlFreeDoc(doc);
-				soap_error2(E_ERROR, "Parsing Schema: can't import schema from '%s', unexpected 'targetNamespace'='%s', expected no 'targetNamespace'", location, target_ns_copy);
+				soap_error(E_ERROR, "Parsing Schema: can't import schema from '%s', unexpected 'targetNamespace'='%s', expected no 'targetNamespace'", location, target_ns_copy);
 			}
 		} else {
 			new_tns = get_attribute(schema->properties, "targetNamespace");
@@ -188,7 +188,7 @@ static void schema_load_file(sdlCtx *ctx, xmlAttrPtr ns, xmlChar *location, xmlA
 			} else if (tns != NULL && xmlStrcmp(tns->children->content, new_tns->children->content) != 0) {
 				requestify_string(&location);
 				xmlFreeDoc(doc);
-				soap_error1(E_ERROR, "Parsing Schema: can't include schema from '%s', different 'targetNamespace'", location);
+				soap_error(E_ERROR, "Parsing Schema: can't include schema from '%s', different 'targetNamespace'", location);
 			}
 		}
 		zend_hash_str_add_ptr(&ctx->docs, (char*)location, xmlStrlen(location), doc);
@@ -263,7 +263,7 @@ int load_schema(sdlCtx *ctx, xmlNodePtr schema)
 
 			location = get_attribute(trav->properties, "schemaLocation");
 			if (location == NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: include has no 'schemaLocation' attribute");
+				soap_error(E_ERROR, "Parsing Schema: include has no 'schemaLocation' attribute");
 			} else {
 				xmlChar *uri = schema_location_construct_uri(location);
 				schema_load_file(ctx, NULL, uri, tns, 0);
@@ -275,7 +275,7 @@ int load_schema(sdlCtx *ctx, xmlNodePtr schema)
 
 			location = get_attribute(trav->properties, "schemaLocation");
 			if (location == NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: redefine has no 'schemaLocation' attribute");
+				soap_error(E_ERROR, "Parsing Schema: redefine has no 'schemaLocation' attribute");
 			} else {
 				xmlChar *uri = schema_location_construct_uri(location);
 				schema_load_file(ctx, NULL, uri, tns, 0);
@@ -292,9 +292,9 @@ int load_schema(sdlCtx *ctx, xmlNodePtr schema)
 
 			if (ns != NULL && tns != NULL && xmlStrcmp(ns->children->content, tns->children->content) == 0) {
 				if (location) {
-					soap_error1(E_ERROR, "Parsing Schema: can't import schema from '%s', namespace must not match the enclosing schema 'targetNamespace'", location->children->content);
+					soap_error(E_ERROR, "Parsing Schema: can't import schema from '%s', namespace must not match the enclosing schema 'targetNamespace'", location->children->content);
 				} else {
-					soap_error0(E_ERROR, "Parsing Schema: can't import schema. Namespace must not match the enclosing schema 'targetNamespace'");
+					soap_error(E_ERROR, "Parsing Schema: can't import schema. Namespace must not match the enclosing schema 'targetNamespace'");
 				}
 			}
 			if (location) {
@@ -335,7 +335,7 @@ int load_schema(sdlCtx *ctx, xmlNodePtr schema)
 		} else if (node_is_equal_xsd(trav,"annotation")) {
 			/* TODO: <annotation> support */
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in schema", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in schema", trav->name);
 		}
 		trav = trav->next;
 	}
@@ -419,7 +419,7 @@ static int schema_simpleType(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr simpleType, 
 
 		create_encoder(sdl, cur_type, ns->children->content, name->children->content);
 	} else {
-		soap_error0(E_ERROR, "Parsing Schema: simpleType has no 'name' attribute");
+		soap_error(E_ERROR, "Parsing Schema: simpleType has no 'name' attribute");
 	}
 
 	trav = simpleType->children;
@@ -440,13 +440,13 @@ static int schema_simpleType(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr simpleType, 
 			schema_union(sdl, tns, trav, cur_type);
 			trav = trav->next;
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in simpleType", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in simpleType", trav->name);
 		}
 	} else {
-		soap_error0(E_ERROR, "Parsing Schema: expected <restriction>, <list> or <union> in simpleType");
+		soap_error(E_ERROR, "Parsing Schema: expected <restriction>, <list> or <union> in simpleType");
 	}
 	if (trav != NULL) {
-		soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in simpleType", trav->name);
+		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in simpleType", trav->name);
 	}
 
 	return TRUE;
@@ -502,7 +502,7 @@ static int schema_list(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr listType, sdlTypeP
 		sdlTypePtr newType;
 
 		if (itemType != NULL) {
-			soap_error0(E_ERROR, "Parsing Schema: element has both 'itemType' attribute and subtype");
+			soap_error(E_ERROR, "Parsing Schema: element has both 'itemType' attribute and subtype");
 		}
 
 		newType = emalloc(sizeof(sdlType));
@@ -530,7 +530,7 @@ static int schema_list(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr listType, sdlTypeP
 		trav = trav->next;
 	}
 	if (trav != NULL) {
-		soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in list", trav->name);
+		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in list", trav->name);
 	}
 	return TRUE;
 }
@@ -625,12 +625,12 @@ static int schema_union(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr unionType, sdlTyp
 			schema_simpleType(sdl, tns, trav, newType);
 
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in union", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in union", trav->name);
 		}
 		trav = trav->next;
 	}
 	if (trav != NULL) {
-		soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in union", trav->name);
+		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in union", trav->name);
 	}
 	return TRUE;
 }
@@ -661,13 +661,13 @@ static int schema_simpleContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr simpCompT
 			schema_extension_simpleContent(sdl, tns, trav, cur_type);
 			trav = trav->next;
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in simpleContent", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in simpleContent", trav->name);
 		}
 	} else {
-		soap_error0(E_ERROR, "Parsing Schema: expected <restriction> or <extension> in simpleContent");
+		soap_error(E_ERROR, "Parsing Schema: expected <restriction> or <extension> in simpleContent");
 	}
 	if (trav != NULL) {
-		soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in simpleContent", trav->name);
+		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in simpleContent", trav->name);
 	}
 
 	return TRUE;
@@ -705,7 +705,7 @@ static int schema_restriction_simpleContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodeP
 		}
 		if (ns) {efree(ns);}
 	} else if (!simpleType) {
-		soap_error0(E_ERROR, "Parsing Schema: restriction has no 'base' attribute");
+		soap_error(E_ERROR, "Parsing Schema: restriction has no 'base' attribute");
 	}
 
 	if (cur_type->restrictions == NULL) {
@@ -772,13 +772,13 @@ static int schema_restriction_simpleContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodeP
 				trav = trav->next;
 				break;
 			} else {
-				soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
+				soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
 			}
 			trav = trav->next;
 		}
 	}
 	if (trav != NULL) {
-		soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
+		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
 	}
 
 	return TRUE;
@@ -810,7 +810,7 @@ static int schema_restriction_complexContent(sdlPtr sdl, xmlAttrPtr tns, xmlNode
 		}
 		if (ns) {efree(ns);}
 	} else {
-		soap_error0(E_ERROR, "Parsing Schema: restriction has no 'base' attribute");
+		soap_error(E_ERROR, "Parsing Schema: restriction has no 'base' attribute");
 	}
 
 	trav = restType->children;
@@ -843,12 +843,12 @@ static int schema_restriction_complexContent(sdlPtr sdl, xmlAttrPtr tns, xmlNode
 			trav = trav->next;
 			break;
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
 		}
 		trav = trav->next;
 	}
 	if (trav != NULL) {
-		soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
+		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
 	}
 
 	return TRUE;
@@ -873,7 +873,7 @@ static int schema_restriction_var_int(xmlNodePtr val, sdlRestrictionIntPtr *valp
 
 	value = get_attribute(val->properties, "value");
 	if (value == NULL) {
-		soap_error0(E_ERROR, "Parsing Schema: missing restriction value");
+		soap_error(E_ERROR, "Parsing Schema: missing restriction value");
 	}
 
 	(*valptr)->value = schema_parse_int(value->children->content, (const char *) val->name, true);
@@ -901,7 +901,7 @@ static int schema_restriction_var_char(xmlNodePtr val, sdlRestrictionCharPtr *va
 
 	value = get_attribute(val->properties, "value");
 	if (value == NULL) {
-		soap_error0(E_ERROR, "Parsing Schema: missing restriction value");
+		soap_error(E_ERROR, "Parsing Schema: missing restriction value");
 	}
 
 	(*valptr)->value = estrdup((char*)value->children->content);
@@ -935,7 +935,7 @@ static int schema_extension_simpleContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr
 		}
 		if (ns) {efree(ns);}
 	} else {
-		soap_error0(E_ERROR, "Parsing Schema: extension has no 'base' attribute");
+		soap_error(E_ERROR, "Parsing Schema: extension has no 'base' attribute");
 	}
 
 	trav = extType->children;
@@ -953,12 +953,12 @@ static int schema_extension_simpleContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr
 			trav = trav->next;
 			break;
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
 		}
 		trav = trav->next;
 	}
 	if (trav != NULL) {
-		soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
+		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
 	}
 	return TRUE;
 }
@@ -990,7 +990,7 @@ static int schema_extension_complexContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePt
 		}
 		if (ns) {efree(ns);}
 	} else {
-		soap_error0(E_ERROR, "Parsing Schema: extension has no 'base' attribute");
+		soap_error(E_ERROR, "Parsing Schema: extension has no 'base' attribute");
 	}
 
 	trav = extType->children;
@@ -1023,12 +1023,12 @@ static int schema_extension_complexContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePt
 			trav = trav->next;
 			break;
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
 		}
 		trav = trav->next;
 	}
 	if (trav != NULL) {
-		soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
+		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
 	}
 	return TRUE;
 }
@@ -1090,7 +1090,7 @@ static int schema_all(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr all, sdlTypePtr cur
 		if (node_is_equal_xsd(trav,"element")) {
 			schema_element(sdl, tns, trav, cur_type, newModel);
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in all", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in all", trav->name);
 		}
 		trav = trav->next;
 	}
@@ -1177,7 +1177,7 @@ static int schema_group(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr groupType, sdlTyp
 				zend_hash_init(sdl->groups, 0, NULL, delete_type, 0);
 			}
 			if (zend_hash_add_ptr(sdl->groups, key.s, newType) == NULL) {
-				soap_error1(E_ERROR, "Parsing Schema: group '%s' already defined", ZSTR_VAL(key.s));
+				soap_error(E_ERROR, "Parsing Schema: group '%s' already defined", ZSTR_VAL(key.s));
 			}
 
 			cur_type = newType;
@@ -1190,7 +1190,7 @@ static int schema_group(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr groupType, sdlTyp
 			zend_hash_next_index_insert_ptr(model->u.content, newModel);
 		}
 	} else {
-		soap_error0(E_ERROR, "Parsing Schema: group has no 'name' nor 'ref' attributes");
+		soap_error(E_ERROR, "Parsing Schema: group has no 'name' nor 'ref' attributes");
 	}
 
 	schema_min_max(groupType, newModel);
@@ -1203,31 +1203,31 @@ static int schema_group(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr groupType, sdlTyp
 	if (trav != NULL) {
 		if (node_is_equal_xsd(trav,"choice")) {
 			if (ref != NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: group has both 'ref' attribute and subcontent");
+				soap_error(E_ERROR, "Parsing Schema: group has both 'ref' attribute and subcontent");
 			}
 			newModel->kind = XSD_CONTENT_CHOICE;
 			schema_choice(sdl, tns, trav, cur_type, newModel);
 			trav = trav->next;
 		} else if (node_is_equal_xsd(trav,"sequence")) {
 			if (ref != NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: group has both 'ref' attribute and subcontent");
+				soap_error(E_ERROR, "Parsing Schema: group has both 'ref' attribute and subcontent");
 			}
 			newModel->kind = XSD_CONTENT_SEQUENCE;
 			schema_sequence(sdl, tns, trav, cur_type, newModel);
 			trav = trav->next;
 		} else if (node_is_equal_xsd(trav,"all")) {
 			if (ref != NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: group has both 'ref' attribute and subcontent");
+				soap_error(E_ERROR, "Parsing Schema: group has both 'ref' attribute and subcontent");
 			}
 			newModel->kind = XSD_CONTENT_ALL;
 			schema_all(sdl, tns, trav, cur_type, newModel);
 			trav = trav->next;
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in group", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in group", trav->name);
 		}
 	}
 	if (trav != NULL) {
-		soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in group", trav->name);
+		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in group", trav->name);
 	}
 	return TRUE;
 }
@@ -1274,7 +1274,7 @@ static int schema_choice(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr choiceType, sdlT
 		} else if (node_is_equal_xsd(trav,"any")) {
 			schema_any(sdl, tns, trav, cur_type, newModel);
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in choice", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in choice", trav->name);
 		}
 		trav = trav->next;
 	}
@@ -1324,7 +1324,7 @@ static int schema_sequence(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr seqType, sdlTy
 		} else if (node_is_equal_xsd(trav,"any")) {
 			schema_any(sdl, tns, trav, cur_type, newModel);
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in sequence", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in sequence", trav->name);
 		}
 		trav = trav->next;
 	}
@@ -1384,13 +1384,13 @@ static int schema_complexContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr compCont
 			schema_extension_complexContent(sdl, tns, trav, cur_type);
 			trav = trav->next;
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in complexContent", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in complexContent", trav->name);
 		}
 	} else {
-		soap_error0(E_ERROR, "Parsing Schema: <restriction> or <extension> expected in complexContent");
+		soap_error(E_ERROR, "Parsing Schema: <restriction> or <extension> expected in complexContent");
 	}
 	if (trav != NULL) {
-		soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in complexContent", trav->name);
+		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in complexContent", trav->name);
 	}
 
 	return TRUE;
@@ -1469,7 +1469,7 @@ static int schema_complexType(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr compType, s
 		cur_type = ptr;
 		create_encoder(sdl, cur_type, ns->children->content, name->children->content);
 	} else {
-		soap_error0(E_ERROR, "Parsing Schema: complexType has no 'name' attribute");
+		soap_error(E_ERROR, "Parsing Schema: complexType has no 'name' attribute");
 		return FALSE;
 	}
 
@@ -1509,14 +1509,14 @@ static int schema_complexType(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr compType, s
 					trav = trav->next;
 					break;
 				} else {
-					soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in complexType", trav->name);
+					soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in complexType", trav->name);
 				}
 				trav = trav->next;
 			}
 		}
 	}
 	if (trav != NULL) {
-		soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in complexType", trav->name);
+		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in complexType", trav->name);
 	}
 	return TRUE;
 }
@@ -1619,7 +1619,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 		smart_str_0(&key);
 		if (zend_hash_add_ptr(addHash, key.s, newType) == NULL) {
 			if (cur_type == NULL) {
-				soap_error1(E_ERROR, "Parsing Schema: element '%s' already defined", ZSTR_VAL(key.s));
+				soap_error(E_ERROR, "Parsing Schema: element '%s' already defined", ZSTR_VAL(key.s));
 			} else {
 				zend_hash_next_index_insert_ptr(addHash, newType);
 			}
@@ -1639,7 +1639,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 		}
 		cur_type = newType;
 	} else {
-		soap_error0(E_ERROR, "Parsing Schema: element has no 'name' nor 'ref' attributes");
+		soap_error(E_ERROR, "Parsing Schema: element has no 'name' nor 'ref' attributes");
 	}
 
 	/* nillable = boolean : false */
@@ -1647,7 +1647,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 	attr = get_attribute(attrs, "nillable");
 	if (attr) {
 		if (ref != NULL) {
-			soap_error0(E_ERROR, "Parsing Schema: element has both 'ref' and 'nillable' attributes");
+			soap_error(E_ERROR, "Parsing Schema: element has both 'ref' and 'nillable' attributes");
 		}
 		if (!stricmp((char*)attr->children->content, "true") ||
 			!stricmp((char*)attr->children->content, "1")) {
@@ -1662,7 +1662,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 	attr = get_attribute(attrs, "fixed");
 	if (attr) {
 		if (ref != NULL) {
-			soap_error0(E_ERROR, "Parsing Schema: element has both 'ref' and 'fixed' attributes");
+			soap_error(E_ERROR, "Parsing Schema: element has both 'ref' and 'fixed' attributes");
 		}
 		cur_type->fixed = estrdup((char*)attr->children->content);
 	}
@@ -1670,7 +1670,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 	attr = get_attribute(attrs, "default");
 	if (attr) {
 		if (ref != NULL) {
-			soap_error0(E_ERROR, "Parsing Schema: element has both 'default' and 'fixed' attributes");
+			soap_error(E_ERROR, "Parsing Schema: element has both 'default' and 'fixed' attributes");
 		}
 		cur_type->def = estrdup((char*)attr->children->content);
 	}
@@ -1716,7 +1716,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 		xmlNsPtr nsptr;
 
 		if (ref != NULL) {
-			soap_error0(E_ERROR, "Parsing Schema: element has both 'ref' and 'type' attributes");
+			soap_error(E_ERROR, "Parsing Schema: element has both 'ref' and 'type' attributes");
 		}
 		parse_namespace(type->children->content, &cptype, &str_ns);
 		nsptr = xmlSearchNs(element->doc, element, BAD_CAST(str_ns));
@@ -1734,17 +1734,17 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 	if (trav != NULL) {
 		if (node_is_equal_xsd(trav,"simpleType")) {
 			if (ref != NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: element has both 'ref' attribute and subtype");
+				soap_error(E_ERROR, "Parsing Schema: element has both 'ref' attribute and subtype");
 			} else if (type != NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: element has both 'type' attribute and subtype");
+				soap_error(E_ERROR, "Parsing Schema: element has both 'type' attribute and subtype");
 			}
 			schema_simpleType(sdl, tns, trav, cur_type);
 			trav = trav->next;
 		} else if (node_is_equal_xsd(trav,"complexType")) {
 			if (ref != NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: element has both 'ref' attribute and subtype");
+				soap_error(E_ERROR, "Parsing Schema: element has both 'ref' attribute and subtype");
 			} else if (type != NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: element has both 'type' attribute and subtype");
+				soap_error(E_ERROR, "Parsing Schema: element has both 'type' attribute and subtype");
 			}
 			schema_complexType(sdl, tns, trav, cur_type);
 			trav = trav->next;
@@ -1758,7 +1758,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 		} else if (node_is_equal_xsd(trav,"keyref")) {
 			/* TODO: <keyref> support */
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in element", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in element", trav->name);
 		}
 		trav = trav->next;
 	}
@@ -1848,11 +1848,11 @@ static int schema_attribute(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrType, sdl
 		}
 
 		if (zend_hash_add_ptr(addHash, key.s, newAttr) == NULL) {
-			soap_error1(E_ERROR, "Parsing Schema: attribute '%s' already defined", ZSTR_VAL(key.s));
+			soap_error(E_ERROR, "Parsing Schema: attribute '%s' already defined", ZSTR_VAL(key.s));
 		}
 		smart_str_free(&key);
 	} else{
-		soap_error0(E_ERROR, "Parsing Schema: attribute has no 'name' nor 'ref' attributes");
+		soap_error(E_ERROR, "Parsing Schema: attribute has no 'name' nor 'ref' attributes");
 		return FALSE; /* the above call is noreturn, but not marked as such */
 	}
 
@@ -1864,7 +1864,7 @@ static int schema_attribute(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrType, sdl
 		xmlNsPtr nsptr;
 
 		if (ref != NULL) {
-			soap_error0(E_ERROR, "Parsing Schema: attribute has both 'ref' and 'type' attributes");
+			soap_error(E_ERROR, "Parsing Schema: attribute has both 'ref' and 'type' attributes");
 		}
 		parse_namespace(type->children->content, &cptype, &str_ns);
 		nsptr = xmlSearchNs(attrType->doc, attrType, BAD_CAST(str_ns));
@@ -1973,9 +1973,9 @@ static int schema_attribute(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrType, sdl
 			zval zv;
 
 			if (ref != NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: attribute has both 'ref' attribute and subtype");
+				soap_error(E_ERROR, "Parsing Schema: attribute has both 'ref' attribute and subtype");
 			} else if (type != NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: attribute has both 'type' attribute and subtype");
+				soap_error(E_ERROR, "Parsing Schema: attribute has both 'type' attribute and subtype");
 			}
 			dummy_type = emalloc(sizeof(sdlType));
 			memset(dummy_type, 0, sizeof(sdlType));
@@ -1997,7 +1997,7 @@ static int schema_attribute(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrType, sdl
 		}
 	}
 	if (trav != NULL) {
-		soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in attribute", trav->name);
+		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in attribute", trav->name);
 	}
 	return TRUE;
 }
@@ -2033,7 +2033,7 @@ static int schema_attributeGroup(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrGrou
 			smart_str_0(&key);
 
 			if (zend_hash_add_ptr(ctx->attributeGroups, key.s, newType) == NULL) {
-				soap_error1(E_ERROR, "Parsing Schema: attributeGroup '%s' already defined", ZSTR_VAL(key.s));
+				soap_error(E_ERROR, "Parsing Schema: attributeGroup '%s' already defined", ZSTR_VAL(key.s));
 			}
 			cur_type = newType;
 			smart_str_free(&key);
@@ -2067,7 +2067,7 @@ static int schema_attributeGroup(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrGrou
 			cur_type = NULL;
 		}
 	} else{
-		soap_error0(E_ERROR, "Parsing Schema: attributeGroup has no 'name' nor 'ref' attributes");
+		soap_error(E_ERROR, "Parsing Schema: attributeGroup has no 'name' nor 'ref' attributes");
 	}
 
 	trav = attrGroup->children;
@@ -2078,28 +2078,28 @@ static int schema_attributeGroup(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrGrou
 	while (trav != NULL) {
 		if (node_is_equal_xsd(trav,"attribute")) {
 			if (ref != NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: attributeGroup has both 'ref' attribute and subattribute");
+				soap_error(E_ERROR, "Parsing Schema: attributeGroup has both 'ref' attribute and subattribute");
 			}
 			schema_attribute(sdl, tns, trav, cur_type, NULL);
 		} else if (node_is_equal_xsd(trav,"attributeGroup")) {
 			if (ref != NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: attributeGroup has both 'ref' attribute and subattribute");
+				soap_error(E_ERROR, "Parsing Schema: attributeGroup has both 'ref' attribute and subattribute");
 			}
 			schema_attributeGroup(sdl, tns, trav, cur_type, NULL);
 		} else if (node_is_equal_xsd(trav,"anyAttribute")) {
 			if (ref != NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: attributeGroup has both 'ref' attribute and subattribute");
+				soap_error(E_ERROR, "Parsing Schema: attributeGroup has both 'ref' attribute and subattribute");
 			}
 			/* TODO: <anyAttribute> support */
 			trav = trav->next;
 			break;
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in attributeGroup", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in attributeGroup", trav->name);
 		}
 		trav = trav->next;
 	}
 	if (trav != NULL) {
-		soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in attributeGroup", trav->name);
+		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in attributeGroup", trav->name);
 	}
 	return TRUE;
 }
@@ -2247,7 +2247,7 @@ static void schema_content_model_fixup(sdlCtx *ctx, sdlContentModelPtr model)
 				model->kind = XSD_CONTENT_GROUP;
 				model->u.group = tmp;
 			} else {
-				soap_error1(E_ERROR, "Parsing Schema: unresolved group 'ref' attribute '%s'", model->u.group_ref);
+				soap_error(E_ERROR, "Parsing Schema: unresolved group 'ref' attribute '%s'", model->u.group_ref);
 			}
 			break;
 		}
@@ -2304,7 +2304,7 @@ static void schema_type_fixup(sdlCtx *ctx, sdlTypePtr type)
 			} else if (strcmp(type->ref, XSD_NAMESPACE ":schema") == 0) {
 				type->encode = get_conversion(XSD_ANYXML);
 			} else {
-				soap_error1(E_ERROR, "Parsing Schema: unresolved element 'ref' attribute '%s'", type->ref);
+				soap_error(E_ERROR, "Parsing Schema: unresolved element 'ref' attribute '%s'", type->ref);
 			}
 		}
 		efree(type->ref);

--- a/ext/soap/php_schema.c
+++ b/ext/soap/php_schema.c
@@ -1689,8 +1689,8 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 	  cur_type->form = XSD_FORM_DEFAULT;
 	}
 	if (cur_type->form == XSD_FORM_DEFAULT) {
- 		xmlNodePtr parent = element->parent;
- 		while (parent) {
+		xmlNodePtr parent = element->parent;
+		while (parent) {
 			if (node_is_equal_xsd(parent, "schema")) {
 				xmlAttrPtr def;
 				def = get_attribute(parent->properties, "elementFormDefault");
@@ -1702,7 +1702,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 				break;
 			}
 			parent = parent->parent;
-  		}
+		}
 		if (parent == NULL) {
 			cur_type->form = XSD_FORM_UNQUALIFIED;
 		}

--- a/ext/soap/php_schema.c
+++ b/ext/soap/php_schema.c
@@ -64,12 +64,12 @@ static int schema_parse_int(const xmlChar *value, const char *name, bool allow_n
 		errno = 0;
 		lval = ZEND_STRTOL(str, NULL, 10);
 		if (UNEXPECTED(oflow_info || (errno == ERANGE && lval != 0))) {
-			soap_error1(E_ERROR, "Parsing Schema: %s value is out of range", name);
+			soap_error(E_ERROR, "Parsing Schema: %s value is out of range", name);
 		}
 	}
 
 	if (UNEXPECTED(ZEND_LONG_EXCEEDS_INT(lval) || (!allow_negative && lval < 0))) {
-		soap_error1(E_ERROR, "Parsing Schema: %s value is out of range", name);
+		soap_error(E_ERROR, "Parsing Schema: %s value is out of range", name);
 	}
 
 	return (int) lval;
@@ -150,13 +150,13 @@ static void schema_load_file(sdlCtx *ctx, xmlAttrPtr ns, xmlChar *location, xmlA
 
 		if (doc == NULL) {
 			requestify_string(&location);
-			soap_error1(E_ERROR, "Parsing Schema: can't import schema from '%s'", location);
+			soap_error(E_ERROR, "Parsing Schema: can't import schema from '%s'", location);
 		}
 		schema = get_node(doc->children, "schema");
 		if (schema == NULL) {
 			requestify_string(&location);
 			xmlFreeDoc(doc);
-			soap_error1(E_ERROR, "Parsing Schema: can't import schema from '%s'", location);
+			soap_error(E_ERROR, "Parsing Schema: can't import schema from '%s'", location);
 		}
 		new_tns = get_attribute(schema->properties, "targetNamespace");
 		if (import) {
@@ -164,12 +164,12 @@ static void schema_load_file(sdlCtx *ctx, xmlAttrPtr ns, xmlChar *location, xmlA
 				requestify_string(&location);
 				if (new_tns == NULL) {
 					xmlFreeDoc(doc);
-					soap_error2(E_ERROR, "Parsing Schema: can't import schema from '%s', missing 'targetNamespace', expected '%s'", location, ns->children->content);
+					soap_error(E_ERROR, "Parsing Schema: can't import schema from '%s', missing 'targetNamespace', expected '%s'", location, ns->children->content);
 				} else {
 					/* Have to make a copy to avoid a UAF after freeing `doc` */
 					const char *target_ns_copy = estrdup((const char *) new_tns->children->content);
 					xmlFreeDoc(doc);
-					soap_error3(E_ERROR, "Parsing Schema: can't import schema from '%s', unexpected 'targetNamespace'='%s', expected '%s'", location, target_ns_copy, ns->children->content);
+					soap_error(E_ERROR, "Parsing Schema: can't import schema from '%s', unexpected 'targetNamespace'='%s', expected '%s'", location, target_ns_copy, ns->children->content);
 				}
 			}
 			if (ns == NULL && new_tns != NULL) {
@@ -177,7 +177,7 @@ static void schema_load_file(sdlCtx *ctx, xmlAttrPtr ns, xmlChar *location, xmlA
 				/* Have to make a copy to avoid a UAF after freeing `doc` */
 				const char *target_ns_copy = estrdup((const char *) new_tns->children->content);
 				xmlFreeDoc(doc);
-				soap_error2(E_ERROR, "Parsing Schema: can't import schema from '%s', unexpected 'targetNamespace'='%s', expected no 'targetNamespace'", location, target_ns_copy);
+				soap_error(E_ERROR, "Parsing Schema: can't import schema from '%s', unexpected 'targetNamespace'='%s', expected no 'targetNamespace'", location, target_ns_copy);
 			}
 		} else {
 			new_tns = get_attribute(schema->properties, "targetNamespace");
@@ -188,7 +188,7 @@ static void schema_load_file(sdlCtx *ctx, xmlAttrPtr ns, xmlChar *location, xmlA
 			} else if (tns != NULL && xmlStrcmp(tns->children->content, new_tns->children->content) != 0) {
 				requestify_string(&location);
 				xmlFreeDoc(doc);
-				soap_error1(E_ERROR, "Parsing Schema: can't include schema from '%s', different 'targetNamespace'", location);
+				soap_error(E_ERROR, "Parsing Schema: can't include schema from '%s', different 'targetNamespace'", location);
 			}
 		}
 		zend_hash_str_add_ptr(&ctx->docs, (char*)location, xmlStrlen(location), doc);
@@ -263,7 +263,7 @@ int load_schema(sdlCtx *ctx, xmlNodePtr schema)
 
 			location = get_attribute(trav->properties, "schemaLocation");
 			if (location == NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: include has no 'schemaLocation' attribute");
+				soap_error(E_ERROR, "Parsing Schema: include has no 'schemaLocation' attribute");
 			} else {
 				xmlChar *uri = schema_location_construct_uri(location);
 				schema_load_file(ctx, NULL, uri, tns, 0);
@@ -275,7 +275,7 @@ int load_schema(sdlCtx *ctx, xmlNodePtr schema)
 
 			location = get_attribute(trav->properties, "schemaLocation");
 			if (location == NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: redefine has no 'schemaLocation' attribute");
+				soap_error(E_ERROR, "Parsing Schema: redefine has no 'schemaLocation' attribute");
 			} else {
 				xmlChar *uri = schema_location_construct_uri(location);
 				schema_load_file(ctx, NULL, uri, tns, 0);
@@ -292,9 +292,9 @@ int load_schema(sdlCtx *ctx, xmlNodePtr schema)
 
 			if (ns != NULL && tns != NULL && xmlStrcmp(ns->children->content, tns->children->content) == 0) {
 				if (location) {
-					soap_error1(E_ERROR, "Parsing Schema: can't import schema from '%s', namespace must not match the enclosing schema 'targetNamespace'", location->children->content);
+					soap_error(E_ERROR, "Parsing Schema: can't import schema from '%s', namespace must not match the enclosing schema 'targetNamespace'", location->children->content);
 				} else {
-					soap_error0(E_ERROR, "Parsing Schema: can't import schema. Namespace must not match the enclosing schema 'targetNamespace'");
+					soap_error(E_ERROR, "Parsing Schema: can't import schema. Namespace must not match the enclosing schema 'targetNamespace'");
 				}
 			}
 			if (location) {
@@ -335,7 +335,7 @@ int load_schema(sdlCtx *ctx, xmlNodePtr schema)
 		} else if (node_is_equal_xsd(trav,"annotation")) {
 			/* TODO: <annotation> support */
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in schema", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in schema", trav->name);
 		}
 		trav = trav->next;
 	}
@@ -419,7 +419,7 @@ static int schema_simpleType(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr simpleType, 
 
 		create_encoder(sdl, cur_type, ns->children->content, name->children->content);
 	} else {
-		soap_error0(E_ERROR, "Parsing Schema: simpleType has no 'name' attribute");
+		soap_error(E_ERROR, "Parsing Schema: simpleType has no 'name' attribute");
 	}
 
 	trav = simpleType->children;
@@ -440,13 +440,13 @@ static int schema_simpleType(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr simpleType, 
 			schema_union(sdl, tns, trav, cur_type);
 			trav = trav->next;
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in simpleType", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in simpleType", trav->name);
 		}
 	} else {
-		soap_error0(E_ERROR, "Parsing Schema: expected <restriction>, <list> or <union> in simpleType");
+		soap_error(E_ERROR, "Parsing Schema: expected <restriction>, <list> or <union> in simpleType");
 	}
 	if (trav != NULL) {
-		soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in simpleType", trav->name);
+		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in simpleType", trav->name);
 	}
 
 	return TRUE;
@@ -502,7 +502,7 @@ static int schema_list(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr listType, sdlTypeP
 		sdlTypePtr newType;
 
 		if (itemType != NULL) {
-			soap_error0(E_ERROR, "Parsing Schema: element has both 'itemType' attribute and subtype");
+			soap_error(E_ERROR, "Parsing Schema: element has both 'itemType' attribute and subtype");
 		}
 
 		newType = emalloc(sizeof(sdlType));
@@ -530,7 +530,7 @@ static int schema_list(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr listType, sdlTypeP
 		trav = trav->next;
 	}
 	if (trav != NULL) {
-		soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in list", trav->name);
+		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in list", trav->name);
 	}
 	return TRUE;
 }
@@ -625,12 +625,12 @@ static int schema_union(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr unionType, sdlTyp
 			schema_simpleType(sdl, tns, trav, newType);
 
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in union", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in union", trav->name);
 		}
 		trav = trav->next;
 	}
 	if (trav != NULL) {
-		soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in union", trav->name);
+		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in union", trav->name);
 	}
 	return TRUE;
 }
@@ -661,13 +661,13 @@ static int schema_simpleContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr simpCompT
 			schema_extension_simpleContent(sdl, tns, trav, cur_type);
 			trav = trav->next;
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in simpleContent", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in simpleContent", trav->name);
 		}
 	} else {
-		soap_error0(E_ERROR, "Parsing Schema: expected <restriction> or <extension> in simpleContent");
+		soap_error(E_ERROR, "Parsing Schema: expected <restriction> or <extension> in simpleContent");
 	}
 	if (trav != NULL) {
-		soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in simpleContent", trav->name);
+		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in simpleContent", trav->name);
 	}
 
 	return TRUE;
@@ -705,7 +705,7 @@ static int schema_restriction_simpleContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodeP
 		}
 		if (ns) {efree(ns);}
 	} else if (!simpleType) {
-		soap_error0(E_ERROR, "Parsing Schema: restriction has no 'base' attribute");
+		soap_error(E_ERROR, "Parsing Schema: restriction has no 'base' attribute");
 	}
 
 	if (cur_type->restrictions == NULL) {
@@ -772,13 +772,13 @@ static int schema_restriction_simpleContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodeP
 				trav = trav->next;
 				break;
 			} else {
-				soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
+				soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
 			}
 			trav = trav->next;
 		}
 	}
 	if (trav != NULL) {
-		soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
+		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
 	}
 
 	return TRUE;
@@ -810,7 +810,7 @@ static int schema_restriction_complexContent(sdlPtr sdl, xmlAttrPtr tns, xmlNode
 		}
 		if (ns) {efree(ns);}
 	} else {
-		soap_error0(E_ERROR, "Parsing Schema: restriction has no 'base' attribute");
+		soap_error(E_ERROR, "Parsing Schema: restriction has no 'base' attribute");
 	}
 
 	trav = restType->children;
@@ -843,12 +843,12 @@ static int schema_restriction_complexContent(sdlPtr sdl, xmlAttrPtr tns, xmlNode
 			trav = trav->next;
 			break;
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
 		}
 		trav = trav->next;
 	}
 	if (trav != NULL) {
-		soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
+		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
 	}
 
 	return TRUE;
@@ -873,7 +873,7 @@ static int schema_restriction_var_int(xmlNodePtr val, sdlRestrictionIntPtr *valp
 
 	value = get_attribute(val->properties, "value");
 	if (value == NULL) {
-		soap_error0(E_ERROR, "Parsing Schema: missing restriction value");
+		soap_error(E_ERROR, "Parsing Schema: missing restriction value");
 	}
 
 	(*valptr)->value = schema_parse_int(value->children->content, (const char *) val->name, true);
@@ -901,7 +901,7 @@ static int schema_restriction_var_char(xmlNodePtr val, sdlRestrictionCharPtr *va
 
 	value = get_attribute(val->properties, "value");
 	if (value == NULL) {
-		soap_error0(E_ERROR, "Parsing Schema: missing restriction value");
+		soap_error(E_ERROR, "Parsing Schema: missing restriction value");
 	}
 
 	(*valptr)->value = estrdup((char*)value->children->content);
@@ -935,7 +935,7 @@ static int schema_extension_simpleContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr
 		}
 		if (ns) {efree(ns);}
 	} else {
-		soap_error0(E_ERROR, "Parsing Schema: extension has no 'base' attribute");
+		soap_error(E_ERROR, "Parsing Schema: extension has no 'base' attribute");
 	}
 
 	trav = extType->children;
@@ -953,12 +953,12 @@ static int schema_extension_simpleContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr
 			trav = trav->next;
 			break;
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
 		}
 		trav = trav->next;
 	}
 	if (trav != NULL) {
-		soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
+		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
 	}
 	return TRUE;
 }
@@ -990,7 +990,7 @@ static int schema_extension_complexContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePt
 		}
 		if (ns) {efree(ns);}
 	} else {
-		soap_error0(E_ERROR, "Parsing Schema: extension has no 'base' attribute");
+		soap_error(E_ERROR, "Parsing Schema: extension has no 'base' attribute");
 	}
 
 	trav = extType->children;
@@ -1023,12 +1023,12 @@ static int schema_extension_complexContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePt
 			trav = trav->next;
 			break;
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
 		}
 		trav = trav->next;
 	}
 	if (trav != NULL) {
-		soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
+		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
 	}
 	return TRUE;
 }
@@ -1090,7 +1090,7 @@ static int schema_all(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr all, sdlTypePtr cur
 		if (node_is_equal_xsd(trav,"element")) {
 			schema_element(sdl, tns, trav, cur_type, newModel);
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in all", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in all", trav->name);
 		}
 		trav = trav->next;
 	}
@@ -1177,7 +1177,7 @@ static int schema_group(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr groupType, sdlTyp
 				zend_hash_init(sdl->groups, 0, NULL, delete_type, 0);
 			}
 			if (zend_hash_add_ptr(sdl->groups, key.s, newType) == NULL) {
-				soap_error1(E_ERROR, "Parsing Schema: group '%s' already defined", ZSTR_VAL(key.s));
+				soap_error(E_ERROR, "Parsing Schema: group '%s' already defined", ZSTR_VAL(key.s));
 			}
 
 			cur_type = newType;
@@ -1190,7 +1190,7 @@ static int schema_group(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr groupType, sdlTyp
 			zend_hash_next_index_insert_ptr(model->u.content, newModel);
 		}
 	} else {
-		soap_error0(E_ERROR, "Parsing Schema: group has no 'name' nor 'ref' attributes");
+		soap_error(E_ERROR, "Parsing Schema: group has no 'name' nor 'ref' attributes");
 	}
 
 	schema_min_max(groupType, newModel);
@@ -1203,31 +1203,31 @@ static int schema_group(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr groupType, sdlTyp
 	if (trav != NULL) {
 		if (node_is_equal_xsd(trav,"choice")) {
 			if (ref != NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: group has both 'ref' attribute and subcontent");
+				soap_error(E_ERROR, "Parsing Schema: group has both 'ref' attribute and subcontent");
 			}
 			newModel->kind = XSD_CONTENT_CHOICE;
 			schema_choice(sdl, tns, trav, cur_type, newModel);
 			trav = trav->next;
 		} else if (node_is_equal_xsd(trav,"sequence")) {
 			if (ref != NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: group has both 'ref' attribute and subcontent");
+				soap_error(E_ERROR, "Parsing Schema: group has both 'ref' attribute and subcontent");
 			}
 			newModel->kind = XSD_CONTENT_SEQUENCE;
 			schema_sequence(sdl, tns, trav, cur_type, newModel);
 			trav = trav->next;
 		} else if (node_is_equal_xsd(trav,"all")) {
 			if (ref != NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: group has both 'ref' attribute and subcontent");
+				soap_error(E_ERROR, "Parsing Schema: group has both 'ref' attribute and subcontent");
 			}
 			newModel->kind = XSD_CONTENT_ALL;
 			schema_all(sdl, tns, trav, cur_type, newModel);
 			trav = trav->next;
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in group", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in group", trav->name);
 		}
 	}
 	if (trav != NULL) {
-		soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in group", trav->name);
+		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in group", trav->name);
 	}
 	return TRUE;
 }
@@ -1274,7 +1274,7 @@ static int schema_choice(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr choiceType, sdlT
 		} else if (node_is_equal_xsd(trav,"any")) {
 			schema_any(sdl, tns, trav, cur_type, newModel);
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in choice", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in choice", trav->name);
 		}
 		trav = trav->next;
 	}
@@ -1324,7 +1324,7 @@ static int schema_sequence(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr seqType, sdlTy
 		} else if (node_is_equal_xsd(trav,"any")) {
 			schema_any(sdl, tns, trav, cur_type, newModel);
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in sequence", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in sequence", trav->name);
 		}
 		trav = trav->next;
 	}
@@ -1384,13 +1384,13 @@ static int schema_complexContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr compCont
 			schema_extension_complexContent(sdl, tns, trav, cur_type);
 			trav = trav->next;
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in complexContent", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in complexContent", trav->name);
 		}
 	} else {
-		soap_error0(E_ERROR, "Parsing Schema: <restriction> or <extension> expected in complexContent");
+		soap_error(E_ERROR, "Parsing Schema: <restriction> or <extension> expected in complexContent");
 	}
 	if (trav != NULL) {
-		soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in complexContent", trav->name);
+		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in complexContent", trav->name);
 	}
 
 	return TRUE;
@@ -1469,7 +1469,7 @@ static int schema_complexType(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr compType, s
 		cur_type = ptr;
 		create_encoder(sdl, cur_type, ns->children->content, name->children->content);
 	} else {
-		soap_error0(E_ERROR, "Parsing Schema: complexType has no 'name' attribute");
+		soap_error(E_ERROR, "Parsing Schema: complexType has no 'name' attribute");
 		return FALSE;
 	}
 
@@ -1509,14 +1509,14 @@ static int schema_complexType(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr compType, s
 					trav = trav->next;
 					break;
 				} else {
-					soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in complexType", trav->name);
+					soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in complexType", trav->name);
 				}
 				trav = trav->next;
 			}
 		}
 	}
 	if (trav != NULL) {
-		soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in complexType", trav->name);
+		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in complexType", trav->name);
 	}
 	return TRUE;
 }
@@ -1619,7 +1619,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 		smart_str_0(&key);
 		if (zend_hash_add_ptr(addHash, key.s, newType) == NULL) {
 			if (cur_type == NULL) {
-				soap_error1(E_ERROR, "Parsing Schema: element '%s' already defined", ZSTR_VAL(key.s));
+				soap_error(E_ERROR, "Parsing Schema: element '%s' already defined", ZSTR_VAL(key.s));
 			} else {
 				zend_hash_next_index_insert_ptr(addHash, newType);
 			}
@@ -1639,7 +1639,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 		}
 		cur_type = newType;
 	} else {
-		soap_error0(E_ERROR, "Parsing Schema: element has no 'name' nor 'ref' attributes");
+		soap_error(E_ERROR, "Parsing Schema: element has no 'name' nor 'ref' attributes");
 	}
 
 	/* nillable = boolean : false */
@@ -1647,7 +1647,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 	attr = get_attribute(attrs, "nillable");
 	if (attr) {
 		if (ref != NULL) {
-			soap_error0(E_ERROR, "Parsing Schema: element has both 'ref' and 'nillable' attributes");
+			soap_error(E_ERROR, "Parsing Schema: element has both 'ref' and 'nillable' attributes");
 		}
 		if (!stricmp((char*)attr->children->content, "true") ||
 			!stricmp((char*)attr->children->content, "1")) {
@@ -1662,7 +1662,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 	attr = get_attribute(attrs, "fixed");
 	if (attr) {
 		if (ref != NULL) {
-			soap_error0(E_ERROR, "Parsing Schema: element has both 'ref' and 'fixed' attributes");
+			soap_error(E_ERROR, "Parsing Schema: element has both 'ref' and 'fixed' attributes");
 		}
 		cur_type->fixed = estrdup((char*)attr->children->content);
 	}
@@ -1670,7 +1670,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 	attr = get_attribute(attrs, "default");
 	if (attr) {
 		if (ref != NULL) {
-			soap_error0(E_ERROR, "Parsing Schema: element has both 'default' and 'fixed' attributes");
+			soap_error(E_ERROR, "Parsing Schema: element has both 'default' and 'fixed' attributes");
 		}
 		cur_type->def = estrdup((char*)attr->children->content);
 	}
@@ -1716,7 +1716,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 		xmlNsPtr nsptr;
 
 		if (ref != NULL) {
-			soap_error0(E_ERROR, "Parsing Schema: element has both 'ref' and 'type' attributes");
+			soap_error(E_ERROR, "Parsing Schema: element has both 'ref' and 'type' attributes");
 		}
 		parse_namespace(type->children->content, &cptype, &str_ns);
 		nsptr = xmlSearchNs(element->doc, element, BAD_CAST(str_ns));
@@ -1734,17 +1734,17 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 	if (trav != NULL) {
 		if (node_is_equal_xsd(trav,"simpleType")) {
 			if (ref != NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: element has both 'ref' attribute and subtype");
+				soap_error(E_ERROR, "Parsing Schema: element has both 'ref' attribute and subtype");
 			} else if (type != NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: element has both 'type' attribute and subtype");
+				soap_error(E_ERROR, "Parsing Schema: element has both 'type' attribute and subtype");
 			}
 			schema_simpleType(sdl, tns, trav, cur_type);
 			trav = trav->next;
 		} else if (node_is_equal_xsd(trav,"complexType")) {
 			if (ref != NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: element has both 'ref' attribute and subtype");
+				soap_error(E_ERROR, "Parsing Schema: element has both 'ref' attribute and subtype");
 			} else if (type != NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: element has both 'type' attribute and subtype");
+				soap_error(E_ERROR, "Parsing Schema: element has both 'type' attribute and subtype");
 			}
 			schema_complexType(sdl, tns, trav, cur_type);
 			trav = trav->next;
@@ -1758,7 +1758,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 		} else if (node_is_equal_xsd(trav,"keyref")) {
 			/* TODO: <keyref> support */
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in element", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in element", trav->name);
 		}
 		trav = trav->next;
 	}
@@ -1848,11 +1848,11 @@ static int schema_attribute(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrType, sdl
 		}
 
 		if (zend_hash_add_ptr(addHash, key.s, newAttr) == NULL) {
-			soap_error1(E_ERROR, "Parsing Schema: attribute '%s' already defined", ZSTR_VAL(key.s));
+			soap_error(E_ERROR, "Parsing Schema: attribute '%s' already defined", ZSTR_VAL(key.s));
 		}
 		smart_str_free(&key);
 	} else{
-		soap_error0(E_ERROR, "Parsing Schema: attribute has no 'name' nor 'ref' attributes");
+		soap_error(E_ERROR, "Parsing Schema: attribute has no 'name' nor 'ref' attributes");
 		return FALSE; /* the above call is noreturn, but not marked as such */
 	}
 
@@ -1864,7 +1864,7 @@ static int schema_attribute(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrType, sdl
 		xmlNsPtr nsptr;
 
 		if (ref != NULL) {
-			soap_error0(E_ERROR, "Parsing Schema: attribute has both 'ref' and 'type' attributes");
+			soap_error(E_ERROR, "Parsing Schema: attribute has both 'ref' and 'type' attributes");
 		}
 		parse_namespace(type->children->content, &cptype, &str_ns);
 		nsptr = xmlSearchNs(attrType->doc, attrType, BAD_CAST(str_ns));
@@ -1973,9 +1973,9 @@ static int schema_attribute(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrType, sdl
 			zval zv;
 
 			if (ref != NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: attribute has both 'ref' attribute and subtype");
+				soap_error(E_ERROR, "Parsing Schema: attribute has both 'ref' attribute and subtype");
 			} else if (type != NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: attribute has both 'type' attribute and subtype");
+				soap_error(E_ERROR, "Parsing Schema: attribute has both 'type' attribute and subtype");
 			}
 			dummy_type = emalloc(sizeof(sdlType));
 			memset(dummy_type, 0, sizeof(sdlType));
@@ -1997,7 +1997,7 @@ static int schema_attribute(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrType, sdl
 		}
 	}
 	if (trav != NULL) {
-		soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in attribute", trav->name);
+		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in attribute", trav->name);
 	}
 	return TRUE;
 }
@@ -2033,7 +2033,7 @@ static int schema_attributeGroup(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrGrou
 			smart_str_0(&key);
 
 			if (zend_hash_add_ptr(ctx->attributeGroups, key.s, newType) == NULL) {
-				soap_error1(E_ERROR, "Parsing Schema: attributeGroup '%s' already defined", ZSTR_VAL(key.s));
+				soap_error(E_ERROR, "Parsing Schema: attributeGroup '%s' already defined", ZSTR_VAL(key.s));
 			}
 			cur_type = newType;
 			smart_str_free(&key);
@@ -2067,7 +2067,7 @@ static int schema_attributeGroup(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrGrou
 			cur_type = NULL;
 		}
 	} else{
-		soap_error0(E_ERROR, "Parsing Schema: attributeGroup has no 'name' nor 'ref' attributes");
+		soap_error(E_ERROR, "Parsing Schema: attributeGroup has no 'name' nor 'ref' attributes");
 	}
 
 	trav = attrGroup->children;
@@ -2078,28 +2078,28 @@ static int schema_attributeGroup(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrGrou
 	while (trav != NULL) {
 		if (node_is_equal_xsd(trav,"attribute")) {
 			if (ref != NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: attributeGroup has both 'ref' attribute and subattribute");
+				soap_error(E_ERROR, "Parsing Schema: attributeGroup has both 'ref' attribute and subattribute");
 			}
 			schema_attribute(sdl, tns, trav, cur_type, NULL);
 		} else if (node_is_equal_xsd(trav,"attributeGroup")) {
 			if (ref != NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: attributeGroup has both 'ref' attribute and subattribute");
+				soap_error(E_ERROR, "Parsing Schema: attributeGroup has both 'ref' attribute and subattribute");
 			}
 			schema_attributeGroup(sdl, tns, trav, cur_type, NULL);
 		} else if (node_is_equal_xsd(trav,"anyAttribute")) {
 			if (ref != NULL) {
-				soap_error0(E_ERROR, "Parsing Schema: attributeGroup has both 'ref' attribute and subattribute");
+				soap_error(E_ERROR, "Parsing Schema: attributeGroup has both 'ref' attribute and subattribute");
 			}
 			/* TODO: <anyAttribute> support */
 			trav = trav->next;
 			break;
 		} else {
-			soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in attributeGroup", trav->name);
+			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in attributeGroup", trav->name);
 		}
 		trav = trav->next;
 	}
 	if (trav != NULL) {
-		soap_error1(E_ERROR, "Parsing Schema: unexpected <%s> in attributeGroup", trav->name);
+		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in attributeGroup", trav->name);
 	}
 	return TRUE;
 }
@@ -2255,7 +2255,7 @@ static void schema_content_model_fixup(sdlCtx *ctx, sdlContentModelPtr model)
 				model->kind = XSD_CONTENT_GROUP;
 				model->u.group = tmp;
 			} else {
-				soap_error1(E_ERROR, "Parsing Schema: unresolved group 'ref' attribute '%s'", model->u.group_ref);
+				soap_error(E_ERROR, "Parsing Schema: unresolved group 'ref' attribute '%s'", model->u.group_ref);
 			}
 			break;
 		}
@@ -2314,7 +2314,7 @@ static void schema_type_fixup(sdlCtx *ctx, sdlTypePtr type)
 			} else if (strcmp(type->ref, XSD_NAMESPACE ":schema") == 0) {
 				type->encode = get_conversion(XSD_ANYXML);
 			} else {
-				soap_error1(E_ERROR, "Parsing Schema: unresolved element 'ref' attribute '%s'", type->ref);
+				soap_error(E_ERROR, "Parsing Schema: unresolved element 'ref' attribute '%s'", type->ref);
 			}
 		}
 		efree(type->ref);

--- a/ext/soap/php_schema.c
+++ b/ext/soap/php_schema.c
@@ -64,12 +64,12 @@ static int schema_parse_int(const xmlChar *value, const char *name, bool allow_n
 		errno = 0;
 		lval = ZEND_STRTOL(str, NULL, 10);
 		if (UNEXPECTED(oflow_info || (errno == ERANGE && lval != 0))) {
-			soap_error(E_ERROR, "Parsing Schema: %s value is out of range", name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: %s value is out of range", name);
 		}
 	}
 
 	if (UNEXPECTED(ZEND_LONG_EXCEEDS_INT(lval) || (!allow_negative && lval < 0))) {
-		soap_error(E_ERROR, "Parsing Schema: %s value is out of range", name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: %s value is out of range", name);
 	}
 
 	return (int) lval;
@@ -150,13 +150,13 @@ static void schema_load_file(sdlCtx *ctx, xmlAttrPtr ns, xmlChar *location, xmlA
 
 		if (doc == NULL) {
 			requestify_string(&location);
-			soap_error(E_ERROR, "Parsing Schema: can't import schema from '%s'", location);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: can't import schema from '%s'", location);
 		}
 		schema = get_node(doc->children, "schema");
 		if (schema == NULL) {
 			requestify_string(&location);
 			xmlFreeDoc(doc);
-			soap_error(E_ERROR, "Parsing Schema: can't import schema from '%s'", location);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: can't import schema from '%s'", location);
 		}
 		new_tns = get_attribute(schema->properties, "targetNamespace");
 		if (import) {
@@ -164,12 +164,12 @@ static void schema_load_file(sdlCtx *ctx, xmlAttrPtr ns, xmlChar *location, xmlA
 				requestify_string(&location);
 				if (new_tns == NULL) {
 					xmlFreeDoc(doc);
-					soap_error(E_ERROR, "Parsing Schema: can't import schema from '%s', missing 'targetNamespace', expected '%s'", location, ns->children->content);
+					php_error_docref(NULL, E_ERROR, "Parsing Schema: can't import schema from '%s', missing 'targetNamespace', expected '%s'", location, ns->children->content);
 				} else {
 					/* Have to make a copy to avoid a UAF after freeing `doc` */
 					const char *target_ns_copy = estrdup((const char *) new_tns->children->content);
 					xmlFreeDoc(doc);
-					soap_error(E_ERROR, "Parsing Schema: can't import schema from '%s', unexpected 'targetNamespace'='%s', expected '%s'", location, target_ns_copy, ns->children->content);
+					php_error_docref(NULL, E_ERROR, "Parsing Schema: can't import schema from '%s', unexpected 'targetNamespace'='%s', expected '%s'", location, target_ns_copy, ns->children->content);
 				}
 			}
 			if (ns == NULL && new_tns != NULL) {
@@ -177,7 +177,7 @@ static void schema_load_file(sdlCtx *ctx, xmlAttrPtr ns, xmlChar *location, xmlA
 				/* Have to make a copy to avoid a UAF after freeing `doc` */
 				const char *target_ns_copy = estrdup((const char *) new_tns->children->content);
 				xmlFreeDoc(doc);
-				soap_error(E_ERROR, "Parsing Schema: can't import schema from '%s', unexpected 'targetNamespace'='%s', expected no 'targetNamespace'", location, target_ns_copy);
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: can't import schema from '%s', unexpected 'targetNamespace'='%s', expected no 'targetNamespace'", location, target_ns_copy);
 			}
 		} else {
 			new_tns = get_attribute(schema->properties, "targetNamespace");
@@ -188,7 +188,7 @@ static void schema_load_file(sdlCtx *ctx, xmlAttrPtr ns, xmlChar *location, xmlA
 			} else if (tns != NULL && xmlStrcmp(tns->children->content, new_tns->children->content) != 0) {
 				requestify_string(&location);
 				xmlFreeDoc(doc);
-				soap_error(E_ERROR, "Parsing Schema: can't include schema from '%s', different 'targetNamespace'", location);
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: can't include schema from '%s', different 'targetNamespace'", location);
 			}
 		}
 		zend_hash_str_add_ptr(&ctx->docs, (char*)location, xmlStrlen(location), doc);
@@ -263,7 +263,7 @@ int load_schema(sdlCtx *ctx, xmlNodePtr schema)
 
 			location = get_attribute(trav->properties, "schemaLocation");
 			if (location == NULL) {
-				soap_error(E_ERROR, "Parsing Schema: include has no 'schemaLocation' attribute");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: include has no 'schemaLocation' attribute");
 			} else {
 				xmlChar *uri = schema_location_construct_uri(location);
 				schema_load_file(ctx, NULL, uri, tns, 0);
@@ -275,7 +275,7 @@ int load_schema(sdlCtx *ctx, xmlNodePtr schema)
 
 			location = get_attribute(trav->properties, "schemaLocation");
 			if (location == NULL) {
-				soap_error(E_ERROR, "Parsing Schema: redefine has no 'schemaLocation' attribute");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: redefine has no 'schemaLocation' attribute");
 			} else {
 				xmlChar *uri = schema_location_construct_uri(location);
 				schema_load_file(ctx, NULL, uri, tns, 0);
@@ -292,9 +292,9 @@ int load_schema(sdlCtx *ctx, xmlNodePtr schema)
 
 			if (ns != NULL && tns != NULL && xmlStrcmp(ns->children->content, tns->children->content) == 0) {
 				if (location) {
-					soap_error(E_ERROR, "Parsing Schema: can't import schema from '%s', namespace must not match the enclosing schema 'targetNamespace'", location->children->content);
+					php_error_docref(NULL, E_ERROR, "Parsing Schema: can't import schema from '%s', namespace must not match the enclosing schema 'targetNamespace'", location->children->content);
 				} else {
-					soap_error(E_ERROR, "Parsing Schema: can't import schema. Namespace must not match the enclosing schema 'targetNamespace'");
+					php_error_docref(NULL, E_ERROR, "Parsing Schema: can't import schema. Namespace must not match the enclosing schema 'targetNamespace'");
 				}
 			}
 			if (location) {
@@ -335,7 +335,7 @@ int load_schema(sdlCtx *ctx, xmlNodePtr schema)
 		} else if (node_is_equal_xsd(trav,"annotation")) {
 			/* TODO: <annotation> support */
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in schema", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in schema", trav->name);
 		}
 		trav = trav->next;
 	}
@@ -419,7 +419,7 @@ static int schema_simpleType(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr simpleType, 
 
 		create_encoder(sdl, cur_type, ns->children->content, name->children->content);
 	} else {
-		soap_error(E_ERROR, "Parsing Schema: simpleType has no 'name' attribute");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: simpleType has no 'name' attribute");
 	}
 
 	trav = simpleType->children;
@@ -440,13 +440,13 @@ static int schema_simpleType(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr simpleType, 
 			schema_union(sdl, tns, trav, cur_type);
 			trav = trav->next;
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in simpleType", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in simpleType", trav->name);
 		}
 	} else {
-		soap_error(E_ERROR, "Parsing Schema: expected <restriction>, <list> or <union> in simpleType");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: expected <restriction>, <list> or <union> in simpleType");
 	}
 	if (trav != NULL) {
-		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in simpleType", trav->name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in simpleType", trav->name);
 	}
 
 	return TRUE;
@@ -502,7 +502,7 @@ static int schema_list(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr listType, sdlTypeP
 		sdlTypePtr newType;
 
 		if (itemType != NULL) {
-			soap_error(E_ERROR, "Parsing Schema: element has both 'itemType' attribute and subtype");
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: element has both 'itemType' attribute and subtype");
 		}
 
 		newType = emalloc(sizeof(sdlType));
@@ -530,7 +530,7 @@ static int schema_list(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr listType, sdlTypeP
 		trav = trav->next;
 	}
 	if (trav != NULL) {
-		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in list", trav->name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in list", trav->name);
 	}
 	return TRUE;
 }
@@ -625,12 +625,12 @@ static int schema_union(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr unionType, sdlTyp
 			schema_simpleType(sdl, tns, trav, newType);
 
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in union", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in union", trav->name);
 		}
 		trav = trav->next;
 	}
 	if (trav != NULL) {
-		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in union", trav->name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in union", trav->name);
 	}
 	return TRUE;
 }
@@ -661,13 +661,13 @@ static int schema_simpleContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr simpCompT
 			schema_extension_simpleContent(sdl, tns, trav, cur_type);
 			trav = trav->next;
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in simpleContent", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in simpleContent", trav->name);
 		}
 	} else {
-		soap_error(E_ERROR, "Parsing Schema: expected <restriction> or <extension> in simpleContent");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: expected <restriction> or <extension> in simpleContent");
 	}
 	if (trav != NULL) {
-		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in simpleContent", trav->name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in simpleContent", trav->name);
 	}
 
 	return TRUE;
@@ -705,7 +705,7 @@ static int schema_restriction_simpleContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodeP
 		}
 		if (ns) {efree(ns);}
 	} else if (!simpleType) {
-		soap_error(E_ERROR, "Parsing Schema: restriction has no 'base' attribute");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: restriction has no 'base' attribute");
 	}
 
 	if (cur_type->restrictions == NULL) {
@@ -772,13 +772,13 @@ static int schema_restriction_simpleContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodeP
 				trav = trav->next;
 				break;
 			} else {
-				soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
 			}
 			trav = trav->next;
 		}
 	}
 	if (trav != NULL) {
-		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
 	}
 
 	return TRUE;
@@ -810,7 +810,7 @@ static int schema_restriction_complexContent(sdlPtr sdl, xmlAttrPtr tns, xmlNode
 		}
 		if (ns) {efree(ns);}
 	} else {
-		soap_error(E_ERROR, "Parsing Schema: restriction has no 'base' attribute");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: restriction has no 'base' attribute");
 	}
 
 	trav = restType->children;
@@ -843,12 +843,12 @@ static int schema_restriction_complexContent(sdlPtr sdl, xmlAttrPtr tns, xmlNode
 			trav = trav->next;
 			break;
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
 		}
 		trav = trav->next;
 	}
 	if (trav != NULL) {
-		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in restriction", trav->name);
 	}
 
 	return TRUE;
@@ -873,7 +873,7 @@ static int schema_restriction_var_int(xmlNodePtr val, sdlRestrictionIntPtr *valp
 
 	value = get_attribute(val->properties, "value");
 	if (value == NULL) {
-		soap_error(E_ERROR, "Parsing Schema: missing restriction value");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: missing restriction value");
 	}
 
 	(*valptr)->value = schema_parse_int(value->children->content, (const char *) val->name, true);
@@ -901,7 +901,7 @@ static int schema_restriction_var_char(xmlNodePtr val, sdlRestrictionCharPtr *va
 
 	value = get_attribute(val->properties, "value");
 	if (value == NULL) {
-		soap_error(E_ERROR, "Parsing Schema: missing restriction value");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: missing restriction value");
 	}
 
 	(*valptr)->value = estrdup((char*)value->children->content);
@@ -935,7 +935,7 @@ static int schema_extension_simpleContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr
 		}
 		if (ns) {efree(ns);}
 	} else {
-		soap_error(E_ERROR, "Parsing Schema: extension has no 'base' attribute");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: extension has no 'base' attribute");
 	}
 
 	trav = extType->children;
@@ -953,12 +953,12 @@ static int schema_extension_simpleContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr
 			trav = trav->next;
 			break;
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
 		}
 		trav = trav->next;
 	}
 	if (trav != NULL) {
-		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
 	}
 	return TRUE;
 }
@@ -990,7 +990,7 @@ static int schema_extension_complexContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePt
 		}
 		if (ns) {efree(ns);}
 	} else {
-		soap_error(E_ERROR, "Parsing Schema: extension has no 'base' attribute");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: extension has no 'base' attribute");
 	}
 
 	trav = extType->children;
@@ -1023,12 +1023,12 @@ static int schema_extension_complexContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePt
 			trav = trav->next;
 			break;
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
 		}
 		trav = trav->next;
 	}
 	if (trav != NULL) {
-		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in extension", trav->name);
 	}
 	return TRUE;
 }
@@ -1090,7 +1090,7 @@ static int schema_all(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr all, sdlTypePtr cur
 		if (node_is_equal_xsd(trav,"element")) {
 			schema_element(sdl, tns, trav, cur_type, newModel);
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in all", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in all", trav->name);
 		}
 		trav = trav->next;
 	}
@@ -1177,7 +1177,7 @@ static int schema_group(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr groupType, sdlTyp
 				zend_hash_init(sdl->groups, 0, NULL, delete_type, 0);
 			}
 			if (zend_hash_add_ptr(sdl->groups, key.s, newType) == NULL) {
-				soap_error(E_ERROR, "Parsing Schema: group '%s' already defined", ZSTR_VAL(key.s));
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: group '%s' already defined", ZSTR_VAL(key.s));
 			}
 
 			cur_type = newType;
@@ -1190,7 +1190,7 @@ static int schema_group(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr groupType, sdlTyp
 			zend_hash_next_index_insert_ptr(model->u.content, newModel);
 		}
 	} else {
-		soap_error(E_ERROR, "Parsing Schema: group has no 'name' nor 'ref' attributes");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: group has no 'name' nor 'ref' attributes");
 	}
 
 	schema_min_max(groupType, newModel);
@@ -1203,31 +1203,31 @@ static int schema_group(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr groupType, sdlTyp
 	if (trav != NULL) {
 		if (node_is_equal_xsd(trav,"choice")) {
 			if (ref != NULL) {
-				soap_error(E_ERROR, "Parsing Schema: group has both 'ref' attribute and subcontent");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: group has both 'ref' attribute and subcontent");
 			}
 			newModel->kind = XSD_CONTENT_CHOICE;
 			schema_choice(sdl, tns, trav, cur_type, newModel);
 			trav = trav->next;
 		} else if (node_is_equal_xsd(trav,"sequence")) {
 			if (ref != NULL) {
-				soap_error(E_ERROR, "Parsing Schema: group has both 'ref' attribute and subcontent");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: group has both 'ref' attribute and subcontent");
 			}
 			newModel->kind = XSD_CONTENT_SEQUENCE;
 			schema_sequence(sdl, tns, trav, cur_type, newModel);
 			trav = trav->next;
 		} else if (node_is_equal_xsd(trav,"all")) {
 			if (ref != NULL) {
-				soap_error(E_ERROR, "Parsing Schema: group has both 'ref' attribute and subcontent");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: group has both 'ref' attribute and subcontent");
 			}
 			newModel->kind = XSD_CONTENT_ALL;
 			schema_all(sdl, tns, trav, cur_type, newModel);
 			trav = trav->next;
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in group", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in group", trav->name);
 		}
 	}
 	if (trav != NULL) {
-		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in group", trav->name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in group", trav->name);
 	}
 	return TRUE;
 }
@@ -1274,7 +1274,7 @@ static int schema_choice(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr choiceType, sdlT
 		} else if (node_is_equal_xsd(trav,"any")) {
 			schema_any(sdl, tns, trav, cur_type, newModel);
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in choice", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in choice", trav->name);
 		}
 		trav = trav->next;
 	}
@@ -1324,7 +1324,7 @@ static int schema_sequence(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr seqType, sdlTy
 		} else if (node_is_equal_xsd(trav,"any")) {
 			schema_any(sdl, tns, trav, cur_type, newModel);
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in sequence", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in sequence", trav->name);
 		}
 		trav = trav->next;
 	}
@@ -1384,13 +1384,13 @@ static int schema_complexContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr compCont
 			schema_extension_complexContent(sdl, tns, trav, cur_type);
 			trav = trav->next;
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in complexContent", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in complexContent", trav->name);
 		}
 	} else {
-		soap_error(E_ERROR, "Parsing Schema: <restriction> or <extension> expected in complexContent");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: <restriction> or <extension> expected in complexContent");
 	}
 	if (trav != NULL) {
-		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in complexContent", trav->name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in complexContent", trav->name);
 	}
 
 	return TRUE;
@@ -1469,7 +1469,7 @@ static int schema_complexType(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr compType, s
 		cur_type = ptr;
 		create_encoder(sdl, cur_type, ns->children->content, name->children->content);
 	} else {
-		soap_error(E_ERROR, "Parsing Schema: complexType has no 'name' attribute");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: complexType has no 'name' attribute");
 		return FALSE;
 	}
 
@@ -1509,14 +1509,14 @@ static int schema_complexType(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr compType, s
 					trav = trav->next;
 					break;
 				} else {
-					soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in complexType", trav->name);
+					php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in complexType", trav->name);
 				}
 				trav = trav->next;
 			}
 		}
 	}
 	if (trav != NULL) {
-		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in complexType", trav->name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in complexType", trav->name);
 	}
 	return TRUE;
 }
@@ -1619,7 +1619,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 		smart_str_0(&key);
 		if (zend_hash_add_ptr(addHash, key.s, newType) == NULL) {
 			if (cur_type == NULL) {
-				soap_error(E_ERROR, "Parsing Schema: element '%s' already defined", ZSTR_VAL(key.s));
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: element '%s' already defined", ZSTR_VAL(key.s));
 			} else {
 				zend_hash_next_index_insert_ptr(addHash, newType);
 			}
@@ -1639,7 +1639,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 		}
 		cur_type = newType;
 	} else {
-		soap_error(E_ERROR, "Parsing Schema: element has no 'name' nor 'ref' attributes");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: element has no 'name' nor 'ref' attributes");
 	}
 
 	/* nillable = boolean : false */
@@ -1647,7 +1647,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 	attr = get_attribute(attrs, "nillable");
 	if (attr) {
 		if (ref != NULL) {
-			soap_error(E_ERROR, "Parsing Schema: element has both 'ref' and 'nillable' attributes");
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: element has both 'ref' and 'nillable' attributes");
 		}
 		if (!stricmp((char*)attr->children->content, "true") ||
 			!stricmp((char*)attr->children->content, "1")) {
@@ -1662,7 +1662,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 	attr = get_attribute(attrs, "fixed");
 	if (attr) {
 		if (ref != NULL) {
-			soap_error(E_ERROR, "Parsing Schema: element has both 'ref' and 'fixed' attributes");
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: element has both 'ref' and 'fixed' attributes");
 		}
 		cur_type->fixed = estrdup((char*)attr->children->content);
 	}
@@ -1670,7 +1670,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 	attr = get_attribute(attrs, "default");
 	if (attr) {
 		if (ref != NULL) {
-			soap_error(E_ERROR, "Parsing Schema: element has both 'default' and 'fixed' attributes");
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: element has both 'default' and 'fixed' attributes");
 		}
 		cur_type->def = estrdup((char*)attr->children->content);
 	}
@@ -1716,7 +1716,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 		xmlNsPtr nsptr;
 
 		if (ref != NULL) {
-			soap_error(E_ERROR, "Parsing Schema: element has both 'ref' and 'type' attributes");
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: element has both 'ref' and 'type' attributes");
 		}
 		parse_namespace(type->children->content, &cptype, &str_ns);
 		nsptr = xmlSearchNs(element->doc, element, BAD_CAST(str_ns));
@@ -1734,17 +1734,17 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 	if (trav != NULL) {
 		if (node_is_equal_xsd(trav,"simpleType")) {
 			if (ref != NULL) {
-				soap_error(E_ERROR, "Parsing Schema: element has both 'ref' attribute and subtype");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: element has both 'ref' attribute and subtype");
 			} else if (type != NULL) {
-				soap_error(E_ERROR, "Parsing Schema: element has both 'type' attribute and subtype");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: element has both 'type' attribute and subtype");
 			}
 			schema_simpleType(sdl, tns, trav, cur_type);
 			trav = trav->next;
 		} else if (node_is_equal_xsd(trav,"complexType")) {
 			if (ref != NULL) {
-				soap_error(E_ERROR, "Parsing Schema: element has both 'ref' attribute and subtype");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: element has both 'ref' attribute and subtype");
 			} else if (type != NULL) {
-				soap_error(E_ERROR, "Parsing Schema: element has both 'type' attribute and subtype");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: element has both 'type' attribute and subtype");
 			}
 			schema_complexType(sdl, tns, trav, cur_type);
 			trav = trav->next;
@@ -1758,7 +1758,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 		} else if (node_is_equal_xsd(trav,"keyref")) {
 			/* TODO: <keyref> support */
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in element", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in element", trav->name);
 		}
 		trav = trav->next;
 	}
@@ -1848,11 +1848,11 @@ static int schema_attribute(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrType, sdl
 		}
 
 		if (zend_hash_add_ptr(addHash, key.s, newAttr) == NULL) {
-			soap_error(E_ERROR, "Parsing Schema: attribute '%s' already defined", ZSTR_VAL(key.s));
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: attribute '%s' already defined", ZSTR_VAL(key.s));
 		}
 		smart_str_free(&key);
 	} else{
-		soap_error(E_ERROR, "Parsing Schema: attribute has no 'name' nor 'ref' attributes");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: attribute has no 'name' nor 'ref' attributes");
 		return FALSE; /* the above call is noreturn, but not marked as such */
 	}
 
@@ -1864,7 +1864,7 @@ static int schema_attribute(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrType, sdl
 		xmlNsPtr nsptr;
 
 		if (ref != NULL) {
-			soap_error(E_ERROR, "Parsing Schema: attribute has both 'ref' and 'type' attributes");
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: attribute has both 'ref' and 'type' attributes");
 		}
 		parse_namespace(type->children->content, &cptype, &str_ns);
 		nsptr = xmlSearchNs(attrType->doc, attrType, BAD_CAST(str_ns));
@@ -1973,9 +1973,9 @@ static int schema_attribute(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrType, sdl
 			zval zv;
 
 			if (ref != NULL) {
-				soap_error(E_ERROR, "Parsing Schema: attribute has both 'ref' attribute and subtype");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: attribute has both 'ref' attribute and subtype");
 			} else if (type != NULL) {
-				soap_error(E_ERROR, "Parsing Schema: attribute has both 'type' attribute and subtype");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: attribute has both 'type' attribute and subtype");
 			}
 			dummy_type = emalloc(sizeof(sdlType));
 			memset(dummy_type, 0, sizeof(sdlType));
@@ -1997,7 +1997,7 @@ static int schema_attribute(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrType, sdl
 		}
 	}
 	if (trav != NULL) {
-		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in attribute", trav->name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in attribute", trav->name);
 	}
 	return TRUE;
 }
@@ -2033,7 +2033,7 @@ static int schema_attributeGroup(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrGrou
 			smart_str_0(&key);
 
 			if (zend_hash_add_ptr(ctx->attributeGroups, key.s, newType) == NULL) {
-				soap_error(E_ERROR, "Parsing Schema: attributeGroup '%s' already defined", ZSTR_VAL(key.s));
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: attributeGroup '%s' already defined", ZSTR_VAL(key.s));
 			}
 			cur_type = newType;
 			smart_str_free(&key);
@@ -2067,7 +2067,7 @@ static int schema_attributeGroup(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrGrou
 			cur_type = NULL;
 		}
 	} else{
-		soap_error(E_ERROR, "Parsing Schema: attributeGroup has no 'name' nor 'ref' attributes");
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: attributeGroup has no 'name' nor 'ref' attributes");
 	}
 
 	trav = attrGroup->children;
@@ -2078,28 +2078,28 @@ static int schema_attributeGroup(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrGrou
 	while (trav != NULL) {
 		if (node_is_equal_xsd(trav,"attribute")) {
 			if (ref != NULL) {
-				soap_error(E_ERROR, "Parsing Schema: attributeGroup has both 'ref' attribute and subattribute");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: attributeGroup has both 'ref' attribute and subattribute");
 			}
 			schema_attribute(sdl, tns, trav, cur_type, NULL);
 		} else if (node_is_equal_xsd(trav,"attributeGroup")) {
 			if (ref != NULL) {
-				soap_error(E_ERROR, "Parsing Schema: attributeGroup has both 'ref' attribute and subattribute");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: attributeGroup has both 'ref' attribute and subattribute");
 			}
 			schema_attributeGroup(sdl, tns, trav, cur_type, NULL);
 		} else if (node_is_equal_xsd(trav,"anyAttribute")) {
 			if (ref != NULL) {
-				soap_error(E_ERROR, "Parsing Schema: attributeGroup has both 'ref' attribute and subattribute");
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: attributeGroup has both 'ref' attribute and subattribute");
 			}
 			/* TODO: <anyAttribute> support */
 			trav = trav->next;
 			break;
 		} else {
-			soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in attributeGroup", trav->name);
+			php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in attributeGroup", trav->name);
 		}
 		trav = trav->next;
 	}
 	if (trav != NULL) {
-		soap_error(E_ERROR, "Parsing Schema: unexpected <%s> in attributeGroup", trav->name);
+		php_error_docref(NULL, E_ERROR, "Parsing Schema: unexpected <%s> in attributeGroup", trav->name);
 	}
 	return TRUE;
 }
@@ -2194,7 +2194,7 @@ static void schema_attributegroup_fixup(sdlCtx *ctx, sdlAttributePtr attr, HashT
 			tmp = (sdlTypePtr)schema_find_by_ref(ctx->attributeGroups, attr->ref);
 			if (tmp) {
 				if (zend_hash_index_find_ptr(&ctx->fixupInProgress, (zend_ulong)(uintptr_t)tmp) != NULL) {
-					soap_error1(E_ERROR, "Parsing Schema: recursive attributeGroup 'ref' attribute '%s'", attr->ref);
+					php_error_docref(NULL, E_ERROR, "Parsing Schema: recursive attributeGroup 'ref' attribute '%s'", attr->ref);
 				}
 				zend_hash_index_add_ptr(&ctx->fixupInProgress, (zend_ulong)(uintptr_t)tmp, tmp);
 				if (tmp->attributes) {
@@ -2248,14 +2248,14 @@ static void schema_content_model_fixup(sdlCtx *ctx, sdlContentModelPtr model)
 
 			if (ctx->sdl->groups && (tmp = zend_hash_str_find_ptr(ctx->sdl->groups, model->u.group_ref, strlen(model->u.group_ref))) != NULL) {
 				if (zend_hash_index_find_ptr(&ctx->fixupInProgress, (zend_ulong)(uintptr_t)tmp) != NULL) {
-					soap_error1(E_ERROR, "Parsing Schema: recursive group 'ref' attribute '%s'", model->u.group_ref);
+					php_error_docref(NULL, E_ERROR, "Parsing Schema: recursive group 'ref' attribute '%s'", model->u.group_ref);
 				}
 				schema_type_fixup(ctx, tmp);
 				efree(model->u.group_ref);
 				model->kind = XSD_CONTENT_GROUP;
 				model->u.group = tmp;
 			} else {
-				soap_error(E_ERROR, "Parsing Schema: unresolved group 'ref' attribute '%s'", model->u.group_ref);
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: unresolved group 'ref' attribute '%s'", model->u.group_ref);
 			}
 			break;
 		}
@@ -2314,7 +2314,7 @@ static void schema_type_fixup(sdlCtx *ctx, sdlTypePtr type)
 			} else if (strcmp(type->ref, XSD_NAMESPACE ":schema") == 0) {
 				type->encode = get_conversion(XSD_ANYXML);
 			} else {
-				soap_error(E_ERROR, "Parsing Schema: unresolved element 'ref' attribute '%s'", type->ref);
+				php_error_docref(NULL, E_ERROR, "Parsing Schema: unresolved element 'ref' attribute '%s'", type->ref);
 			}
 		}
 		efree(type->ref);

--- a/ext/soap/php_sdl.c
+++ b/ext/soap/php_sdl.c
@@ -191,7 +191,7 @@ static int is_wsdl_element(xmlNodePtr node)
 		     attr->children && attr->children->content &&
 		     (strcmp((char*)attr->children->content, "1") == 0 ||
 		      strcmp((char*)attr->children->content, "true") == 0)) {
-			soap_error(E_ERROR, "Parsing WSDL: Unknown required WSDL extension '%s'", node->ns->href);
+			php_error_docref(NULL, E_ERROR, "Parsing WSDL: Unknown required WSDL extension '%s'", node->ns->href);
 		}
 		return 0;
 	}
@@ -310,9 +310,9 @@ static void load_wsdl_ex(zval *this_ptr, char *struri, sdlCtx *ctx, bool include
 		const xmlError *xmlErrorPtr = xmlGetLastError();
 
 		if (xmlErrorPtr) {
-			soap_error(E_ERROR, "Parsing WSDL: Couldn't load from '%s' : %s", struri, xmlErrorPtr->message);
+			php_error_docref(NULL, E_ERROR, "Parsing WSDL: Couldn't load from '%s' : %s", struri, xmlErrorPtr->message);
 		} else {
-			soap_error(E_ERROR, "Parsing WSDL: Couldn't load from '%s'", struri);
+			php_error_docref(NULL, E_ERROR, "Parsing WSDL: Couldn't load from '%s'", struri);
 		}
 	}
 
@@ -328,7 +328,7 @@ static void load_wsdl_ex(zval *this_ptr, char *struri, sdlCtx *ctx, bool include
 				return;
 			}
 		}
-		soap_error(E_ERROR, "Parsing WSDL: Couldn't find <definitions> in '%s'", struri);
+		php_error_docref(NULL, E_ERROR, "Parsing WSDL: Couldn't find <definitions> in '%s'", struri);
 	}
 
 	if (!include) {
@@ -352,7 +352,7 @@ static void load_wsdl_ex(zval *this_ptr, char *struri, sdlCtx *ctx, bool include
 				if (node_is_equal_ex(trav2, "schema", XSD_NAMESPACE)) {
 					load_schema(ctx, trav2);
 				} else if (is_wsdl_element(trav2) && !node_is_equal(trav2,"documentation")) {
-					soap_error(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>", SAFE_STR(trav2->name));
+					php_error_docref(NULL, E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>", SAFE_STR(trav2->name));
 				}
 				trav2 = trav2->next;
 			}
@@ -369,43 +369,43 @@ static void load_wsdl_ex(zval *this_ptr, char *struri, sdlCtx *ctx, bool include
 			xmlAttrPtr name = get_attribute(trav->properties, "name");
 			if (name && name->children && name->children->content) {
 				if (zend_hash_str_add_ptr(&ctx->messages, (char*)name->children->content, xmlStrlen(name->children->content), trav) == NULL) {
-					soap_error(E_ERROR, "Parsing WSDL: <message> '%s' already defined", name->children->content);
+					php_error_docref(NULL, E_ERROR, "Parsing WSDL: <message> '%s' already defined", name->children->content);
 				}
 			} else {
-				soap_error(E_ERROR, "Parsing WSDL: <message> has no name attribute");
+				php_error_docref(NULL, E_ERROR, "Parsing WSDL: <message> has no name attribute");
 			}
 
 		} else if (node_is_equal(trav,"portType")) {
 			xmlAttrPtr name = get_attribute(trav->properties, "name");
 			if (name && name->children && name->children->content) {
 				if (zend_hash_str_add_ptr(&ctx->portTypes, (char*)name->children->content, xmlStrlen(name->children->content), trav) == NULL) {
-					soap_error(E_ERROR, "Parsing WSDL: <portType> '%s' already defined", name->children->content);
+					php_error_docref(NULL, E_ERROR, "Parsing WSDL: <portType> '%s' already defined", name->children->content);
 				}
 			} else {
-				soap_error(E_ERROR, "Parsing WSDL: <portType> has no name attribute");
+				php_error_docref(NULL, E_ERROR, "Parsing WSDL: <portType> has no name attribute");
 			}
 
 		} else if (node_is_equal(trav,"binding")) {
 			xmlAttrPtr name = get_attribute(trav->properties, "name");
 			if (name && name->children && name->children->content) {
 				if (zend_hash_str_add_ptr(&ctx->bindings, (char*)name->children->content, xmlStrlen(name->children->content), trav) == NULL) {
-					soap_error(E_ERROR, "Parsing WSDL: <binding> '%s' already defined", name->children->content);
+					php_error_docref(NULL, E_ERROR, "Parsing WSDL: <binding> '%s' already defined", name->children->content);
 				}
 			} else {
-				soap_error(E_ERROR, "Parsing WSDL: <binding> has no name attribute");
+				php_error_docref(NULL, E_ERROR, "Parsing WSDL: <binding> has no name attribute");
 			}
 
 		} else if (node_is_equal(trav,"service")) {
 			xmlAttrPtr name = get_attribute(trav->properties, "name");
 			if (name && name->children && name->children->content) {
 				if (zend_hash_str_add_ptr(&ctx->services, (char*)name->children->content, xmlStrlen(name->children->content), trav) == NULL) {
-					soap_error(E_ERROR, "Parsing WSDL: <service> '%s' already defined", name->children->content);
+					php_error_docref(NULL, E_ERROR, "Parsing WSDL: <service> '%s' already defined", name->children->content);
 				}
 			} else {
-				soap_error(E_ERROR, "Parsing WSDL: <service> has no name attribute");
+				php_error_docref(NULL, E_ERROR, "Parsing WSDL: <service> has no name attribute");
 			}
 		} else if (!node_is_equal(trav,"documentation")) {
-			soap_error(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav->name));
+			php_error_docref(NULL, E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav->name));
 		}
 		trav = trav->next;
 	}
@@ -420,7 +420,7 @@ static sdlSoapBindingFunctionHeaderPtr wsdl_soap_binding_header(sdlCtx* ctx, xml
 
 	tmp = get_attribute(header->properties, "message");
 	if (!tmp) {
-		soap_error(E_ERROR, "Parsing WSDL: Missing message attribute for <header>");
+		php_error_docref(NULL, E_ERROR, "Parsing WSDL: Missing message attribute for <header>");
 	}
 
 	ctype = strrchr((char*)tmp->children->content,':');
@@ -430,16 +430,16 @@ static sdlSoapBindingFunctionHeaderPtr wsdl_soap_binding_header(sdlCtx* ctx, xml
 		++ctype;
 	}
 	if ((message = zend_hash_str_find_ptr(&ctx->messages, ctype, strlen(ctype))) == NULL) {
-		soap_error(E_ERROR, "Parsing WSDL: Missing <message> with name '%s'", tmp->children->content);
+		php_error_docref(NULL, E_ERROR, "Parsing WSDL: Missing <message> with name '%s'", tmp->children->content);
 	}
 
 	tmp = get_attribute(header->properties, "part");
 	if (!tmp) {
-		soap_error(E_ERROR, "Parsing WSDL: Missing part attribute for <header>");
+		php_error_docref(NULL, E_ERROR, "Parsing WSDL: Missing part attribute for <header>");
 	}
 	part = get_node_with_attribute_ex(message->children, "part", WSDL_NAMESPACE, "name", (char*)tmp->children->content, NULL);
 	if (!part) {
-		soap_error(E_ERROR, "Parsing WSDL: Missing part '%s' in <message>", tmp->children->content);
+		php_error_docref(NULL, E_ERROR, "Parsing WSDL: Missing part '%s' in <message>", tmp->children->content);
 	}
 
 	h = emalloc(sizeof(sdlSoapBindingFunctionHeader));
@@ -466,10 +466,10 @@ static sdlSoapBindingFunctionHeaderPtr wsdl_soap_binding_header(sdlCtx* ctx, xml
 			} else if (strncmp((char*)tmp->children->content, SOAP_1_2_ENC_NAMESPACE, sizeof(SOAP_1_2_ENC_NAMESPACE)) == 0) {
 				h->encodingStyle = SOAP_ENCODING_1_2;
 			} else {
-				soap_error(E_ERROR, "Parsing WSDL: Unknown encodingStyle '%s'", tmp->children->content);
+				php_error_docref(NULL, E_ERROR, "Parsing WSDL: Unknown encodingStyle '%s'", tmp->children->content);
 			}
 		} else {
-			soap_error(E_ERROR, "Parsing WSDL: Unspecified encodingStyle");
+			php_error_docref(NULL, E_ERROR, "Parsing WSDL: Unspecified encodingStyle");
 		}
 	}
 
@@ -515,7 +515,7 @@ static sdlSoapBindingFunctionHeaderPtr wsdl_soap_binding_header(sdlCtx* ctx, xml
 				}
 				smart_str_free(&key);
 			} else if (is_wsdl_element(trav) && !node_is_equal(trav,"documentation")) {
-				soap_error(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav->name));
+				php_error_docref(NULL, E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav->name));
 			}
 			trav = trav->next;
 		}
@@ -572,7 +572,7 @@ static void wsdl_soap_binding_body(sdlCtx* ctx, xmlNodePtr node, char* wsdl_soap
 						}
 					} ZEND_HASH_FOREACH_END();
 					if (!found) {
-						soap_error(E_ERROR, "Parsing WSDL: Missing part '%s' in <message>", parts);
+						php_error_docref(NULL, E_ERROR, "Parsing WSDL: Missing part '%s' in <message>", parts);
 					}
 					parts += strlen(parts);
 					if (end) *end = ' ';
@@ -589,10 +589,10 @@ static void wsdl_soap_binding_body(sdlCtx* ctx, xmlNodePtr node, char* wsdl_soap
 					} else if (strncmp((char*)encodingStyleAttribute->children->content, SOAP_1_2_ENC_NAMESPACE, sizeof(SOAP_1_2_ENC_NAMESPACE)) == 0) {
 						binding->encodingStyle = SOAP_ENCODING_1_2;
 					} else {
-						soap_error(E_ERROR, "Parsing WSDL: Unknown encodingStyle '%s'", encodingStyleAttribute->children->content);
+						php_error_docref(NULL, E_ERROR, "Parsing WSDL: Unknown encodingStyle '%s'", encodingStyleAttribute->children->content);
 					}
 				} else {
-					soap_error(E_ERROR, "Parsing WSDL: Unspecified encodingStyle");
+					php_error_docref(NULL, E_ERROR, "Parsing WSDL: Unspecified encodingStyle");
 				}
 			}
 		} else if (node_is_equal_ex(trav, "header", wsdl_soap_namespace)) {
@@ -615,7 +615,7 @@ static void wsdl_soap_binding_body(sdlCtx* ctx, xmlNodePtr node, char* wsdl_soap
 			}
 			smart_str_free(&key);
 		} else if (is_wsdl_element(trav) && !node_is_equal(trav,"documentation")) {
-			soap_error(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav->name));
+			php_error_docref(NULL, E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav->name));
 		}
 		trav = trav->next;
 	}
@@ -634,7 +634,7 @@ static HashTable* wsdl_message(const sdlCtx *ctx, const xmlChar* message_name)
 
 	xmlNodePtr message = zend_hash_str_find_ptr(&ctx->messages, ctype, strlen(ctype));
 	if (message == NULL) {
-		soap_error(E_ERROR, "Parsing WSDL: Missing <message> with name '%s'", (const char*)message_name);
+		php_error_docref(NULL, E_ERROR, "Parsing WSDL: Missing <message> with name '%s'", (const char*)message_name);
 	}
 
 	parameters = emalloc(sizeof(HashTable));
@@ -646,14 +646,14 @@ static HashTable* wsdl_message(const sdlCtx *ctx, const xmlChar* message_name)
 		sdlParamPtr param;
 
 		if (trav->ns != NULL && strcmp((char*)trav->ns->href, WSDL_NAMESPACE) != 0) {
-			soap_error(E_ERROR, "Parsing WSDL: Unexpected extensibility element <%s>",  SAFE_STR(trav->name));
+			php_error_docref(NULL, E_ERROR, "Parsing WSDL: Unexpected extensibility element <%s>",  SAFE_STR(trav->name));
 		}
 		if (node_is_equal(trav,"documentation")) {
 			trav = trav->next;
 			continue;
 		}
 		if (!node_is_equal(trav,"part")) {
-			soap_error(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav->name));
+			php_error_docref(NULL, E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav->name));
 		}
 		xmlNodePtr part = trav;
 		param = emalloc(sizeof(sdlParam));
@@ -662,7 +662,7 @@ static HashTable* wsdl_message(const sdlCtx *ctx, const xmlChar* message_name)
 
 		name = get_attribute(part->properties, "name");
 		if (name == NULL) {
-			soap_error(E_ERROR, "Parsing WSDL: No name associated with <part> '%s'",  SAFE_STR(message->name));
+			php_error_docref(NULL, E_ERROR, "Parsing WSDL: No name associated with <part> '%s'",  SAFE_STR(message->name));
 		}
 
 		param->paramName = estrdup((char*)name->children->content);
@@ -708,7 +708,7 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 
 		uint32_t n = zend_hash_num_elements(&ctx.services);
 		if (n == 0) {
-			soap_error(E_ERROR, "Parsing WSDL: Couldn't bind to service");
+			php_error_docref(NULL, E_ERROR, "Parsing WSDL: Couldn't bind to service");
 		}
 
 		zend_hash_internal_pointer_reset(&ctx.services);
@@ -733,7 +733,7 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 					continue;
 				}
 				if (!node_is_equal(trav,"port")) {
-					soap_error(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav->name));
+					php_error_docref(NULL, E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav->name));
 				}
 
 				port = trav;
@@ -743,7 +743,7 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 
 				bindingAttr = get_attribute(port->properties, "binding");
 				if (bindingAttr == NULL) {
-					soap_error(E_ERROR, "Parsing WSDL: No binding associated with <port>");
+					php_error_docref(NULL, E_ERROR, "Parsing WSDL: No binding associated with <port>");
 				}
 
 				/* find address and figure out binding type */
@@ -772,7 +772,7 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 						}
 					}
 					if (trav2 != address && is_wsdl_element(trav2) && !node_is_equal(trav2,"documentation")) {
-						soap_error(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav2->name));
+						php_error_docref(NULL, E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav2->name));
 					}
 				  trav2 = trav2->next;
 				}
@@ -782,14 +782,14 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 						trav = trav->next;
 						continue;
 					} else if (!address) {
-						soap_error(E_ERROR, "Parsing WSDL: No address associated with <port>");
+						php_error_docref(NULL, E_ERROR, "Parsing WSDL: No address associated with <port>");
 					}
 				}
 				has_soap_port = true;
 
 				location = get_attribute(address->properties, "location");
 				if (!location) {
-					soap_error(E_ERROR, "Parsing WSDL: No location associated with <port>");
+					php_error_docref(NULL, E_ERROR, "Parsing WSDL: No location associated with <port>");
 				}
 
 				tmpbinding->location = estrdup((char*)location->children->content);
@@ -801,7 +801,7 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 					++ctype;
 				}
 				if ((tmp = zend_hash_str_find_ptr(&ctx.bindings, ctype, strlen(ctype))) == NULL) {
-					soap_error(E_ERROR, "Parsing WSDL: No <binding> element with name '%s'", ctype);
+					php_error_docref(NULL, E_ERROR, "Parsing WSDL: No <binding> element with name '%s'", ctype);
 				}
 				binding = tmp;
 
@@ -839,13 +839,13 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 
 				name = get_attribute(binding->properties, "name");
 				if (name == NULL) {
-					soap_error(E_ERROR, "Parsing WSDL: Missing 'name' attribute for <binding>");
+					php_error_docref(NULL, E_ERROR, "Parsing WSDL: Missing 'name' attribute for <binding>");
 				}
 				tmpbinding->name = estrdup((char*)name->children->content);
 
 				type = get_attribute(binding->properties, "type");
 				if (type == NULL) {
-					soap_error(E_ERROR, "Parsing WSDL: Missing 'type' attribute for <binding>");
+					php_error_docref(NULL, E_ERROR, "Parsing WSDL: Missing 'type' attribute for <binding>");
 				}
 
 				ctype = strchr((char*)type->children->content,':');
@@ -855,7 +855,7 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 					++ctype;
 				}
 				if ((tmp = zend_hash_str_find_ptr(&ctx.portTypes, ctype, strlen(ctype))) == NULL) {
-					soap_error(E_ERROR, "Parsing WSDL: Missing <portType> with name '%s'", name->children->content);
+					php_error_docref(NULL, E_ERROR, "Parsing WSDL: Missing <portType> with name '%s'", name->children->content);
 				}
 				portType = tmp;
 
@@ -873,14 +873,14 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 						continue;
 					}
 					if (!node_is_equal(trav2,"operation")) {
-						soap_error(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav2->name));
+						php_error_docref(NULL, E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav2->name));
 					}
 
 					operation = trav2;
 
 					op_name = get_attribute(operation->properties, "name");
 					if (op_name == NULL) {
-						soap_error(E_ERROR, "Parsing WSDL: Missing 'name' attribute for <operation>");
+						php_error_docref(NULL, E_ERROR, "Parsing WSDL: Missing 'name' attribute for <operation>");
 					}
 
 					trav3 = operation->children;
@@ -892,14 +892,14 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 						           !node_is_equal(trav3,"output") &&
 						           !node_is_equal(trav3,"fault") &&
 						           !node_is_equal(trav3,"documentation")) {
-							soap_error(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav3->name));
+							php_error_docref(NULL, E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav3->name));
 						}
 						trav3 = trav3->next;
 					}
 
 					portTypeOperation = get_node_with_attribute_ex(portType->children, "operation", WSDL_NAMESPACE, "name", (char*)op_name->children->content, NULL);
 					if (portTypeOperation == NULL) {
-						soap_error(E_ERROR, "Parsing WSDL: Missing <portType>/<operation> with name '%s'", op_name->children->content);
+						php_error_docref(NULL, E_ERROR, "Parsing WSDL: Missing <portType>/<operation> with name '%s'", op_name->children->content);
 					}
 
 					function = emalloc(sizeof(sdlFunction));
@@ -944,7 +944,7 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 
 						message = get_attribute(input->properties, "message");
 						if (message == NULL) {
-							soap_error(E_ERROR, "Parsing WSDL: Missing name for <input> of '%s'", op_name->children->content);
+							php_error_docref(NULL, E_ERROR, "Parsing WSDL: Missing name for <input> of '%s'", op_name->children->content);
 						}
 						function->requestParameters = wsdl_message(&ctx, message->children->content);
 
@@ -973,7 +973,7 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 
 						message = get_attribute(output->properties, "message");
 						if (message == NULL) {
-							soap_error(E_ERROR, "Parsing WSDL: Missing name for <output> of '%s'", op_name->children->content);
+							php_error_docref(NULL, E_ERROR, "Parsing WSDL: Missing name for <output> of '%s'", op_name->children->content);
 						}
 						function->responseParameters = wsdl_message(&ctx, message->children->content);
 
@@ -1014,11 +1014,11 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 
 							xmlAttrPtr faultNameAttribute = get_attribute(fault->properties, "name");
 							if (faultNameAttribute == NULL) {
-								soap_error(E_ERROR, "Parsing WSDL: Missing name for <fault> of '%s'", op_name->children->content);
+								php_error_docref(NULL, E_ERROR, "Parsing WSDL: Missing name for <fault> of '%s'", op_name->children->content);
 							}
 							message = get_attribute(fault->properties, "message");
 							if (message == NULL) {
-								soap_error(E_ERROR, "Parsing WSDL: Missing name for <output> of '%s'", op_name->children->content);
+								php_error_docref(NULL, E_ERROR, "Parsing WSDL: Missing name for <output> of '%s'", op_name->children->content);
 							}
 
 							f = emalloc(sizeof(sdlFault));
@@ -1027,7 +1027,7 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 							f->name = estrdup((char*)faultNameAttribute->children->content);
 							f->details = wsdl_message(&ctx, message->children->content);
 							if (f->details == NULL || zend_hash_num_elements(f->details) > 1) {
-								soap_error(E_ERROR, "Parsing WSDL: The fault message '%s' must have a single part", message->children->content);
+								php_error_docref(NULL, E_ERROR, "Parsing WSDL: The fault message '%s' must have a single part", message->children->content);
 							}
 
 							if (tmpbinding->bindingType == BINDING_SOAP) {
@@ -1061,14 +1061,14 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 													} else if (strncmp((char*)faultEncodingStyleAttribute->children->content, SOAP_1_2_ENC_NAMESPACE, sizeof(SOAP_1_2_ENC_NAMESPACE)) == 0) {
 														faultBinding->encodingStyle = SOAP_ENCODING_1_2;
 													} else {
-														soap_error(E_ERROR, "Parsing WSDL: Unknown encodingStyle '%s'", faultEncodingStyleAttribute->children->content);
+														php_error_docref(NULL, E_ERROR, "Parsing WSDL: Unknown encodingStyle '%s'", faultEncodingStyleAttribute->children->content);
 													}
 												} else {
-													soap_error(E_ERROR, "Parsing WSDL: Unspecified encodingStyle");
+													php_error_docref(NULL, E_ERROR, "Parsing WSDL: Unspecified encodingStyle");
 												}
 											}
 										} else if (is_wsdl_element(faultNodes) && !node_is_equal(faultNodes,"documentation")) {
-											soap_error(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(faultNodes->name));
+											php_error_docref(NULL, E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(faultNodes->name));
 										}
 										faultNodes = faultNodes->next;
 									}
@@ -1079,7 +1079,7 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 								zend_hash_init(function->faults, 0, NULL, delete_fault, 0);
 							}
 							if (zend_hash_str_add_ptr(function->faults, f->name, strlen(f->name), f) == NULL) {
-								soap_error(E_ERROR, "Parsing WSDL: <fault> with name '%s' already defined in '%s'", f->name, op_name->children->content);
+								php_error_docref(NULL, E_ERROR, "Parsing WSDL: <fault> with name '%s' already defined in '%s'", f->name, op_name->children->content);
 							}
 						}
 						fault = fault->next;
@@ -1126,7 +1126,7 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 		}
 
 		if (ctx.sdl->bindings == NULL || ctx.sdl->bindings->nNumOfElements == 0) {
-			soap_error(E_ERROR, "Parsing WSDL: Could not find any usable binding services in WSDL.");
+			php_error_docref(NULL, E_ERROR, "Parsing WSDL: Could not find any usable binding services in WSDL.");
 		}
 
 	} zend_catch {

--- a/ext/soap/php_sdl.c
+++ b/ext/soap/php_sdl.c
@@ -562,13 +562,13 @@ static void wsdl_soap_binding_body(sdlCtx* ctx, xmlNodePtr node, char* wsdl_soap
 					if (end) *end = '\0';
 					ZEND_HASH_FOREACH_PTR(params, param) {
 						if (param->paramName && strcmp(parts, param->paramName) == 0) {
-					  		sdlParamPtr x_param;
-					  		x_param = emalloc(sizeof(sdlParam));
-					  		*x_param = *param;
-					  		param->paramName = NULL;
-					  		zend_hash_next_index_insert_ptr(&ht, x_param);
-					  		found = true;
-					  		break;
+							sdlParamPtr x_param;
+							x_param = emalloc(sizeof(sdlParam));
+							*x_param = *param;
+							param->paramName = NULL;
+							zend_hash_next_index_insert_ptr(&ht, x_param);
+							found = true;
+							break;
 						}
 					} ZEND_HASH_FOREACH_END();
 					if (!found) {
@@ -2540,7 +2540,7 @@ static HashTable* make_persistent_sdl_function_faults(sdlFunctionPtr func, HashT
 		if (func->binding->bindingType == BINDING_SOAP && pfault->bindingAttributes) {
 			sdlSoapBindingFunctionFaultPtr soap_binding;
 
-		   	soap_binding = malloc(sizeof(sdlSoapBindingFunctionFault));
+			soap_binding = malloc(sizeof(sdlSoapBindingFunctionFault));
 			memset(soap_binding, 0, sizeof(sdlSoapBindingFunctionFault));
 			*soap_binding = *(sdlSoapBindingFunctionFaultPtr)pfault->bindingAttributes;
 			if (soap_binding->ns) {
@@ -2876,7 +2876,7 @@ static sdlFunctionPtr make_persistent_sdl_function(sdlFunctionPtr func, HashTabl
 		if (pfunc->binding->bindingType == BINDING_SOAP && pfunc->bindingAttributes) {
 			sdlSoapBindingFunctionPtr soap_binding;
 
-		   	soap_binding = malloc(sizeof(sdlSoapBindingFunction));
+			soap_binding = malloc(sizeof(sdlSoapBindingFunction));
 			memset(soap_binding, 0, sizeof(sdlSoapBindingFunction));
 			*soap_binding = *(sdlSoapBindingFunctionPtr)pfunc->bindingAttributes;
 			if (soap_binding->soapAction) {

--- a/ext/soap/php_sdl.c
+++ b/ext/soap/php_sdl.c
@@ -191,7 +191,7 @@ static int is_wsdl_element(xmlNodePtr node)
 		     attr->children && attr->children->content &&
 		     (strcmp((char*)attr->children->content, "1") == 0 ||
 		      strcmp((char*)attr->children->content, "true") == 0)) {
-			soap_error1(E_ERROR, "Parsing WSDL: Unknown required WSDL extension '%s'", node->ns->href);
+			soap_error(E_ERROR, "Parsing WSDL: Unknown required WSDL extension '%s'", node->ns->href);
 		}
 		return 0;
 	}
@@ -310,9 +310,9 @@ static void load_wsdl_ex(zval *this_ptr, char *struri, sdlCtx *ctx, bool include
 		const xmlError *xmlErrorPtr = xmlGetLastError();
 
 		if (xmlErrorPtr) {
-			soap_error2(E_ERROR, "Parsing WSDL: Couldn't load from '%s' : %s", struri, xmlErrorPtr->message);
+			soap_error(E_ERROR, "Parsing WSDL: Couldn't load from '%s' : %s", struri, xmlErrorPtr->message);
 		} else {
-			soap_error1(E_ERROR, "Parsing WSDL: Couldn't load from '%s'", struri);
+			soap_error(E_ERROR, "Parsing WSDL: Couldn't load from '%s'", struri);
 		}
 	}
 
@@ -328,7 +328,7 @@ static void load_wsdl_ex(zval *this_ptr, char *struri, sdlCtx *ctx, bool include
 				return;
 			}
 		}
-		soap_error1(E_ERROR, "Parsing WSDL: Couldn't find <definitions> in '%s'", struri);
+		soap_error(E_ERROR, "Parsing WSDL: Couldn't find <definitions> in '%s'", struri);
 	}
 
 	if (!include) {
@@ -352,7 +352,7 @@ static void load_wsdl_ex(zval *this_ptr, char *struri, sdlCtx *ctx, bool include
 				if (node_is_equal_ex(trav2, "schema", XSD_NAMESPACE)) {
 					load_schema(ctx, trav2);
 				} else if (is_wsdl_element(trav2) && !node_is_equal(trav2,"documentation")) {
-					soap_error1(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>", SAFE_STR(trav2->name));
+					soap_error(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>", SAFE_STR(trav2->name));
 				}
 				trav2 = trav2->next;
 			}
@@ -369,43 +369,43 @@ static void load_wsdl_ex(zval *this_ptr, char *struri, sdlCtx *ctx, bool include
 			xmlAttrPtr name = get_attribute(trav->properties, "name");
 			if (name && name->children && name->children->content) {
 				if (zend_hash_str_add_ptr(&ctx->messages, (char*)name->children->content, xmlStrlen(name->children->content), trav) == NULL) {
-					soap_error1(E_ERROR, "Parsing WSDL: <message> '%s' already defined", name->children->content);
+					soap_error(E_ERROR, "Parsing WSDL: <message> '%s' already defined", name->children->content);
 				}
 			} else {
-				soap_error0(E_ERROR, "Parsing WSDL: <message> has no name attribute");
+				soap_error(E_ERROR, "Parsing WSDL: <message> has no name attribute");
 			}
 
 		} else if (node_is_equal(trav,"portType")) {
 			xmlAttrPtr name = get_attribute(trav->properties, "name");
 			if (name && name->children && name->children->content) {
 				if (zend_hash_str_add_ptr(&ctx->portTypes, (char*)name->children->content, xmlStrlen(name->children->content), trav) == NULL) {
-					soap_error1(E_ERROR, "Parsing WSDL: <portType> '%s' already defined", name->children->content);
+					soap_error(E_ERROR, "Parsing WSDL: <portType> '%s' already defined", name->children->content);
 				}
 			} else {
-				soap_error0(E_ERROR, "Parsing WSDL: <portType> has no name attribute");
+				soap_error(E_ERROR, "Parsing WSDL: <portType> has no name attribute");
 			}
 
 		} else if (node_is_equal(trav,"binding")) {
 			xmlAttrPtr name = get_attribute(trav->properties, "name");
 			if (name && name->children && name->children->content) {
 				if (zend_hash_str_add_ptr(&ctx->bindings, (char*)name->children->content, xmlStrlen(name->children->content), trav) == NULL) {
-					soap_error1(E_ERROR, "Parsing WSDL: <binding> '%s' already defined", name->children->content);
+					soap_error(E_ERROR, "Parsing WSDL: <binding> '%s' already defined", name->children->content);
 				}
 			} else {
-				soap_error0(E_ERROR, "Parsing WSDL: <binding> has no name attribute");
+				soap_error(E_ERROR, "Parsing WSDL: <binding> has no name attribute");
 			}
 
 		} else if (node_is_equal(trav,"service")) {
 			xmlAttrPtr name = get_attribute(trav->properties, "name");
 			if (name && name->children && name->children->content) {
 				if (zend_hash_str_add_ptr(&ctx->services, (char*)name->children->content, xmlStrlen(name->children->content), trav) == NULL) {
-					soap_error1(E_ERROR, "Parsing WSDL: <service> '%s' already defined", name->children->content);
+					soap_error(E_ERROR, "Parsing WSDL: <service> '%s' already defined", name->children->content);
 				}
 			} else {
-				soap_error0(E_ERROR, "Parsing WSDL: <service> has no name attribute");
+				soap_error(E_ERROR, "Parsing WSDL: <service> has no name attribute");
 			}
 		} else if (!node_is_equal(trav,"documentation")) {
-			soap_error1(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav->name));
+			soap_error(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav->name));
 		}
 		trav = trav->next;
 	}
@@ -420,7 +420,7 @@ static sdlSoapBindingFunctionHeaderPtr wsdl_soap_binding_header(sdlCtx* ctx, xml
 
 	tmp = get_attribute(header->properties, "message");
 	if (!tmp) {
-		soap_error0(E_ERROR, "Parsing WSDL: Missing message attribute for <header>");
+		soap_error(E_ERROR, "Parsing WSDL: Missing message attribute for <header>");
 	}
 
 	ctype = strrchr((char*)tmp->children->content,':');
@@ -430,16 +430,16 @@ static sdlSoapBindingFunctionHeaderPtr wsdl_soap_binding_header(sdlCtx* ctx, xml
 		++ctype;
 	}
 	if ((message = zend_hash_str_find_ptr(&ctx->messages, ctype, strlen(ctype))) == NULL) {
-		soap_error1(E_ERROR, "Parsing WSDL: Missing <message> with name '%s'", tmp->children->content);
+		soap_error(E_ERROR, "Parsing WSDL: Missing <message> with name '%s'", tmp->children->content);
 	}
 
 	tmp = get_attribute(header->properties, "part");
 	if (!tmp) {
-		soap_error0(E_ERROR, "Parsing WSDL: Missing part attribute for <header>");
+		soap_error(E_ERROR, "Parsing WSDL: Missing part attribute for <header>");
 	}
 	part = get_node_with_attribute_ex(message->children, "part", WSDL_NAMESPACE, "name", (char*)tmp->children->content, NULL);
 	if (!part) {
-		soap_error1(E_ERROR, "Parsing WSDL: Missing part '%s' in <message>", tmp->children->content);
+		soap_error(E_ERROR, "Parsing WSDL: Missing part '%s' in <message>", tmp->children->content);
 	}
 
 	h = emalloc(sizeof(sdlSoapBindingFunctionHeader));
@@ -466,10 +466,10 @@ static sdlSoapBindingFunctionHeaderPtr wsdl_soap_binding_header(sdlCtx* ctx, xml
 			} else if (strncmp((char*)tmp->children->content, SOAP_1_2_ENC_NAMESPACE, sizeof(SOAP_1_2_ENC_NAMESPACE)) == 0) {
 				h->encodingStyle = SOAP_ENCODING_1_2;
 			} else {
-				soap_error1(E_ERROR, "Parsing WSDL: Unknown encodingStyle '%s'", tmp->children->content);
+				soap_error(E_ERROR, "Parsing WSDL: Unknown encodingStyle '%s'", tmp->children->content);
 			}
 		} else {
-			soap_error0(E_ERROR, "Parsing WSDL: Unspecified encodingStyle");
+			soap_error(E_ERROR, "Parsing WSDL: Unspecified encodingStyle");
 		}
 	}
 
@@ -515,7 +515,7 @@ static sdlSoapBindingFunctionHeaderPtr wsdl_soap_binding_header(sdlCtx* ctx, xml
 				}
 				smart_str_free(&key);
 			} else if (is_wsdl_element(trav) && !node_is_equal(trav,"documentation")) {
-				soap_error1(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav->name));
+				soap_error(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav->name));
 			}
 			trav = trav->next;
 		}
@@ -572,7 +572,7 @@ static void wsdl_soap_binding_body(sdlCtx* ctx, xmlNodePtr node, char* wsdl_soap
 						}
 					} ZEND_HASH_FOREACH_END();
 					if (!found) {
-						soap_error1(E_ERROR, "Parsing WSDL: Missing part '%s' in <message>", parts);
+						soap_error(E_ERROR, "Parsing WSDL: Missing part '%s' in <message>", parts);
 					}
 					parts += strlen(parts);
 					if (end) *end = ' ';
@@ -589,10 +589,10 @@ static void wsdl_soap_binding_body(sdlCtx* ctx, xmlNodePtr node, char* wsdl_soap
 					} else if (strncmp((char*)encodingStyleAttribute->children->content, SOAP_1_2_ENC_NAMESPACE, sizeof(SOAP_1_2_ENC_NAMESPACE)) == 0) {
 						binding->encodingStyle = SOAP_ENCODING_1_2;
 					} else {
-						soap_error1(E_ERROR, "Parsing WSDL: Unknown encodingStyle '%s'", encodingStyleAttribute->children->content);
+						soap_error(E_ERROR, "Parsing WSDL: Unknown encodingStyle '%s'", encodingStyleAttribute->children->content);
 					}
 				} else {
-					soap_error0(E_ERROR, "Parsing WSDL: Unspecified encodingStyle");
+					soap_error(E_ERROR, "Parsing WSDL: Unspecified encodingStyle");
 				}
 			}
 		} else if (node_is_equal_ex(trav, "header", wsdl_soap_namespace)) {
@@ -615,7 +615,7 @@ static void wsdl_soap_binding_body(sdlCtx* ctx, xmlNodePtr node, char* wsdl_soap
 			}
 			smart_str_free(&key);
 		} else if (is_wsdl_element(trav) && !node_is_equal(trav,"documentation")) {
-			soap_error1(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav->name));
+			soap_error(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav->name));
 		}
 		trav = trav->next;
 	}
@@ -634,7 +634,7 @@ static HashTable* wsdl_message(const sdlCtx *ctx, const xmlChar* message_name)
 
 	xmlNodePtr message = zend_hash_str_find_ptr(&ctx->messages, ctype, strlen(ctype));
 	if (message == NULL) {
-		soap_error1(E_ERROR, "Parsing WSDL: Missing <message> with name '%s'", (const char*)message_name);
+		soap_error(E_ERROR, "Parsing WSDL: Missing <message> with name '%s'", (const char*)message_name);
 	}
 
 	parameters = emalloc(sizeof(HashTable));
@@ -646,14 +646,14 @@ static HashTable* wsdl_message(const sdlCtx *ctx, const xmlChar* message_name)
 		sdlParamPtr param;
 
 		if (trav->ns != NULL && strcmp((char*)trav->ns->href, WSDL_NAMESPACE) != 0) {
-			soap_error1(E_ERROR, "Parsing WSDL: Unexpected extensibility element <%s>",  SAFE_STR(trav->name));
+			soap_error(E_ERROR, "Parsing WSDL: Unexpected extensibility element <%s>",  SAFE_STR(trav->name));
 		}
 		if (node_is_equal(trav,"documentation")) {
 			trav = trav->next;
 			continue;
 		}
 		if (!node_is_equal(trav,"part")) {
-			soap_error1(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav->name));
+			soap_error(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav->name));
 		}
 		xmlNodePtr part = trav;
 		param = emalloc(sizeof(sdlParam));
@@ -662,7 +662,7 @@ static HashTable* wsdl_message(const sdlCtx *ctx, const xmlChar* message_name)
 
 		name = get_attribute(part->properties, "name");
 		if (name == NULL) {
-			soap_error1(E_ERROR, "Parsing WSDL: No name associated with <part> '%s'",  SAFE_STR(message->name));
+			soap_error(E_ERROR, "Parsing WSDL: No name associated with <part> '%s'",  SAFE_STR(message->name));
 		}
 
 		param->paramName = estrdup((char*)name->children->content);
@@ -708,7 +708,7 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 
 		uint32_t n = zend_hash_num_elements(&ctx.services);
 		if (n == 0) {
-			soap_error0(E_ERROR, "Parsing WSDL: Couldn't bind to service");
+			soap_error(E_ERROR, "Parsing WSDL: Couldn't bind to service");
 		}
 
 		zend_hash_internal_pointer_reset(&ctx.services);
@@ -733,7 +733,7 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 					continue;
 				}
 				if (!node_is_equal(trav,"port")) {
-					soap_error1(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav->name));
+					soap_error(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav->name));
 				}
 
 				port = trav;
@@ -743,7 +743,7 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 
 				bindingAttr = get_attribute(port->properties, "binding");
 				if (bindingAttr == NULL) {
-					soap_error0(E_ERROR, "Parsing WSDL: No binding associated with <port>");
+					soap_error(E_ERROR, "Parsing WSDL: No binding associated with <port>");
 				}
 
 				/* find address and figure out binding type */
@@ -772,7 +772,7 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 						}
 					}
 					if (trav2 != address && is_wsdl_element(trav2) && !node_is_equal(trav2,"documentation")) {
-						soap_error1(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav2->name));
+						soap_error(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav2->name));
 					}
 				  trav2 = trav2->next;
 				}
@@ -782,14 +782,14 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 						trav = trav->next;
 						continue;
 					} else if (!address) {
-						soap_error0(E_ERROR, "Parsing WSDL: No address associated with <port>");
+						soap_error(E_ERROR, "Parsing WSDL: No address associated with <port>");
 					}
 				}
 				has_soap_port = true;
 
 				location = get_attribute(address->properties, "location");
 				if (!location) {
-					soap_error0(E_ERROR, "Parsing WSDL: No location associated with <port>");
+					soap_error(E_ERROR, "Parsing WSDL: No location associated with <port>");
 				}
 
 				tmpbinding->location = estrdup((char*)location->children->content);
@@ -801,7 +801,7 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 					++ctype;
 				}
 				if ((tmp = zend_hash_str_find_ptr(&ctx.bindings, ctype, strlen(ctype))) == NULL) {
-					soap_error1(E_ERROR, "Parsing WSDL: No <binding> element with name '%s'", ctype);
+					soap_error(E_ERROR, "Parsing WSDL: No <binding> element with name '%s'", ctype);
 				}
 				binding = tmp;
 
@@ -839,13 +839,13 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 
 				name = get_attribute(binding->properties, "name");
 				if (name == NULL) {
-					soap_error0(E_ERROR, "Parsing WSDL: Missing 'name' attribute for <binding>");
+					soap_error(E_ERROR, "Parsing WSDL: Missing 'name' attribute for <binding>");
 				}
 				tmpbinding->name = estrdup((char*)name->children->content);
 
 				type = get_attribute(binding->properties, "type");
 				if (type == NULL) {
-					soap_error0(E_ERROR, "Parsing WSDL: Missing 'type' attribute for <binding>");
+					soap_error(E_ERROR, "Parsing WSDL: Missing 'type' attribute for <binding>");
 				}
 
 				ctype = strchr((char*)type->children->content,':');
@@ -855,7 +855,7 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 					++ctype;
 				}
 				if ((tmp = zend_hash_str_find_ptr(&ctx.portTypes, ctype, strlen(ctype))) == NULL) {
-					soap_error1(E_ERROR, "Parsing WSDL: Missing <portType> with name '%s'", name->children->content);
+					soap_error(E_ERROR, "Parsing WSDL: Missing <portType> with name '%s'", name->children->content);
 				}
 				portType = tmp;
 
@@ -873,14 +873,14 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 						continue;
 					}
 					if (!node_is_equal(trav2,"operation")) {
-						soap_error1(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav2->name));
+						soap_error(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav2->name));
 					}
 
 					operation = trav2;
 
 					op_name = get_attribute(operation->properties, "name");
 					if (op_name == NULL) {
-						soap_error0(E_ERROR, "Parsing WSDL: Missing 'name' attribute for <operation>");
+						soap_error(E_ERROR, "Parsing WSDL: Missing 'name' attribute for <operation>");
 					}
 
 					trav3 = operation->children;
@@ -892,14 +892,14 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 						           !node_is_equal(trav3,"output") &&
 						           !node_is_equal(trav3,"fault") &&
 						           !node_is_equal(trav3,"documentation")) {
-							soap_error1(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav3->name));
+							soap_error(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(trav3->name));
 						}
 						trav3 = trav3->next;
 					}
 
 					portTypeOperation = get_node_with_attribute_ex(portType->children, "operation", WSDL_NAMESPACE, "name", (char*)op_name->children->content, NULL);
 					if (portTypeOperation == NULL) {
-						soap_error1(E_ERROR, "Parsing WSDL: Missing <portType>/<operation> with name '%s'", op_name->children->content);
+						soap_error(E_ERROR, "Parsing WSDL: Missing <portType>/<operation> with name '%s'", op_name->children->content);
 					}
 
 					function = emalloc(sizeof(sdlFunction));
@@ -944,7 +944,7 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 
 						message = get_attribute(input->properties, "message");
 						if (message == NULL) {
-							soap_error1(E_ERROR, "Parsing WSDL: Missing name for <input> of '%s'", op_name->children->content);
+							soap_error(E_ERROR, "Parsing WSDL: Missing name for <input> of '%s'", op_name->children->content);
 						}
 						function->requestParameters = wsdl_message(&ctx, message->children->content);
 
@@ -973,7 +973,7 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 
 						message = get_attribute(output->properties, "message");
 						if (message == NULL) {
-							soap_error1(E_ERROR, "Parsing WSDL: Missing name for <output> of '%s'", op_name->children->content);
+							soap_error(E_ERROR, "Parsing WSDL: Missing name for <output> of '%s'", op_name->children->content);
 						}
 						function->responseParameters = wsdl_message(&ctx, message->children->content);
 
@@ -1014,11 +1014,11 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 
 							xmlAttrPtr faultNameAttribute = get_attribute(fault->properties, "name");
 							if (faultNameAttribute == NULL) {
-								soap_error1(E_ERROR, "Parsing WSDL: Missing name for <fault> of '%s'", op_name->children->content);
+								soap_error(E_ERROR, "Parsing WSDL: Missing name for <fault> of '%s'", op_name->children->content);
 							}
 							message = get_attribute(fault->properties, "message");
 							if (message == NULL) {
-								soap_error1(E_ERROR, "Parsing WSDL: Missing name for <output> of '%s'", op_name->children->content);
+								soap_error(E_ERROR, "Parsing WSDL: Missing name for <output> of '%s'", op_name->children->content);
 							}
 
 							f = emalloc(sizeof(sdlFault));
@@ -1027,7 +1027,7 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 							f->name = estrdup((char*)faultNameAttribute->children->content);
 							f->details = wsdl_message(&ctx, message->children->content);
 							if (f->details == NULL || zend_hash_num_elements(f->details) > 1) {
-								soap_error1(E_ERROR, "Parsing WSDL: The fault message '%s' must have a single part", message->children->content);
+								soap_error(E_ERROR, "Parsing WSDL: The fault message '%s' must have a single part", message->children->content);
 							}
 
 							if (tmpbinding->bindingType == BINDING_SOAP) {
@@ -1061,14 +1061,14 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 													} else if (strncmp((char*)faultEncodingStyleAttribute->children->content, SOAP_1_2_ENC_NAMESPACE, sizeof(SOAP_1_2_ENC_NAMESPACE)) == 0) {
 														faultBinding->encodingStyle = SOAP_ENCODING_1_2;
 													} else {
-														soap_error1(E_ERROR, "Parsing WSDL: Unknown encodingStyle '%s'", faultEncodingStyleAttribute->children->content);
+														soap_error(E_ERROR, "Parsing WSDL: Unknown encodingStyle '%s'", faultEncodingStyleAttribute->children->content);
 													}
 												} else {
-													soap_error0(E_ERROR, "Parsing WSDL: Unspecified encodingStyle");
+													soap_error(E_ERROR, "Parsing WSDL: Unspecified encodingStyle");
 												}
 											}
 										} else if (is_wsdl_element(faultNodes) && !node_is_equal(faultNodes,"documentation")) {
-											soap_error1(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(faultNodes->name));
+											soap_error(E_ERROR, "Parsing WSDL: Unexpected WSDL element <%s>",  SAFE_STR(faultNodes->name));
 										}
 										faultNodes = faultNodes->next;
 									}
@@ -1079,7 +1079,7 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 								zend_hash_init(function->faults, 0, NULL, delete_fault, 0);
 							}
 							if (zend_hash_str_add_ptr(function->faults, f->name, strlen(f->name), f) == NULL) {
-								soap_error2(E_ERROR, "Parsing WSDL: <fault> with name '%s' already defined in '%s'", f->name, op_name->children->content);
+								soap_error(E_ERROR, "Parsing WSDL: <fault> with name '%s' already defined in '%s'", f->name, op_name->children->content);
 							}
 						}
 						fault = fault->next;
@@ -1126,7 +1126,7 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 		}
 
 		if (ctx.sdl->bindings == NULL || ctx.sdl->bindings->nNumOfElements == 0) {
-			soap_error0(E_ERROR, "Parsing WSDL: Could not find any usable binding services in WSDL.");
+			soap_error(E_ERROR, "Parsing WSDL: Could not find any usable binding services in WSDL.");
 		}
 
 	} zend_catch {

--- a/ext/soap/php_soap.h
+++ b/ext/soap/php_soap.h
@@ -197,17 +197,8 @@ extern HashTable php_soap_defEncNs, php_soap_defEnc, php_soap_defEncIndex;
 
 void add_soap_fault(zval *obj, const char *fault_code, const char *fault_string, zend_string *fault_actor, zval *fault_detail, zend_string *lang);
 
-#define soap_error0(severity, format) \
-	php_error(severity, "SOAP-ERROR: " format)
-
-#define soap_error1(severity, format, param1) \
-	php_error(severity, "SOAP-ERROR: " format, param1)
-
-#define soap_error2(severity, format, param1, param2) \
-	php_error(severity, "SOAP-ERROR: " format, param1, param2)
-
-#define soap_error3(severity, format, param1, param2, param3) \
-	php_error(severity, "SOAP-ERROR: " format, param1, param2, param3)
+#define soap_error(severity, format, ...) \
+	php_error(severity, "SOAP-ERROR: " format, ## __VA_ARGS__)
 
 static zend_always_inline zval *php_soap_deref(zval *zv) {
 	if (UNEXPECTED(Z_TYPE_P(zv) == IS_REFERENCE)) {

--- a/ext/soap/php_soap.h
+++ b/ext/soap/php_soap.h
@@ -197,9 +197,6 @@ extern HashTable php_soap_defEncNs, php_soap_defEnc, php_soap_defEncIndex;
 
 void add_soap_fault(zval *obj, const char *fault_code, const char *fault_string, zend_string *fault_actor, zval *fault_detail, zend_string *lang);
 
-#define soap_error(severity, format, ...) \
-	php_error(severity, "SOAP-ERROR: " format, ## __VA_ARGS__)
-
 static zend_always_inline zval *php_soap_deref(zval *zv) {
 	if (UNEXPECTED(Z_TYPE_P(zv) == IS_REFERENCE)) {
 		return Z_REFVAL_P(zv);

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -1693,7 +1693,7 @@ PHP_METHOD(SoapServer, handle)
 			call_status = call_user_function(EG(function_table), NULL, &function_name, &retval, num_params, params);
 		}
 	} else {
-		php_error(E_ERROR, "Function '%s' doesn't exist", Z_STRVAL(function_name));
+		php_error_docref(NULL, E_ERROR, "Function '%s' doesn't exist", Z_STRVAL(function_name));
 	}
 
 	if (EG(exception)) {
@@ -4104,7 +4104,7 @@ static xmlDocPtr serialize_function_call(zval *this_ptr, sdlFunctionPtr function
 		ns = xmlNewNs(envelope, BAD_CAST(SOAP_1_2_ENV_NAMESPACE), BAD_CAST(SOAP_1_2_ENV_NS_PREFIX));
 		xmlSetNs(envelope, ns);
 	} else {
-		soap_error(E_ERROR, "Unknown SOAP version");
+		php_error_docref(NULL, E_ERROR, "Unknown SOAP version");
 	}
 	xmlDocSetRootElement(doc, envelope);
 

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -2499,7 +2499,7 @@ static void do_soap_call(zend_execute_data *execute_data,
 	}
 
 	zend_try {
-	 	if (sdl != NULL) {
+		if (sdl != NULL) {
 			fn = get_function(sdl, ZSTR_VAL(function), ZSTR_LEN(function));
 			if (fn != NULL) {
 				sdlBindingPtr binding = fn->binding;
@@ -2523,7 +2523,7 @@ static void do_soap_call(zend_execute_data *execute_data,
 					request = serialize_function_call(this_ptr, fn, NULL, fnb->input.ns, real_args, arg_count, soap_version, soap_headers);
 					ret = do_request(this_ptr, request, location_c_str, fnb->soapAction, soap_version, one_way, &response);
 				} else {
-	 				request = serialize_function_call(this_ptr, fn, NULL, sdl->target_ns, real_args, arg_count, soap_version, soap_headers);
+					request = serialize_function_call(this_ptr, fn, NULL, sdl->target_ns, real_args, arg_count, soap_version, soap_headers);
 					ret = do_request(this_ptr, request, location_c_str, NULL, soap_version, one_way, &response);
 				}
 
@@ -2548,12 +2548,12 @@ static void do_soap_call(zend_execute_data *execute_data,
 
 				zval_ptr_dtor(&response);
 
-	 		} else {
-	 			smart_str error = {0};
-	 			smart_str_appends(&error,"Function (\"");
+			} else {
+				smart_str error = {0};
+				smart_str_appends(&error,"Function (\"");
 				smart_str_append(&error,function);
-	 			smart_str_appends(&error,"\") is not a valid method for this service");
-	 			smart_str_0(&error);
+				smart_str_appends(&error,"\") is not a valid method for this service");
+				smart_str_0(&error);
 				add_soap_fault_en(this_ptr, "Client", ZSTR_VAL(error.s));
 				smart_str_free(&error);
 			}
@@ -2569,7 +2569,7 @@ static void do_soap_call(zend_execute_data *execute_data,
 				}
 				request = serialize_function_call(this_ptr, NULL, ZSTR_VAL(function), ZSTR_VAL(call_uri), real_args, arg_count, soap_version, soap_headers);
 
-		 		if (soap_action == NULL) {
+				if (soap_action == NULL) {
 					smart_str_append(&action, call_uri);
 					smart_str_appendc(&action, '#');
 					smart_str_append(&action, function);
@@ -2580,7 +2580,7 @@ static void do_soap_call(zend_execute_data *execute_data,
 
 				ret = do_request(this_ptr, request, ZSTR_VAL(location), ZSTR_VAL(action.s), soap_version, 0, &response);
 
-		 		smart_str_free(&action);
+				smart_str_free(&action);
 				xmlFreeDoc(request);
 				request = NULL;
 
@@ -2602,7 +2602,7 @@ static void do_soap_call(zend_execute_data *execute_data,
 
 				zval_ptr_dtor(&response);
 			}
-	 	}
+		}
 
 		zval *fault = Z_CLIENT_SOAP_FAULT_P(this_ptr);
 		if (!ret) {
@@ -3098,7 +3098,7 @@ static void set_soap_fault(zval *obj, const char *fault_code_ns, const char *fau
 				if (strcmp(fault_code,"Client") == 0 ||
 				    strcmp(fault_code,"Server") == 0 ||
 				    strcmp(fault_code,"VersionMismatch") == 0 ||
-			  	  strcmp(fault_code,"MustUnderstand") == 0) {
+				    strcmp(fault_code,"MustUnderstand") == 0) {
 					ZVAL_STRING(Z_FAULT_CODENS_P(obj), SOAP_1_1_ENV_NAMESPACE);
 				}
 			} else if (soap_version == SOAP_1_2) {

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -4104,7 +4104,7 @@ static xmlDocPtr serialize_function_call(zval *this_ptr, sdlFunctionPtr function
 		ns = xmlNewNs(envelope, BAD_CAST(SOAP_1_2_ENV_NAMESPACE), BAD_CAST(SOAP_1_2_ENV_NS_PREFIX));
 		xmlSetNs(envelope, ns);
 	} else {
-		soap_error0(E_ERROR, "Unknown SOAP version");
+		soap_error(E_ERROR, "Unknown SOAP version");
 	}
 	xmlDocSetRootElement(doc, envelope);
 

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -4099,7 +4099,7 @@ static xmlDocPtr serialize_function_call(zval *this_ptr, sdlFunctionPtr function
 		ns = xmlNewNs(envelope, BAD_CAST(SOAP_1_2_ENV_NAMESPACE), BAD_CAST(SOAP_1_2_ENV_NS_PREFIX));
 		xmlSetNs(envelope, ns);
 	} else {
-		soap_error0(E_ERROR, "Unknown SOAP version");
+		soap_error(E_ERROR, "Unknown SOAP version");
 	}
 	xmlDocSetRootElement(doc, envelope);
 

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -1688,7 +1688,7 @@ PHP_METHOD(SoapServer, handle)
 			}
 		}
 	} else {
-		php_error(E_ERROR, "Function '%s' doesn't exist", Z_STRVAL(function_name));
+		php_error_docref(NULL, E_ERROR, "Function '%s' doesn't exist", Z_STRVAL(function_name));
 	}
 
 	if (EG(exception)) {
@@ -4099,7 +4099,7 @@ static xmlDocPtr serialize_function_call(zval *this_ptr, sdlFunctionPtr function
 		ns = xmlNewNs(envelope, BAD_CAST(SOAP_1_2_ENV_NAMESPACE), BAD_CAST(SOAP_1_2_ENV_NS_PREFIX));
 		xmlSetNs(envelope, ns);
 	} else {
-		soap_error(E_ERROR, "Unknown SOAP version");
+		php_error_docref(NULL, E_ERROR, "Unknown SOAP version");
 	}
 	xmlDocSetRootElement(doc, envelope);
 

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -2494,7 +2494,7 @@ static void do_soap_call(zend_execute_data *execute_data,
 	}
 
 	zend_try {
-	 	if (sdl != NULL) {
+		if (sdl != NULL) {
 			fn = get_function(sdl, ZSTR_VAL(function), ZSTR_LEN(function));
 			if (fn != NULL) {
 				sdlBindingPtr binding = fn->binding;
@@ -2518,7 +2518,7 @@ static void do_soap_call(zend_execute_data *execute_data,
 					request = serialize_function_call(this_ptr, fn, NULL, fnb->input.ns, real_args, arg_count, soap_version, soap_headers);
 					ret = do_request(this_ptr, request, location_c_str, fnb->soapAction, soap_version, one_way, &response);
 				} else {
-	 				request = serialize_function_call(this_ptr, fn, NULL, sdl->target_ns, real_args, arg_count, soap_version, soap_headers);
+					request = serialize_function_call(this_ptr, fn, NULL, sdl->target_ns, real_args, arg_count, soap_version, soap_headers);
 					ret = do_request(this_ptr, request, location_c_str, NULL, soap_version, one_way, &response);
 				}
 
@@ -2543,12 +2543,12 @@ static void do_soap_call(zend_execute_data *execute_data,
 
 				zval_ptr_dtor(&response);
 
-	 		} else {
-	 			smart_str error = {0};
-	 			smart_str_appends(&error,"Function (\"");
+			} else {
+				smart_str error = {0};
+				smart_str_appends(&error,"Function (\"");
 				smart_str_append(&error,function);
-	 			smart_str_appends(&error,"\") is not a valid method for this service");
-	 			smart_str_0(&error);
+				smart_str_appends(&error,"\") is not a valid method for this service");
+				smart_str_0(&error);
 				add_soap_fault_en(this_ptr, "Client", ZSTR_VAL(error.s));
 				smart_str_free(&error);
 			}
@@ -2564,7 +2564,7 @@ static void do_soap_call(zend_execute_data *execute_data,
 				}
 				request = serialize_function_call(this_ptr, NULL, ZSTR_VAL(function), ZSTR_VAL(call_uri), real_args, arg_count, soap_version, soap_headers);
 
-		 		if (soap_action == NULL) {
+				if (soap_action == NULL) {
 					smart_str_append(&action, call_uri);
 					smart_str_appendc(&action, '#');
 					smart_str_append(&action, function);
@@ -2575,7 +2575,7 @@ static void do_soap_call(zend_execute_data *execute_data,
 
 				ret = do_request(this_ptr, request, ZSTR_VAL(location), ZSTR_VAL(action.s), soap_version, 0, &response);
 
-		 		smart_str_free(&action);
+				smart_str_free(&action);
 				xmlFreeDoc(request);
 				request = NULL;
 
@@ -2597,7 +2597,7 @@ static void do_soap_call(zend_execute_data *execute_data,
 
 				zval_ptr_dtor(&response);
 			}
-	 	}
+		}
 
 		zval *fault = Z_CLIENT_SOAP_FAULT_P(this_ptr);
 		if (!ret) {
@@ -3093,7 +3093,7 @@ static void set_soap_fault(zval *obj, const char *fault_code_ns, const char *fau
 				if (strcmp(fault_code,"Client") == 0 ||
 				    strcmp(fault_code,"Server") == 0 ||
 				    strcmp(fault_code,"VersionMismatch") == 0 ||
-			  	  strcmp(fault_code,"MustUnderstand") == 0) {
+				    strcmp(fault_code,"MustUnderstand") == 0) {
 					ZVAL_STRING(Z_FAULT_CODENS_P(obj), SOAP_1_1_ENV_NAMESPACE);
 				}
 			} else if (soap_version == SOAP_1_2) {

--- a/ext/soap/tests/GHSA-hmxp-6pc4-f3vv.phpt
+++ b/ext/soap/tests/GHSA-hmxp-6pc4-f3vv.phpt
@@ -36,4 +36,4 @@ $server->handle($request);
 ?>
 --EXPECT--
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"><SOAP-ENV:Body><SOAP-ENV:Fault><faultcode>SOAP-ENV:Server</faultcode><faultstring>SOAP-ERROR: Encoding: Can't decode apache map, missing value</faultstring></SOAP-ENV:Fault></SOAP-ENV:Body></SOAP-ENV:Envelope>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"><SOAP-ENV:Body><SOAP-ENV:Fault><faultcode>SOAP-ENV:Server</faultcode><faultstring>SoapServer::handle(): Encoding: Can't decode apache map, missing value</faultstring></SOAP-ENV:Fault></SOAP-ENV:Body></SOAP-ENV:Envelope>

--- a/ext/soap/tests/bugs/bug34657.phpt
+++ b/ext/soap/tests/bugs/bug34657.phpt
@@ -17,5 +17,5 @@ try {
 ?>
 --EXPECTF--
 SoapFault
-SOAP-ERROR: Parsing WSDL: Couldn't load from 'http://i_dont_exist.com/some.wsdl'%A
+SoapClient::__construct(): Parsing WSDL: Couldn't load from 'http://i_dont_exist.com/some.wsdl'%A
 ok

--- a/ext/soap/tests/bugs/bug39832.phpt
+++ b/ext/soap/tests/bugs/bug39832.phpt
@@ -26,4 +26,4 @@ $x->handle($HTTP_RAW_POST_DATA);
 ?>
 --EXPECT--
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"><SOAP-ENV:Body><SOAP-ENV:Fault><faultcode>SOAP-ENV:Server</faultcode><faultstring>SOAP-ERROR: Encoding: Invalid value for type 'integer'</faultstring></SOAP-ENV:Fault></SOAP-ENV:Body></SOAP-ENV:Envelope>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"><SOAP-ENV:Body><SOAP-ENV:Fault><faultcode>SOAP-ENV:Server</faultcode><faultstring>SoapServer::handle(): Encoding: Invalid value for type 'integer'</faultstring></SOAP-ENV:Fault></SOAP-ENV:Body></SOAP-ENV:Envelope>

--- a/ext/soap/tests/bugs/bug42151.phpt
+++ b/ext/soap/tests/bugs/bug42151.phpt
@@ -26,7 +26,7 @@ try {
 echo "ok\n";
 ?>
 --EXPECTF--
-SOAP-ERROR: Parsing WSDL: Couldn't load from 'httpx://' : failed to load %s
+SoapClient::__construct(): Parsing WSDL: Couldn't load from 'httpx://' : failed to load %s
 
 ok
 I don't get executed either.

--- a/ext/soap/tests/bugs/bug42151.phpt
+++ b/ext/soap/tests/bugs/bug42151.phpt
@@ -26,7 +26,7 @@ try {
 echo "ok\n";
 ?>
 --EXPECTF--
-SoapFault: SOAP-ERROR: Parsing WSDL: Couldn't load from 'httpx://' : failed to load %s
+SoapFault: SoapClient::__construct(): Parsing WSDL: Couldn't load from 'httpx://' : failed to load %s
 
 ok
 I don't get executed either.

--- a/ext/soap/tests/bugs/bug42488.phpt
+++ b/ext/soap/tests/bugs/bug42488.phpt
@@ -19,4 +19,4 @@ $soap->handle($request);
 ?>
 --EXPECT--
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"><SOAP-ENV:Body><SOAP-ENV:Fault><faultcode>SOAP-ENV:Server</faultcode><faultstring>SOAP-ERROR: Encoding: string 'stuff\x93...' is not a valid utf-8 string</faultstring></SOAP-ENV:Fault></SOAP-ENV:Body></SOAP-ENV:Envelope>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"><SOAP-ENV:Body><SOAP-ENV:Fault><faultcode>SOAP-ENV:Server</faultcode><faultstring>SoapServer::handle(): Encoding: string 'stuff\x93...' is not a valid utf-8 string</faultstring></SOAP-ENV:Fault></SOAP-ENV:Body></SOAP-ENV:Envelope>

--- a/ext/soap/tests/bugs/bug44686.phpt
+++ b/ext/soap/tests/bugs/bug44686.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug #44686 (SOAP-ERROR: Parsing WSDL with references)
+Bug #44686 (Parsing WSDL with references)
 --EXTENSIONS--
 soap
 --INI--

--- a/ext/soap/tests/bugs/bug44811.phpt
+++ b/ext/soap/tests/bugs/bug44811.phpt
@@ -16,6 +16,6 @@ try {
 die('ok');
 ?>
 --EXPECTF--
-SOAP-ERROR: Parsing WSDL: Couldn't load from 'https://php.net' : %s
+Parsing WSDL: Couldn't load from 'https://php.net' : %s
 
 ok

--- a/ext/soap/tests/bugs/bug50698_2.phpt
+++ b/ext/soap/tests/bugs/bug50698_2.phpt
@@ -10,7 +10,7 @@ try {
     new SoapClient(__DIR__ . '/bug50698_2.wsdl');
     echo "Call: \"new SoapClient(__DIR__.'/bug50698_2.wsdl');\" should throw an exception of type 'SoapFault'";
 } catch (SoapFault $e) {
-    if ($e->faultcode == 'WSDL' && $e->faultstring == 'SOAP-ERROR: Parsing WSDL: Could not find any usable binding services in WSDL.') {
+    if ($e->faultcode == 'WSDL' && $e->faultstring == 'SoapClient::__construct(): Parsing WSDL: Could not find any usable binding services in WSDL.') {
         echo "ok\n";
     } else {
         echo "Call: \"new SoapClient(__DIR__.'/bug50698_2.wsdl');\" threw a SoapFault with an incorrect faultcode or faultmessage.";

--- a/ext/soap/tests/bugs/bug50698_3.phpt
+++ b/ext/soap/tests/bugs/bug50698_3.phpt
@@ -10,7 +10,7 @@ try {
     new SoapClient(__DIR__ . '/bug50698_3.wsdl');
     echo "Call: \"new SoapClient(__DIR__.'/bug50698_3.wsdl');\" should throw an exception of type 'SoapFault'";
 } catch (SoapFault $e) {
-    if ($e->faultcode == 'WSDL' && $e->faultstring == 'SOAP-ERROR: Parsing WSDL: Could not find any usable binding services in WSDL.') {
+    if ($e->faultcode == 'WSDL' && $e->faultstring == 'SoapClient::__construct(): Parsing WSDL: Could not find any usable binding services in WSDL.') {
         echo "ok\n";
     } else {
         echo "Call: \"new SoapClient(__DIR__.'/bug50698_3.wsdl');\" threw a SoapFault with an incorrect faultcode or faultmessage.";

--- a/ext/soap/tests/bugs/bug62900.phpt
+++ b/ext/soap/tests/bugs/bug62900.phpt
@@ -70,25 +70,25 @@ foreach ($combinations as list($wsdl, $xsd)) {
 @unlink(__DIR__."/bug62900.xsd");
 ?>
 --EXPECTF--
-Fatal error: Uncaught SoapFault exception: [WSDL] SOAP-ERROR: Parsing Schema: can't import schema from '%sbug62900.xsd', unexpected 'targetNamespace'='http://www.w3.org/XML/1998/namespacex', expected 'http://www.w3.org/XML/1998/namespace' in %s:%d
+Fatal error: Uncaught SoapFault exception: [WSDL] SoapClient::__construct(): Parsing Schema: can't import schema from '%s/ext/soap/tests/bugs/bug62900.xsd', unexpected 'targetNamespace'='http://www.w3.org/XML/1998/namespacex', expected 'http://www.w3.org/XML/1998/namespace' in %s:%d
 Stack trace:
 #0 %s(%d): SoapClient->__construct(%s)
 #1 {main}
   thrown in %s on line %d
 
-Fatal error: Uncaught SoapFault exception: [WSDL] SOAP-ERROR: Parsing Schema: can't import schema from '%sbug62900.xsd', missing 'targetNamespace', expected 'http://www.w3.org/XML/1998/namespace' in %s:%d
+Fatal error: Uncaught SoapFault exception: [WSDL] SoapClient::__construct(): Parsing Schema: can't import schema from '%s/ext/soap/tests/bugs/bug62900.xsd', missing 'targetNamespace', expected 'http://www.w3.org/XML/1998/namespace' in %s:%d
 Stack trace:
 #0 %s(%d): SoapClient->__construct(%s)
 #1 {main}
   thrown in %s on line %d
 
-Fatal error: Uncaught SoapFault exception: [WSDL] SOAP-ERROR: Parsing Schema: can't import schema from '%sbug62900.xsd', unexpected 'targetNamespace'='http://www.w3.org/XML/1998/namespacex', expected no 'targetNamespace' in %s:%d
+Fatal error: Uncaught SoapFault exception: [WSDL] SoapClient::__construct(): Parsing Schema: can't import schema from '%s/ext/soap/tests/bugs/bug62900.xsd', unexpected 'targetNamespace'='http://www.w3.org/XML/1998/namespacex', expected no 'targetNamespace' in %s:%d
 Stack trace:
 #0 %s(%d): SoapClient->__construct(%s)
 #1 {main}
   thrown in %s on line %d
 
-Fatal error: Uncaught SoapFault exception: [WSDL] SOAP-ERROR: Parsing WSDL: Couldn't bind to service in %s:%d
+Fatal error: Uncaught SoapFault exception: [WSDL] SoapClient::__construct(): Parsing WSDL: Couldn't bind to service in %s:%d
 Stack trace:
 #0 %s(%d): SoapClient->__construct(%s)
 #1 {main}

--- a/ext/soap/tests/bugs/bug68576.phpt
+++ b/ext/soap/tests/bugs/bug68576.phpt
@@ -14,4 +14,4 @@ try {
 ?>
 --EXPECT--
 SoapFault
-SOAP-ERROR: Parsing WSDL: Couldn't bind to service
+SoapClient::__construct(): Parsing WSDL: Couldn't bind to service

--- a/ext/soap/tests/bugs/bug73037.phpt
+++ b/ext/soap/tests/bugs/bug73037.phpt
@@ -136,43 +136,43 @@ cleanup:
 --EXPECT--
 Iteration 0
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
 
 Iteration 1
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
 
 Iteration 2
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
 
 Iteration 3
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
 
 Iteration 4
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
 
 Iteration 5
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
 
 Iteration 6
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
 

--- a/ext/soap/tests/bugs/bug73037.phpt
+++ b/ext/soap/tests/bugs/bug73037.phpt
@@ -136,42 +136,43 @@ cleanup:
 --EXPECT--
 Iteration 0
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
 
 Iteration 1
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
 
 Iteration 2
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
 
 Iteration 3
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
 
 Iteration 4
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
 
 Iteration 5
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
 
 Iteration 6
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
 
-Function 'CATALOG' doesn't exist
+SoapServer::handle(): Function 'CATALOG' doesn't exist
+

--- a/ext/soap/tests/bugs/bug79357.phpt
+++ b/ext/soap/tests/bugs/bug79357.phpt
@@ -11,7 +11,7 @@ var_dump($res);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught SoapFault exception: [Client] SOAP-ERROR: Encoding: object has no 'intB' property in %s:%d
+Fatal error: Uncaught SoapFault exception: [Client] SoapClient::__call(): Encoding: object has no 'intB' property in %s:%d
 Stack trace:
 #0 %s(%d): SoapClient->__call('Add', Array)
 #1 {main}

--- a/ext/soap/tests/bugs/bug80672.phpt
+++ b/ext/soap/tests/bugs/bug80672.phpt
@@ -12,4 +12,4 @@ try {
 }
 ?>
 --EXPECT--
-SOAP-ERROR: Parsing WSDL: Unexpected WSDL element <>
+SoapClient::__construct(): Parsing WSDL: Unexpected WSDL element <>

--- a/ext/soap/tests/bugs/bug80672.phpt
+++ b/ext/soap/tests/bugs/bug80672.phpt
@@ -12,4 +12,4 @@ try {
 }
 ?>
 --EXPECT--
-SoapFault: SOAP-ERROR: Parsing WSDL: Unexpected WSDL element <>
+SoapFault: SoapClient::__construct(): Parsing WSDL: Unexpected WSDL element <>

--- a/ext/soap/tests/bugs/gh22167.phpt
+++ b/ext/soap/tests/bugs/gh22167.phpt
@@ -105,24 +105,24 @@ foreach ($cases as $name => $schema) {
 }
 ?>
 --EXPECT--
-minOccurs: SOAP-ERROR: Parsing Schema: minOccurs value is out of range
-maxOccurs: SOAP-ERROR: Parsing Schema: maxOccurs value is out of range
-negative minOccurs: SOAP-ERROR: Parsing Schema: minOccurs value is out of range
-negative maxOccurs: SOAP-ERROR: Parsing Schema: maxOccurs value is out of range
-minExclusive: SOAP-ERROR: Parsing Schema: minExclusive value is out of range
-minInclusive: SOAP-ERROR: Parsing Schema: minInclusive value is out of range
-maxExclusive: SOAP-ERROR: Parsing Schema: maxExclusive value is out of range
-maxInclusive: SOAP-ERROR: Parsing Schema: maxInclusive value is out of range
-totalDigits: SOAP-ERROR: Parsing Schema: totalDigits value is out of range
-fractionDigits: SOAP-ERROR: Parsing Schema: fractionDigits value is out of range
-length: SOAP-ERROR: Parsing Schema: length value is out of range
-minLength: SOAP-ERROR: Parsing Schema: minLength value is out of range
-maxLength: SOAP-ERROR: Parsing Schema: maxLength value is out of range
-leading whitespace numeric-string: SOAP-ERROR: Parsing Schema: maxOccurs value is out of range
-leading plus numeric-string: SOAP-ERROR: Parsing Schema: maxOccurs value is out of range
-leading zero numeric-string: SOAP-ERROR: Parsing Schema: maxOccurs value is out of range
-leading numeric-string with trailing data: SOAP-ERROR: Parsing Schema: maxOccurs value is out of range
-negative out-of-range numeric-string: SOAP-ERROR: Parsing Schema: maxOccurs value is out of range
-decimal numeric-string: SOAP-ERROR: Parsing Schema: maxOccurs value is out of range
-exponent numeric-string: SOAP-ERROR: Parsing Schema: maxOccurs value is out of range
+minOccurs: SoapClient::__construct(): Parsing Schema: minOccurs value is out of range
+maxOccurs: SoapClient::__construct(): Parsing Schema: maxOccurs value is out of range
+negative minOccurs: SoapClient::__construct(): Parsing Schema: minOccurs value is out of range
+negative maxOccurs: SoapClient::__construct(): Parsing Schema: maxOccurs value is out of range
+minExclusive: SoapClient::__construct(): Parsing Schema: minExclusive value is out of range
+minInclusive: SoapClient::__construct(): Parsing Schema: minInclusive value is out of range
+maxExclusive: SoapClient::__construct(): Parsing Schema: maxExclusive value is out of range
+maxInclusive: SoapClient::__construct(): Parsing Schema: maxInclusive value is out of range
+totalDigits: SoapClient::__construct(): Parsing Schema: totalDigits value is out of range
+fractionDigits: SoapClient::__construct(): Parsing Schema: fractionDigits value is out of range
+length: SoapClient::__construct(): Parsing Schema: length value is out of range
+minLength: SoapClient::__construct(): Parsing Schema: minLength value is out of range
+maxLength: SoapClient::__construct(): Parsing Schema: maxLength value is out of range
+leading whitespace numeric-string: SoapClient::__construct(): Parsing Schema: maxOccurs value is out of range
+leading plus numeric-string: SoapClient::__construct(): Parsing Schema: maxOccurs value is out of range
+leading zero numeric-string: SoapClient::__construct(): Parsing Schema: maxOccurs value is out of range
+leading numeric-string with trailing data: SoapClient::__construct(): Parsing Schema: maxOccurs value is out of range
+negative out-of-range numeric-string: SoapClient::__construct(): Parsing Schema: maxOccurs value is out of range
+decimal numeric-string: SoapClient::__construct(): Parsing Schema: maxOccurs value is out of range
+exponent numeric-string: SoapClient::__construct(): Parsing Schema: maxOccurs value is out of range
 fractional numeric-string within int range: parsed

--- a/ext/soap/tests/bugs/gh22167.phpt
+++ b/ext/soap/tests/bugs/gh22167.phpt
@@ -105,24 +105,24 @@ foreach ($cases as $name => $schema) {
 }
 ?>
 --EXPECT--
-minOccurs: SoapFault: SOAP-ERROR: Parsing Schema: minOccurs value is out of range
-maxOccurs: SoapFault: SOAP-ERROR: Parsing Schema: maxOccurs value is out of range
-negative minOccurs: SoapFault: SOAP-ERROR: Parsing Schema: minOccurs value is out of range
-negative maxOccurs: SoapFault: SOAP-ERROR: Parsing Schema: maxOccurs value is out of range
-minExclusive: SoapFault: SOAP-ERROR: Parsing Schema: minExclusive value is out of range
-minInclusive: SoapFault: SOAP-ERROR: Parsing Schema: minInclusive value is out of range
-maxExclusive: SoapFault: SOAP-ERROR: Parsing Schema: maxExclusive value is out of range
-maxInclusive: SoapFault: SOAP-ERROR: Parsing Schema: maxInclusive value is out of range
-totalDigits: SoapFault: SOAP-ERROR: Parsing Schema: totalDigits value is out of range
-fractionDigits: SoapFault: SOAP-ERROR: Parsing Schema: fractionDigits value is out of range
-length: SoapFault: SOAP-ERROR: Parsing Schema: length value is out of range
-minLength: SoapFault: SOAP-ERROR: Parsing Schema: minLength value is out of range
-maxLength: SoapFault: SOAP-ERROR: Parsing Schema: maxLength value is out of range
-leading whitespace numeric-string: SoapFault: SOAP-ERROR: Parsing Schema: maxOccurs value is out of range
-leading plus numeric-string: SoapFault: SOAP-ERROR: Parsing Schema: maxOccurs value is out of range
-leading zero numeric-string: SoapFault: SOAP-ERROR: Parsing Schema: maxOccurs value is out of range
-leading numeric-string with trailing data: SoapFault: SOAP-ERROR: Parsing Schema: maxOccurs value is out of range
-negative out-of-range numeric-string: SoapFault: SOAP-ERROR: Parsing Schema: maxOccurs value is out of range
-decimal numeric-string: SoapFault: SOAP-ERROR: Parsing Schema: maxOccurs value is out of range
-exponent numeric-string: SoapFault: SOAP-ERROR: Parsing Schema: maxOccurs value is out of range
+minOccurs: SoapFault: SoapClient::__construct(): Parsing Schema: minOccurs value is out of range
+maxOccurs: SoapFault: SoapClient::__construct(): Parsing Schema: maxOccurs value is out of range
+negative minOccurs: SoapFault: SoapClient::__construct(): Parsing Schema: minOccurs value is out of range
+negative maxOccurs: SoapFault: SoapClient::__construct(): Parsing Schema: maxOccurs value is out of range
+minExclusive: SoapFault: SoapClient::__construct(): Parsing Schema: minExclusive value is out of range
+minInclusive: SoapFault: SoapClient::__construct(): Parsing Schema: minInclusive value is out of range
+maxExclusive: SoapFault: SoapClient::__construct(): Parsing Schema: maxExclusive value is out of range
+maxInclusive: SoapFault: SoapClient::__construct(): Parsing Schema: maxInclusive value is out of range
+totalDigits: SoapFault: SoapClient::__construct(): Parsing Schema: totalDigits value is out of range
+fractionDigits: SoapFault: SoapClient::__construct(): Parsing Schema: fractionDigits value is out of range
+length: SoapFault: SoapClient::__construct(): Parsing Schema: length value is out of range
+minLength: SoapFault: SoapClient::__construct(): Parsing Schema: minLength value is out of range
+maxLength: SoapFault: SoapClient::__construct(): Parsing Schema: maxLength value is out of range
+leading whitespace numeric-string: SoapFault: SoapClient::__construct(): Parsing Schema: maxOccurs value is out of range
+leading plus numeric-string: SoapFault: SoapClient::__construct(): Parsing Schema: maxOccurs value is out of range
+leading zero numeric-string: SoapFault: SoapClient::__construct(): Parsing Schema: maxOccurs value is out of range
+leading numeric-string with trailing data: SoapFault: SoapClient::__construct(): Parsing Schema: maxOccurs value is out of range
+negative out-of-range numeric-string: SoapFault: SoapClient::__construct(): Parsing Schema: maxOccurs value is out of range
+decimal numeric-string: SoapFault: SoapClient::__construct(): Parsing Schema: maxOccurs value is out of range
+exponent numeric-string: SoapFault: SoapClient::__construct(): Parsing Schema: maxOccurs value is out of range
 fractional numeric-string within int range: parsed

--- a/ext/soap/tests/hexbin_odd_length.phpt
+++ b/ext/soap/tests/hexbin_odd_length.phpt
@@ -34,4 +34,4 @@ try {
 }
 ?>
 --EXPECT--
-SOAP-ERROR: Encoding: Type 'hexBinary' value must contain an even number of hexadecimal digits
+SoapClient::__call(): Encoding: Type 'hexBinary' value must contain an even number of hexadecimal digits

--- a/ext/soap/tests/interop/Round3/GroupF/r3_groupF_extreq_001w.phpt
+++ b/ext/soap/tests/interop/Round3/GroupF/r3_groupF_extreq_001w.phpt
@@ -14,4 +14,4 @@ echo $client->__getlastrequest();
 echo "ok\n";
 ?>
 --EXPECTF--
-Fatal error: SOAP-ERROR: Parsing WSDL: Unknown required WSDL extension 'http://soapinterop.org/ext' in %sr3_groupF_extreq_001w.php on line %d
+Fatal error: SoapClient::__construct(): Parsing WSDL: Unknown required WSDL extension 'http://soapinterop.org/ext' in %s on line %d

--- a/ext/soap/tests/scalar_error_messages.phpt
+++ b/ext/soap/tests/scalar_error_messages.phpt
@@ -47,6 +47,6 @@ run_case('long', 'xsd:long', 'abc');
 run_case('base64Binary node', 'xsd:base64Binary', '<value>abc</value>');
 ?>
 --EXPECT--
-double: SOAP-ERROR: Encoding: Invalid value for type 'double'
-long: SOAP-ERROR: Encoding: Invalid value for type 'long'
-base64Binary node: SOAP-ERROR: Encoding: Type 'base64Binary' value must contain a single text or CDATA node
+double: SoapClient::__soapCall(): Encoding: Invalid value for type 'double'
+long: SoapClient::__soapCall(): Encoding: Invalid value for type 'long'
+base64Binary node: SoapClient::__soapCall(): Encoding: Type 'base64Binary' value must contain a single text or CDATA node

--- a/ext/soap/tests/schema-selfref-attrgroup.phpt
+++ b/ext/soap/tests/schema-selfref-attrgroup.phpt
@@ -40,5 +40,5 @@ echo "done\n";
 @unlink(__DIR__ . '/schema-selfref-attrgroup.wsdl');
 ?>
 --EXPECTF--
-SoapFault: SOAP-ERROR: Parsing Schema: recursive attributeGroup 'ref' attribute '%s'
+SoapFault: SoapClient::__construct(): Parsing Schema: recursive attributeGroup 'ref' attribute '%s'
 done

--- a/ext/soap/tests/schema-selfref-group.phpt
+++ b/ext/soap/tests/schema-selfref-group.phpt
@@ -42,5 +42,5 @@ echo "done\n";
 @unlink(__DIR__ . '/schema-selfref-group.wsdl');
 ?>
 --EXPECTF--
-SoapFault: SOAP-ERROR: Parsing Schema: recursive group 'ref' attribute '%s'
+SoapFault: SoapClient::__construct(): Parsing Schema: recursive group 'ref' attribute '%s'
 done

--- a/ext/soap/tests/schema/schema068.phpt
+++ b/ext/soap/tests/schema/schema068.phpt
@@ -16,4 +16,4 @@ test_schema($schema,'type="tns:testType"',(object)array("str"=>"str","int"=>4));
 echo "ok";
 ?>
 --EXPECTF--
-Fatal error: SOAP-ERROR: Encoding: Attribute 'int' has fixed value '5' (value '4' is not allowed) in %stest_schema.inc on line %d
+Fatal error: SoapClient::__call(): Encoding: Attribute 'int' has fixed value '5' (value '4' is not allowed) in %s on line %d

--- a/ext/soap/tests/soap12/T27.phpt
+++ b/ext/soap/tests/soap12/T27.phpt
@@ -25,4 +25,4 @@ include "soap12-test.inc";
 ?>
 --EXPECT--
 <?xml version="1.0" encoding="UTF-8"?>
-<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><env:Fault><env:Code><env:Value>env:Receiver</env:Value></env:Code><env:Reason><env:Text xml:lang="en">SOAP-ERROR: Encoding: Type 'string' value must contain a single text or CDATA node</env:Text></env:Reason></env:Fault></env:Body></env:Envelope>
+<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><env:Fault><env:Code><env:Value>env:Receiver</env:Value></env:Code><env:Reason><env:Text xml:lang="en">SoapServer::handle(): Encoding: Type 'string' value must contain a single text or CDATA node</env:Text></env:Reason></env:Fault></env:Body></env:Envelope>

--- a/ext/soap/tests/soap12/T56.phpt
+++ b/ext/soap/tests/soap12/T56.phpt
@@ -30,4 +30,4 @@ include "soap12-test.inc";
 ?>
 --EXPECT--
 <?xml version="1.0" encoding="UTF-8"?>
-<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><env:Fault><env:Code><env:Value>env:Receiver</env:Value></env:Code><env:Reason><env:Text xml:lang="en">SOAP-ERROR: Encoding: Unresolved reference '#data-2'</env:Text></env:Reason></env:Fault></env:Body></env:Envelope>
+<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><env:Fault><env:Code><env:Value>env:Receiver</env:Value></env:Code><env:Reason><env:Text xml:lang="en">SoapServer::handle(): Encoding: Unresolved reference '#data-2'</env:Text></env:Reason></env:Fault></env:Body></env:Envelope>

--- a/ext/soap/tests/soap12/T58.phpt
+++ b/ext/soap/tests/soap12/T58.phpt
@@ -24,4 +24,4 @@ include "soap12-test.inc";
 ?>
 --EXPECT--
 <?xml version="1.0" encoding="UTF-8"?>
-<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><env:Fault><env:Code><env:Value>env:Receiver</env:Value></env:Code><env:Reason><env:Text xml:lang="en">SOAP-ERROR: Encoding: Type 'int' value must contain a single text or CDATA node</env:Text></env:Reason></env:Fault></env:Body></env:Envelope>
+<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><env:Fault><env:Code><env:Value>env:Receiver</env:Value></env:Code><env:Reason><env:Text xml:lang="en">SoapServer::handle(): Encoding: Type 'int' value must contain a single text or CDATA node</env:Text></env:Reason></env:Fault></env:Body></env:Envelope>

--- a/ext/soap/tests/soap12/T59.phpt
+++ b/ext/soap/tests/soap12/T59.phpt
@@ -25,4 +25,4 @@ include "soap12-test.inc";
 ?>
 --EXPECT--
 <?xml version="1.0" encoding="UTF-8"?>
-<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><env:Fault><env:Code><env:Value>env:Receiver</env:Value></env:Code><env:Reason><env:Text xml:lang="en">SOAP-ERROR: Encoding: Violation of id and ref information items '#data'</env:Text></env:Reason></env:Fault></env:Body></env:Envelope>
+<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><env:Fault><env:Code><env:Value>env:Receiver</env:Value></env:Code><env:Reason><env:Text xml:lang="en">SoapServer::handle(): Encoding: Violation of id and ref information items '#data'</env:Text></env:Reason></env:Fault></env:Body></env:Envelope>

--- a/ext/soap/tests/soap12/T61.phpt
+++ b/ext/soap/tests/soap12/T61.phpt
@@ -25,4 +25,4 @@ include "soap12-test.inc";
 ?>
 --EXPECT--
 <?xml version="1.0" encoding="UTF-8"?>
-<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><env:Fault><env:Code><env:Value>env:Receiver</env:Value></env:Code><env:Reason><env:Text xml:lang="en">SOAP-ERROR: Encoding: '*' may only be first arraySize value in list</env:Text></env:Reason></env:Fault></env:Body></env:Envelope>
+<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><env:Fault><env:Code><env:Value>env:Receiver</env:Value></env:Code><env:Reason><env:Text xml:lang="en">SoapServer::handle(): Encoding: '*' may only be first arraySize value in list</env:Text></env:Reason></env:Fault></env:Body></env:Envelope>

--- a/ext/soap/tests/soap_array_index_overflow.phpt
+++ b/ext/soap/tests/soap_array_index_overflow.phpt
@@ -80,9 +80,9 @@ test_overflow(
 test_boundary_position();
 ?>
 --EXPECT--
-arrayType: SOAP-ERROR: Encoding: array index out of range
-offset: SOAP-ERROR: Encoding: array index out of range
-position: SOAP-ERROR: Encoding: array index out of range
+arrayType: SoapClient::__call(): Encoding: array index out of range
+offset: SoapClient::__call(): Encoding: array index out of range
+position: SoapClient::__call(): Encoding: array index out of range
 array(1) {
   [2147483646]=>
   string(5) "value"

--- a/ext/zend_test/tests/observer_error_04.phpt
+++ b/ext/zend_test/tests/observer_error_04.phpt
@@ -47,9 +47,9 @@ echo 'Done.' . PHP_EOL;
   </main:NULL>
 SoapFault:   <!-- init Exception::getMessage() -->
   <Exception::getMessage>
-  </Exception::getMessage:'SOAP-ERROR: Parsing WSDL: %s
+  </Exception::getMessage:'SoapClient::__construct(): Parsing WSDL: %s
 '>
-SOAP-ERROR: Parsing WSDL: %s
+SoapClient::__construct(): Parsing WSDL: %s
 
 Done.
 </file '%s%eobserver_error_%d.php'>


### PR DESCRIPTION
Remove some useless macros, use the standard `php_error_docref` mechanism for error reporting, clean up inconsistent whitespace. Extracted out of GH-22927.