### PR TITLE
Fix GH-22206: avoid musttail in zend_runtime_jit() in the tail-call VM

### DIFF
--- a/Zend/zend_vm_gen.php
+++ b/Zend/zend_vm_gen.php
@@ -2523,7 +2523,7 @@ ENDNAMES;
         $str .= "# define ZEND_VM_KIND\t\tZEND_VM_KIND_HYBRID\n";
     }
     if ($GLOBALS["vm_kind_name"][ZEND_VM_GEN_KIND] === "ZEND_VM_KIND_HYBRID" || $GLOBALS["vm_kind_name"][ZEND_VM_GEN_KIND] === "ZEND_VM_KIND_CALL") {
-        $str .= "#elif defined(HAVE_MUSTTAIL) && defined(HAVE_PRESERVE_NONE) && (defined(__x86_64__) || defined(__aarch64__))\n";
+        $str .= "#elif defined(HAVE_MUSTTAIL) && defined(HAVE_PRESERVE_NONE) && (defined(__x86_64__) || defined(__aarch64__)) && defined(__clang__)\n";
         $str .= "# define ZEND_VM_KIND\t\tZEND_VM_KIND_TAILCALL\n";
         $str .= "#else\n";
         $str .= "# define ZEND_VM_KIND\t\tZEND_VM_KIND_CALL\n";

--- a/Zend/zend_vm_opcodes.h
+++ b/Zend/zend_vm_opcodes.h
@@ -42,7 +42,7 @@ static const char *const zend_vm_kind_name[] = {
 /* HYBRID requires support for computed GOTO and global register variables*/
 #elif (defined(__GNUC__) && defined(HAVE_GCC_GLOBAL_REGS))
 # define ZEND_VM_KIND		ZEND_VM_KIND_HYBRID
-#elif defined(HAVE_MUSTTAIL) && defined(HAVE_PRESERVE_NONE) && (defined(__x86_64__) || defined(__aarch64__))
+#elif defined(HAVE_MUSTTAIL) && defined(HAVE_PRESERVE_NONE) && (defined(__x86_64__) || defined(__aarch64__)) && defined(__clang__)
 # define ZEND_VM_KIND		ZEND_VM_KIND_TAILCALL
 #else
 # define ZEND_VM_KIND		ZEND_VM_KIND_CALL

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -3159,7 +3159,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV zend_runtime_jit(Z
 	return; // ZEND_VM_CONTINUE
 #else
 	opline = orig_opline;
+# if ZEND_VM_KIND == ZEND_VM_KIND_TAILCALL
+	/* zend_try() uses setjmp(), which GCC 16 refuses to combine with the guaranteed
+	 * tail call of ZEND_OPCODE_RETURN(); a plain call is fine for this cold path. */
+	return ((zend_vm_opcode_handler_t)opline->handler)(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU);
+# else
 	ZEND_OPCODE_RETURN();
+# endif
 #endif
 }
 

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -3159,13 +3159,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV zend_runtime_jit(Z
 	return; // ZEND_VM_CONTINUE
 #else
 	opline = orig_opline;
-# if ZEND_VM_KIND == ZEND_VM_KIND_TAILCALL
-	/* zend_try() uses setjmp(), which GCC 16 refuses to combine with the guaranteed
-	 * tail call of ZEND_OPCODE_RETURN(); a plain call is fine for this cold path. */
-	return ((zend_vm_opcode_handler_t)opline->handler)(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU);
-# else
 	ZEND_OPCODE_RETURN();
-# endif
 #endif
 }
 


### PR DESCRIPTION
With `--disable-gcc-global-regs` and a compiler that supports `preserve_none`, opcache is built with `ZEND_VM_KIND_TAILCALL`, where `ZEND_OPCODE_RETURN()` expands to a guaranteed tail call. `zend_runtime_jit()` does its work inside `zend_try()`, which uses `setjmp()`, and GCC 16 rejects that combination with "cannot tail-call: caller uses setjmp".

GH-22320 fixed the `--enable-gcc-global-regs` side of the same report. Here the tail call isn't needed: `zend_runtime_jit()` is a cold one-shot JIT trigger rather than a hot VM handler, so a plain call works and the returned opline still goes back to the VM loop as before.

Checked with GCC 16.1.0: a `--disable-gcc-global-regs` build fails on `ext/opcache/jit/zend_jit.lo` before the change and compiles after it. ext/opcache and Zend tests pass on a tail-call VM build.

Fixes GH-22206