### PR TITLE
Remove `php_error_docref_unchecked`

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -2579,7 +2579,7 @@ static void php_compact_var(HashTable *eg_active_symbol_table, zval *return_valu
 				zend_hash_update(Z_ARRVAL_P(return_value), Z_STR_P(entry), &data);
 			}
 		} else {
-			php_error_docref_unchecked(NULL, E_WARNING, "Undefined variable $%S", Z_STR_P(entry));
+			php_error_docref(NULL, E_WARNING, "Undefined variable $%pS", Z_STR_P(entry));
 		}
 	} else if (Z_TYPE_P(entry) == IS_ARRAY) {
 		if (Z_REFCOUNTED_P(entry)) {

--- a/main/main.c
+++ b/main/main.c
@@ -1241,21 +1241,12 @@ PHPAPI ZEND_COLD void php_verror(const char *docref, int type, const char *forma
 
 /* {{{ php_error_docref */
 /* Generate an error which links to docref or the php.net documentation if docref is NULL */
-#define php_error_docref_impl(docref, type, format) do {\
-		va_list args; \
-		va_start(args, format); \
-		php_verror(docref, type, format, args); \
-		va_end(args); \
-	} while (0)
-
 PHPAPI ZEND_COLD void php_error_docref(const char *docref, int type, const char *format, ...)
 {
-	php_error_docref_impl(docref, type, format);
-}
-
-PHPAPI ZEND_COLD void php_error_docref_unchecked(const char *docref, int type, const char *format, ...)
-{
-	php_error_docref_impl(docref, type, format);
+	va_list args;
+	va_start(args, format);
+	php_verror(docref, type, format, args);
+	va_end(args);
 }
 /* }}} */
 

--- a/main/php.h
+++ b/main/php.h
@@ -304,7 +304,6 @@ PHPAPI ZEND_COLD void php_verror(const char *docref, int type, const char *forma
 /* PHPAPI void php_error(int type, const char *format, ...); */
 PHPAPI ZEND_COLD void php_error_docref(const char *docref, int type, const char *format, ...)
 	PHP_ATTRIBUTE_FORMAT(printf, 3, 4);
-PHPAPI ZEND_COLD void php_error_docref_unchecked(const char *docref, int type, const char *format, ...);
 END_EXTERN_C()
 
 #define zenderror phperror


### PR DESCRIPTION
Following up GH-22930, this is some low hanging fruit (there's a lot more `zend_error_unchecked` and `php_printf_unchecked`).