### PR TITLE
ext/odbc: applied fixers to improve test robustness

### DIFF
--- a/ext/odbc/tests/bug78473.phpt
+++ b/ext/odbc/tests/bug78473.phpt
@@ -7,10 +7,10 @@ odbc
 try {
     odbc_close(STDIN);
 } catch (TypeError $err) {
-    echo $err->getMessage(), PHP_EOL;
+    echo $err::class, ': ', $err->getMessage(), PHP_EOL;
 }
 var_dump(STDIN);
 ?>
 --EXPECT--
-odbc_close(): Argument #1 ($odbc) must be of type Odbc\Connection, resource given
+TypeError: odbc_close(): Argument #1 ($odbc) must be of type Odbc\Connection, resource given
 resource(1) of type (stream)


### PR DESCRIPTION
Asserts error class; extracted from: https://github.com/php/php-src/pull/22799