### PR TITLE
Fix GH-23088: Stack overflow when comparing deeply nested arrays

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,10 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 8.4.25
 
+- Core:
+  . Fixed bug GH-23088 (Stack overflow when comparing deeply nested arrays).
+    (Lazizbek Ergashev)
+
 - Date:
   . Fixed leak on double DatePeriod::__construct() call. (ilutov)
 

--- a/Zend/tests/gh18572.phpt
+++ b/Zend/tests/gh18572.phpt
@@ -36,4 +36,4 @@ try {
 }
 ?>
 --EXPECTREGEX--
-(Maximum call stack size reached during object comparison|Nesting level too deep - recursive dependency\?)
+(Maximum call stack size reached during (object )?comparison|Nesting level too deep - recursive dependency\?)

--- a/Zend/tests/gh23088.phpt
+++ b/Zend/tests/gh23088.phpt
@@ -36,5 +36,5 @@ try {
 
 ?>
 --EXPECT--
-Maximum call stack size reached during array comparison
-Maximum call stack size reached during array comparison
+Maximum call stack size reached during comparison
+Maximum call stack size reached during comparison

--- a/Zend/tests/gh23088.phpt
+++ b/Zend/tests/gh23088.phpt
@@ -1,0 +1,40 @@
+--TEST--
+GH-23088 (Stack overflow when comparing deeply nested arrays)
+--SKIPIF--
+<?php
+if (ini_get('zend.max_allowed_stack_size') === false) {
+    die('skip No stack limit support');
+}
+if (getenv('SKIP_ASAN')) {
+    die('skip ASAN needs different stack limit setting due to more stack space usage');
+}
+?>
+--INI--
+zend.max_allowed_stack_size=256K
+--FILE--
+<?php
+
+$a = [];
+$b = [];
+
+for ($i = 0; $i < 20000; $i++) {
+    $a = [$a];
+    $b = [$b];
+}
+
+try {
+    var_dump($a == $b);
+} catch (Error $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($a === $b);
+} catch (Error $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+Maximum call stack size reached during array comparison
+Maximum call stack size reached during array comparison

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -3214,6 +3214,13 @@ ZEND_API int zend_hash_compare(HashTable *ht1, HashTable *ht2, compare_func_t co
 		return 0;
 	}
 
+#ifdef ZEND_CHECK_STACK_LIMIT
+	if (UNEXPECTED(zend_call_stack_overflowed(EG(stack_limit)))) {
+		zend_throw_error(NULL, "Maximum call stack size reached during comparison");
+		return ZEND_UNCOMPARABLE;
+	}
+#endif
+
 	/* It's enough to protect only one of the arrays.
 	 * The second one may be referenced from the first and this may cause
 	 * false recursion detection.

--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -2417,8 +2417,16 @@ ZEND_API bool ZEND_FASTCALL zend_is_identical(const zval *op1, const zval *op2) 
 		case IS_STRING:
 			return zend_string_equals(Z_STR_P(op1), Z_STR_P(op2));
 		case IS_ARRAY:
-			return (Z_ARRVAL_P(op1) == Z_ARRVAL_P(op2) ||
-				zend_hash_compare(Z_ARRVAL_P(op1), Z_ARRVAL_P(op2), (compare_func_t) hash_zval_identical_function, 1) == 0);
+			if (Z_ARRVAL_P(op1) == Z_ARRVAL_P(op2)) {
+				return 1;
+			}
+#ifdef ZEND_CHECK_STACK_LIMIT
+			if (UNEXPECTED(zend_call_stack_overflowed(EG(stack_limit)))) {
+				zend_throw_error(NULL, "Maximum call stack size reached during array comparison");
+				return 0;
+			}
+#endif
+			return zend_hash_compare(Z_ARRVAL_P(op1), Z_ARRVAL_P(op2), (compare_func_t) hash_zval_identical_function, 1) == 0;
 		case IS_OBJECT:
 			return (Z_OBJ_P(op1) == Z_OBJ_P(op2));
 		default:
@@ -3423,6 +3431,13 @@ ZEND_API int ZEND_FASTCALL zend_compare_symbol_tables(HashTable *ht1, HashTable 
 
 ZEND_API int ZEND_FASTCALL zend_compare_arrays(zval *a1, zval *a2) /* {{{ */
 {
+#ifdef ZEND_CHECK_STACK_LIMIT
+	if (UNEXPECTED(zend_call_stack_overflowed(EG(stack_limit)))) {
+		zend_throw_error(NULL, "Maximum call stack size reached during array comparison");
+		return ZEND_UNCOMPARABLE;
+	}
+#endif
+
 	return zend_compare_symbol_tables(Z_ARRVAL_P(a1), Z_ARRVAL_P(a2));
 }
 /* }}} */

--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -2417,16 +2417,8 @@ ZEND_API bool ZEND_FASTCALL zend_is_identical(const zval *op1, const zval *op2) 
 		case IS_STRING:
 			return zend_string_equals(Z_STR_P(op1), Z_STR_P(op2));
 		case IS_ARRAY:
-			if (Z_ARRVAL_P(op1) == Z_ARRVAL_P(op2)) {
-				return 1;
-			}
-#ifdef ZEND_CHECK_STACK_LIMIT
-			if (UNEXPECTED(zend_call_stack_overflowed(EG(stack_limit)))) {
-				zend_throw_error(NULL, "Maximum call stack size reached during array comparison");
-				return 0;
-			}
-#endif
-			return zend_hash_compare(Z_ARRVAL_P(op1), Z_ARRVAL_P(op2), (compare_func_t) hash_zval_identical_function, 1) == 0;
+			return (Z_ARRVAL_P(op1) == Z_ARRVAL_P(op2) ||
+				zend_hash_compare(Z_ARRVAL_P(op1), Z_ARRVAL_P(op2), (compare_func_t) hash_zval_identical_function, 1) == 0);
 		case IS_OBJECT:
 			return (Z_OBJ_P(op1) == Z_OBJ_P(op2));
 		default:
@@ -3431,13 +3423,6 @@ ZEND_API int ZEND_FASTCALL zend_compare_symbol_tables(HashTable *ht1, HashTable 
 
 ZEND_API int ZEND_FASTCALL zend_compare_arrays(zval *a1, zval *a2) /* {{{ */
 {
-#ifdef ZEND_CHECK_STACK_LIMIT
-	if (UNEXPECTED(zend_call_stack_overflowed(EG(stack_limit)))) {
-		zend_throw_error(NULL, "Maximum call stack size reached during array comparison");
-		return ZEND_UNCOMPARABLE;
-	}
-#endif
-
 	return zend_compare_symbol_tables(Z_ARRVAL_P(a1), Z_ARRVAL_P(a2));
 }
 /* }}} */


### PR DESCRIPTION
Comparing two deeply nested arrays recurses through `zend_compare_arrays` -> `zend_compare_symbol_tables` -> `zend_hash_compare` once per nesting level, and nothing bounds that recursion. `zend_hash_compare()` only guards against cycles, so a non-cyclic array a few tens of thousands of levels deep runs the C stack out and the process dies with a segfault. `===` crashes the same way through `zend_is_identical()`.

Both now check the stack limit before descending and throw an `Error` instead, the same way `zend_std_compare_objects()` already handles the object case.

Fixes GH-23088