### PR TITLE
Zend: Refactor deduplicate auto-global checks

### DIFF
--- a/Zend/Optimizer/zend_inference.c
+++ b/Zend/Optimizer/zend_inference.c
@@ -1958,7 +1958,7 @@ static uint32_t get_ssa_alias_types(zend_ssa_alias_kind alias) {
 			zend_ssa_var *__ssa_var = &ssa_vars[__var];					\
 			if (__ssa_var->var < op_array->num_args) {					\
 				if (__type & MAY_BE_RC1) {                              \
-					/* TODO: may be captured by exception backtreace */ \
+					/* TODO: may be captured by exception backtrace */ \
 					__type |= MAY_BE_RCN;                               \
 				}                                                       \
 			}                                                           \

--- a/Zend/Optimizer/zend_inference.c
+++ b/Zend/Optimizer/zend_inference.c
@@ -1958,7 +1958,7 @@ static uint32_t get_ssa_alias_types(zend_ssa_alias_kind alias) {
 			zend_ssa_var *__ssa_var = &ssa_vars[__var];					\
 			if (__ssa_var->var < op_array->num_args) {					\
 				if (__type & MAY_BE_RC1) {                              \
-					/* TODO: may be captured by exception backtrace */ \
+					/* TODO: may be captured by exception backtreace */ \
 					__type |= MAY_BE_RCN;                               \
 				}                                                       \
 			}                                                           \

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1995,30 +1995,27 @@ static void zend_do_extended_fcall_end(void) /* {{{ */
 }
 /* }}} */
 
-ZEND_API bool zend_is_auto_global_str(const char *name, size_t len) /* {{{ */ {
-	zend_auto_global *auto_global;
-
-	if ((auto_global = zend_hash_str_find_ptr(CG(auto_globals), name, len)) != NULL) {
-		if (auto_global->armed) {
-			auto_global->armed = auto_global->auto_global_callback(auto_global->name);
-		}
-		return 1;
+static zend_always_inline bool zend_auto_global_check(zend_auto_global *auto_global)
+{
+	if (auto_global == NULL) {
+		return false;
 	}
-	return 0;
+
+	if (auto_global->armed) {
+		auto_global->armed = auto_global->auto_global_callback(auto_global->name);
+	}
+	return true;
+}
+
+ZEND_API bool zend_is_auto_global_str(const char *name, size_t len) /* {{{ */
+{
+	return zend_auto_global_check(zend_hash_str_find_ptr(CG(auto_globals), name, len));
 }
 /* }}} */
 
 ZEND_API bool zend_is_auto_global(zend_string *name) /* {{{ */
 {
-	zend_auto_global *auto_global;
-
-	if ((auto_global = zend_hash_find_ptr(CG(auto_globals), name)) != NULL) {
-		if (auto_global->armed) {
-			auto_global->armed = auto_global->auto_global_callback(auto_global->name);
-		}
-		return 1;
-	}
-	return 0;
+	return zend_auto_global_check(zend_hash_find_ptr(CG(auto_globals), name));
 }
 /* }}} */
 


### PR DESCRIPTION
Reuse the part of logic which duplicates in two functions.

I also clean up a typo cspell scans.