### PR TITLE
Fix GH-23016: pdo_odbc returns garbage for NULL long columns

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -34,6 +34,10 @@ PHP                                                                        NEWS
   . Fixed bug GH-21134 (Crash with \C + UTF-8). Using \C in UTF-8 patterns is
     now forbidden. (Arnaud)
 
+- PDO_ODBC:
+  . Fixed bug GH-23016 (NULL values in long columns come back as garbage
+    binary strings). (Calvin Buckley, iliaal)
+
 - Reflection:
   . Fixed bug GH-22905 (Reflection exception messages truncate on null bytes).
     (DanielEScherzer)

--- a/ext/pdo_odbc/odbc_stmt.c
+++ b/ext/pdo_odbc/odbc_stmt.c
@@ -27,7 +27,7 @@
 #include "php_pdo_odbc_int.h"
 
 /* Buffer size; bigger columns than this become a "long column" */
-#define LONG_COLUMN_BUFFER_SIZE (ZEND_MM_PAGE_SIZE- ZSTR_MAX_OVERHEAD)
+#define LONG_COLUMN_BUFFER_SIZE ((SQLLEN)(ZEND_MM_PAGE_SIZE - ZSTR_MAX_OVERHEAD))
 
 enum pdo_odbc_conv_result {
 	PDO_ODBC_CONV_NOT_REQUIRED,
@@ -733,6 +733,10 @@ static int odbc_stmt_get_col(pdo_stmt_t *stmt, int colno, zval *result, enum pdo
 		if (rc == SQL_SUCCESS && C->fetched_len < LONG_COLUMN_BUFFER_SIZE) {
 			/* all the data fit into our little buffer;
 			 * jump down to the generic bound data case */
+			goto in_data;
+		}
+
+		if (C->fetched_len < 0 && C->fetched_len != SQL_NO_TOTAL) {
 			goto in_data;
 		}
 

--- a/ext/pdo_odbc/tests/gh23016.phpt
+++ b/ext/pdo_odbc/tests/gh23016.phpt
@@ -1,0 +1,27 @@
+--TEST--
+GH-23016 (NULL in a long column is fetched as a garbage binary string)
+--EXTENSIONS--
+pdo_odbc
+--SKIPIF--
+<?php
+require __DIR__ . '/config.inc';
+try {
+    $pdo = new PDO(PDO_ODBC_SQLITE_DSN);
+} catch (PDOException $e) {
+    die("skip requires the SQLite3 ODBC driver");
+}
+?>
+--FILE--
+<?php
+require __DIR__ . '/config.inc';
+$pdo = new PDO(PDO_ODBC_SQLITE_DSN);
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$pdo->exec('CREATE TABLE test_gh23016 (data text)');
+$pdo->exec('INSERT INTO test_gh23016 VALUES (NULL)');
+
+$row = $pdo->query('SELECT data FROM test_gh23016')->fetch(PDO::FETCH_NUM);
+var_dump($row[0]);
+?>
+--EXPECT--
+NULL


### PR DESCRIPTION
`LONG_COLUMN_BUFFER_SIZE` derives from `ZSTR_MAX_OVERHEAD`, which is a `size_t`, so `C->fetched_len < LONG_COLUMN_BUFFER_SIZE` was evaluated unsigned and `SQL_NULL_DATA` compared as `SIZE_MAX`. A NULL long column therefore skipped the early exit to `in_data`, and `seed_len` clamped to `LONG_COLUMN_BUFFER_SIZE - 1`, seeding the result with uninitialized bytes out of `C->data`.

Both comparisons predate 8.5.9. The 8.5 long column rewrite replaced the signed literal `256` with the macro, which is why 8.4 is unaffected; 8.5.9 changed the seed from 0 bytes to 4064 and turned an empty string into a disclosure.

Fixes #23016
