### PR TITLE
streams: tidy the wrapper error log on every open_wrapper return

### DIFF
--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -2144,6 +2144,7 @@ PHPAPI php_stream *_php_stream_open_wrapper_ex(const char *path, const char *mod
 		php_stream_tidy_wrapper_name_error_log(wrapper_name);
 		goto cleanup;
 	}
+	php_stream_tidy_wrapper_name_error_log(wrapper_name);
 
 	/* if the caller asked for a persistent stream but the wrapper did not
 	 * return one, force an error here */


### PR DESCRIPTION
Until d75f79e2acf the tidy call sat on the single return path of `_php_stream_open_wrapper_ex()`, so it ran whether or not the opener produced a stream. The early-return refactor duplicated it into the three failure branches, and 605ff6e11bc then folded those into a shared `cleanup:` while keeping only the copy in the opener-failure branch. Openers run with REPORT_ERRORS masked and store into `FG(wrapper_logged_errors)` instead of printing, so anything stored by an opener that goes on to succeed now survives until request shutdown and is replayed by the next failure for the same wrapper.

I could not build a userland reproducer: every built-in opener that stores a message returns NULL right after, and instrumenting the shared cleanup produced no hit across the test suite. The invariant is still that the list only holds messages for an open that is in flight, so this restores it rather than fixing an observable symptom.
