### PR TITLE
Do not install internal main/io headers on Windows

### DIFF
--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -315,7 +315,7 @@ ADD_SOURCES("win32", "dllmain.c readdir.c \
 
 ADD_FLAG("CFLAGS_BD_WIN32", "/D ZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 
-PHP_INSTALL_HEADERS("", "Zend/ TSRM/ main/ main/io main/streams/ win32/");
+PHP_INSTALL_HEADERS("", "Zend/ TSRM/ main/ main/streams/ win32/");
 PHP_INSTALL_HEADERS("Zend/Optimizer", "zend_call_graph.h zend_cfg.h zend_dfg.h zend_dump.h zend_func_info.h zend_inference.h zend_optimizer.h zend_ssa.h zend_worklist.h");
 
 STDOUT.WriteBlankLines(1);


### PR DESCRIPTION
Follow-up https://github.com/php/php-src/pull/22913#issuecomment-5160441342, remove `main/io` from the Windows `PHP_INSTALL_HEADERS` list so Windows matches the Autotools behavior. `main/php_io.h` should be exported publicly.