### PR TITLE
Fix GH-23089: stack overflow in array_merge_recursive() with deep arrays

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -48,6 +48,10 @@ PHP                                                                        NEWS
 - SQLite:
   . Fix leak when trying to close db if blob stream is still open. (ndossche)
 
+- Standard:
+  . Fixed bug GH-23089 (Stack overflow in array_merge_recursive() with deeply
+    nested arrays). (Lazizbek Ergashev)
+
 - Streams:
   . Fixed bug GH-15836 (Use-after-free when a user stream filter accesses
     $this->stream during the close flush). (iliaal)

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -4097,6 +4097,7 @@ PHPAPI int php_array_merge_recursive(HashTable *dest, HashTable *src) /* {{{ */
 						GC_TRY_UNPROTECT_RECURSION(thash);
 					}
 					if (!ret) {
+						zval_ptr_dtor(&tmp);
 						return 0;
 					}
 				} else {
@@ -4105,6 +4106,7 @@ PHPAPI int php_array_merge_recursive(HashTable *dest, HashTable *src) /* {{{ */
 					if (EXPECTED(!zv)) {
 						Z_TRY_DELREF_P(src_zval);
 						zend_cannot_add_element();
+						zval_ptr_dtor(&tmp);
 						return 0;
 					}
 				}

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -4047,6 +4047,13 @@ PHPAPI int php_array_merge_recursive(HashTable *dest, HashTable *src) /* {{{ */
 	zval *src_entry, *dest_entry;
 	zend_string *string_key;
 
+#ifdef ZEND_CHECK_STACK_LIMIT
+	if (UNEXPECTED(zend_call_stack_overflowed(EG(stack_limit)))) {
+		zend_call_stack_size_error();
+		return 0;
+	}
+#endif
+
 	ZEND_HASH_FOREACH_STR_KEY_VAL(src, string_key, src_entry) {
 		if (string_key) {
 			if ((dest_entry = zend_hash_find_known_hash(dest, string_key)) != NULL) {

--- a/ext/standard/tests/array/gh23089.phpt
+++ b/ext/standard/tests/array/gh23089.phpt
@@ -1,0 +1,27 @@
+--TEST--
+GH-23089 (Stack overflow in array_merge_recursive with deeply nested arrays)
+--SKIPIF--
+<?php
+if (ini_get('zend.max_allowed_stack_size') === false) {
+    die('skip No stack limit support');
+}
+if (getenv('SKIP_ASAN')) {
+    die('skip ASAN needs different stack limit setting due to more stack space usage');
+}
+?>
+--INI--
+zend.max_allowed_stack_size=256K
+--FILE--
+<?php
+$a = [];
+for ($i = 0; $i < 30000; $i++) {
+    $a = ['k' => $a];
+}
+try {
+    array_merge_recursive($a, $a);
+} catch (Throwable $e) {
+    echo $e::class, ": ", $e->getMessage(), "\n";
+}
+?>
+--EXPECTF--
+Error: Maximum call stack size of %d bytes (zend.max_allowed_stack_size - zend.reserved_stack_size) reached. Infinite recursion?

--- a/ext/standard/tests/array/gh23089_leak.phpt
+++ b/ext/standard/tests/array/gh23089_leak.phpt
@@ -1,0 +1,32 @@
+--TEST--
+GH-23089 (Memory leak in array_merge_recursive on stack overflow with object)
+--SKIPIF--
+<?php
+if (ini_get('zend.max_allowed_stack_size') === false) {
+    die('skip No stack limit support');
+}
+if (getenv('SKIP_ASAN')) {
+    die('skip ASAN needs different stack limit setting due to more stack space usage');
+}
+?>
+--INI--
+zend.max_allowed_stack_size=256K
+--FILE--
+<?php
+$obj = new stdClass();
+$deep = [];
+for ($i = 0; $i < 30000; $i++) {
+    $deep = ['k' => $deep];
+}
+$obj->val = $deep;
+$a = ['obj' => $obj];
+try {
+    array_merge_recursive($a, $a);
+} catch (Throwable $e) {
+    echo $e::class, ": ", $e->getMessage(), "\n";
+}
+echo "done\n";
+?>
+--EXPECTF--
+Error: Maximum call stack size of %d bytes (zend.max_allowed_stack_size - zend.reserved_stack_size) reached. Infinite recursion?
+done


### PR DESCRIPTION
php_array_merge_recursive() recurses once per nesting level with no stack check, so array_merge_recursive() on a deeply nested array exhausts the native stack and the process dies with a segfault.

This adds the same stack limit check ext/standard already uses in var.c and http.c, so the call throws an Error instead of crashing.

array_replace_recursive() has the same unguarded recursion. I kept this to the reported crash, but can cover it here too if you'd rather have both in one go.

Fixes #23089.