### PR TITLE
Fix mbregex search state after cache invalidation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,8 @@ PHP                                                                        NEWS
 - MBString:
   . Fixed bug GH-22779 (mb_strrpos() returns the wrong position for a negative
     offset in a non-UTF-8 encoding). (Eyüp Can Akman)
+  . Fixed bug GH-21036 (mb_ereg_search_getregs() crashes after mb_eregi()
+    invalidates the regex cache). (Matthias Goergens)
 
 - PCRE:
   . Fixed bug GH-21134 (Crash with \C + UTF-8). Using \C in UTF-8 patterns is

--- a/ext/mbstring/php_mbregex.c
+++ b/ext/mbstring/php_mbregex.c
@@ -481,6 +481,10 @@ static php_mb_regex_t *php_mbregex_compile_pattern(const char *pattern, size_t p
 		if (rc == MBREX(search_re)) {
 			/* reuse the new rc? see bug #72399 */
 			MBREX(search_re) = NULL;
+			if (MBREX(search_regs) != NULL) {
+				onig_region_free(MBREX(search_regs), 1);
+				MBREX(search_regs) = NULL;
+			}
 		}
 		zend_hash_str_update_ptr(&MBREX(ht_rc), (char *)pattern, patlen, retval);
 	} else {

--- a/ext/mbstring/tests/gh21036.phpt
+++ b/ext/mbstring/tests/gh21036.phpt
@@ -1,0 +1,17 @@
+--TEST--
+GH-21036 (mb_ereg_search_getregs() after regex cache invalidation)
+--EXTENSIONS--
+mbstring
+--FILE--
+<?php
+error_reporting(E_ALL & ~E_DEPRECATED);
+
+$pattern = '(?<name>a)';
+mb_ereg_search_init('a', $pattern);
+mb_ereg_search_pos();
+mb_eregi($pattern, 'a');
+
+var_dump(mb_ereg_search_getregs());
+?>
+--EXPECT--
+bool(false)

--- a/ext/mbstring/tests/gh21036.phpt
+++ b/ext/mbstring/tests/gh21036.phpt
@@ -2,6 +2,10 @@
 GH-21036 (mb_ereg_search_getregs() after regex cache invalidation)
 --EXTENSIONS--
 mbstring
+--SKIPIF--
+<?php
+if (!function_exists("mb_ereg")) print "skip mb_ereg() not available";
+?>
 --FILE--
 <?php
 error_reporting(E_ALL & ~E_DEPRECATED);


### PR DESCRIPTION
Fixes GH-21036.

`php_mbregex_compile_pattern()` may replace the cache entry currently referenced by `search_re`. The replacement destroys that regex and clears `search_re`, but leaves `search_regs` holding match offsets associated with the destroyed regex. `mb_ereg_search_getregs()` then treats those registers as valid and dereferences the null regex when processing named captures.

Free and clear `search_regs` whenever cache replacement clears `search_re`. This preserves the existing invariant that match registers do not outlive their regex and makes `mb_ereg_search_getregs()` return `false` instead of returning stale numeric captures while losing named captures.

PR #21038 identified the crash and proposed guarding the named-capture lookup. This alternative also discards the invalidated match state, following the approach used for the analogous invalid-pattern path in commit 392ad206a4f63fedf61d8086e390c73de8b72767.
