### PR TITLE
Fix GH-23061: SessionHandler::create_sid() failure leaks memory in debug build

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -41,6 +41,8 @@ PHP                                                                        NEWS
   . Fix corruption in mod_mm. (ndossche)
   . Fixed bug GH-23043 (broken session id code can cause zend_mm_heap
     corrupted). (ndossche)
+  . Fixed bug GH-23061 (SessionHandler::create_sid() callback failure leaks
+    memory in debug build). (Lazizbek Ergashev)
 
 - Sockets:
   . Fixed various memory related issues in ext/sockets. (David Carlier)

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -145,6 +145,14 @@ static void php_rshutdown_session_globals(void) /* {{{ */
 			PS(mod)->s_close(&PS(mod_data));
 		} zend_end_try();
 	}
+	/* The user handler may not have closed the default handler it opened, e.g. because a pending
+	 * exception prevented its close callback from running at all */
+	if (PS(mod_user_is_open)) {
+		zend_try {
+			PS(default_mod)->s_close(&PS(mod_data));
+		} zend_end_try();
+		PS(mod_user_is_open) = false;
+	}
 	if (PS(id)) {
 		zend_string_release_ex(PS(id), 0);
 		PS(id) = NULL;

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -1768,6 +1768,12 @@ static zend_result php_session_abort(void) /* {{{ */
 		if (PS(mod_data) || PS(mod_user_implemented)) {
 			PS(mod)->s_close(&PS(mod_data));
 		}
+		/* The user handler may not have closed the default handler it opened, e.g. because a pending
+		 * exception prevented its close callback from running at all */
+		if (PS(mod_user_is_open)) {
+			PS(default_mod)->s_close(&PS(mod_data));
+			PS(mod_user_is_open) = false;
+		}
 		PS(session_status) = php_session_none;
 		return SUCCESS;
 	}

--- a/ext/session/tests/user_session_module/gh23061-abort.phpt
+++ b/ext/session/tests/user_session_module/gh23061-abort.phpt
@@ -1,0 +1,46 @@
+--TEST--
+GH-23061 (SessionHandler::create_sid() callback failure leaves the default handler open)
+--EXTENSIONS--
+session
+--FILE--
+<?php
+class BrokenSidHandler extends SessionHandler {
+    public function create_sid(): string {
+        return [3, 6];
+    }
+}
+
+class OwnStorageHandler extends SessionHandler {
+    public function open(string $path, string $name): bool {
+        return true;
+    }
+    public function read(string $id): string|false {
+        return parent::read($id);
+    }
+    public function close(): bool {
+        return true;
+    }
+}
+
+session_set_save_handler(new BrokenSidHandler());
+$message = '';
+try {
+    session_start();
+} catch (Error $e) {
+    $message = get_class($e) . ': ' . $e->getMessage();
+}
+
+/* The aborted session must not leave the default handler open for the next one */
+session_set_save_handler(new OwnStorageHandler());
+$started = session_start();
+session_write_close();
+
+echo $message, "\n";
+var_dump($started);
+?>
+--EXPECTF--
+Warning: SessionHandler::read(): Parent session handler is not open in %s on line %d
+
+Warning: session_start(): Failed to read session data: user (path: ) in %s on line %d
+Error: Session id must be a string
+bool(false)

--- a/ext/session/tests/user_session_module/gh23061.phpt
+++ b/ext/session/tests/user_session_module/gh23061.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-23061 (SessionHandler::create_sid() callback failure leaks memory in debug build)
+--EXTENSIONS--
+session
+--FILE--
+<?php
+class a extends SessionHandler {
+    function create_sid(): string {
+        return [3, 6];
+    }
+}
+$c = new a;
+session_set_save_handler($c);
+try {
+    session_start();
+} catch (Error $e) {
+    echo get_class($e), ": ", $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Error: Session id must be a string


### PR DESCRIPTION
When a save handler extending `SessionHandler` throws while the session is starting, `php_session_abort()` calls the user close callback, but `zend_call_function()` refuses to run userland code while an exception is pending. `SessionHandler::close()` therefore never runs, and the default handler that `SessionHandler::open()` opened stays open, so its `mod_data` is never freed. A debug build reports it as two leaks.

Since `PS(mod_user_is_open)` already tracks whether the default handler is open, request shutdown can close it when the user handler did not. This also covers a handler that overrides `close()` without calling `parent::close()`, which leaked the same way.

Fixes GH-23061