### PR TITLE
Fix OPcache memory protection race under ZTS

### DIFF
--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -199,6 +199,9 @@ typedef struct _zend_accel_globals {
 	bool               counted;   /* the process uses shared memory */
 	bool               enabled;
 	bool               locked;    /* thread obtained exclusive lock */
+#ifdef ZTS
+	uint32_t           unprotect_depth;
+#endif
 	bool               accelerator_enabled; /* accelerator enabled for current request */
 	bool               pcre_reseted;
 	zend_accel_directives   accel_directives;

--- a/ext/opcache/zend_shared_alloc.c
+++ b/ext/opcache/zend_shared_alloc.c
@@ -55,6 +55,11 @@ static const char *g_shared_model;
 /* pointer to globals allocated in SHM and shared across processes */
 ZEND_EXT_API zend_smm_shared_globals *smm_shared_globals;
 
+#ifdef ZTS
+static MUTEX_T zts_protect_lock;
+static uint32_t zts_unprotected_threads;
+#endif
+
 #ifndef ZEND_WIN32
 #ifdef ZTS
 static MUTEX_T zts_lock;
@@ -183,6 +188,11 @@ int zend_shared_alloc_startup(size_t requested_size, size_t reserved_size)
 	const zend_shared_memory_handler_entry *he;
 	int res = ALLOC_FAILURE;
 	int i;
+
+#ifdef ZTS
+	zts_protect_lock = tsrm_mutex_alloc();
+	zts_unprotected_threads = 0;
+#endif
 
 	/* shared_free must be valid before we call zend_shared_alloc()
 	 * - make it temporarily point to a local variable
@@ -337,6 +347,9 @@ void zend_shared_alloc_shutdown(void)
 # ifdef ZTS
 	tsrm_mutex_free(zts_lock);
 # endif
+#endif
+#ifdef ZTS
+	tsrm_mutex_free(zts_protect_lock);
 #endif
 }
 
@@ -625,13 +638,31 @@ const char *zend_accel_get_shared_model(void)
 
 void zend_accel_shared_protect(bool protected)
 {
-#ifdef HAVE_MPROTECT
+#if defined(HAVE_MPROTECT) || defined(ZEND_WIN32)
 	int i;
 
 	if (!smm_shared_globals) {
 		return;
 	}
 
+#ifdef ZTS
+	/* Memory protection is process-wide, so overlapping writers must be tracked across threads. */
+	tsrm_mutex_lock(zts_protect_lock);
+	if (protected) {
+		if (ZCG(unprotect_depth) && --ZCG(unprotect_depth) == 0) {
+			ZEND_ASSERT(zts_unprotected_threads > 0);
+			zts_unprotected_threads--;
+		}
+		if (zts_unprotected_threads) {
+			tsrm_mutex_unlock(zts_protect_lock);
+			return;
+		}
+	} else if (ZCG(unprotect_depth)++ == 0) {
+		zts_unprotected_threads++;
+	}
+#endif
+
+#ifdef HAVE_MPROTECT
 	const int mode = protected ? PROT_READ : PROT_READ|PROT_WRITE;
 
 	for (i = 0; i < ZSMMG(shared_segments_count); i++) {
@@ -652,6 +683,11 @@ void zend_accel_shared_protect(bool protected)
 			zend_accel_error_noreturn(ACCEL_LOG_ERROR, "Failed to protect memory");
 		}
 	}
+#endif
+
+#ifdef ZTS
+	tsrm_mutex_unlock(zts_protect_lock);
+#endif
 #endif
 }
 

--- a/ext/opcache/zend_shared_alloc.c
+++ b/ext/opcache/zend_shared_alloc.c
@@ -669,12 +669,6 @@ void zend_accel_shared_protect(bool protected)
 		mprotect(ZSMMG(shared_segments)[i]->p, ZSMMG(shared_segments)[i]->end, mode);
 	}
 #elif defined(ZEND_WIN32)
-	int i;
-
-	if (!smm_shared_globals) {
-		return;
-	}
-
 	const int mode = protected ? PAGE_READONLY : PAGE_READWRITE;
 
 	for (i = 0; i < ZSMMG(shared_segments_count); i++) {

--- a/ext/opcache/zend_shared_alloc.c
+++ b/ext/opcache/zend_shared_alloc.c
@@ -645,7 +645,7 @@ void zend_accel_shared_protect(bool protected)
 		return;
 	}
 
-#ifdef ZTS
+# ifdef ZTS
 	/* Memory protection is process-wide, so overlapping writers must be tracked across threads. */
 	tsrm_mutex_lock(zts_protect_lock);
 	if (protected) {
@@ -660,15 +660,15 @@ void zend_accel_shared_protect(bool protected)
 	} else if (ZCG(unprotect_depth)++ == 0) {
 		zts_unprotected_threads++;
 	}
-#endif
+# endif
 
-#ifdef HAVE_MPROTECT
+# ifdef HAVE_MPROTECT
 	const int mode = protected ? PROT_READ : PROT_READ|PROT_WRITE;
 
 	for (i = 0; i < ZSMMG(shared_segments_count); i++) {
 		mprotect(ZSMMG(shared_segments)[i]->p, ZSMMG(shared_segments)[i]->end, mode);
 	}
-#elif defined(ZEND_WIN32)
+# elif defined(ZEND_WIN32)
 	const int mode = protected ? PAGE_READONLY : PAGE_READWRITE;
 
 	for (i = 0; i < ZSMMG(shared_segments_count); i++) {
@@ -677,11 +677,11 @@ void zend_accel_shared_protect(bool protected)
 			zend_accel_error_noreturn(ACCEL_LOG_ERROR, "Failed to protect memory");
 		}
 	}
-#endif
+# endif
 
-#ifdef ZTS
+# ifdef ZTS
 	tsrm_mutex_unlock(zts_protect_lock);
-#endif
+# endif
 #endif
 }
 


### PR DESCRIPTION
I found this after [adding tracing-JIT jobs to the `parallel` CI](https://github.com/krakjoe/parallel/pull/394), which so far only run function JIT. The new job reproducibly [crashed while compiling a trace](https://github.com/krakjoe/parallel/actions/runs/31096841698/job/92600788303?pr=394#step:4:510):

```text
AddressSanitizer: SEGV caused by a WRITE
#0 zend_jit_trace_add_code ext/opcache/jit/zend_jit_trace.c:214
#1 zend_jit_finish ext/opcache/jit/zend_jit_ir.c:16295
#2 zend_jit_trace ext/opcache/jit/zend_jit_trace.c:7244
#3 zend_jit_compile_root_trace ext/opcache/jit/zend_jit_trace.c:7454
#4 zend_jit_trace_hot_root ext/opcache/jit/zend_jit_trace.c:8127
```

The crash occurs because `opcache.protect_memory` changes shared-memory permissions process-wide, while ZTS threads manage the protection scopes independently. `run-tests.php` sets `opcache.protect_memory=1`, which is why this became visible in CI, default is `opcache.protect_memory=0` so most likely no one will actually see this crash in prod.

The race is:

1. Worker A starts compiling a hot trace.
2. It acquires `zend_shared_alloc_lock()`.
3. It calls `SHM_UNPROTECT()`, making OPcache shared memory writable.
4. Worker B concurrently runs OPcache request activation, which is not guarded by `zend_shared_alloc_lock()`.
5. Worker B calls `SHM_UNPROTECT()` followed by `SHM_PROTECT()`.
6. Because memory protection is process-wide, Worker B makes the mapping read-only for all threads.
7. Worker A is still compiling and writes JIT trace metadata into the mapping.
8. PHP crashes with `SIGSEGV` or `EXC_BAD_ACCESS`.

This PR makes unprotected sections nested and process-aware under ZTS:

- Each thread tracks its own unprotect depth.
- A process-wide counter tracks threads with an active unprotected section.
- A dedicated mutex serializes the counter and memory-protection transitions.
- Shared memory returns to read-only only after the last thread leaves its outermost unprotected section.

The dedicated mutex is separate from `zend_shared_alloc_lock()` because some callers already hold that lock when calling `SHM_UNPROTECT()`.

We do not see this in the `php-src` ci in ZTS runs, because those are not running multiple threads, but everything is still single threaded.