### PR TITLE
Check object_init_ex() in ReflectionMethod::createFromMethodName()

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -3400,7 +3400,10 @@ static void instantiate_reflection_method(INTERNAL_FUNCTION_PARAMETERS, bool is_
 	if (is_constructor) {
 		object = ZEND_THIS;
 	} else {
-		object_init_ex(return_value, execute_data->This.value.ce ? execute_data->This.value.ce : reflection_method_ptr);
+		zend_class_entry *called_ce = execute_data->This.value.ce ? execute_data->This.value.ce : reflection_method_ptr;
+		if (UNEXPECTED(object_init_ex(return_value, called_ce) != SUCCESS)) {
+			RETURN_THROWS();
+		}
 		object = return_value;
 	}
 	intern = Z_REFLECTION_P(object);

--- a/ext/reflection/tests/ReflectionMethod_createFromMethodName_abstract.phpt
+++ b/ext/reflection/tests/ReflectionMethod_createFromMethodName_abstract.phpt
@@ -1,0 +1,23 @@
+--TEST--
+ReflectionMethod::createFromMethodName() called on an abstract subclass
+--FILE--
+<?php
+
+class C {
+    public function a() {}
+}
+
+abstract class R extends ReflectionMethod {}
+
+try {
+    R::createFromMethodName('C::a');
+} catch (Throwable $e) {
+    echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+}
+
+var_dump(ReflectionMethod::createFromMethodName('C::a')->name);
+
+?>
+--EXPECT--
+Error: Cannot instantiate abstract class R
+string(1) "a"


### PR DESCRIPTION
`instantiate_reflection_method()` ignores the result of `object_init_ex()`. On an uninstantiable subclass that call throws, sets the return value to NULL and reports FAILURE, and the helper then runs `Z_REFLECTION_P()` over the NULL `zend_object`, offsetting backwards out of the allocation.

```php
class C { public function a() {} }
abstract class R extends ReflectionMethod {}
R::createFromMethodName('C::a');
// SIGSEGV in reflection_prop_name(), php_reflection.c:71
```

Segfaults on 8.4, 8.5 and master; 8.3 carries the same code. `ReflectionClass::newInstance()`, `newInstanceArgs()` and `newInstanceWithoutConstructor()` already test the result the same way. Found while reviewing #22968, which touches the same helper but does not cause this.
