### PR TITLE
opcache: set ZEND_ACC_PRELOADED for compile-only preloaded enums

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -21,6 +21,8 @@ PHP                                                                        NEWS
 - Opcache:
   . Fixed bug GH-22857 (Function JIT emits wrong code for FETCH_OBJ_FUNC_ARG on a
     property hook getter, losing register-held variables). (Zhao Hao)
+  . Fixed crash in observer API calling cases() on an enum preloaded with
+    opcache_compile_file(). (Thomas Atkinson)
 
 - OpenSSL:
   . Fix missing error check on invalid alpn protocols. (ndossche)

--- a/Zend/zend_enum.c
+++ b/Zend/zend_enum.c
@@ -418,10 +418,10 @@ static void zend_enum_register_func(zend_class_entry *ce, zend_known_string_id n
 	zif->module = EG(current_module);
 	zif->scope = ce;
 	zif->T = ZEND_OBSERVER_ENABLED;
+	if (CG(compiler_options) & ZEND_COMPILE_PRELOAD) {
+		zif->fn_flags |= ZEND_ACC_PRELOADED;
+	}
 	if (EG(active)) { // at run-time
-		if (CG(compiler_options) & ZEND_COMPILE_PRELOAD) {
-			zif->fn_flags |= ZEND_ACC_PRELOADED;
-		}
 		ZEND_MAP_PTR_INIT(zif->run_time_cache, zend_arena_calloc(&CG(arena), 1, zend_internal_run_time_cache_reserved_size()));
 	} else {
 #ifdef ZTS

--- a/ext/opcache/tests/preload_enum_compile_only.inc
+++ b/ext/opcache/tests/preload_enum_compile_only.inc
@@ -1,0 +1,3 @@
+<?php
+
+opcache_compile_file(__DIR__ . '/preload_enum.inc');

--- a/ext/opcache/tests/preload_enum_observed_compile_only.phpt
+++ b/ext/opcache/tests/preload_enum_observed_compile_only.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Crash in observer API calling cases() on a compile-only preloaded enum
+--EXTENSIONS--
+opcache
+zend_test
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.optimization_level=-1
+opcache.preload={PWD}/preload_enum_compile_only.inc
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+zend_test.observer.show_output=0
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY == 'Windows') die('skip Preloading is not supported on Windows');
+?>
+--FILE--
+<?php
+
+var_dump(MyEnum::cases());
+
+?>
+--EXPECT--
+array(2) {
+  [0]=>
+  enum(MyEnum::Foo)
+  [1]=>
+  enum(MyEnum::Bar)
+}


### PR DESCRIPTION
> **Disclosure: this description, the patch and its test were drafted with an LLM.**

### Summary

GH-17835 fixed [GH-17715](https://github.com/php/php-src/issues/17715) for enums that preload **declares**. It does not cover enums that preload only **compiles**, and those still crash on 8.4 and 8.5.

```php
// preload.php
opcache_compile_file(__DIR__ . '/e.php');

// e.php
enum E { case Foo; }

// request
E::cases();   // SIGSEGV with any Observer API extension loaded
```

### Cause

`zend_enum_register_func()` sets `ZEND_ACC_PRELOADED` inside the `if (EG(active))` branch. `zend_persist_class_method()` keys on that flag to choose `ZEND_MAP_PTR_NEW_STATIC()` over `ZEND_MAP_PTR_NEW()`, i.e. a run_time_cache slot that survives into every request — which is what a class living in SHM permanently needs.

An enum that preload reaches via `opcache_compile_file()` is not linked while the preload script executes. It is linked from `preload_link()`, which runs after the preload request has ended, so `EG(active)` is already false, the `else` branch is taken and the flag is never set.

gdb on the crash, on an unpatched 8.5.9:

```
Program received signal SIGSEGV, Segmentation fault.
#0  zend_observer_fcall_begin_specialized (...) at Zend/zend_observer.h:92
#1  ZEND_DO_FCALL_SPEC_OBSERVER_HANDLER ()   at Zend/zend_vm_execute.h:2281
#2  execute_ex (...)                         at Zend/zend_vm_execute.h:116541

function : cases        type: 1 (internal)     T: 1
fn_flags : 0x2002011  = PUBLIC|STATIC|HAS_RETURN_TYPE|ARENA_ALLOCATED
                        ZEND_ACC_PRELOADED (1<<10) absent
run_time_cache : 0
```

`ZEND_OBSERVER_DATA()` computes `RUN_TIME_CACHE(...) + handle` = `NULL + 0` and dereferences it — the same null deref, and the same `Zend/zend_observer.h:92`, that GH-17715's UBSAN output reports.

### Fix

Move the tag out of the `EG(active)` branch so both linking paths set it. The compile-only case then follows the identical, already-proven route as the declared case; no new mechanism is introduced.

### Test

`ext/opcache/tests/preload_enum_observed_compile_only.phpt` mirrors the existing `preload_enum_observed.phpt` and reuses its `preload_enum.inc` fixture, changing only how preload reaches it.