### PR TITLE
standard: Fix error reporting for negative timeouts in `Io\Poll\Context::wait()`

### DIFF
--- a/ext/standard/io_poll.c
+++ b/ext/standard/io_poll.c
@@ -791,7 +791,7 @@ PHP_METHOD(Io_Poll_Context, wait)
 	struct timespec timeout_ts;
 	if (timeout) {
 		if (timeout->duration.negative) {
-			zend_argument_value_error(2, "must not be negative");
+			zend_argument_value_error(1, "must not be negative");
 			RETURN_THROWS();
 		}
 

--- a/ext/standard/tests/poll/poll_ctx_wait.phpt
+++ b/ext/standard/tests/poll/poll_ctx_wait.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Io\Poll\Context::wait(): Parameter validation
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+
+$poll_ctx = new Io\Poll\Context();
+
+try {
+    $poll_ctx->wait(timeout: Time\Duration::fromSeconds(1)->negate());
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    $poll_ctx->wait(maxEvents: -1);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+ValueError: Io\Poll\Context::wait(): Argument #1 ($timeout) must not be negative
+ValueError: Io\Poll\Context::wait(): Argument #2 ($maxEvents) must be greater than 0


### PR DESCRIPTION
Following #23092.