### PR TITLE
tree-wide: Generate nicer code in `Z_PARAM_*()` helpers wrapping `Z_PARAM_*()`

### DIFF
--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -2057,9 +2057,9 @@ ZEND_API ZEND_COLD void zend_class_redeclaration_error_ex(int type, zend_string 
 
 #define Z_PARAM_ENUM(dest, _ce) \
 	{ \
-		zend_object *_tmp = NULL; \
-		Z_PARAM_OBJ_OF_CLASS(_tmp, _ce); \
-		dest = zend_enum_fetch_case_id(_tmp); \
+		zend_object *__##dest = NULL; \
+		Z_PARAM_OBJ_OF_CLASS(__##dest, _ce); \
+		dest = zend_enum_fetch_case_id(__##dest); \
 	}
 
 /* old "p" */

--- a/ext/date/php_time.h
+++ b/ext/date/php_time.h
@@ -29,15 +29,15 @@ typedef struct php_date_time_duration {
 # define Z_DATE_TIME_DURATION_P(zv)  php_date_time_duration_from_obj(Z_OBJ_P((zv)))
 
 # define Z_PARAM_DATE_TIME_DURATION(d) { \
-		zend_object *__d; \
-		Z_PARAM_OBJ_OF_CLASS(__d, php_date_ce_time_duration); \
-		d = php_date_time_duration_from_obj(__d); \
+		zend_object *__##d; \
+		Z_PARAM_OBJ_OF_CLASS(__##d, php_date_ce_time_duration); \
+		d = php_date_time_duration_from_obj(__##d); \
 	}
 
 # define Z_PARAM_DATE_TIME_DURATION_OR_NULL(d) { \
-		zend_object *__d; \
-		Z_PARAM_OBJ_OF_CLASS_OR_NULL(__d, php_date_ce_time_duration); \
-		d = __d ? php_date_time_duration_from_obj(__d) : NULL; \
+		zend_object *__##d; \
+		Z_PARAM_OBJ_OF_CLASS_OR_NULL(__##d, php_date_ce_time_duration); \
+		d = __##d ? php_date_time_duration_from_obj(__##d) : NULL; \
 	}
 
 PHPAPI extern zend_class_entry *php_date_ce_time_duration;

--- a/ext/date/time_duration.c
+++ b/ext/date/time_duration.c
@@ -29,14 +29,14 @@ ZEND_STATIC_ASSERT(NANOS_IN_MICRO * MICROS_IN_SEC == NANOS_IN_SEC, "");
 ZEND_STATIC_ASSERT(NANOS_IN_MILLI * MILLIS_IN_SEC == NANOS_IN_SEC, "");
 
 #define Z_PARAM_ULONG(l) { \
-		zend_long __l; \
-		Z_PARAM_LONG(__l); \
-		if (__l < 0) { \
+		zend_long __##l; \
+		Z_PARAM_LONG(__##l); \
+		if (__##l < 0) { \
 			zend_argument_value_error(_i, "must be greater than or equal to 0"); \
 			_error_code = ZPP_ERROR_FAILURE; \
 			break; \
 		} \
-		l = __l; \
+		l = __##l; \
 	}
 
 ZEND_COLD static void throw_out_of_range_exception(void)


### PR DESCRIPTION
Instead of using a fixed variable name for the temporary, it is now derived from the name of the target variable.