### PR TITLE
ext/standard: notice on long passwords in bcrypt

### DIFF
--- a/ext/standard/password.c
+++ b/ext/standard/password.c
@@ -184,6 +184,10 @@ static zend_string* php_password_bcrypt_hash(const zend_string *password, zend_a
 		return NULL;
 	}
 
+	if (ZSTR_LEN(password) > 72) {
+		zend_error(E_NOTICE, "Passwords longer than 72 characters are truncated by bcrypt");
+	}
+
 	if (options && (zcost = zend_hash_str_find(options, "cost", sizeof("cost")-1)) != NULL) {
 		cost = zval_get_long(zcost);
 	}

--- a/ext/standard/tests/password/bcrypt_72_char_limit.phpt
+++ b/ext/standard/tests/password/bcrypt_72_char_limit.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test error operation of password_hash() with bcrypt hashing
+--FILE--
+<?php
+$long_pass = str_repeat('a', 71);
+
+$hash = password_hash($long_pass . 'a', PASSWORD_BCRYPT, array("cost" => 4));
+var_dump(password_verify($long_pass . 'a', $hash));
+var_dump(password_verify($long_pass . 'b', $hash));
+
+$hash = password_hash($long_pass . 'aa', PASSWORD_BCRYPT, array("cost" => 4));
+var_dump(password_verify($long_pass . 'aa', $hash));
+
+?>
+--EXPECTF--
+bool(true)
+bool(false)
+
+Notice: Passwords longer than 72 characters are truncated by bcrypt in %s on line %d
+bool(true)

--- a/ext/standard/tests/password/bcrypt_72_char_limit.phpt
+++ b/ext/standard/tests/password/bcrypt_72_char_limit.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test error operation of password_hash() with bcrypt hashing
+Test 72 character limit of bcrypt
 --FILE--
 <?php
 $long_pass = str_repeat('a', 71);

--- a/ext/standard/tests/password/bcrypt_72_char_limit.phpt
+++ b/ext/standard/tests/password/bcrypt_72_char_limit.phpt
@@ -11,10 +11,15 @@ var_dump(password_verify($long_pass . 'b', $hash));
 $hash = password_hash($long_pass . 'aa', PASSWORD_BCRYPT, array("cost" => 4));
 var_dump(password_verify($long_pass . 'aa', $hash));
 
+echo "This is the unexpected behavior we warn about: password is different but password_verify returns true.\n";
+var_dump(password_verify($long_pass . 'ab', $hash));
+
 ?>
 --EXPECTF--
 bool(true)
 bool(false)
 
 Notice: Passwords longer than 72 characters are truncated by bcrypt in %s on line %d
+bool(true)
+This is the unexpected behavior we warn about: password is different but password_verify returns true.
 bool(true)


### PR DESCRIPTION
Bcrypt supports passwords up to 72 characters. The remainder is ignored.

Earlier proposed here:
- https://news-web.php.net/php.internals/75692
- https://wiki.php.net/rfc/password_hash_spec
- https://bugs.php.net/bug.php?id=67653

Bcrypt truncation can result in serious security bugs:
- https://pentesterlab.com/blog/freshrss-bcrypt-truncation-auth-bypass
- https://www.invicti.com/blog/web-security/okta-vulnerability-bcrypt-auth