### PR TITLE
Fix GH-23056: missing handler name in session write warning

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -531,7 +531,10 @@ static void php_session_save_current_state(bool write)
 					&& zend_string_equals(val, PS(session_vars))
 				) {
 					ret = PS(mod)->s_update_timestamp(&PS(mod_data), PS(id), val, PS(gc_maxlifetime));
-					handler_function = &PS(mod_user_names).ps_update_timestamp;
+					/* The user handler falls back to the write handler if no update timestamp handler is set */
+					if (!Z_ISUNDEF(PS(mod_user_names).ps_update_timestamp)) {
+						handler_function = &PS(mod_user_names).ps_update_timestamp;
+					}
 				} else {
 					ret = PS(mod)->s_write(&PS(mod_data), PS(id), val, PS(gc_maxlifetime));
 				}

--- a/ext/session/tests/user_session_module/gh23043.phpt
+++ b/ext/session/tests/user_session_module/gh23043.phpt
@@ -27,9 +27,9 @@ string(0) ""
 
 Warning: SessionHandler::write(): Session ID is too long or contains illegal characters. Only the A-Z, a-z, 0-9, "-", and "," characters are allowed in %s on line %d
 
-Warning: session_write_close(): Failed to write session data using user defined save handler. (session.save_path: , handler: ) in %s on line %d
+Warning: session_write_close(): Failed to write session data using user defined save handler. (session.save_path: , handler: a::write) in %s on line %d
 string(0) ""
 
 Warning: SessionHandler::write(): Session ID is too long or contains illegal characters. Only the A-Z, a-z, 0-9, "-", and "," characters are allowed in Unknown on line 0
 
-Warning: session_write_close(): Failed to write session data using user defined save handler. (session.save_path: , handler: ) in Unknown on line 0
+Warning: session_write_close(): Failed to write session data using user defined save handler. (session.save_path: , handler: a::write) in Unknown on line 0


### PR DESCRIPTION
When the session data is unchanged, lazy write calls the update timestamp handler, and the warning names `ps_update_timestamp`. That zval stays undefined for handlers that do not provide an `updateTimestamp()` method, so the name came out empty. In that case `ps_update_timestamp_user()` calls the write handler instead, so the warning should name the write handler.

This only shows on master because an empty session now encodes to an empty string rather than NULL, which lets the lazy write branch run where it previously did not.

Fixes GH-23056.