### PR TITLE
[ci skip] Add myself as ext/session maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,7 +46,7 @@
 /ext/phar @LamentXU123
 /ext/random @TimWolla @zeriyoshi
 /ext/reflection @DanielEScherzer
-/ext/session @Girgias
+/ext/session @Girgias @jorgsowa
 /ext/simplexml @devnexen
 /ext/soap @devnexen
 /ext/sockets @devnexen


### PR DESCRIPTION
I have made a number of PRs already to the extension, and I intend to improve its state even more.