### PR TITLE
[RFC] Deprecate using `namespace` as class constant name

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,7 @@ PHP                                                                        NEWS
     operation depth. (iliaal)
 
 - Core:
+  . Deprecated "namespace" as a class constant name. (NickSdot)
   . Changed run-tests.php to run in parallel by default, using up to 10
     automatically detected workers. Pass -j1 for sequential execution.
     (NickSdot)

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@ PHP                                                                        NEWS
 ?? ??? ????, PHP 8.6.0beta1
 
 - Core:
+  . Deprecated "namespace" as a class constant name. (NickSdot)
   . Changed run-tests.php to run test subprocesses without a shell where
     possible. (NickSdot)
   . Fixed GH-23083 (SEGV build_trace_args in zend_exceptions.c with

--- a/UPGRADING
+++ b/UPGRADING
@@ -441,6 +441,7 @@ PHP 8.6 UPGRADE NOTES
 ========================================
 
 - Core:
+  . Using "namespace" as a class constant name is deprecated.
   . Specifying a return type of array|null / ?array for __debugInfo() is now
     deprecated. Specify array instead.
   . Returning values from __construct() and __destruct() is now deprecated.

--- a/UPGRADING
+++ b/UPGRADING
@@ -433,6 +433,7 @@ PHP 8.6 UPGRADE NOTES
 ========================================
 
 - Core:
+  . Using "namespace" as a class constant name is deprecated.
   . Specifying a return type of array|null / ?array for __debugInfo() is now
     deprecated. Specify array instead.
   . Returning values from __construct() and __destruct() is now deprecated.

--- a/Zend/tests/deprecate_namespace_class_constant.phpt
+++ b/Zend/tests/deprecate_namespace_class_constant.phpt
@@ -1,0 +1,67 @@
+--TEST--
+Using "namespace" as a class constant name is deprecated
+--FILE--
+<?php
+
+define('namespace', 'global constant value');
+
+class Foo {
+    const NAMESPACE = 'class constant value';
+}
+
+interface Bar {
+    const Namespace = 'interface constant value';
+}
+
+enum Baz {
+    const nAmEsPaCe = 'enum constant value';
+}
+
+trait YooTrait {
+    const namespace = 'trait constant value';
+}
+
+class Sup {
+    use YooTrait;
+}
+
+enum Yoo: string {
+    case namespace = 'enum case value';
+}
+
+class Can {
+    public static $namespace = 'property value';
+
+    public static function namespace() {
+        return 'method value';
+    }
+}
+
+echo Foo::NAMESPACE, PHP_EOL;
+echo Bar::Namespace, PHP_EOL;
+echo Baz::nAmEsPaCe, PHP_EOL;
+echo Yoo::namespace->value, PHP_EOL;
+echo Sup::namespace, PHP_EOL;
+echo Can::$namespace, PHP_EOL;
+echo Can::namespace(), PHP_EOL;
+echo constant('namespace'), PHP_EOL;
+
+?>
+--EXPECTF--
+Deprecated: Declaring class constant called 'namespace' is deprecated in %s on line %d
+
+Deprecated: Declaring interface constant called 'namespace' is deprecated in %s on line %d
+
+Deprecated: Declaring enum constant called 'namespace' is deprecated in %s on line %d
+
+Deprecated: Declaring trait constant called 'namespace' is deprecated in %s on line %d
+
+Deprecated: Declaring enum constant called 'namespace' is deprecated in %s on line %d
+class constant value
+interface constant value
+enum constant value
+enum case value
+trait constant value
+property value
+method value
+global constant value

--- a/Zend/tests/grammar/semi_reserved_005.phpt
+++ b/Zend/tests/grammar/semi_reserved_005.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test semi-reserved words as class constants
+--INI--
+error_reporting=E_ALL&~E_DEPRECATED
 --FILE--
 <?php
 

--- a/Zend/tests/grammar/semi_reserved_005.phpt
+++ b/Zend/tests/grammar/semi_reserved_005.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test semi-reserved words as class constants
---INI--
-error_reporting=E_ALL&~E_DEPRECATED
 --FILE--
 <?php
 
@@ -162,7 +160,8 @@ echo Obj::__NAMESPACE__, PHP_EOL;
 
 echo "\nDone\n";
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Declaring class constant called 'namespace' is deprecated in %s on line %d
 empty
 callable
 trait

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -4833,6 +4833,9 @@ ZEND_API zend_class_constant *zend_declare_typed_class_constant(zend_class_entry
 	if (zend_string_equals_ci(name, ZSTR_KNOWN(ZEND_STR_CLASS))) {
 		zend_error_noreturn(ce->type == ZEND_INTERNAL_CLASS ? E_CORE_ERROR : E_COMPILE_ERROR,
 				"A class constant must not be called 'class'; it is reserved for class name fetching");
+	} else if (zend_string_equals_literal_ci(name, "namespace")) {
+		zend_error(E_DEPRECATED, "Declaring %s constant called 'namespace' is deprecated",
+			zend_get_object_type(ce));
 	}
 
 	if (Z_TYPE_P(value) == IS_STRING && !ZSTR_IS_INTERNED(Z_STR_P(value))) {

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -4821,6 +4821,9 @@ ZEND_API zend_class_constant *zend_declare_typed_class_constant(zend_class_entry
 	if (zend_string_equals_ci(name, ZSTR_KNOWN(ZEND_STR_CLASS))) {
 		zend_error_noreturn(ce->type == ZEND_INTERNAL_CLASS ? E_CORE_ERROR : E_COMPILE_ERROR,
 				"A class constant must not be called 'class'; it is reserved for class name fetching");
+	} else if (zend_string_equals_literal_ci(name, "namespace")) {
+		zend_error(E_DEPRECATED, "Declaring %s constant called 'namespace' is deprecated",
+			zend_get_object_type(ce));
 	}
 
 	if (Z_TYPE_P(value) == IS_STRING && !ZSTR_IS_INTERNED(Z_STR_P(value))) {


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_using_namespace_as_a_class_constant_name
Discussion: https://news-web.php.net/php.internals/131626