### PR TITLE
Fix hMailServer URL in Windows CI

### DIFF
--- a/.github/scripts/windows/test_task.bat
+++ b/.github/scripts/windows/test_task.bat
@@ -116,8 +116,9 @@ set PHP_BUILD_DIR=%PHP_BUILD_OBJ_DIR%\Release
 if "%THREAD_SAFE%" equ "1" set PHP_BUILD_DIR=%PHP_BUILD_DIR%_TS
 
 rem prepare for mail
-curl -sLo hMailServer.exe https://www.hmailserver.com/download_file/?downloadid=271
-hMailServer.exe /verysilent
+curl -sLo hMailServer.zip https://downloads.php.net/~windows/php-sdk/deps/vs18/x64/hmailserver-5.7.0-vs18-x64.zip
+unzip -q hMailServer.zip -d hMailServer
+hMailServer\bin\hMailServer.exe /verysilent
 cd %APPVEYOR_BUILD_FOLDER%
 %PHP_BUILD_DIR%\php.exe -dextension_dir=%PHP_BUILD_DIR% -dextension=com_dotnet appveyor\setup_hmailserver.php
 

--- a/ext/standard/tests/mail/bug80751.phpt
+++ b/ext/standard/tests/mail/bug80751.phpt
@@ -37,7 +37,7 @@ function find_and_delete_message($username, $subject) {
             if ($info->subject === $subject) {
                 $header = imap_fetchheader($imap_stream, $i);
                 echo "Return-Path header found: ";
-                var_dump(strpos($header, 'Return-Path: joe@example.com') !== false);
+                var_dump(strpos($header, 'Return-Path: <joe@example.com>') !== false);
                 echo "To header found: ";
                 var_dump(strpos($header, "To: \"<bob@example.com>\" <{$users[1]}@$domain>") !== false);
                 echo "From header found: ";


### PR DESCRIPTION
This PR switches the hMailServer URL to a build that we maintain in Winlibs.

Also fixes a test to use angle brackets in `Return-Path`.
Ref: https://github.com/hmailserver/hmailserver/pull/514

Fixes #23008