### PR TITLE
Zend: remove zend_save_error_handling()

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -120,6 +120,7 @@ PHP 8.6 INTERNALS UPGRADE NOTES
     flags parameter was never used.
   . The PHP stream function _php_stream_flush() was removed,
     instead the PHP macro php_stream_flush() is now a proper function.
+  . The zend_save_error_handling() function was removed.
 
 - Changed:
   . Internal functions that return by reference are now expected to

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -446,7 +446,6 @@ typedef struct {
 } zend_error_handling;
 
 BEGIN_EXTERN_C()
-ZEND_API void zend_save_error_handling(zend_error_handling *current);
 ZEND_API void zend_replace_error_handling(zend_error_handling_t error_handling, zend_class_entry *exception_class, zend_error_handling *current);
 ZEND_API void zend_restore_error_handling(const zend_error_handling *saved);
 ZEND_API void zend_begin_record_errors(void);

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -5193,17 +5193,11 @@ ZEND_API zval *zend_read_static_property(zend_class_entry *scope, const char *na
 }
 /* }}} */
 
-ZEND_API void zend_save_error_handling(zend_error_handling *current) /* {{{ */
-{
-	current->handling = EG(error_handling);
-	current->exception = EG(exception_class);
-}
-/* }}} */
-
 ZEND_API void zend_replace_error_handling(zend_error_handling_t error_handling, zend_class_entry *exception_class, zend_error_handling *current) /* {{{ */
 {
 	if (current) {
-		zend_save_error_handling(current);
+		current->handling = EG(error_handling);
+		current->exception = EG(exception_class);
 	}
 	ZEND_ASSERT(error_handling == EH_THROW || exception_class == NULL);
 	EG(error_handling) = error_handling;


### PR DESCRIPTION
This function is only used once internally, and no usage is reported from a SourceGraph search. [1]

[1] https://sourcegraph.com/search?q=context:global+-f:zend_API.c+-f:zend.h+zend_save_error_handling&patternType=keyword&sm=0