### PR TITLE
Honor ERRMODE_SILENT in pdo_raise_impl_error

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -27,6 +27,10 @@ PHP                                                                        NEWS
   . Added SpoofChecker::getBidiSkeleton(). (Weilin Du)
   . Added SpoofChecker::getSkeleton(). (David Carlier)
 
+- PDO:
+  . Fixed pdo_raise_impl_error() emitting a warning under ERRMODE_SILENT.
+    (iliaal)
+
 - PDO_ODBC:
   . Fixed bug GH-23016 (NULL values in long columns come back as garbage
     binary strings). (Calvin Buckley, iliaal)

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -73,20 +73,15 @@ void pdo_raise_impl_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, pdo_error_type sqlst
 	pdo_error_type *pdo_err = &dbh->error_code;
 	const char *msg;
 
-	if (dbh->error_mode == PDO_ERRMODE_SILENT) {
-#if 0
-		/* BUG: if user is running in silent mode and hits an error at the driver level
-		 * when they use the PDO methods to call up the error information, they may
-		 * get bogus information */
-		return;
-#endif
-	}
-
 	if (stmt) {
 		pdo_err = &stmt->error_code;
 	}
 
 	memcpy(*pdo_err, sqlstate, sizeof(pdo_error_type));
+
+	if (dbh->error_mode == PDO_ERRMODE_SILENT) {
+		return;
+	}
 
 	/* hash sqlstate to error messages */
 	msg = pdo_sqlstate_state_to_description(*pdo_err);

--- a/ext/pdo_sqlite/tests/pdo_silent_impl_error.phpt
+++ b/ext/pdo_sqlite/tests/pdo_silent_impl_error.phpt
@@ -1,0 +1,21 @@
+--TEST--
+pdo_raise_impl_error honors ERRMODE_SILENT (no warning)
+--EXTENSIONS--
+pdo_sqlite
+--FILE--
+<?php
+$pdo = new PDO('sqlite::memory:');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
+set_error_handler(function (int $errno, string $errstr): bool {
+    echo "warning: $errstr\n";
+    return true;
+});
+$result = $pdo->getAttribute(123456);
+echo "result: ";
+var_dump($result);
+echo "errorInfo: ";
+var_dump($pdo->errorInfo()[0]);
+?>
+--EXPECT--
+result: bool(false)
+errorInfo: string(5) "IM001"


### PR DESCRIPTION
ERRMODE_SILENT is documented to record the error without raising anything, but pdo_raise_impl_error falls through to php_error_docref for every mode except EXCEPTION, so `$pdo->getAttribute(123456)` warns under SILENT. The early return is there, disabled behind #if 0, because returning ahead of the memcpy left errorInfo() reporting the previous SQLSTATE. Copying the code first and returning after it drops the warning and keeps errorInfo() accurate. GH-12032 reported the same behaviour, and the suggestion there was that changing it may want internals discussion, so this targets master rather than a stable branch.
