### PR TITLE
SAPI: clear current_user and content_type_dup after releasing them

### DIFF
--- a/main/SAPI.c
+++ b/main/SAPI.c
@@ -495,9 +495,11 @@ SAPI_API void sapi_deactivate_module(void)
 	}
 	if (SG(request_info).content_type_dup) {
 		efree(SG(request_info).content_type_dup);
+		SG(request_info).content_type_dup = NULL;
 	}
 	if (SG(request_info).current_user) {
 		zend_string_release_ex(SG(request_info).current_user, false);
+		SG(request_info).current_user = NULL;
 	}
 	if (sapi_module.deactivate) {
 		sapi_module.deactivate();


### PR DESCRIPTION
`sapi_deactivate_module()` releases `current_user` and `content_type_dup` but leaves both pointers set, unlike the auth_user, auth_password and auth_digest fields right above them. Nothing reads either between the release and the next `sapi_activate()`, so this is consistency rather than a live bug.
