### PR TITLE
zip: require remove_path to be shorter than the path it strips

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -1832,7 +1832,8 @@ static void php_zip_add_from_pattern(INTERNAL_FUNCTION_PARAMETERS, int type) /* 
 					basename = php_basename(Z_STRVAL_P(zval_file), Z_STRLEN_P(zval_file), NULL, 0);
 					file_stripped = ZSTR_VAL(basename);
 					file_stripped_len = ZSTR_LEN(basename);
-				} else if (opts.remove_path && zend_string_starts_with(Z_STR_P(zval_file), opts.remove_path)) {
+				} else if (opts.remove_path && Z_STRLEN_P(zval_file) > ZSTR_LEN(opts.remove_path)
+						&& zend_string_starts_with(Z_STR_P(zval_file), opts.remove_path)) {
 					if (IS_SLASH(Z_STRVAL_P(zval_file)[ZSTR_LEN(opts.remove_path)])) {
 						file_stripped = Z_STRVAL_P(zval_file) + ZSTR_LEN(opts.remove_path) + 1;
 						file_stripped_len = Z_STRLEN_P(zval_file) - ZSTR_LEN(opts.remove_path) - 1;

--- a/ext/zip/tests/addGlob_remove_path_full_match.phpt
+++ b/ext/zip/tests/addGlob_remove_path_full_match.phpt
@@ -1,0 +1,40 @@
+--TEST--
+ZipArchive::addGlob() with remove_path equal to a matched path
+--EXTENSIONS--
+zip
+--FILE--
+<?php
+$dirname = __DIR__ . '/addGlob_remove_path_full_match_dir';
+@mkdir($dirname);
+touch($dirname . '/foo.txt');
+touch($dirname . '/bar.txt');
+
+$zip = new ZipArchive();
+$zip->open($dirname . '/tmp.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE);
+$zip->addGlob($dirname . '/*.txt', 0, ['remove_path' => $dirname . '/foo.txt']);
+
+$names = [];
+for ($i = 0; $i < $zip->numFiles; $i++) {
+    $names[] = str_replace(__DIR__ . '/', '', $zip->getNameIndex($i));
+}
+sort($names);
+var_dump($names);
+
+$zip->close();
+
+?>
+--CLEAN--
+<?php
+$dirname = __DIR__ . '/addGlob_remove_path_full_match_dir';
+unlink($dirname . '/tmp.zip');
+unlink($dirname . '/foo.txt');
+unlink($dirname . '/bar.txt');
+rmdir($dirname);
+?>
+--EXPECT--
+array(2) {
+  [0]=>
+  string(42) "addGlob_remove_path_full_match_dir/bar.txt"
+  [1]=>
+  string(42) "addGlob_remove_path_full_match_dir/foo.txt"
+}


### PR DESCRIPTION
`zend_string_starts_with()` also matches on equality, so the length check dropped in bcb05dcf6f3 was load-bearing. A globbed path that equals remove_path now reads its own NUL terminator in the `IS_SLASH` test, falls into the non-slash branch and strips its whole length, so the entry lands in the archive under an empty name. Before the conversion the path was kept as-is, which is what 8.4 and 8.5 still do.

```php
$zip->addGlob("$dir/*.txt", 0, ['remove_path' => "$dir/a.txt"]);
// a.txt is added as "", b.txt keeps its full path
```
