### PR TITLE
 zend_objects_API: Assert that the `.offset` is correct in `zend_object_alloc()`

### DIFF
--- a/Zend/zend_objects.c
+++ b/Zend/zend_objects.c
@@ -187,7 +187,7 @@ ZEND_API void zend_objects_destroy_object(zend_object *object)
 
 ZEND_API zend_object* ZEND_FASTCALL zend_objects_new(zend_class_entry *ce)
 {
-	zend_object *object = emalloc(sizeof(zend_object) + zend_object_properties_size(ce));
+	zend_object *object = zend_object_alloc(sizeof(zend_object), ce);
 
 	_zend_object_std_init(object, ce);
 	return object;

--- a/Zend/zend_objects_API.h
+++ b/Zend/zend_objects_API.h
@@ -90,8 +90,11 @@ static zend_always_inline size_t zend_object_properties_size(const zend_class_en
  * Standard object MUST be initialized using zend_object_std_init().
  * Properties MUST be initialized using object_properties_init(). */
 static zend_always_inline void *zend_object_alloc(size_t obj_size, const zend_class_entry *ce) {
+	const size_t extra_data = obj_size - sizeof(zend_object);
+	ZEND_ASSERT(ce->default_object_handlers->offset == extra_data);
+
 	void *obj = emalloc(obj_size + zend_object_properties_size(ce));
-	memset(obj, 0, obj_size - sizeof(zend_object));
+	memset(obj, 0, extra_data);
 	return obj;
 }
 


### PR DESCRIPTION
Motivation is that I initially didn't implement the `.clone_obj` handler for `Time\Duration`, since I thought I didn't need it (since I don't have allocated data there and a simple memcpy of the extra data would suffice), which lead to an obscure error in ZendMM due to pointer alignment.