### PR TITLE
Fix segfault comparing uninitialized SimpleXMLElement instances

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -58,6 +58,8 @@ PHP                                                                        NEWS
 - SimpleXML:
   . Fixed integer element offsets that cannot resolve aliasing an existing
     element. (iliaal)
+  . Fixed segfault when comparing uninitialized SimpleXMLElement
+    instances. (iliaal)
 
 - Sockets:
   . Fixed various memory related issues in ext/sockets. (David Carlier)

--- a/NEWS
+++ b/NEWS
@@ -42,6 +42,10 @@ PHP                                                                        NEWS
   . Fixed bug GH-23043 (broken session id code can cause zend_mm_heap
     corrupted). (ndossche)
 
+- SimpleXML:
+  . Fixed segfault when comparing uninitialized SimpleXMLElement
+    instances. (iliaal)
+
 - Sockets:
   . Fixed various memory related issues in ext/sockets. (David Carlier)
 

--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -1229,6 +1229,12 @@ static int sxe_objects_compare(zval *object1, zval *object2) /* {{{ */
 
 	if (sxe1->node == NULL && sxe2->node == NULL) {
 		/* Both nodes not set: Only support equality comparison between documents. */
+		if (sxe1->document == NULL || sxe2->document == NULL) {
+			if (sxe1->document == sxe2->document) {
+				return 0;
+			}
+			return ZEND_UNCOMPARABLE;
+		}
 		if (sxe1->document->ptr == sxe2->document->ptr) {
 			return 0;
 		}

--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -1237,7 +1237,7 @@ static int sxe_objects_compare(zval *object1, zval *object2) /* {{{ */
 
 	if (sxe1->node == NULL && sxe2->node == NULL) {
 		/* Both nodes not set: Only support equality comparison between documents. */
-		if (sxe1->document->ptr == sxe2->document->ptr) {
+		if (sxe1->document != NULL && sxe2->document != NULL && sxe1->document->ptr == sxe2->document->ptr) {
 			return 0;
 		}
 		return ZEND_UNCOMPARABLE;

--- a/ext/simplexml/tests/bug_sxe_compare_uninitialized.phpt
+++ b/ext/simplexml/tests/bug_sxe_compare_uninitialized.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Comparing uninitialized SimpleXMLElement instances must not segfault
+--EXTENSIONS--
+simplexml
+--FILE--
+<?php
+class MySXE extends SimpleXMLElement {
+    public function __construct() {}
+}
+$a = new MySXE;
+$b = new MySXE;
+echo "self: ";
+var_dump($a == $a);
+echo "equal: ";
+var_dump($a == $b);
+echo "identical: ";
+var_dump($a === $b);
+$c = simplexml_load_string('<r/>');
+echo "uninit vs init: ";
+var_dump($a == $c);
+echo "done\n";
+?>
+--EXPECT--
+self: bool(true)
+equal: bool(false)
+identical: bool(false)
+uninit vs init: bool(false)
+done

--- a/ext/simplexml/tests/bug_sxe_compare_uninitialized.phpt
+++ b/ext/simplexml/tests/bug_sxe_compare_uninitialized.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Comparing uninitialized SimpleXMLElement instances must not segfault
+--EXTENSIONS--
+simplexml
+--FILE--
+<?php
+class MySXE extends SimpleXMLElement {
+    public function __construct() {}
+}
+$a = new MySXE;
+$b = new MySXE;
+echo "equal: ";
+var_dump($a == $b);
+echo "identical: ";
+var_dump($a === $b);
+$c = simplexml_load_string('<r/>');
+echo "uninit vs init: ";
+var_dump($a == $c);
+echo "done\n";
+?>
+--EXPECT--
+equal: bool(true)
+identical: bool(false)
+uninit vs init: bool(false)
+done


### PR DESCRIPTION
sxe_objects_compare reaches sxe1->document->ptr whenever both operands have a NULL node, without checking that document is set. A subclass whose constructor skips parent::__construct leaves both fields NULL, so `new MySXE == new MySXE` dereferences NULL and segfaults. The documents are compared only when both are set, so two uninitialized instances are uncomparable, matching the node comparison directly above.
