### PR TITLE
[skip ci] Add UPGRADING.INTERNALS entry for php_stream_wrapper_log_error

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -166,6 +166,13 @@ PHP 8.6 INTERNALS UPGRADE NOTES
   . Extended php_stream_filter_ops with seek method.
   . zend_argument_error_variadic() now takes a new 'function' parameter.
   . The param argument in the php_verror() function has been removed.
+  . The php_stream_wrapper_log_error() signature changed from
+    (wrapper, options, fmt, ...) to
+    (wrapper, context, options, severity, terminating, code, fmt, ...).
+    To keep the previous behaviour pass NULL for the context, or the context at
+    hand if there is one, E_WARNING for the severity, and
+    ZEND_ENUM_StreamErrorCode_Generic for the code. terminating should be true
+    only if the error aborts the operation.
 
 - Added:
   . New zend_class_entry.ce_flags2 and zend_function.fn_flags2 fields were


### PR DESCRIPTION
`php_stream_wrapper_log_error()` went from 3 parameters to 7 in 8.6, which breaks extensions that call it (sqlsrv and php-rar both do) with nothing in UPGRADING.INTERNALS to point at. This adds an entry with the new signature and the values to pass to keep the old behaviour, based on the advice given in the issue.

Closes #22958