### PR TITLE
configure: disable Apple clang size optimizations that hurt runtime speed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -219,6 +219,18 @@ esac
 dnl See https://github.com/php/php-src/issues/14140
 AX_CHECK_COMPILE_FLAG([-ffp-contract=off], [CFLAGS="$CFLAGS -ffp-contract=off"])
 
+dnl Apple clang enables the AArch64 machine outliner and hot/cold code
+dnl splitting by default at -O2. Both trade speed for size: outlining
+dnl inserts extra calls into hot paths (including the zval destructor
+dnl loops) and cold-split fragments are compiled for size. Disabling them
+dnl speeds up CPU-bound scripts measurably (~4% on a large static
+dnl analysis workload). -Werror is needed because clang only warns about
+dnl unknown -m flags.
+AX_CHECK_COMPILE_FLAG([-mno-outline],
+  [CFLAGS="$CFLAGS -mno-outline"], [], [-Werror])
+AX_CHECK_COMPILE_FLAG([-Xclang -fno-split-cold-code],
+  [CFLAGS="$CFLAGS -Xclang -fno-split-cold-code"], [], [-Werror])
+
 dnl Mark symbols hidden by default if the compiler (for example, gcc >= 4)
 dnl supports it. This can help reduce the binary size and startup time.
 AX_CHECK_COMPILE_FLAG([-fvisibility=hidden],


### PR DESCRIPTION
disclaimer: this change was generated by claude opus. I have little experience with php-src development

----

Apple clang enables the AArch64 machine outliner and hot/cold code splitting by default at -O2. Both trade speed for size: the outliner inserts extra bl/ret pairs into hot paths (measured inside the inlined zval destructor loops of zend_array_destroy, among others), and cold-split fragments (4700+ in a default cli build) are compiled for size, which mispredicted branch hints turn into slow hot code.

Disabling both speeds up a CPU-bound static analysis workload (PHPStan analysing its own codebase, no opcache) by ~4% wall time on an Apple M-series machine. The flags are added only when the compiler accepts them (-Werror guards against clang's unknown -m flag warnings), so non-Apple toolchains are unaffected.

----

benchmark (3 runs after 2 warmup runs):

run `/Users/staabm/workspace/php-src/sapi/cli/php bin/phpstan clear-result-cache -q &&  /Users/staabm/workspace/php-src/sapi/cli/php -d memory_limit=450M bin/phpstan -v` after checking out https://github.com/phpstan/phpstan-src/pull/5942 from the git root folder.
(on first time phpstan-src checkout you need `composer install` and `make` to prepare the codebase)

before this PR:
14,47s
14,87s
14,60s

after this PR:
13,91s
13,68s
13,86s


on M4-Pro with macOS 26.6 (25G72)