### PR TITLE
GH-23043: broken session id code can cause zend_mm_heap corrupted

### DIFF
--- a/ext/session/mod_mm.c
+++ b/ext/session/mod_mm.c
@@ -351,7 +351,7 @@ PS_READ_FUNC(mm)
 		&& ps_mm_key_exists(data, key) == FAILURE) {
 		/* key points to PS(id), but cannot change here. */
 		if (key) {
-			efree(PS(id));
+			zend_string_release_ex(PS(id), false);
 			PS(id) = NULL;
 		}
 		PS(id) = PS(mod)->s_create_sid((void **)&data);

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -443,6 +443,7 @@ static zend_result php_session_initialize(void) /* {{{ */
 	if (!PS(id) || !ZSTR_VAL(PS(id))[0]) {
 		if (PS(id)) {
 			zend_string_release_ex(PS(id), 0);
+			PS(id) = NULL;
 		}
 		PS(id) = PS(mod)->s_create_sid(&PS(mod_data));
 		if (!PS(id)) {
@@ -460,6 +461,7 @@ static zend_result php_session_initialize(void) /* {{{ */
 	) {
 		if (PS(id)) {
 			zend_string_release_ex(PS(id), 0);
+			PS(id) = NULL;
 		}
 		PS(id) = PS(mod)->s_create_sid(&PS(mod_data));
 		if (!PS(id)) {
@@ -2440,6 +2442,7 @@ PHP_FUNCTION(session_regenerate_id)
 			/* Try to generate non-existing ID */
 			while (limit-- && PS(mod)->s_validate_sid(&PS(mod_data), PS(id)) == SUCCESS) {
 				zend_string_release_ex(PS(id), 0);
+				PS(id) = NULL;
 				PS(id) = PS(mod)->s_create_sid(&PS(mod_data));
 				if (!PS(id)) {
 					PS(mod)->s_close(&PS(mod_data));

--- a/ext/session/tests/user_session_module/gh23043.phpt
+++ b/ext/session/tests/user_session_module/gh23043.phpt
@@ -1,0 +1,35 @@
+--TEST--
+GH-23043 (broken session id code can cause zend_mm_heap corrupted)
+--EXTENSIONS--
+session
+--CREDITS--
+lmaltsis
+--FILE--
+<?php
+ob_start();
+class a extends SessionHandler {
+    function read($b): string {
+        return "";
+    }
+    function create_sid(): string {
+        var_dump(session_id());
+        return '';
+    }
+}
+$c = new a;
+session_set_save_handler($c);
+session_start();
+session_write_close();
+session_start();
+?>
+--EXPECTF--
+string(0) ""
+
+Warning: SessionHandler::write(): Session ID is too long or contains illegal characters. Only the A-Z, a-z, 0-9, "-", and "," characters are allowed in %s on line %d
+
+Warning: session_write_close(): Failed to write session data using user defined save handler. (session.save_path: , handler: a::write) in %s on line %d
+string(0) ""
+
+Warning: SessionHandler::write(): Session ID is too long or contains illegal characters. Only the A-Z, a-z, 0-9, "-", and "," characters are allowed in Unknown on line 0
+
+Warning: session_write_close(): Failed to write session data using user defined save handler. (session.save_path: , handler: a::write) in Unknown on line 0


### PR DESCRIPTION
Includes also a related bonus fix