### PR TITLE
date: Add new timelib/duration.c source file to autoconf

### DIFF
--- a/ext/date/config.w32
+++ b/ext/date/config.w32
@@ -2,7 +2,7 @@
 
 EXTENSION("date", "php_date.c", false, "/Iext/date/lib /DHAVE_TIMELIB_CONFIG_H=1");
 PHP_DATE = "yes";
-ADD_SOURCES("ext/date/lib", "astro.c timelib.c dow.c parse_date.c parse_posix.c parse_tz.c tm2unixtime.c unixtime2tm.c parse_iso_intervals.c interval.c", "date");
+ADD_SOURCES("ext/date/lib", "astro.c timelib.c dow.c duration.c parse_date.c parse_posix.c parse_tz.c tm2unixtime.c unixtime2tm.c parse_iso_intervals.c interval.c", "date");
 
 ADD_FLAG('CFLAGS_DATE', "/wd4244");
 

--- a/ext/date/config0.m4
+++ b/ext/date/config0.m4
@@ -14,7 +14,7 @@ PHP_DATE_CFLAGS="$PHP_DATE_CFLAGS -I@ext_builddir@/lib"
 AX_CHECK_COMPILE_FLAG([-fwrapv],
   [PHP_TIMELIB_CFLAGS="$PHP_TIMELIB_CFLAGS -fwrapv"])
 
-timelib_sources="lib/astro.c lib/dow.c lib/parse_date.c lib/parse_tz.c lib/parse_posix.c
+timelib_sources="lib/astro.c lib/dow.c lib/duration.c lib/parse_date.c lib/parse_tz.c lib/parse_posix.c
                  lib/timelib.c lib/tm2unixtime.c lib/unixtime2tm.c lib/parse_iso_intervals.c lib/interval.c"
 
 PHP_NEW_EXTENSION([date],


### PR DESCRIPTION
Following php/php-src#23063.

Extracted from #23073.