### PR TITLE
Zend: remove zend_parse_parameter()

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -1129,18 +1129,6 @@ static zend_result zend_parse_arg(uint32_t arg_num, zval *arg, va_list *va, cons
 }
 /* }}} */
 
-ZEND_API zend_result zend_parse_parameter(int flags, uint32_t arg_num, zval *arg, const char *spec, ...)
-{
-	va_list va;
-	zend_result ret;
-
-	va_start(va, spec);
-	ret = zend_parse_arg(arg_num, arg, &va, &spec, flags);
-	va_end(va);
-
-	return ret;
-}
-
 static ZEND_COLD void zend_parse_parameters_debug_error(const char *msg) {
 	const zend_function *active_function = EG(current_execute_data)->func;
 	const char *class_name = active_function->common.scope

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -373,8 +373,6 @@ ZEND_API zend_string *zend_zval_get_legacy_type(const zval *arg);
 ZEND_API zend_result zend_parse_method_parameters(uint32_t num_args, zval *this_ptr, const char *type_spec, ...);
 ZEND_API zend_result zend_parse_method_parameters_ex(int flags, uint32_t num_args, zval *this_ptr, const char *type_spec, ...);
 
-ZEND_API zend_result zend_parse_parameter(int flags, uint32_t arg_num, zval *arg, const char *spec, ...);
-
 /* End of parameter parsing API -- andrei */
 
 ZEND_API zend_result zend_register_functions(zend_class_entry *scope, const zend_function_entry *functions, HashTable *function_table, int type);


### PR DESCRIPTION
This API is far worse than just using the existing zend_parse_arg_TYPE() APIs.

A SourceGraph search [1] shows this API is effectively only used by ext/ds to which a PR migrating away from this API has been submitted. [2] The other two usages are from a now deprecated extension [3] and @arnauld-lb's now longer maintained php-go project. [4]

As such we think it is reasonable to remove said API.

[1] https://sourcegraph.com/search?q=context:global+-f:zend_API.c+-f:zend_API.h+zend_parse_parameter%28&patternType=keyword&sm=0
[2] https://github.com/php-ds/ext-ds/pull/232
[3] https://github.com/libvips/php-vips-ext
[4] https://github.com/arnaud-lb/php-go