### PR TITLE
streams: call php_stream_wrapper_warn calls checking REPORT_ERRORS is set

### DIFF
--- a/ext/standard/ftp_fopen_wrapper.c
+++ b/ext/standard/ftp_fopen_wrapper.c
@@ -915,18 +915,14 @@ static int php_stream_ftp_unlink(php_stream_wrapper *wrapper, const char *url, i
 
 	stream = php_ftp_fopen_connect(wrapper, url, "r", 0, NULL, context, NULL, &resource, NULL, NULL);
 	if (!stream) {
-		if (options & REPORT_ERRORS) {
-			php_stream_wrapper_warn(wrapper, context, options, AuthFailed,
-				"Unable to connect to %s", url);
-		}
+		php_stream_wrapper_warn(wrapper, context, options, AuthFailed,
+			"Unable to connect to %s", url);
 		goto unlink_errexit;
 	}
 
 	if (resource->path == NULL) {
-		if (options & REPORT_ERRORS) {
-			php_stream_wrapper_warn(wrapper, context, options, InvalidPath,
-				"Invalid path provided in %s", url);
-		}
+		php_stream_wrapper_warn(wrapper, context, options, InvalidPath,
+			"Invalid path provided in %s", url);
 		goto unlink_errexit;
 	}
 
@@ -935,10 +931,8 @@ static int php_stream_ftp_unlink(php_stream_wrapper *wrapper, const char *url, i
 
 	result = GET_FTP_RESULT(stream);
 	if (result < 200 || result > 299) {
-		if (options & REPORT_ERRORS) {
-			php_stream_wrapper_warn(wrapper, context, options, UnlinkFailed,
-				"Error Deleting file: %s", tmp_line);
-		}
+		php_stream_wrapper_warn(wrapper, context, options, UnlinkFailed,
+			"Error Deleting file: %s", tmp_line);
 		goto unlink_errexit;
 	}
 
@@ -1000,10 +994,8 @@ static int php_stream_ftp_rename(php_stream_wrapper *wrapper, const char *url_fr
 
 	stream = php_ftp_fopen_connect(wrapper, url_from, "r", 0, NULL, context, NULL, NULL, NULL, NULL);
 	if (!stream) {
-		if (options & REPORT_ERRORS) {
-			php_stream_wrapper_warn(wrapper, context, options, AuthFailed,
-				"Unable to connect to %s", ZSTR_VAL(resource_from->host));
-		}
+		php_stream_wrapper_warn(wrapper, context, options, AuthFailed,
+			"Unable to connect to %s", ZSTR_VAL(resource_from->host));
 		goto rename_errexit;
 	}
 
@@ -1012,10 +1004,8 @@ static int php_stream_ftp_rename(php_stream_wrapper *wrapper, const char *url_fr
 
 	result = GET_FTP_RESULT(stream);
 	if (result < 300 || result > 399) {
-		if (options & REPORT_ERRORS) {
-			php_stream_wrapper_warn(wrapper, context, options, RenameFailed,
-				"Error Renaming file: %s", tmp_line);
-		}
+		php_stream_wrapper_warn(wrapper, context, options, RenameFailed,
+			"Error Renaming file: %s", tmp_line);
 		goto rename_errexit;
 	}
 
@@ -1024,10 +1014,8 @@ static int php_stream_ftp_rename(php_stream_wrapper *wrapper, const char *url_fr
 
 	result = GET_FTP_RESULT(stream);
 	if (result < 200 || result > 299) {
-		if (options & REPORT_ERRORS) {
-			php_stream_wrapper_warn(wrapper, context, options, RenameFailed,
-				"Error Renaming file: %s", tmp_line);
-		}
+		php_stream_wrapper_warn(wrapper, context, options, RenameFailed,
+			"Error Renaming file: %s", tmp_line);
 		goto rename_errexit;
 	}
 
@@ -1058,18 +1046,14 @@ static int php_stream_ftp_mkdir(php_stream_wrapper *wrapper, const char *url, in
 
 	stream = php_ftp_fopen_connect(wrapper, url, "r", 0, NULL, context, NULL, &resource, NULL, NULL);
 	if (!stream) {
-		if (options & REPORT_ERRORS) {
-			php_stream_wrapper_warn(wrapper, context, options, AuthFailed,
-				"Unable to connect to %s", url);
-		}
+		php_stream_wrapper_warn(wrapper, context, options, AuthFailed,
+			"Unable to connect to %s", url);
 		goto mkdir_errexit;
 	}
 
 	if (resource->path == NULL) {
-		if (options & REPORT_ERRORS) {
-			php_stream_wrapper_warn(wrapper, context, options, InvalidPath,
-				"Invalid path provided in %s", url);
-		}
+		php_stream_wrapper_warn(wrapper, context, options, InvalidPath,
+			"Invalid path provided in %s", url);
 		goto mkdir_errexit;
 	}
 
@@ -1108,10 +1092,8 @@ static int php_stream_ftp_mkdir(php_stream_wrapper *wrapper, const char *url, in
 					php_stream_printf(stream, "MKD %s\r\n", buf);
 					result = GET_FTP_RESULT(stream);
 					if (result < 200 || result > 299) {
-						if (options & REPORT_ERRORS) {
-							php_stream_wrapper_warn(wrapper, context, options, MkdirFailed,
-								"%s", tmp_line);
-						}
+						php_stream_wrapper_warn(wrapper, context, options, MkdirFailed,
+							"%s", tmp_line);
 						break;
 					}
 				}
@@ -1153,18 +1135,14 @@ static int php_stream_ftp_rmdir(php_stream_wrapper *wrapper, const char *url, in
 
 	stream = php_ftp_fopen_connect(wrapper, url, "r", 0, NULL, context, NULL, &resource, NULL, NULL);
 	if (!stream) {
-		if (options & REPORT_ERRORS) {
-			php_stream_wrapper_warn(wrapper, context, options, AuthFailed,
-				"Unable to connect to %s", url);
-		}
+		php_stream_wrapper_warn(wrapper, context, options, AuthFailed,
+			"Unable to connect to %s", url);
 		goto rmdir_errexit;
 	}
 
 	if (resource->path == NULL) {
-		if (options & REPORT_ERRORS) {
-			php_stream_wrapper_warn(wrapper, context, options, InvalidPath,
-				"Invalid path provided in %s", url);
-		}
+		php_stream_wrapper_warn(wrapper, context, options, InvalidPath,
+			"Invalid path provided in %s", url);
 		goto rmdir_errexit;
 	}
 
@@ -1172,10 +1150,8 @@ static int php_stream_ftp_rmdir(php_stream_wrapper *wrapper, const char *url, in
 	result = GET_FTP_RESULT(stream);
 
 	if (result < 200 || result > 299) {
-		if (options & REPORT_ERRORS) {
-			php_stream_wrapper_warn(wrapper, context, options, RmdirFailed,
-				"%s", tmp_line);
-		}
+		php_stream_wrapper_warn(wrapper, context, options, RmdirFailed,
+			"%s", tmp_line);
 		goto rmdir_errexit;
 	}
 

--- a/ext/standard/php_fopen_wrapper.c
+++ b/ext/standard/php_fopen_wrapper.c
@@ -220,11 +220,9 @@ static php_stream * php_stream_url_wrap_php(php_stream_wrapper *wrapper, const c
 		php_stream_input_t *input;
 
 		if ((options & STREAM_OPEN_FOR_INCLUDE) && !PG(allow_url_include) ) {
-			if (options & REPORT_ERRORS) {
-				php_stream_wrapper_warn(wrapper, context, options,
-					Disabled,
-					"URL file-access is disabled in the server configuration");
-			}
+			php_stream_wrapper_warn(wrapper, context, options,
+				Disabled,
+				"URL file-access is disabled in the server configuration");
 			return NULL;
 		}
 
@@ -241,11 +239,9 @@ static php_stream * php_stream_url_wrap_php(php_stream_wrapper *wrapper, const c
 
 	if (!strcasecmp(path, "stdin")) {
 		if ((options & STREAM_OPEN_FOR_INCLUDE) && !PG(allow_url_include) ) {
-			if (options & REPORT_ERRORS) {
-				php_stream_wrapper_warn(wrapper, context, options,
-					Disabled,
-					"URL file-access is disabled in the server configuration");
-			}
+			php_stream_wrapper_warn(wrapper, context, options,
+				Disabled,
+				"URL file-access is disabled in the server configuration");
 			return NULL;
 		}
 		if (!strcmp(sapi_module.name, "cli")) {
@@ -302,20 +298,16 @@ static php_stream * php_stream_url_wrap_php(php_stream_wrapper *wrapper, const c
 		int		   dtablesize;
 
 		if (strcmp(sapi_module.name, "cli")) {
-			if (options & REPORT_ERRORS) {
-				php_stream_wrapper_warn(wrapper, context, options,
-					Disabled,
-					"Direct access to file descriptors is only available from command-line PHP");
-			}
+			php_stream_wrapper_warn(wrapper, context, options,
+				Disabled,
+				"Direct access to file descriptors is only available from command-line PHP");
 			return NULL;
 		}
 
 		if ((options & STREAM_OPEN_FOR_INCLUDE) && !PG(allow_url_include) ) {
-			if (options & REPORT_ERRORS) {
-				php_stream_wrapper_warn(wrapper, context, options,
-					Disabled,
-					"URL file-access is disabled in the server configuration");
-			}
+			php_stream_wrapper_warn(wrapper, context, options,
+				Disabled,
+				"URL file-access is disabled in the server configuration");
 			return NULL;
 		}
 

--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -1482,7 +1482,7 @@ static int php_plain_files_mkdir(php_stream_wrapper *wrapper, const char *dir, i
 		}
 
 		int ret = VCWD_MKDIR(dir, (mode_t)mode);
-		if (ret < 0 && (options & REPORT_ERRORS)) {
+		if (ret < 0) {
 			php_stream_wrapper_warn(wrapper, context, options,
 					MkdirFailed, "%s", strerror(errno));
 			return 0;

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -1909,11 +1909,10 @@ PHPAPI php_stream_wrapper *php_stream_locate_url_wrapper(const char *path, const
 #else
 			if (!localhost && path[n+3] != '\0' && path[n+3] != '/') {
 #endif
-				if (options & REPORT_ERRORS) {
-					php_stream_wrapper_warn(plain_files_wrapper, NULL, options,
-							ProtocolUnsupported,
-							"Remote host file access not supported, %s", path);
-				}
+				php_stream_wrapper_warn(plain_files_wrapper, NULL, options,
+						ProtocolUnsupported,
+						"Remote host file access not supported, %s", path);
+
 				return NULL;
 			}
 
@@ -1950,11 +1949,9 @@ PHPAPI php_stream_wrapper *php_stream_locate_url_wrapper(const char *path, const
 				return wrapper;
 			}
 
-			if (options & REPORT_ERRORS) {
-				php_stream_wrapper_warn(plain_files_wrapper, NULL, options,
-					Disabled,
-					"file:// wrapper is disabled in the server configuration");
-			}
+			php_stream_wrapper_warn(plain_files_wrapper, NULL, options,
+				Disabled,
+				"file:// wrapper is disabled in the server configuration");
 			return NULL;
 		}
 


### PR DESCRIPTION
As the underlying function already checks that REPORT_ERRORS is set in the `options` parameter.