### PR TITLE
Autotools: main/io missing from the out-of-source build directories.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1834,6 +1834,7 @@ AC_DEFINE([HAVE_BUILD_DEFS_H], [1],
 
 PHP_ADD_BUILD_DIR([
   main
+  main/io
   main/poll
   main/streams
   scripts


### PR DESCRIPTION
Fix #22989

The directory was never registered with PHP_ADD_BUILD_DIR(), so out-of-source builds failed opening main/io/*.dep.