### PR TITLE
Make strtolower()/strtoupper() frameless

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -2365,10 +2365,16 @@ function join(string|array $separator, ?array $array = null): string {}
  */
 function strtok(string $string, ?string $token = null): string|false {}
 
-/** @compile-time-eval */
+/**
+ * @compile-time-eval
+ * @frameless-function {"arity": 1}
+ */
 function strtoupper(string $string): string {}
 
-/** @compile-time-eval */
+/**
+ * @compile-time-eval
+ * @frameless-function {"arity": 1}
+ */
 function strtolower(string $string): string {}
 
 function str_increment(string $string): string {}

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit basic_functions.stub.php instead.
- * Stub hash: 0c8af3b78b3d6e1ee3e59c60363d0d941bea9faa
+ * Stub hash: 9f7ce50f366a0e72d4fb2ff3951c957863a27579
  * Has decl header: yes */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
@@ -2246,6 +2246,18 @@ static const zend_frameless_function_info frameless_function_infos_implode[] = {
 	{ 0 },
 };
 
+ZEND_FRAMELESS_FUNCTION(strtoupper, 1);
+static const zend_frameless_function_info frameless_function_infos_strtoupper[] = {
+	{ ZEND_FRAMELESS_FUNCTION_NAME(strtoupper, 1), 1 },
+	{ 0 },
+};
+
+ZEND_FRAMELESS_FUNCTION(strtolower, 1);
+static const zend_frameless_function_info frameless_function_infos_strtolower[] = {
+	{ ZEND_FRAMELESS_FUNCTION_NAME(strtolower, 1), 1 },
+	{ 0 },
+};
+
 ZEND_FRAMELESS_FUNCTION(dirname, 1);
 ZEND_FRAMELESS_FUNCTION(dirname, 2);
 static const zend_frameless_function_info frameless_function_infos_dirname[] = {
@@ -3168,8 +3180,8 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_RAW_FENTRY("implode", zif_implode, arginfo_implode, ZEND_ACC_COMPILE_TIME_EVAL, frameless_function_infos_implode, NULL)
 	ZEND_RAW_FENTRY("join", zif_implode, arginfo_join, 0, NULL, NULL)
 	ZEND_FE(strtok, arginfo_strtok)
-	ZEND_RAW_FENTRY("strtoupper", zif_strtoupper, arginfo_strtoupper, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
-	ZEND_RAW_FENTRY("strtolower", zif_strtolower, arginfo_strtolower, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
+	ZEND_RAW_FENTRY("strtoupper", zif_strtoupper, arginfo_strtoupper, ZEND_ACC_COMPILE_TIME_EVAL, frameless_function_infos_strtoupper, NULL)
+	ZEND_RAW_FENTRY("strtolower", zif_strtolower, arginfo_strtolower, ZEND_ACC_COMPILE_TIME_EVAL, frameless_function_infos_strtolower, NULL)
 	ZEND_FE(str_increment, arginfo_str_increment)
 	ZEND_FE(str_decrement, arginfo_str_decrement)
 	ZEND_FE(basename, arginfo_basename)

--- a/ext/standard/basic_functions_decl.h
+++ b/ext/standard/basic_functions_decl.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit basic_functions.stub.php instead.
- * Stub hash: 0c8af3b78b3d6e1ee3e59c60363d0d941bea9faa */
+ * Stub hash: 9f7ce50f366a0e72d4fb2ff3951c957863a27579 */
 
-#ifndef ZEND_BASIC_FUNCTIONS_DECL_0c8af3b78b3d6e1ee3e59c60363d0d941bea9faa_H
-#define ZEND_BASIC_FUNCTIONS_DECL_0c8af3b78b3d6e1ee3e59c60363d0d941bea9faa_H
+#ifndef ZEND_BASIC_FUNCTIONS_DECL_9f7ce50f366a0e72d4fb2ff3951c957863a27579_H
+#define ZEND_BASIC_FUNCTIONS_DECL_9f7ce50f366a0e72d4fb2ff3951c957863a27579_H
 
 typedef enum zend_enum_SortDirection {
 	ZEND_ENUM_SortDirection_Ascending = 1,
@@ -20,4 +20,4 @@ typedef enum zend_enum_RoundingMode {
 	ZEND_ENUM_RoundingMode_PositiveInfinity = 8,
 } zend_enum_RoundingMode;
 
-#endif /* ZEND_BASIC_FUNCTIONS_DECL_0c8af3b78b3d6e1ee3e59c60363d0d941bea9faa_H */
+#endif /* ZEND_BASIC_FUNCTIONS_DECL_9f7ce50f366a0e72d4fb2ff3951c957863a27579_H */

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -1188,6 +1188,19 @@ PHP_FUNCTION(strtoupper)
 }
 /* }}} */
 
+ZEND_FRAMELESS_FUNCTION(strtoupper, 1)
+{
+	zval str_tmp;
+	zend_string *str;
+
+	Z_FLF_PARAM_STR(1, str, str_tmp);
+
+	RETVAL_STR(zend_string_toupper(str));
+
+flf_clean:
+	Z_FLF_PARAM_FREE_STR(1, str_tmp);
+}
+
 /* {{{ Makes a string lowercase */
 PHP_FUNCTION(strtolower)
 {
@@ -1200,6 +1213,19 @@ PHP_FUNCTION(strtolower)
 	RETURN_STR(zend_string_tolower(str));
 }
 /* }}} */
+
+ZEND_FRAMELESS_FUNCTION(strtolower, 1)
+{
+	zval str_tmp;
+	zend_string *str;
+
+	Z_FLF_PARAM_STR(1, str, str_tmp);
+
+	RETVAL_STR(zend_string_tolower(str));
+
+flf_clean:
+	Z_FLF_PARAM_FREE_STR(1, str_tmp);
+}
 
 PHP_FUNCTION(str_increment)
 {


### PR DESCRIPTION
disclaimer: this change was generated by claude opus. I have little experience with php-src development

----

Both are single-argument wrappers around zend_string_tolower/upper; static analyzers and general string handling call them at very high frequency. The frameless call convention removes the call frame setup and argument copying.

----

benchmark (3 runs after 2 warmup runs):

run `/Users/staabm/workspace/php-src/sapi/cli/php bin/phpstan clear-result-cache -q &&  /Users/staabm/workspace/php-src/sapi/cli/php -d memory_limit=450M bin/phpstan -v` after checking out https://github.com/phpstan/phpstan-src/pull/5942 from the git root folder.
(on first time phpstan-src checkout you need `composer install` and `make` to prepare the codebase)

before this PR:
14.39s
14.44s
14.36s

after this PR:
14.18s
14.14s
14.12s


on M4-Pro with macOS 26.6 (25G72)