### PR TITLE
ext/intl: Include <limits> for std::numeric_limits

### DIFF
--- a/ext/intl/dateformat/dateformat_helpers.cpp
+++ b/ext/intl/dateformat/dateformat_helpers.cpp
@@ -14,6 +14,8 @@
 
 #include "../intl_cppshims.h"
 
+#include <limits>
+
 #include <unicode/calendar.h>
 #include <unicode/gregocal.h>
 


### PR DESCRIPTION
This fix https://github.com/php/php-src/pull/21101#issuecomment-5188586937

The bug is quite hidden. This line of code in the commit
```c
 gcal->setGregorianChange(-std::numeric_limits<double>::infinity(), status);
```
Some extreme build environments happen to get std::numeric_limits through transitive includes. So we need to put a Include <limits> manually

