### PR TITLE
Avoid truncation on null bytes in class and function names

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -364,7 +364,7 @@ static void _class_string(smart_str *str, zend_class_entry *ce, zval *obj, const
 		}
 		smart_str_append_printf(str, "class ");
 	}
-	smart_str_append_printf(str, "%s", ZSTR_VAL(ce->name));
+	smart_str_append(str, ce->name);
 	if (ce->parent) {
 		smart_str_append_printf(str, " extends %s", ZSTR_VAL(ce->parent->name));
 	}
@@ -904,7 +904,8 @@ static void _function_string(smart_str *str, zend_function *fptr, zend_class_ent
 	if (fptr->op_array.fn_flags & ZEND_ACC_RETURN_REFERENCE) {
 		smart_str_appendc(str, '&');
 	}
-	smart_str_append_printf(str, "%s ] {\n", ZSTR_VAL(fptr->common.function_name));
+	smart_str_append(str, fptr->common.function_name);
+	smart_str_appends(str, " ] {\n");
 	/* The information where a function is declared is only available for user classes */
 	if (fptr->type == ZEND_USER_FUNCTION) {
 		smart_str_append_printf(str, "%s  @@ %s %d - %d\n", indent,

--- a/ext/reflection/tests/gh22681/ReflectionClass_name.phpt
+++ b/ext/reflection/tests/gh22681/ReflectionClass_name.phpt
@@ -1,0 +1,32 @@
+--TEST--
+GH-22681: null bytes in name truncate ReflectionClass::__toString()
+--FILE--
+<?php
+
+$obj = new class {};
+
+$r = new ReflectionClass($obj);
+echo $r;
+var_dump( $r->getName() );
+
+?>
+--EXPECTF--
+Class [ <user> class class@anonymous%0%s ] {
+  @@ %s %d-%d
+
+  - Constants [0] {
+  }
+
+  - Static properties [0] {
+  }
+
+  - Static methods [0] {
+  }
+
+  - Properties [0] {
+  }
+
+  - Methods [0] {
+  }
+}
+string(%d) "class@anonymous%0%s"

--- a/ext/reflection/tests/gh22681/ReflectionFunctionAbstract_name.phpt
+++ b/ext/reflection/tests/gh22681/ReflectionFunctionAbstract_name.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-22681: null bytes in name truncate ReflectionFunction::__toString()
+--FILE--
+<?php
+
+$obj = new class {
+    public function make(): Closure {
+        return function () {};
+    }
+};
+
+$r = new ReflectionFunction($obj->make());
+echo $r;
+var_dump( $r->getName() );
+
+?>
+--EXPECTF--
+Closure [ <user> public method {closure:class@anonymous%0%s::make():%d} ] {
+  @@ %s %d - %d
+}
+string(%d) "{closure:class@anonymous%0%s::make():%d}"


### PR DESCRIPTION
Follow-up to GH-22681. `_class_string()` and `_function_string()` still format the class name and the function name with %s, so Reflection*::__toString() cuts both at the first NUL byte. Anonymous class names embed one, directly and also inside the generated name of a closure declared in such a class.

```php
$obj = new class {
    public function make(): Closure { return function () {}; }
};
echo new ReflectionFunction($obj->make());
// Closure [ <user> public method {closure:class@anonymous ] {
```

master already appends the class name as a zend_string, so only the function name changes once this is merged up.
