### PR TITLE
Free previous state when re-calling Reflection*::__construct()

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -3420,6 +3420,13 @@ static void instantiate_reflection_method(INTERNAL_FUNCTION_PARAMETERS, bool is_
 	}
 	efree(lcname);
 
+	if (intern->ptr) {
+		ZEND_ASSERT(is_constructor);
+		_free_function(intern->ptr);
+		zval_ptr_dtor(reflection_prop_name(object));
+		zval_ptr_dtor(reflection_prop_class(object));
+	}
+
 	ZVAL_STR_COPY(reflection_prop_name(object), mptr->common.function_name);
 	ZVAL_STR_COPY(reflection_prop_class(object), mptr->common.scope->name);
 	intern->ptr = mptr;
@@ -3930,6 +3937,11 @@ ZEND_METHOD(ReflectionClassConstant, __construct)
 	if ((constant = zend_hash_find_ptr(CE_CONSTANTS_TABLE(ce), constname)) == NULL) {
 		zend_throw_exception_ex(reflection_exception_ptr, 0, "Constant %s::%s does not exist", ZSTR_VAL(ce->name), ZSTR_VAL(constname));
 		RETURN_THROWS();
+	}
+
+	if (intern->ptr) {
+		zval_ptr_dtor(reflection_prop_name(object));
+		zval_ptr_dtor(reflection_prop_class(object));
 	}
 
 	intern->ptr = constant;

--- a/ext/reflection/tests/ReflectionClassConstant_double_construct.phpt
+++ b/ext/reflection/tests/ReflectionClassConstant_double_construct.phpt
@@ -1,0 +1,33 @@
+--TEST--
+ReflectionClassConstant double construct call does not leak $name and $class
+--FILE--
+<?php
+
+class C {
+    const FOO = 1;
+}
+
+function test(ReflectionClassConstant $r) {
+    /* implode() so that the name is not an interned string. */
+    $r->__construct(C::class, implode('', ['F', 'O', 'O']));
+}
+
+$r = new ReflectionClassConstant(C::class, 'FOO');
+for ($i = 0; $i < 10; $i++) {
+    test($r);
+}
+
+$before = memory_get_usage();
+for ($i = 0; $i < 1000; $i++) {
+    test($r);
+}
+$after = memory_get_usage();
+
+var_dump($before === $after);
+var_dump($r->name, $r->class);
+
+?>
+--EXPECT--
+bool(true)
+string(3) "FOO"
+string(1) "C"

--- a/ext/reflection/tests/ReflectionMethod_double_construct_closure.phpt
+++ b/ext/reflection/tests/ReflectionMethod_double_construct_closure.phpt
@@ -1,0 +1,28 @@
+--TEST--
+ReflectionMethod double construct call on Closure::__invoke() does not leak
+--FILE--
+<?php
+
+function test(ReflectionMethod $r) {
+    $r->__construct(function () {}, '__invoke');
+}
+
+$r = new ReflectionMethod(function () {}, '__invoke');
+for ($i = 0; $i < 10; $i++) {
+    test($r);
+}
+
+$before = memory_get_usage();
+for ($i = 0; $i < 1000; $i++) {
+    test($r);
+}
+$after = memory_get_usage();
+
+var_dump($before === $after);
+var_dump($r->name, $r->class);
+
+?>
+--EXPECT--
+bool(true)
+string(8) "__invoke"
+string(7) "Closure"


### PR DESCRIPTION
`ReflectionMethod::__construct()` overwrites intern->ptr without releasing the previous value. When the reflected method is Closure::__invoke() that value is a trampoline allocated by `zend_get_closure_invoke_method()`, so every re-construct leaks one. ReflectionClassConstant::__construct() has the same shape for the $name and $class property slots and leaks a string reference whenever the constant name is not interned. ReflectionFunction, ReflectionParameter and ReflectionProperty already release prior state on re-entry.

```php
$r = new ReflectionMethod(function () {}, '__invoke');
for ($i = 0; $i < 10000; $i++) {
    $r->__construct(function () {}, '__invoke');
}
// 2.5 MB of growth on PHP-8.4, zero with the patch
```
