### PR TITLE
Zend: remove zend_get_compiled_variable_value()

### DIFF
--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -234,11 +234,6 @@ ZEND_API void* zend_vm_stack_extend(size_t size)
 	return ptr;
 }
 
-ZEND_API zval* zend_get_compiled_variable_value(const zend_execute_data *execute_data, uint32_t var)
-{
-	return EX_VAR(var);
-}
-
 ZEND_API bool zend_gcc_global_regs(void)
 {
   #if defined(HAVE_GCC_GLOBAL_REGS)

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -488,8 +488,6 @@ ZEND_API void ZEND_FASTCALL zend_init_func_run_time_cache(zend_op_array *op_arra
 
 ZEND_API void zend_fetch_dimension_const(zval *result, const zval *container, zval *dim, int type);
 
-ZEND_API zval* zend_get_compiled_variable_value(const zend_execute_data *execute_data_ptr, uint32_t var);
-
 ZEND_API bool zend_gcc_global_regs(void);
 
 #define ZEND_USER_OPCODE_CONTINUE   0 /* execute next opcode */


### PR DESCRIPTION
As it is unused, and there is no usage on SourceGraph either. [1]

[1] https://sourcegraph.com/search?q=context:global+-f:zend_execute.c+-f:zend_execute.h+zend_get_compiled_variable_value&patternType=keyword&sm=0