### PR TITLE
tests: Allow overriding TEST_PHP_EXECUTABLE for FPM SAPI

### DIFF
--- a/sapi/fpm/tests/tester.inc
+++ b/sapi/fpm/tests/tester.inc
@@ -225,7 +225,7 @@ class Tester
      */
     static public function findExecutable(): bool|string
     {
-        $phpPath = getenv("TEST_PHP_EXECUTABLE");
+        $phpPath = getenv("TEST_PHP_FPM_EXECUTABLE") ?: getenv("TEST_PHP_EXECUTABLE");
         for ($i = 0; $i < 2; $i++) {
             $slashPosition = strrpos($phpPath, "/");
             if ($slashPosition) {


### PR DESCRIPTION
The test suite derives the path to php-fpm from TEST_PHP_EXECUTABLE. This fails on custom build directory layouts, leading to skipping all php-fpm related tests.

Users can provide TEST_PHP_FPM_EXECUTABLE for a custom binary path; if this is unset, we'll fall back to TEST_PHP_EXECUTABLE instead.

See https://github.com/gentoo/gentoo/pull/46637#issuecomment-5156485661 for reference.