### PR TITLE
ext/sysvshm: don't orphan the segment shm_attach() just created

### DIFF
--- a/ext/sysvshm/sysvshm.c
+++ b/ext/sysvshm/sysvshm.c
@@ -132,6 +132,7 @@ PHP_FUNCTION(shm_attach)
 	sysvshm_chunk_head *chunk_ptr;
 	zend_long shm_key, shm_id, shm_size, shm_flag = 0666;
 	bool shm_size_is_null = 1;
+	bool created = false;
 
 	if (SUCCESS != zend_parse_parameters(ZEND_NUM_ARGS(), "l|l!l", &shm_key, &shm_size, &shm_size_is_null, &shm_flag)) {
 		RETURN_THROWS();
@@ -156,10 +157,14 @@ PHP_FUNCTION(shm_attach)
 			php_error_docref(NULL, E_WARNING, "Failed for key 0x" ZEND_XLONG_FMT ": %s", shm_key, strerror(errno));
 			RETURN_FALSE;
 		}
+		created = true;
 	}
 
 	if ((shm_ptr = shmat(shm_id, NULL, 0)) == (void *) -1) {
 		php_error_docref(NULL, E_WARNING, "Failed for key 0x" ZEND_XLONG_FMT ": %s", shm_key, strerror(errno));
+		if (created) {
+			shmctl(shm_id, IPC_RMID, NULL);
+		}
 		RETURN_FALSE;
 	}
 

--- a/ext/sysvshm/tests/shm_attach_failed_attach.phpt
+++ b/ext/sysvshm/tests/shm_attach_failed_attach.phpt
@@ -1,0 +1,34 @@
+--TEST--
+shm_attach() removes the segment it created when shmat() fails
+--EXTENSIONS--
+sysvshm
+posix
+--SKIPIF--
+<?php
+if (posix_geteuid() === 0) die('skip cannot run as root');
+?>
+--FILE--
+<?php
+$key = ftok(__FILE__, 't');
+
+var_dump(shm_attach($key, 1024, 0));
+
+$segment = shm_attach($key, 1024, 0600);
+
+if (!$segment instanceof SysvSharedMemory) {
+    die("the key is still held by the segment of the failed attach\n");
+}
+
+try {
+    var_dump(shm_put_var($segment, 1, 'value'));
+    var_dump(shm_get_var($segment, 1));
+} finally {
+    var_dump(shm_remove($segment));
+}
+?>
+--EXPECTF--
+Warning: shm_attach(): Failed for key 0x%x: %s in %s on line %d
+bool(false)
+bool(true)
+string(5) "value"
+bool(true)


### PR DESCRIPTION
`shm_attach()` probes with `shmget($key, 0, 0)` and, when that fails, creates the segment with `IPC_CREAT | IPC_EXCL` before attaching. A failing `shmat()` then returns false and drops the id, so the segment it created stays in the kernel with nothing on the PHP side able to remove it. The next call probes successfully, finds the orphan and fails on the same shmat(), so the key stays wedged until someone runs ipcrm:

```php
$key = ftok(__FILE__, 't');
var_dump(shm_attach($key, 1024, 0));     // false: mode 0000 denies the owner's own attach
var_dump(shm_attach($key, 1024, 0600));  // false, and stays false on every later run
```

IPC_EXCL is what makes the ownership flag safe here. A successful probe means the segment predates the call, so only the create branch sets it, and the removal can't destroy a segment we merely opened. ext/opcache/shared_alloc_shm.c does the same IPC_RMID on shmat() failure without an ownership check, since it only ever creates its own.

shmop_open() has the same defect on three exits after a create and cannot take this guard as-is: its "c" mode passes IPC_CREAT without IPC_EXCL, so one shmget() can't tell a create from an open. That needs its own change.
