### PR TITLE
ftp: use SSL_write_ex() in single_send() to fix signed/unsigned handling

### DIFF
--- a/ext/ftp/ftp.c
+++ b/ext/ftp/ftp.c
@@ -1334,6 +1334,7 @@ static ssize_t single_send(ftpbuf_t *ftp, php_socket_t s, void *buf, size_t size
 	}
 
 	do {
+		sent = 0;
 		ret = SSL_write_ex(handle, buf, size, &sent);
 		err = SSL_get_error(handle, ret);
 
@@ -1344,7 +1345,6 @@ static ssize_t single_send(ftpbuf_t *ftp, php_socket_t s, void *buf, size_t size
 
 			case SSL_ERROR_ZERO_RETURN:
 				retry = false;
-				sent = 0;
 				SSL_shutdown(handle);
 				break;
 

--- a/ext/ftp/ftp.c
+++ b/ext/ftp/ftp.c
@@ -1314,7 +1314,7 @@ static ssize_t my_recv_wrapper_with_restart(php_socket_t fd, void *buf, size_t s
 	return n;
 }
 
-static int single_send(ftpbuf_t *ftp, php_socket_t s, void *buf, size_t size) {
+static ssize_t single_send(ftpbuf_t *ftp, php_socket_t s, void *buf, size_t size) {
 #ifdef HAVE_FTP_SSL
 	int err;
 	bool retry = false;
@@ -1368,7 +1368,7 @@ static int single_send(ftpbuf_t *ftp, php_socket_t s, void *buf, size_t size) {
 				return -1;
 		}
 	} while (retry);
-	return (int)sent;
+	return sent;
 #else
 	return my_send_wrapper_with_restart(s, buf, size, 0);
 #endif


### PR DESCRIPTION
This continues #19912, adding a fix for the outstanding review comment from @ndossche that hadn't been addressed yet.

The first commit here (by @zeff-ir) replaces `SSL_write()` with `SSL_write_ex()`, which reports success/failure via its own `int` return value while writing the number of bytes sent through a separate `size_t*` out-parameter — avoiding the conversion issue entirely and matching the OpenSSL API contract.

The second commit finishes the fix requested in review: `single_send()` still narrowed its result to `int` on return (`return (int)sent;`), even though it now computes a `size_t` (from `SSL_write_ex()`) or an `ssize_t` (from `my_send_wrapper_with_restart()` in the non-SSL path). Returning `ssize_t` instead avoids a theoretical truncation/overflow for writes larger than `INT_MAX`, which could otherwise collide with the `-1` error sentinel checked by the caller (`my_send()`) or corrupt its buffer pointer arithmetic.

In case this PR is accepted, #19912 should be closed. 