### PR TITLE
ext/intl: Add IntlDatePatternGenerator skeleton methods

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,7 +15,7 @@ PHP                                                                        NEWS
   . Added gmp_powm_sec(). (Weilin Du)
 
 - Intl:
-  . Added IntlDatePatternGenerator::getSkeleton() and
+  . Added static methods IntlDatePatternGenerator::getSkeleton() and
     IntlDatePatternGenerator::getBaseSkeleton(). (Weilin Du)
   . Fixed Collator::sort(), collator_sort(), Collator::asort(), and
     collator_asort() to report UTF-8/UTF-16 conversion errors through the intl

--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,8 @@ PHP                                                                        NEWS
   . Added gmp_powm_sec(). (Weilin Du)
 
 - Intl:
+  . Added IntlDatePatternGenerator::getSkeleton() and
+    IntlDatePatternGenerator::getBaseSkeleton(). (Weilin Du)
   . Fixed Collator::sort(), collator_sort(), Collator::asort(), and
     collator_asort() to report UTF-8/UTF-16 conversion errors through the intl
     error handler instead of emitting a warning and continuing with an empty

--- a/UPGRADING
+++ b/UPGRADING
@@ -314,6 +314,9 @@ PHP 8.6 UPGRADE NOTES
     on official Windows builds using MPIR.
 
 - Intl:
+  . Added IntlDatePatternGenerator::getSkeleton() and
+    IntlDatePatternGenerator::getBaseSkeleton() to generate the unique skeleton
+    and base skeleton for a date/time pattern.
   . Added Locale::getDisplayKeyword() and Locale::getDisplayKeywordValue(),
     with the alias of locale_get_display_keyword() and
     locale_get_display_keyword_value() respectively.
@@ -489,6 +492,8 @@ PHP 8.6 UPGRADE NOTES
 - Intl:
   . grapheme_strrev()
     RFC: https://wiki.php.net/rfc/grapheme_strrev
+  . IntlDatePatternGenerator::getSkeleton()
+  . IntlDatePatternGenerator::getBaseSkeleton()
   . Locale::getDisplayKeyword() and Locale::getDisplayKeywordValue()
     RFC: https://wiki.php.net/rfc/getdisplaykeyword_and_getdisplaykeywordvalue
   . SpoofChecker::areBidiConfusable()

--- a/UPGRADING
+++ b/UPGRADING
@@ -314,7 +314,7 @@ PHP 8.6 UPGRADE NOTES
     on official Windows builds using MPIR.
 
 - Intl:
-  . Added IntlDatePatternGenerator::getSkeleton() and
+  . Added the static methods IntlDatePatternGenerator::getSkeleton() and
     IntlDatePatternGenerator::getBaseSkeleton() to generate the unique skeleton
     and base skeleton for a date/time pattern.
   . Added Locale::getDisplayKeyword() and Locale::getDisplayKeywordValue(),

--- a/ext/intl/dateformat/datepatterngenerator.stub.php
+++ b/ext/intl/dateformat/datepatterngenerator.stub.php
@@ -11,7 +11,7 @@ class IntlDatePatternGenerator
 
     public function getBestPattern(string $skeleton): string|false {}
 
-    public function getSkeleton(string $pattern): string|false {}
+    public static function getSkeleton(string $pattern): string|false {}
 
-    public function getBaseSkeleton(string $pattern): string|false {}
+    public static function getBaseSkeleton(string $pattern): string|false {}
 }

--- a/ext/intl/dateformat/datepatterngenerator.stub.php
+++ b/ext/intl/dateformat/datepatterngenerator.stub.php
@@ -10,4 +10,8 @@ class IntlDatePatternGenerator
     public static function create(?string $locale = null): ?IntlDatePatternGenerator {}
 
     public function getBestPattern(string $skeleton): string|false {}
+
+    public function getSkeleton(string $pattern): string|false {}
+
+    public function getBaseSkeleton(string $pattern): string|false {}
 }

--- a/ext/intl/dateformat/datepatterngenerator_arginfo.h
+++ b/ext/intl/dateformat/datepatterngenerator_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit datepatterngenerator.stub.php instead.
- * Stub hash: 4456b13f7ed59847bbf129cd45b0d1f63ce70108 */
+ * Stub hash: c11c63e6ba20b2fd8494a236a820f84d59d75bad */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_IntlDatePatternGenerator___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, locale, IS_STRING, 1, "null")
@@ -13,14 +13,24 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_IntlDatePatternGenerator_g
 	ZEND_ARG_TYPE_INFO(0, skeleton, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_IntlDatePatternGenerator_getSkeleton, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, pattern, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_IntlDatePatternGenerator_getBaseSkeleton arginfo_class_IntlDatePatternGenerator_getSkeleton
+
 ZEND_METHOD(IntlDatePatternGenerator, __construct);
 ZEND_METHOD(IntlDatePatternGenerator, create);
 ZEND_METHOD(IntlDatePatternGenerator, getBestPattern);
+ZEND_METHOD(IntlDatePatternGenerator, getSkeleton);
+ZEND_METHOD(IntlDatePatternGenerator, getBaseSkeleton);
 
 static const zend_function_entry class_IntlDatePatternGenerator_methods[] = {
 	ZEND_ME(IntlDatePatternGenerator, __construct, arginfo_class_IntlDatePatternGenerator___construct, ZEND_ACC_PUBLIC)
 	ZEND_ME(IntlDatePatternGenerator, create, arginfo_class_IntlDatePatternGenerator_create, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(IntlDatePatternGenerator, getBestPattern, arginfo_class_IntlDatePatternGenerator_getBestPattern, ZEND_ACC_PUBLIC)
+	ZEND_ME(IntlDatePatternGenerator, getSkeleton, arginfo_class_IntlDatePatternGenerator_getSkeleton, ZEND_ACC_PUBLIC)
+	ZEND_ME(IntlDatePatternGenerator, getBaseSkeleton, arginfo_class_IntlDatePatternGenerator_getBaseSkeleton, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 

--- a/ext/intl/dateformat/datepatterngenerator_arginfo.h
+++ b/ext/intl/dateformat/datepatterngenerator_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit datepatterngenerator.stub.php instead.
- * Stub hash: c11c63e6ba20b2fd8494a236a820f84d59d75bad */
+ * Stub hash: cea997295023d9f6f6451150bf19867e7dac8c90 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_IntlDatePatternGenerator___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, locale, IS_STRING, 1, "null")
@@ -29,8 +29,8 @@ static const zend_function_entry class_IntlDatePatternGenerator_methods[] = {
 	ZEND_ME(IntlDatePatternGenerator, __construct, arginfo_class_IntlDatePatternGenerator___construct, ZEND_ACC_PUBLIC)
 	ZEND_ME(IntlDatePatternGenerator, create, arginfo_class_IntlDatePatternGenerator_create, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(IntlDatePatternGenerator, getBestPattern, arginfo_class_IntlDatePatternGenerator_getBestPattern, ZEND_ACC_PUBLIC)
-	ZEND_ME(IntlDatePatternGenerator, getSkeleton, arginfo_class_IntlDatePatternGenerator_getSkeleton, ZEND_ACC_PUBLIC)
-	ZEND_ME(IntlDatePatternGenerator, getBaseSkeleton, arginfo_class_IntlDatePatternGenerator_getBaseSkeleton, ZEND_ACC_PUBLIC)
+	ZEND_ME(IntlDatePatternGenerator, getSkeleton, arginfo_class_IntlDatePatternGenerator_getSkeleton, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(IntlDatePatternGenerator, getBaseSkeleton, arginfo_class_IntlDatePatternGenerator_getBaseSkeleton, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_FE_END
 };
 

--- a/ext/intl/dateformat/datepatterngenerator_methods.cpp
+++ b/ext/intl/dateformat/datepatterngenerator_methods.cpp
@@ -165,7 +165,7 @@ static void dtpg_get_skeleton(INTERNAL_FUNCTION_PARAMETERS, F&& skeletonfn, cons
 U_CFUNC PHP_METHOD(IntlDatePatternGenerator, getSkeleton)
 {
 	dtpg_get_skeleton(INTERNAL_FUNCTION_PARAM_PASSTHRU,
-		[](const UnicodeString& pattern, UErrorCode& status) {
+		[](const UnicodeString &pattern, UErrorCode &status) {
 			return DateTimePatternGenerator::staticGetSkeleton(pattern, status);
 		},
 		"Error getting skeleton");
@@ -174,7 +174,7 @@ U_CFUNC PHP_METHOD(IntlDatePatternGenerator, getSkeleton)
 U_CFUNC PHP_METHOD(IntlDatePatternGenerator, getBaseSkeleton)
 {
 	dtpg_get_skeleton(INTERNAL_FUNCTION_PARAM_PASSTHRU,
-		[](const UnicodeString& pattern, UErrorCode& status) {
+		[](const UnicodeString &pattern, UErrorCode &status) {
 			return DateTimePatternGenerator::staticGetBaseSkeleton(pattern, status);
 		},
 		"Error getting base skeleton");

--- a/ext/intl/dateformat/datepatterngenerator_methods.cpp
+++ b/ext/intl/dateformat/datepatterngenerator_methods.cpp
@@ -134,7 +134,8 @@ U_CFUNC PHP_METHOD( IntlDatePatternGenerator, getBestPattern )
 	RETVAL_STR(u8str);
 }
 
-static void dtpg_get_skeleton(INTERNAL_FUNCTION_PARAMETERS, bool base)
+template <typename F>
+static void dtpg_get_skeleton(INTERNAL_FUNCTION_PARAMETERS, F&& skeletonfn, const char *errmsg)
 {
 	zend_string *pattern_str;
 	UnicodeString pattern;
@@ -150,11 +151,9 @@ static void dtpg_get_skeleton(INTERNAL_FUNCTION_PARAMETERS, bool base)
 
 	INTL_CHECK_STATUS(status, "Pattern is not a valid UTF-8 string");
 
-	UnicodeString result = base
-		? DateTimePatternGenerator::staticGetBaseSkeleton(pattern, status)
-		: DateTimePatternGenerator::staticGetSkeleton(pattern, status);
+	UnicodeString result = skeletonfn(pattern, status);
 
-	INTL_CHECK_STATUS(status, base ? "Error getting base skeleton" : "Error getting skeleton");
+	INTL_CHECK_STATUS(status, errmsg);
 
 	zend_string *u8str = intl_charFromString(result, &status);
 
@@ -165,10 +164,18 @@ static void dtpg_get_skeleton(INTERNAL_FUNCTION_PARAMETERS, bool base)
 
 U_CFUNC PHP_METHOD(IntlDatePatternGenerator, getSkeleton)
 {
-	dtpg_get_skeleton(INTERNAL_FUNCTION_PARAM_PASSTHRU, false);
+	dtpg_get_skeleton(INTERNAL_FUNCTION_PARAM_PASSTHRU,
+		[](const UnicodeString& pattern, UErrorCode& status) {
+			return DateTimePatternGenerator::staticGetSkeleton(pattern, status);
+		},
+		"Error getting skeleton");
 }
 
 U_CFUNC PHP_METHOD(IntlDatePatternGenerator, getBaseSkeleton)
 {
-	dtpg_get_skeleton(INTERNAL_FUNCTION_PARAM_PASSTHRU, true);
+	dtpg_get_skeleton(INTERNAL_FUNCTION_PARAM_PASSTHRU,
+		[](const UnicodeString& pattern, UErrorCode& status) {
+			return DateTimePatternGenerator::staticGetBaseSkeleton(pattern, status);
+		},
+		"Error getting base skeleton");
 }

--- a/ext/intl/dateformat/datepatterngenerator_methods.cpp
+++ b/ext/intl/dateformat/datepatterngenerator_methods.cpp
@@ -118,7 +118,8 @@ U_CFUNC PHP_METHOD( IntlDatePatternGenerator, getBestPattern )
 
 	INTL_METHOD_CHECK_STATUS(dtpgo, "Skeleton is not a valid UTF-8 string");
 
-	UnicodeString skeleton = dtpgo->dtpg->getSkeleton(skeleton_uncleaned, DTPATTERNGEN_ERROR_CODE(dtpgo));
+	UnicodeString skeleton = DateTimePatternGenerator::staticGetSkeleton(
+		skeleton_uncleaned, DTPATTERNGEN_ERROR_CODE(dtpgo));
 
 	INTL_METHOD_CHECK_STATUS(dtpgo, "Error getting cleaned skeleton");
 
@@ -137,29 +138,27 @@ static void dtpg_get_skeleton(INTERNAL_FUNCTION_PARAMETERS, bool base)
 {
 	zend_string *pattern_str;
 	UnicodeString pattern;
+	UErrorCode status = U_ZERO_ERROR;
 
-	DTPATTERNGEN_METHOD_INIT_VARS;
+	intl_error_reset(NULL);
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
 		Z_PARAM_STR(pattern_str)
 	ZEND_PARSE_PARAMETERS_END();
 
-	object = ZEND_THIS;
-	DTPATTERNGEN_METHOD_FETCH_OBJECT;
+	intl_stringFromChar(pattern, ZSTR_VAL(pattern_str), ZSTR_LEN(pattern_str), &status);
 
-	intl_stringFromChar(pattern, ZSTR_VAL(pattern_str), ZSTR_LEN(pattern_str), DTPATTERNGEN_ERROR_CODE_P(dtpgo));
-
-	INTL_METHOD_CHECK_STATUS(dtpgo, "Pattern is not a valid UTF-8 string");
+	INTL_CHECK_STATUS(status, "Pattern is not a valid UTF-8 string");
 
 	UnicodeString result = base
-		? dtpgo->dtpg->getBaseSkeleton(pattern, DTPATTERNGEN_ERROR_CODE(dtpgo))
-		: dtpgo->dtpg->getSkeleton(pattern, DTPATTERNGEN_ERROR_CODE(dtpgo));
+		? DateTimePatternGenerator::staticGetBaseSkeleton(pattern, status)
+		: DateTimePatternGenerator::staticGetSkeleton(pattern, status);
 
-	INTL_METHOD_CHECK_STATUS(dtpgo, base ? "Error getting base skeleton" : "Error getting skeleton");
+	INTL_CHECK_STATUS(status, base ? "Error getting base skeleton" : "Error getting skeleton");
 
-	zend_string *u8str = intl_charFromString(result, DTPATTERNGEN_ERROR_CODE_P(dtpgo));
+	zend_string *u8str = intl_charFromString(result, &status);
 
-	INTL_METHOD_CHECK_STATUS(dtpgo, "Error converting result to UTF-8");
+	INTL_CHECK_STATUS(status, "Error converting result to UTF-8");
 
 	RETVAL_STR(u8str);
 }

--- a/ext/intl/dateformat/datepatterngenerator_methods.cpp
+++ b/ext/intl/dateformat/datepatterngenerator_methods.cpp
@@ -132,3 +132,44 @@ U_CFUNC PHP_METHOD( IntlDatePatternGenerator, getBestPattern )
 
 	RETVAL_STR(u8str);
 }
+
+static void dtpg_get_skeleton(INTERNAL_FUNCTION_PARAMETERS, bool base)
+{
+	zend_string *pattern_str;
+	UnicodeString pattern;
+
+	DTPATTERNGEN_METHOD_INIT_VARS;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(pattern_str)
+	ZEND_PARSE_PARAMETERS_END();
+
+	object = ZEND_THIS;
+	DTPATTERNGEN_METHOD_FETCH_OBJECT;
+
+	intl_stringFromChar(pattern, ZSTR_VAL(pattern_str), ZSTR_LEN(pattern_str), DTPATTERNGEN_ERROR_CODE_P(dtpgo));
+
+	INTL_METHOD_CHECK_STATUS(dtpgo, "Pattern is not a valid UTF-8 string");
+
+	UnicodeString result = base
+		? dtpgo->dtpg->getBaseSkeleton(pattern, DTPATTERNGEN_ERROR_CODE(dtpgo))
+		: dtpgo->dtpg->getSkeleton(pattern, DTPATTERNGEN_ERROR_CODE(dtpgo));
+
+	INTL_METHOD_CHECK_STATUS(dtpgo, base ? "Error getting base skeleton" : "Error getting skeleton");
+
+	zend_string *u8str = intl_charFromString(result, DTPATTERNGEN_ERROR_CODE_P(dtpgo));
+
+	INTL_METHOD_CHECK_STATUS(dtpgo, "Error converting result to UTF-8");
+
+	RETVAL_STR(u8str);
+}
+
+U_CFUNC PHP_METHOD(IntlDatePatternGenerator, getSkeleton)
+{
+	dtpg_get_skeleton(INTERNAL_FUNCTION_PARAM_PASSTHRU, false);
+}
+
+U_CFUNC PHP_METHOD(IntlDatePatternGenerator, getBaseSkeleton)
+{
+	dtpg_get_skeleton(INTERNAL_FUNCTION_PARAM_PASSTHRU, true);
+}

--- a/ext/intl/tests/datepatterngenerator_get_skeleton.phpt
+++ b/ext/intl/tests/datepatterngenerator_get_skeleton.phpt
@@ -5,14 +5,12 @@ intl
 --FILE--
 <?php
 
-$dtpg = new IntlDatePatternGenerator();
-
-var_dump($dtpg->getSkeleton("dd/MMM"));
-var_dump($dtpg->getSkeleton("MMM-dd"));
-var_dump($dtpg->getBaseSkeleton("dd/MMM"));
-var_dump($dtpg->getBaseSkeleton("MMM-dd"));
-var_dump($dtpg->getSkeleton(""));
-var_dump($dtpg->getBaseSkeleton(""));
+var_dump(IntlDatePatternGenerator::getSkeleton("dd/MMM"));
+var_dump(IntlDatePatternGenerator::getSkeleton("MMM-dd"));
+var_dump(IntlDatePatternGenerator::getBaseSkeleton("dd/MMM"));
+var_dump(IntlDatePatternGenerator::getBaseSkeleton("MMM-dd"));
+var_dump(IntlDatePatternGenerator::getSkeleton(""));
+var_dump(IntlDatePatternGenerator::getBaseSkeleton(""));
 
 ?>
 --EXPECT--

--- a/ext/intl/tests/datepatterngenerator_get_skeleton.phpt
+++ b/ext/intl/tests/datepatterngenerator_get_skeleton.phpt
@@ -12,6 +12,25 @@ var_dump(IntlDatePatternGenerator::getBaseSkeleton("MMM-dd"));
 var_dump(IntlDatePatternGenerator::getSkeleton(""));
 var_dump(IntlDatePatternGenerator::getBaseSkeleton(""));
 
+$patterns = [
+    "'at' HH:mm",
+    "y年M月d日",
+    "yyyy-MM-dd",
+    "MMMMM",
+    "MMM",
+    "HH:mm:ss zzz dd/MM/y",
+    "'at HH:mm",
+];
+
+foreach ($patterns as $pattern) {
+    printf(
+        "%s => [%s] [%s]\n",
+        $pattern,
+        IntlDatePatternGenerator::getSkeleton($pattern),
+        IntlDatePatternGenerator::getBaseSkeleton($pattern),
+    );
+}
+
 ?>
 --EXPECT--
 string(5) "MMMdd"
@@ -20,3 +39,10 @@ string(4) "MMMd"
 string(4) "MMMd"
 string(0) ""
 string(0) ""
+'at' HH:mm => [HHmm] [Hm]
+y年M月d日 => [yMd] [yMd]
+yyyy-MM-dd => [yyyyMMdd] [yMd]
+MMMMM => [MMMMM] [MMMMM]
+MMM => [MMM] [MMM]
+HH:mm:ss zzz dd/MM/y => [yMMddHHmmsszzz] [yMdHmsz]
+'at HH:mm => [] []

--- a/ext/intl/tests/datepatterngenerator_get_skeleton.phpt
+++ b/ext/intl/tests/datepatterngenerator_get_skeleton.phpt
@@ -1,0 +1,24 @@
+--TEST--
+IntlDatePatternGenerator::getSkeleton() and getBaseSkeleton()
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+
+$dtpg = new IntlDatePatternGenerator();
+
+var_dump($dtpg->getSkeleton("dd/MMM"));
+var_dump($dtpg->getSkeleton("MMM-dd"));
+var_dump($dtpg->getBaseSkeleton("dd/MMM"));
+var_dump($dtpg->getBaseSkeleton("MMM-dd"));
+var_dump($dtpg->getSkeleton(""));
+var_dump($dtpg->getBaseSkeleton(""));
+
+?>
+--EXPECT--
+string(5) "MMMdd"
+string(5) "MMMdd"
+string(4) "MMMd"
+string(4) "MMMd"
+string(0) ""
+string(0) ""

--- a/ext/intl/tests/datepatterngenerator_skeleton_error.phpt
+++ b/ext/intl/tests/datepatterngenerator_skeleton_error.phpt
@@ -1,0 +1,20 @@
+--TEST--
+IntlDatePatternGenerator::getSkeleton() and getBaseSkeleton(): errors
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+
+$dtpg = new IntlDatePatternGenerator();
+
+foreach (["getSkeleton", "getBaseSkeleton"] as $method) {
+    var_dump($dtpg->$method("dd/MMM\x80"));
+    echo intl_get_error_message(), "\n";
+}
+
+?>
+--EXPECT--
+bool(false)
+IntlDatePatternGenerator::getSkeleton(): Pattern is not a valid UTF-8 string: U_INVALID_CHAR_FOUND
+bool(false)
+IntlDatePatternGenerator::getBaseSkeleton(): Pattern is not a valid UTF-8 string: U_INVALID_CHAR_FOUND

--- a/ext/intl/tests/datepatterngenerator_skeleton_error.phpt
+++ b/ext/intl/tests/datepatterngenerator_skeleton_error.phpt
@@ -5,10 +5,8 @@ intl
 --FILE--
 <?php
 
-$dtpg = new IntlDatePatternGenerator();
-
 foreach (["getSkeleton", "getBaseSkeleton"] as $method) {
-    var_dump($dtpg->$method("dd/MMM\x80"));
+    var_dump(IntlDatePatternGenerator::$method("dd/MMM\x80"));
     echo intl_get_error_message(), "\n";
 }
 


### PR DESCRIPTION
This add missing Skeleton functions similar to #23049 and #23017 for `IntlDatePatternGenerator`. This adds `IntlDatePatternGenerator::getSkeleton()` and `IntlDatePatternGenerator::getBaseSkeleton()`

  - DateTimePatternGenerator::getSkeleton()
    https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/classicu_1_1DateTimePatternGenerator.html#ac27933661baec901aaf690b4e6db9159

  - DateTimePatternGenerator::getBaseSkeleton()
    https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/classicu_1_1DateTimePatternGenerator.html#ae635530015fcad95a1bae9123b2f79f6