### PR TITLE
Enforce zero arity in apache_get_version() and apache_get_modules()

### DIFF
--- a/sapi/apache2handler/php_functions.c
+++ b/sapi/apache2handler/php_functions.c
@@ -308,6 +308,8 @@ static const char *php_apache_get_version(void)
 /* {{{ Fetch Apache version */
 PHP_FUNCTION(apache_get_version)
 {
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	const char *apv = php_apache_get_version();
 
 	if (apv && *apv) {
@@ -323,6 +325,8 @@ PHP_FUNCTION(apache_get_modules)
 {
 	int n;
 	char *p;
+
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	array_init(return_value);
 


### PR DESCRIPTION
Both functions are declared with no parameters in `sapi/apache2handler/php_functions.stub.php`, and the generated arginfo agrees, but neither implementation calls `ZEND_PARSE_PARAMETERS_NONE()`, so extra positional arguments are silently accepted.

Served by `php:8.4-apache` and `php:8.5-apache` (PHP 8.4.24 and 8.5.9, Apache 2.4.68), identical on both:

```php
<?php
var_dump(apache_get_version(1, 2, 3));
var_dump(apache_request_headers(1));
```

```
string(22) "Apache/2.4.68 (Debian)"

Fatal error: Uncaught ArgumentCountError: apache_request_headers() expects exactly 0 arguments, 1 given
```

The first call should throw like the second one. Every other zero-arity function of this SAPI does enforce its arity, and so does `PHP_FUNCTION(apache_get_modules)` in `sapi/litespeed/lsapi_main.c:1710`, so the two SAPIs currently disagree on whether `apache_get_modules(1)` is an error.

No stub or arginfo change is needed. Targeting master rather than a stable branch, since the change turns a silently accepted call into an `ArgumentCountError`.

Sources:
- 11a95749b1 "Convert more zend_parse_parameters_none() to fast ZPP" converted the existing call sites in this file; these two never had one, so the sweep did not reach them.
