### PR TITLE
ext/sysvshm: do not trust $size when opening an existing segment

### DIFF
--- a/ext/sysvshm/sysvshm.c
+++ b/ext/sysvshm/sysvshm.c
@@ -130,6 +130,7 @@ PHP_FUNCTION(shm_attach)
 	sysvshm_shm *shm_list_ptr;
 	char *shm_ptr;
 	sysvshm_chunk_head *chunk_ptr;
+	struct shmid_ds shm_desc;
 	zend_long shm_key, shm_id, shm_size, shm_flag = 0666;
 	bool shm_size_is_null = 1;
 	bool created = false;
@@ -162,6 +163,25 @@ PHP_FUNCTION(shm_attach)
 
 	if ((shm_ptr = shmat(shm_id, NULL, 0)) == (void *) -1) {
 		php_error_docref(NULL, E_WARNING, "Failed for key 0x" ZEND_XLONG_FMT ": %s", shm_key, strerror(errno));
+		if (created) {
+			shmctl(shm_id, IPC_RMID, NULL);
+		}
+		RETURN_FALSE;
+	}
+
+	if (shmctl(shm_id, IPC_STAT, &shm_desc) < 0) {
+		php_error_docref(NULL, E_WARNING, "Failed for key 0x" ZEND_XLONG_FMT ": %s", shm_key, strerror(errno));
+		shmdt(shm_ptr);
+		if (created) {
+			shmctl(shm_id, IPC_RMID, NULL);
+		}
+		RETURN_FALSE;
+	}
+	shm_size = (zend_long)shm_desc.shm_segsz;
+
+	if (shm_size < (zend_long) sizeof(sysvshm_chunk_head)) {
+		php_error_docref(NULL, E_WARNING, "Failed for key 0x" ZEND_XLONG_FMT ": segment too small", shm_key);
+		shmdt(shm_ptr);
 		if (created) {
 			shmctl(shm_id, IPC_RMID, NULL);
 		}

--- a/ext/sysvshm/tests/shm_attach_existing_segment_size.phpt
+++ b/ext/sysvshm/tests/shm_attach_existing_segment_size.phpt
@@ -1,0 +1,36 @@
+--TEST--
+shm_attach() takes the size of an existing segment from the kernel, not from $size
+--EXTENSIONS--
+sysvshm
+shmop
+--FILE--
+<?php
+$key = 0x53484D31;
+
+$raw = shmop_open($key, 'n', 0600, 4096);
+
+$shm = shm_attach($key, 10 * 1024 * 1024);
+var_dump($shm instanceof SysvSharedMemory);
+
+var_dump(shm_put_var($shm, 1, str_repeat('A', 1024 * 1024)));
+
+var_dump(shm_put_var($shm, 2, 'ok'));
+var_dump(shm_get_var($shm, 2));
+
+var_dump(shm_remove($shm));
+?>
+--EXPECTF--
+bool(true)
+
+Warning: shm_put_var(): Not enough shared memory left in %s on line %d
+bool(false)
+bool(true)
+string(2) "ok"
+bool(true)
+--CLEAN--
+<?php
+$raw = @shmop_open(0x53484D31, 'w', 0, 0);
+if ($raw) {
+    shmop_delete($raw);
+}
+?>

--- a/ext/sysvshm/tests/shm_attach_existing_segment_too_small.phpt
+++ b/ext/sysvshm/tests/shm_attach_existing_segment_too_small.phpt
@@ -1,0 +1,25 @@
+--TEST--
+shm_attach() rejects an existing segment too small to hold its header
+--EXTENSIONS--
+sysvshm
+shmop
+--FILE--
+<?php
+$key = 0x53484D32;
+
+$raw = shmop_open($key, 'n', 0600, 8);
+
+var_dump(shm_attach($key, 1024));
+
+shmop_delete($raw);
+?>
+--EXPECTF--
+Warning: shm_attach(): Failed for key 0x%x: segment too small in %s on line %d
+bool(false)
+--CLEAN--
+<?php
+$raw = @shmop_open(0x53484D32, 'w', 0, 0);
+if ($raw) {
+    shmop_delete($raw);
+}
+?>


### PR DESCRIPTION
shm_attach() wrote the requested size into the header of a segment it did not create, so a foreign segment framed as larger than it is let shm_put_var() write past the mapping. Take the size from shmctl() IPC_STAT instead, and reject a segment too small to hold the header.

Noticed while reviewing GH-22959.