### PR TITLE
Zend: refactor zend_parse_arg_class() so that it can be reused

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -225,48 +225,6 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_parameters_count_error(uint32_t
 }
 /* }}} */
 
-ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_parameter_error(zpp_error error_code, uint32_t num, char *name, zend_expected_type expected_type, const zval *arg) /* {{{ */
-{
-	switch (error_code) {
-		case ZPP_ERROR_WRONG_CALLBACK:
-			zend_wrong_callback_error(num, name);
-			break;
-		case ZPP_ERROR_WRONG_CALLBACK_OR_NULL:
-			zend_wrong_callback_or_null_error(num, name);
-			break;
-		case ZPP_ERROR_WRONG_CLASS:
-			zend_wrong_parameter_class_error(num, name, arg);
-			break;
-		case ZPP_ERROR_WRONG_CLASS_OR_NULL:
-			zend_wrong_parameter_class_or_null_error(num, name, arg);
-			break;
-		case ZPP_ERROR_WRONG_CLASS_OR_STRING:
-			zend_wrong_parameter_class_or_string_error(num, name, arg);
-			break;
-		case ZPP_ERROR_WRONG_CLASS_OR_STRING_OR_NULL:
-			zend_wrong_parameter_class_or_string_or_null_error(num, name, arg);
-			break;
-		case ZPP_ERROR_WRONG_CLASS_OR_LONG:
-			zend_wrong_parameter_class_or_long_error(num, name, arg);
-			break;
-		case ZPP_ERROR_WRONG_CLASS_OR_LONG_OR_NULL:
-			zend_wrong_parameter_class_or_long_or_null_error(num, name, arg);
-			break;
-		case ZPP_ERROR_WRONG_ARG:
-			zend_wrong_parameter_type_error(num, expected_type, arg);
-			break;
-		case ZPP_ERROR_UNEXPECTED_EXTRA_NAMED:
-			zend_unexpected_extra_named_error();
-			break;
-		case ZPP_ERROR_FAILURE:
-			ZEND_ASSERT(EG(exception) && "Should have produced an error already");
-			break;
-		case ZPP_ERROR_OK:
-			ZEND_UNREACHABLE();
-	}
-}
-/* }}} */
-
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_parameter_type_error(uint32_t num, zend_expected_type expected_type, const zval *arg) /* {{{ */
 {
 	static const char * const expected_error[] = {
@@ -358,6 +316,34 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_parameter_class_or_string_or_nu
 }
 /* }}} */
 
+static ZEND_COLD void ZEND_FASTCALL zend_wrong_class_name_error(uint32_t num, const char *name, const zval *arg)
+{
+	if (EG(exception)) {
+		return;
+	}
+
+	if (name && Z_TYPE_P(arg) == IS_STRING) {
+		zend_argument_type_error(num, "must be a class name derived from %s, %s given", name, Z_STRVAL_P(arg));
+		return;
+	}
+
+	zend_wrong_parameter_type_error(num, Z_EXPECTED_CLASS_NAME, arg);
+}
+
+static ZEND_COLD void ZEND_FASTCALL zend_wrong_class_name_or_null_error(uint32_t num, const char *name, const zval *arg)
+{
+	if (EG(exception)) {
+		return;
+	}
+
+	if (name && Z_TYPE_P(arg) == IS_STRING) {
+		zend_argument_type_error(num, "must be a class name derived from %s, %s given", name, Z_STRVAL_P(arg));
+		return;
+	}
+
+	zend_wrong_parameter_type_error(num, Z_EXPECTED_CLASS_NAME_OR_NULL, arg);
+}
+
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_callback_error(uint32_t num, char *error) /* {{{ */
 {
 	if (!EG(exception)) {
@@ -373,6 +359,54 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_callback_or_null_error(uint32_t
 		zend_argument_type_error(num, "must be a valid callback or null, %s", error);
 	}
 	efree(error);
+}
+/* }}} */
+
+ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_parameter_error(zpp_error error_code, uint32_t num, char *name, zend_expected_type expected_type, const zval *arg) /* {{{ */
+{
+	switch (error_code) {
+		case ZPP_ERROR_WRONG_CALLBACK:
+			zend_wrong_callback_error(num, name);
+			break;
+		case ZPP_ERROR_WRONG_CALLBACK_OR_NULL:
+			zend_wrong_callback_or_null_error(num, name);
+			break;
+		case ZPP_ERROR_WRONG_CLASS_NAME:
+			zend_wrong_class_name_error(num, name, arg);
+			break;
+		case ZPP_ERROR_WRONG_CLASS_NAME_OR_NULL:
+			zend_wrong_class_name_or_null_error(num, name, arg);
+			break;
+		case ZPP_ERROR_WRONG_CLASS:
+			zend_wrong_parameter_class_error(num, name, arg);
+			break;
+		case ZPP_ERROR_WRONG_CLASS_OR_NULL:
+			zend_wrong_parameter_class_or_null_error(num, name, arg);
+			break;
+		case ZPP_ERROR_WRONG_CLASS_OR_STRING:
+			zend_wrong_parameter_class_or_string_error(num, name, arg);
+			break;
+		case ZPP_ERROR_WRONG_CLASS_OR_STRING_OR_NULL:
+			zend_wrong_parameter_class_or_string_or_null_error(num, name, arg);
+			break;
+		case ZPP_ERROR_WRONG_CLASS_OR_LONG:
+			zend_wrong_parameter_class_or_long_error(num, name, arg);
+			break;
+		case ZPP_ERROR_WRONG_CLASS_OR_LONG_OR_NULL:
+			zend_wrong_parameter_class_or_long_or_null_error(num, name, arg);
+			break;
+		case ZPP_ERROR_WRONG_ARG:
+			zend_wrong_parameter_type_error(num, expected_type, arg);
+			break;
+		case ZPP_ERROR_UNEXPECTED_EXTRA_NAMED:
+			zend_unexpected_extra_named_error();
+			break;
+		case ZPP_ERROR_FAILURE:
+			ZEND_ASSERT(EG(exception) && "Should have produced an error already");
+			break;
+		case ZPP_ERROR_OK:
+			ZEND_UNREACHABLE();
+	}
 }
 /* }}} */
 
@@ -494,20 +528,20 @@ ZEND_API ZEND_COLD void zend_class_redeclaration_error(int type, const zend_clas
 	zend_class_redeclaration_error_ex(type, old_ce->name, old_ce);
 }
 
-ZEND_API bool ZEND_FASTCALL zend_parse_arg_class(zval *arg, zend_class_entry **pce, uint32_t num, bool check_null) /* {{{ */
+ZEND_API ZEND_FASTCALL bool zend_parse_arg_class(zval *arg, zend_class_entry **pce, uint32_t num, bool check_null)
 {
 	const zend_class_entry *ce_base = *pce;
 
 	if (check_null && Z_TYPE_P(arg) == IS_NULL) {
 		*pce = NULL;
-		return 1;
+		return true;
 	}
 	/* Only accept string and Stringable(?) as int/foat/bool are not valid class names */
 	if (UNEXPECTED(Z_TYPE_P(arg) != IS_STRING)) {
 		if (Z_TYPE_P(arg) != IS_OBJECT || !zend_parse_arg_str_slow(arg, num)) {
 			*pce = NULL;
 			zend_wrong_parameter_type_error(num, check_null ? Z_EXPECTED_CLASS_NAME_OR_NULL : Z_EXPECTED_CLASS_NAME, arg);
-			return 0;
+			return false;
 		}
 		/* Object was converted to string */
 		ZEND_ASSERT(Z_TYPE_P(arg) == IS_STRING);
@@ -515,20 +549,15 @@ ZEND_API bool ZEND_FASTCALL zend_parse_arg_class(zval *arg, zend_class_entry **p
 	zend_string *class_name = Z_STR_P(arg);
 
 	*pce = zend_lookup_class(class_name);
-	if (ce_base) {
-		if ((!*pce || !instanceof_function(*pce, ce_base))) {
-			zend_argument_type_error(num, "must be a class name derived from %s, \"%s\" given", ZSTR_VAL(ce_base->name), ZSTR_VAL(class_name));
-			*pce = NULL;
-			return 0;
-		}
-	}
 	if (!*pce) {
-		zend_wrong_parameter_type_error(num, check_null ? Z_EXPECTED_CLASS_NAME_OR_NULL : Z_EXPECTED_CLASS_NAME, arg);
-		return 0;
+		return false;
 	}
-	return 1;
+	if (ce_base && !instanceof_function(*pce, ce_base)) {
+		*pce = NULL;
+		return false;
+	}
+	return true;
 }
-/* }}} */
 
 static ZEND_COLD bool zend_null_arg_deprecated(const char *fallback_type, uint32_t arg_num) {
 	const zend_function *func = zend_active_function();
@@ -1022,41 +1051,10 @@ static zend_expected_type zend_parse_arg_impl(zval *arg, va_list *va, const char
 				zend_class_entry **pce = va_arg(*va, zend_class_entry **);
 				const zend_class_entry *ce_base = *pce;
 
-				if (check_null && Z_TYPE_P(arg) == IS_NULL) {
-					*pce = NULL;
-					break;
-				}
-
-				/* Only accept string and Stringable(?) as int/foat/bool are not valid class names */
-				if (UNEXPECTED(Z_TYPE_P(arg) != IS_STRING)) {
-					if (Z_TYPE_P(arg) != IS_OBJECT || !zend_parse_arg_str_slow(arg, arg_num)) {
-						/* __toString may throw */
-						if (!EG(exception)) {
-							zend_spprintf(error, 0, "must be a valid class name%s, %s given",
-								check_null ? " or null" : "", zend_zval_value_name(arg));
-						}
-						*pce = NULL;
-						return check_null ? Z_EXPECTED_CLASS_NAME_OR_NULL : Z_EXPECTED_CLASS_NAME;
-					}
-					/* Object was converted to string */
-					ZEND_ASSERT(Z_TYPE_P(arg) == IS_STRING);
-				}
-				zend_string *class_name = Z_STR_P(arg);
-
-				*pce = zend_lookup_class(class_name);
-				if (ce_base) {
-					if ((!*pce || !instanceof_function(*pce, ce_base))) {
-						zend_spprintf(error, 0, "must be a class name derived from %s%s, \"%s\" given",
-							ZSTR_VAL(ce_base->name), check_null ? " or null" : "", Z_STRVAL_P(arg));
-						*pce = NULL;
-						return check_null ? Z_EXPECTED_CLASS_NAME_OR_NULL : Z_EXPECTED_CLASS_NAME;
-					}
-				}
-				if (!*pce) {
+				*error = *pce ? ZSTR_VAL(ce_base->name) : NULL;
+				if (!zend_parse_arg_class(arg, pce, arg_num, check_null)) {
 					return check_null ? Z_EXPECTED_CLASS_NAME_OR_NULL : Z_EXPECTED_CLASS_NAME;
 				}
-				break;
-
 			}
 			break;
 
@@ -1135,9 +1133,12 @@ static zend_result zend_parse_arg(uint32_t arg_num, zval *arg, va_list *va, cons
 						zend_wrong_callback_or_null_error(arg_num, error);
 						break;
 					case Z_EXPECTED_CLASS_NAME:
+						/* DO NOT FREE error: it's a pointer to ZSTR_VAL(ce->name) */
+						zend_wrong_class_name_error(arg_num, error, arg);
+						break;
 					case Z_EXPECTED_CLASS_NAME_OR_NULL:
-						zend_argument_type_error(arg_num, "%s", error);
-						efree(error);
+						/* DO NOT FREE error: it's a pointer to ZSTR_VAL(ce->name) */
+						zend_wrong_class_name_or_null_error(arg_num, error, arg);
 						break;
 					default:
 						ZEND_UNREACHABLE();
@@ -1145,8 +1146,8 @@ static zend_result zend_parse_arg(uint32_t arg_num, zval *arg, va_list *va, cons
 			}
 			zend_wrong_parameter_type_error(arg_num, expected_type, arg);
 		} else if (error
-			/* DO NOT FREE error when it's a pointer to ZSTR_VAL(ce->name) */
-			&& expected_type != Z_EXPECTED_OBJECT && expected_type != Z_EXPECTED_OBJECT_OR_NULL) {
+			/* Only free error if it's a callable expected type, as otherwise it's a pointer to ZSTR_VAL(ce->name) */
+			&& (expected_type == Z_EXPECTED_FUNC || expected_type == Z_EXPECTED_FUNC_OR_NULL)) {
 			efree(error);
 		}
 

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -323,7 +323,7 @@ static ZEND_COLD void ZEND_FASTCALL zend_wrong_class_name_error(uint32_t num, co
 	}
 
 	if (name && Z_TYPE_P(arg) == IS_STRING) {
-		zend_argument_type_error(num, "must be a class name derived from %s, %s given", name, Z_STRVAL_P(arg));
+		zend_argument_type_error(num, "must be a class name derived from %s, \"%s\" given", name, Z_STRVAL_P(arg));
 		return;
 	}
 
@@ -337,7 +337,7 @@ static ZEND_COLD void ZEND_FASTCALL zend_wrong_class_name_or_null_error(uint32_t
 	}
 
 	if (name && Z_TYPE_P(arg) == IS_STRING) {
-		zend_argument_type_error(num, "must be a class name derived from %s, %s given", name, Z_STRVAL_P(arg));
+		zend_argument_type_error(num, "must be a class name derived from %s, \"%s\" given", name, Z_STRVAL_P(arg));
 		return;
 	}
 

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -225,48 +225,6 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_parameters_count_error(uint32_t
 }
 /* }}} */
 
-ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_parameter_error(zpp_error error_code, uint32_t num, char *name, zend_expected_type expected_type, const zval *arg) /* {{{ */
-{
-	switch (error_code) {
-		case ZPP_ERROR_WRONG_CALLBACK:
-			zend_wrong_callback_error(num, name);
-			break;
-		case ZPP_ERROR_WRONG_CALLBACK_OR_NULL:
-			zend_wrong_callback_or_null_error(num, name);
-			break;
-		case ZPP_ERROR_WRONG_CLASS:
-			zend_wrong_parameter_class_error(num, name, arg);
-			break;
-		case ZPP_ERROR_WRONG_CLASS_OR_NULL:
-			zend_wrong_parameter_class_or_null_error(num, name, arg);
-			break;
-		case ZPP_ERROR_WRONG_CLASS_OR_STRING:
-			zend_wrong_parameter_class_or_string_error(num, name, arg);
-			break;
-		case ZPP_ERROR_WRONG_CLASS_OR_STRING_OR_NULL:
-			zend_wrong_parameter_class_or_string_or_null_error(num, name, arg);
-			break;
-		case ZPP_ERROR_WRONG_CLASS_OR_LONG:
-			zend_wrong_parameter_class_or_long_error(num, name, arg);
-			break;
-		case ZPP_ERROR_WRONG_CLASS_OR_LONG_OR_NULL:
-			zend_wrong_parameter_class_or_long_or_null_error(num, name, arg);
-			break;
-		case ZPP_ERROR_WRONG_ARG:
-			zend_wrong_parameter_type_error(num, expected_type, arg);
-			break;
-		case ZPP_ERROR_UNEXPECTED_EXTRA_NAMED:
-			zend_unexpected_extra_named_error();
-			break;
-		case ZPP_ERROR_FAILURE:
-			ZEND_ASSERT(EG(exception) && "Should have produced an error already");
-			break;
-		case ZPP_ERROR_OK:
-			ZEND_UNREACHABLE();
-	}
-}
-/* }}} */
-
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_parameter_type_error(uint32_t num, zend_expected_type expected_type, const zval *arg) /* {{{ */
 {
 	static const char * const expected_error[] = {
@@ -348,6 +306,42 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_parameter_class_or_string_or_nu
 }
 /* }}} */
 
+static ZEND_COLD void ZEND_FASTCALL zend_wrong_class_name_error(uint32_t num, char *name, const zval *arg)
+{
+	if (EG(exception)) {
+		return;
+	}
+
+	if (Z_TYPE_P(arg) != IS_STRING) {
+		zend_wrong_parameter_type_error(num, Z_EXPECTED_STRING, arg);
+		return;
+	}
+
+	if (name) {
+		zend_argument_type_error(num, "must be a class name derived from %s, %s given", name, Z_STRVAL_P(arg));
+	} else {
+		zend_argument_type_error(num, "must be a valid class name, %s given", Z_STRVAL_P(arg));
+	}
+}
+
+static ZEND_COLD void ZEND_FASTCALL zend_wrong_class_name_or_null_error(uint32_t num, char *name, const zval *arg)
+{
+	if (EG(exception)) {
+		return;
+	}
+
+	if (Z_TYPE_P(arg) != IS_STRING) {
+		zend_wrong_parameter_type_error(num, Z_EXPECTED_STRING_OR_NULL, arg);
+		return;
+	}
+
+	if (name) {
+		zend_argument_type_error(num, "must be a class name derived from %s or null, %s given", name, Z_STRVAL_P(arg));
+	} else {
+		zend_argument_type_error(num, "must be a valid class name or null, %s given", Z_STRVAL_P(arg));
+	}
+}
+
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_callback_error(uint32_t num, char *error) /* {{{ */
 {
 	if (!EG(exception)) {
@@ -363,6 +357,54 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_callback_or_null_error(uint32_t
 		zend_argument_type_error(num, "must be a valid callback or null, %s", error);
 	}
 	efree(error);
+}
+/* }}} */
+
+ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_parameter_error(zpp_error error_code, uint32_t num, char *name, zend_expected_type expected_type, const zval *arg) /* {{{ */
+{
+	switch (error_code) {
+		case ZPP_ERROR_WRONG_CALLBACK:
+			zend_wrong_callback_error(num, name);
+			break;
+		case ZPP_ERROR_WRONG_CALLBACK_OR_NULL:
+			zend_wrong_callback_or_null_error(num, name);
+			break;
+		case ZPP_ERROR_WRONG_CLASS_NAME:
+			zend_wrong_class_name_error(num, name, arg);
+			break;
+		case ZPP_ERROR_WRONG_CLASS_NAME_OR_NULL:
+			zend_wrong_class_name_or_null_error(num, name, arg);
+			break;
+		case ZPP_ERROR_WRONG_CLASS:
+			zend_wrong_parameter_class_error(num, name, arg);
+			break;
+		case ZPP_ERROR_WRONG_CLASS_OR_NULL:
+			zend_wrong_parameter_class_or_null_error(num, name, arg);
+			break;
+		case ZPP_ERROR_WRONG_CLASS_OR_STRING:
+			zend_wrong_parameter_class_or_string_error(num, name, arg);
+			break;
+		case ZPP_ERROR_WRONG_CLASS_OR_STRING_OR_NULL:
+			zend_wrong_parameter_class_or_string_or_null_error(num, name, arg);
+			break;
+		case ZPP_ERROR_WRONG_CLASS_OR_LONG:
+			zend_wrong_parameter_class_or_long_error(num, name, arg);
+			break;
+		case ZPP_ERROR_WRONG_CLASS_OR_LONG_OR_NULL:
+			zend_wrong_parameter_class_or_long_or_null_error(num, name, arg);
+			break;
+		case ZPP_ERROR_WRONG_ARG:
+			zend_wrong_parameter_type_error(num, expected_type, arg);
+			break;
+		case ZPP_ERROR_UNEXPECTED_EXTRA_NAMED:
+			zend_unexpected_extra_named_error();
+			break;
+		case ZPP_ERROR_FAILURE:
+			ZEND_ASSERT(EG(exception) && "Should have produced an error already");
+			break;
+		case ZPP_ERROR_OK:
+			ZEND_UNREACHABLE();
+	}
 }
 /* }}} */
 
@@ -484,36 +526,30 @@ ZEND_API ZEND_COLD void zend_class_redeclaration_error(int type, const zend_clas
 	zend_class_redeclaration_error_ex(type, old_ce->name, old_ce);
 }
 
-ZEND_API bool ZEND_FASTCALL zend_parse_arg_class(zval *arg, zend_class_entry **pce, uint32_t num, bool check_null) /* {{{ */
+ZEND_API ZEND_FASTCALL bool zend_parse_arg_class(zval *arg, zend_class_entry **pce, uint32_t num, bool check_null)
 {
 	const zend_class_entry *ce_base = *pce;
 
 	if (check_null && Z_TYPE_P(arg) == IS_NULL) {
 		*pce = NULL;
-		return 1;
+		return true;
 	}
 	zend_string *class_name;
 	if (!zend_parse_arg_str(arg, &class_name, check_null, num)) {
 		*pce = NULL;
-		zend_wrong_parameter_error(ZPP_ERROR_WRONG_ARG, num, NULL, check_null ? Z_EXPECTED_STRING_OR_NULL : Z_EXPECTED_STRING, arg);
-		return 0;
+		return false;
 	}
 
 	*pce = zend_lookup_class(class_name);
-	if (ce_base) {
-		if ((!*pce || !instanceof_function(*pce, ce_base))) {
-			zend_argument_type_error(num, "must be a class name derived from %s, %s given", ZSTR_VAL(ce_base->name), ZSTR_VAL(class_name));
-			*pce = NULL;
-			return 0;
-		}
-	}
 	if (!*pce) {
-		zend_argument_type_error(num, "must be a valid class name, %s given", ZSTR_VAL(class_name));
-		return 0;
+		return false;
 	}
-	return 1;
+	if (ce_base && !instanceof_function(*pce, ce_base)) {
+		*pce = NULL;
+		return false;
+	}
+	return true;
 }
-/* }}} */
 
 static ZEND_COLD bool zend_null_arg_deprecated(const char *fallback_type, uint32_t arg_num) {
 	const zend_function *func = zend_active_function();
@@ -1007,33 +1043,10 @@ static zend_expected_type zend_parse_arg_impl(zval *arg, va_list *va, const char
 				zend_class_entry **pce = va_arg(*va, zend_class_entry **);
 				const zend_class_entry *ce_base = *pce;
 
-				if (check_null && Z_TYPE_P(arg) == IS_NULL) {
-					*pce = NULL;
-					break;
+				*error = *pce ? ZSTR_VAL(ce_base->name) : NULL;
+				if (!zend_parse_arg_class(arg, pce, arg_num, check_null)) {
+					return check_null ? Z_EXPECTED_CLASS_NAME_OR_NULL : Z_EXPECTED_CLASS_NAME;
 				}
-
-				zend_string *class_name = NULL;
-				if (!zend_parse_arg_str(arg, &class_name, check_null, arg_num)) {
-					*pce = NULL;
-					return check_null ? Z_EXPECTED_STRING_OR_NULL : Z_EXPECTED_STRING;
-				}
-
-				*pce = zend_lookup_class(class_name);
-				if (ce_base) {
-					if ((!*pce || !instanceof_function(*pce, ce_base))) {
-						zend_spprintf(error, 0, "must be a class name derived from %s%s, %s given",
-							ZSTR_VAL(ce_base->name), check_null ? " or null" : "", Z_STRVAL_P(arg));
-						*pce = NULL;
-						return check_null ? Z_EXPECTED_OBJECT_OR_CLASS_NAME_OR_NULL : Z_EXPECTED_OBJECT_OR_CLASS_NAME;
-					}
-				}
-				if (!*pce) {
-					zend_spprintf(error, 0, "must be a valid class name%s, %s given",
-						check_null ? " or null" : "", Z_STRVAL_P(arg));
-					return check_null ? Z_EXPECTED_OBJECT_OR_CLASS_NAME_OR_NULL : Z_EXPECTED_OBJECT_OR_CLASS_NAME;
-				}
-				break;
-
 			}
 			break;
 
@@ -1111,10 +1124,13 @@ static zend_result zend_parse_arg(uint32_t arg_num, zval *arg, va_list *va, cons
 						/* error is freed by zend_wrong_callback_or_null_error() */
 						zend_wrong_callback_or_null_error(arg_num, error);
 						break;
-					case Z_EXPECTED_OBJECT_OR_CLASS_NAME:
-					case Z_EXPECTED_OBJECT_OR_CLASS_NAME_OR_NULL:
-						zend_argument_type_error(arg_num, "%s", error);
-						efree(error);
+					case Z_EXPECTED_CLASS_NAME:
+						/* DO NOT FREE error: it's a pointer to ZSTR_VAL(ce->name) */
+						zend_wrong_class_name_error(arg_num, error, arg);
+						break;
+					case Z_EXPECTED_CLASS_NAME_OR_NULL:
+						/* DO NOT FREE error: it's a pointer to ZSTR_VAL(ce->name) */
+						zend_wrong_class_name_or_null_error(arg_num, error, arg);
 						break;
 					default:
 						ZEND_UNREACHABLE();
@@ -1122,8 +1138,8 @@ static zend_result zend_parse_arg(uint32_t arg_num, zval *arg, va_list *va, cons
 			}
 			zend_wrong_parameter_type_error(arg_num, expected_type, arg);
 		} else if (error
-			/* DO NOT FREE error when it's a pointer to ZSTR_VAL(ce->name) */
-			&& expected_type != Z_EXPECTED_OBJECT && expected_type != Z_EXPECTED_OBJECT_OR_NULL) {
+			/* Only free error if it's a callable expected type, as otherwise it's a pointer to ZSTR_VAL(ce->name) */
+			&& (expected_type == Z_EXPECTED_FUNC || expected_type == Z_EXPECTED_FUNC_OR_NULL)) {
 			efree(error);
 		}
 

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -829,7 +829,7 @@ ZEND_API bool ZEND_FASTCALL zend_parse_arg_str_or_long_slow(zval *arg, zend_stri
 }
 /* }}} */
 
-static const char *zend_parse_arg_impl(zval *arg, va_list *va, const char **spec, char **error, uint32_t arg_num) /* {{{ */
+static zend_expected_type zend_parse_arg_impl(zval *arg, va_list *va, const char **spec, char **error, uint32_t arg_num) /* {{{ */
 {
 	const char *spec_walk = *spec;
 	char c = *spec_walk++;
@@ -863,7 +863,7 @@ static const char *zend_parse_arg_impl(zval *arg, va_list *va, const char **spec
 				}
 
 				if (!zend_parse_arg_long(arg, p, is_null, check_null, arg_num)) {
-					return check_null ? "?int" : "int";
+					return check_null ? Z_EXPECTED_LONG_OR_NULL : Z_EXPECTED_LONG;
 				}
 			}
 			break;
@@ -878,7 +878,7 @@ static const char *zend_parse_arg_impl(zval *arg, va_list *va, const char **spec
 				}
 
 				if (!zend_parse_arg_double(arg, p, is_null, check_null, arg_num)) {
-					return check_null ? "?float" : "float";
+					return check_null ? Z_EXPECTED_DOUBLE_OR_NULL : Z_EXPECTED_DOUBLE;
 				}
 			}
 			break;
@@ -888,7 +888,7 @@ static const char *zend_parse_arg_impl(zval *arg, va_list *va, const char **spec
 				zval **p = va_arg(*va, zval **);
 
 				if (!zend_parse_arg_number(arg, p, check_null, arg_num)) {
-					return check_null ? "int|float|null" : "int|float";
+					return check_null ? Z_EXPECTED_NUMBER : Z_EXPECTED_NUMBER;
 				}
 			}
 			break;
@@ -898,7 +898,7 @@ static const char *zend_parse_arg_impl(zval *arg, va_list *va, const char **spec
 				char **p = va_arg(*va, char **);
 				size_t *pl = va_arg(*va, size_t *);
 				if (!zend_parse_arg_string(arg, p, pl, check_null, arg_num)) {
-					return check_null ? "?string" : "string";
+					return check_null ? Z_EXPECTED_STRING_OR_NULL : Z_EXPECTED_STRING;
 				}
 			}
 			break;
@@ -908,12 +908,7 @@ static const char *zend_parse_arg_impl(zval *arg, va_list *va, const char **spec
 				char **p = va_arg(*va, char **);
 				size_t *pl = va_arg(*va, size_t *);
 				if (!zend_parse_arg_path(arg, p, pl, check_null, arg_num)) {
-					if (Z_TYPE_P(arg) == IS_STRING) {
-						zend_spprintf(error, 0, "must not contain any null bytes");
-						return "";
-					} else {
-						return check_null ? "?string" : "string";
-					}
+					return check_null ? Z_EXPECTED_PATH_OR_NULL : Z_EXPECTED_PATH;
 				}
 			}
 			break;
@@ -922,12 +917,7 @@ static const char *zend_parse_arg_impl(zval *arg, va_list *va, const char **spec
 			{
 				zend_string **str = va_arg(*va, zend_string **);
 				if (!zend_parse_arg_path_str(arg, str, check_null, arg_num)) {
-					if (Z_TYPE_P(arg) == IS_STRING) {
-						zend_spprintf(error, 0, "must not contain any null bytes");
-						return "";
-					} else {
-						return check_null ? "?string" : "string";
-					}
+					return check_null ? Z_EXPECTED_PATH_OR_NULL : Z_EXPECTED_PATH;
 				}
 			}
 			break;
@@ -936,7 +926,7 @@ static const char *zend_parse_arg_impl(zval *arg, va_list *va, const char **spec
 			{
 				zend_string **str = va_arg(*va, zend_string **);
 				if (!zend_parse_arg_str(arg, str, check_null, arg_num)) {
-					return check_null ? "?string" : "string";
+					return check_null ? Z_EXPECTED_STRING_OR_NULL : Z_EXPECTED_STRING;
 				}
 			}
 			break;
@@ -951,7 +941,7 @@ static const char *zend_parse_arg_impl(zval *arg, va_list *va, const char **spec
 				}
 
 				if (!zend_parse_arg_bool(arg, p, is_null, check_null, arg_num)) {
-					return check_null ? "?bool" : "bool";
+					return check_null ? Z_EXPECTED_BOOL_OR_NULL : Z_EXPECTED_BOOL;
 				}
 			}
 			break;
@@ -961,7 +951,7 @@ static const char *zend_parse_arg_impl(zval *arg, va_list *va, const char **spec
 				zval **p = va_arg(*va, zval **);
 
 				if (!zend_parse_arg_resource(arg, p, check_null)) {
-					return check_null ? "resource or null" : "resource";
+					return check_null ? Z_EXPECTED_RESOURCE_OR_NULL : Z_EXPECTED_RESOURCE;
 				}
 			}
 			break;
@@ -972,7 +962,7 @@ static const char *zend_parse_arg_impl(zval *arg, va_list *va, const char **spec
 				zval **p = va_arg(*va, zval **);
 
 				if (!zend_parse_arg_array(arg, p, check_null, c == 'A')) {
-					return check_null ? "?array" : "array";
+					return check_null ? Z_EXPECTED_ARRAY_OR_NULL : Z_EXPECTED_ARRAY;
 				}
 			}
 			break;
@@ -983,7 +973,7 @@ static const char *zend_parse_arg_impl(zval *arg, va_list *va, const char **spec
 				HashTable **p = va_arg(*va, HashTable **);
 
 				if (!zend_parse_arg_array_ht(arg, p, check_null, c == 'H', separate)) {
-					return check_null ? "?array" : "array";
+					return check_null ? Z_EXPECTED_ARRAY_OR_NULL : Z_EXPECTED_ARRAY;
 				}
 			}
 			break;
@@ -993,7 +983,7 @@ static const char *zend_parse_arg_impl(zval *arg, va_list *va, const char **spec
 				zval **p = va_arg(*va, zval **);
 
 				if (!zend_parse_arg_object(arg, p, NULL, check_null)) {
-					return check_null ? "?object" : "object";
+					return check_null ? Z_EXPECTED_OBJECT_OR_NULL : Z_EXPECTED_OBJECT;
 				}
 			}
 			break;
@@ -1005,50 +995,42 @@ static const char *zend_parse_arg_impl(zval *arg, va_list *va, const char **spec
 
 				if (!zend_parse_arg_object(arg, p, ce, check_null)) {
 					if (ce) {
-						if (check_null) {
-							zend_spprintf(error, 0, "must be of type ?%s, %s given", ZSTR_VAL(ce->name), zend_zval_value_name(arg));
-							return "";
-						} else {
-							return ZSTR_VAL(ce->name);
-						}
-					} else {
-						return check_null ? "?object" : "object";
+						*error = ZSTR_VAL(ce->name);
 					}
+					return check_null ? Z_EXPECTED_OBJECT_OR_NULL : Z_EXPECTED_OBJECT;
 				}
 			}
 			break;
 
 		case 'C':
 			{
-				zend_class_entry *lookup, **pce = va_arg(*va, zend_class_entry **);
-				zend_class_entry *ce_base = *pce;
+				zend_class_entry **pce = va_arg(*va, zend_class_entry **);
+				const zend_class_entry *ce_base = *pce;
 
 				if (check_null && Z_TYPE_P(arg) == IS_NULL) {
 					*pce = NULL;
 					break;
 				}
-				if (!try_convert_to_string(arg)) {
+
+				zend_string *class_name = NULL;
+				if (!zend_parse_arg_str(arg, &class_name, check_null, arg_num)) {
 					*pce = NULL;
-					return ""; /* try_convert_to_string() throws an exception */
+					return check_null ? Z_EXPECTED_STRING_OR_NULL : Z_EXPECTED_STRING;
 				}
 
-				if ((lookup = zend_lookup_class(Z_STR_P(arg))) == NULL) {
-					*pce = NULL;
-				} else {
-					*pce = lookup;
-				}
+				*pce = zend_lookup_class(class_name);
 				if (ce_base) {
 					if ((!*pce || !instanceof_function(*pce, ce_base))) {
 						zend_spprintf(error, 0, "must be a class name derived from %s%s, %s given",
 							ZSTR_VAL(ce_base->name), check_null ? " or null" : "", Z_STRVAL_P(arg));
 						*pce = NULL;
-						return "";
+						return check_null ? Z_EXPECTED_OBJECT_OR_CLASS_NAME_OR_NULL : Z_EXPECTED_OBJECT_OR_CLASS_NAME;
 					}
 				}
 				if (!*pce) {
 					zend_spprintf(error, 0, "must be a valid class name%s, %s given",
 						check_null ? " or null" : "", Z_STRVAL_P(arg));
-					return "";
+					return check_null ? Z_EXPECTED_OBJECT_OR_CLASS_NAME_OR_NULL : Z_EXPECTED_OBJECT_OR_CLASS_NAME;
 				}
 				break;
 
@@ -1060,19 +1042,11 @@ static const char *zend_parse_arg_impl(zval *arg, va_list *va, const char **spec
 			{
 				zend_fcall_info *fci = va_arg(*va, zend_fcall_info *);
 				zend_fcall_info_cache *fcc = va_arg(*va, zend_fcall_info_cache *);
-				char *is_callable_error = NULL;
-				if (EXPECTED(zend_parse_arg_func(arg, fci, fcc, check_null, &is_callable_error, c == 'f'))) {
-					ZEND_ASSERT(!is_callable_error);
+				if (EXPECTED(zend_parse_arg_func(arg, fci, fcc, check_null, error, c == 'f'))) {
+					ZEND_ASSERT(!*error);
 					break;
 				}
-
-				if (is_callable_error) {
-					zend_spprintf(error, 0, "must be a valid callback%s, %s", check_null ? " or null" : "", is_callable_error);
-					efree(is_callable_error);
-					return "";
-				} else {
-					return check_null ? "a valid callback or null" : "a valid callback";
-				}
+				return check_null ? Z_EXPECTED_FUNC_OR_NULL : Z_EXPECTED_FUNC;
 			}
 
 		case 'z':
@@ -1088,37 +1062,68 @@ static const char *zend_parse_arg_impl(zval *arg, va_list *va, const char **spec
 			ZEND_ASSERT(0 && "ZPP modifier no longer supported");
 			ZEND_FALLTHROUGH;
 		default:
-			return "unknown";
+			ZEND_ASSERT(false && "Unknown ZPP modifier");
 	}
 
 	*spec = spec_walk;
 
-	return NULL;
+	return Z_EXPECTED_LAST;
 }
 /* }}} */
 
 static zend_result zend_parse_arg(uint32_t arg_num, zval *arg, va_list *va, const char **spec, int flags) /* {{{ */
 {
-	const char *expected_type = NULL;
 	char *error = NULL;
 
-	expected_type = zend_parse_arg_impl(arg, va, spec, &error, arg_num);
-	if (expected_type) {
+	zend_expected_type expected_type = zend_parse_arg_impl(arg, va, spec, &error, arg_num);
+	if (expected_type != Z_EXPECTED_LAST) {
 		if (EG(exception)) {
 			return FAILURE;
 		}
-		if (!(flags & ZEND_PARSE_PARAMS_QUIET) && (*expected_type || error)) {
+
+		if (!(flags & ZEND_PARSE_PARAMS_QUIET)) {
+			/* More complex error, can only happen for:
+			 * Objects of a specific class
+			 * Z_EXPECTED_OBJECT
+			 * Z_EXPECTED_OBJECT_OR_NULL
+			 * Class names
+			 * Z_EXPECTED_OBJECT_OR_CLASS_NAME
+			 * Z_EXPECTED_OBJECT_OR_CLASS_NAME_OR_NULL
+			 * Functions
+			 * Z_EXPECTED_FUNC
+			 * Z_EXPECTED_FUNC_OR_NULL
+			 */
 			if (error) {
-				if (strcmp(error, "must not contain any null bytes") == 0) {
-					zend_argument_value_error(arg_num, "%s", error);
-				} else {
-					zend_argument_type_error(arg_num, "%s", error);
+				switch (expected_type) {
+					case Z_EXPECTED_OBJECT:
+						/* DO NOT FREE error: it's a pointer to ZSTR_VAL(ce->name) */
+						zend_wrong_parameter_class_error(arg_num, error, arg);
+						break;
+					case Z_EXPECTED_OBJECT_OR_NULL:
+						/* DO NOT FREE error: it's a pointer to ZSTR_VAL(ce->name) */
+						zend_wrong_parameter_class_or_null_error(arg_num, error, arg);
+						break;
+					case Z_EXPECTED_FUNC:
+						/* error is freed by zend_wrong_callback_error() */
+						zend_wrong_callback_error(arg_num, error);
+						break;
+					case Z_EXPECTED_FUNC_OR_NULL:
+						/* error is freed by zend_wrong_callback_or_null_error() */
+						zend_wrong_callback_or_null_error(arg_num, error);
+						break;
+					case Z_EXPECTED_OBJECT_OR_CLASS_NAME:
+					case Z_EXPECTED_OBJECT_OR_CLASS_NAME_OR_NULL:
+						zend_argument_type_error(arg_num, "%s", error);
+						efree(error);
+						break;
+					default:
+						ZEND_UNREACHABLE();
 				}
-				efree(error);
-			} else {
-				zend_argument_type_error(arg_num, "must be of type %s, %s given", expected_type, zend_zval_value_name(arg));
 			}
-		} else if (error) {
+			zend_wrong_parameter_type_error(arg_num, expected_type, arg);
+		} else if (error
+			/* DO NOT FREE error when it's a pointer to ZSTR_VAL(ce->name) */
+			&& expected_type != Z_EXPECTED_OBJECT && expected_type != Z_EXPECTED_OBJECT_OR_NULL) {
 			efree(error);
 		}
 

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -528,7 +528,7 @@ ZEND_API ZEND_COLD void zend_class_redeclaration_error(int type, const zend_clas
 	zend_class_redeclaration_error_ex(type, old_ce->name, old_ce);
 }
 
-ZEND_API ZEND_FASTCALL bool zend_parse_arg_class(zval *arg, zend_class_entry **pce, uint32_t num, bool check_null)
+ZEND_API bool ZEND_FASTCALL zend_parse_arg_class(zval *arg, zend_class_entry **pce, uint32_t num, bool check_null)
 {
 	const zend_class_entry *ce_base = *pce;
 

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -528,10 +528,8 @@ ZEND_API ZEND_COLD void zend_class_redeclaration_error(int type, const zend_clas
 	zend_class_redeclaration_error_ex(type, old_ce->name, old_ce);
 }
 
-ZEND_API bool ZEND_FASTCALL zend_parse_arg_class(zval *arg, zend_class_entry **pce, uint32_t num, bool check_null)
+ZEND_API bool ZEND_FASTCALL zend_parse_arg_class(zval *arg, zend_class_entry **pce, const zend_class_entry *ce_base, uint32_t num, bool check_null)
 {
-	const zend_class_entry *ce_base = *pce;
-
 	if (check_null && Z_TYPE_P(arg) == IS_NULL) {
 		*pce = NULL;
 		return true;
@@ -1051,8 +1049,8 @@ static zend_expected_type zend_parse_arg_impl(zval *arg, va_list *va, const char
 				zend_class_entry **pce = va_arg(*va, zend_class_entry **);
 				const zend_class_entry *ce_base = *pce;
 
-				*error = *pce ? ZSTR_VAL(ce_base->name) : NULL;
-				if (!zend_parse_arg_class(arg, pce, arg_num, check_null)) {
+				if (!zend_parse_arg_class(arg, pce, ce_base, arg_num, check_null)) {
+					*error = ce_base ? ZSTR_VAL(ce_base->name) : NULL;
 					return check_null ? Z_EXPECTED_CLASS_NAME_OR_NULL : Z_EXPECTED_CLASS_NAME;
 				}
 			}

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -1590,6 +1590,9 @@ C23_ENUM(zpp_error, uint8_t) {
 	ZPP_ERROR_OK,
 	ZPP_ERROR_FAILURE,
 	ZPP_ERROR_WRONG_CALLBACK,
+	ZPP_ERROR_WRONG_CALLBACK_OR_NULL,
+	ZPP_ERROR_WRONG_CLASS_NAME,
+	ZPP_ERROR_WRONG_CLASS_NAME_OR_NULL,
 	ZPP_ERROR_WRONG_CLASS,
 	ZPP_ERROR_WRONG_CLASS_OR_NULL,
 	ZPP_ERROR_WRONG_CLASS_OR_STRING,
@@ -1598,7 +1601,6 @@ C23_ENUM(zpp_error, uint8_t) {
 	ZPP_ERROR_WRONG_CLASS_OR_LONG_OR_NULL,
 	ZPP_ERROR_WRONG_ARG,
 	ZPP_ERROR_UNEXPECTED_EXTRA_NAMED,
-	ZPP_ERROR_WRONG_CALLBACK_OR_NULL,
 };
 
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_parameters_none_error(void);
@@ -1767,8 +1769,10 @@ ZEND_API ZEND_COLD void zend_class_redeclaration_error_ex(int type, zend_string 
 /* old "C" */
 #define Z_PARAM_CLASS_EX(dest, check_null, deref) \
 		Z_PARAM_PROLOGUE(deref, 0); \
+		_error = dest ? ZSTR_VAL((dest)->name) : NULL; \
 		if (UNEXPECTED(!zend_parse_arg_class(_arg, &dest, _i, check_null))) { \
-			_error_code = ZPP_ERROR_FAILURE; \
+			_expected_type = check_null ? Z_EXPECTED_CLASS_NAME_OR_NULL : Z_EXPECTED_CLASS_NAME; \
+			_error_code = check_null ? ZPP_ERROR_WRONG_CLASS_NAME_OR_NULL : ZPP_ERROR_WRONG_CLASS_NAME; \
 			break; \
 		}
 

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -1577,6 +1577,8 @@ static zend_always_inline zval *zend_try_array_init(zval *zv)
 	_(Z_EXPECTED_OBJECT_OR_CLASS_NAME_OR_NULL, "an object, a valid class name, or null") \
 	_(Z_EXPECTED_OBJECT_OR_STRING,	"of type object|string") \
 	_(Z_EXPECTED_OBJECT_OR_STRING_OR_NULL, "of type object|string|null") \
+	_(Z_EXPECTED_CLASS_NAME,	"a valid class name") \
+	_(Z_EXPECTED_CLASS_NAME_OR_NULL, "a valid class name or null") \
 
 #define Z_EXPECTED_TYPE
 
@@ -1592,6 +1594,9 @@ C23_ENUM(zpp_error, uint8_t) {
 	ZPP_ERROR_OK,
 	ZPP_ERROR_FAILURE,
 	ZPP_ERROR_WRONG_CALLBACK,
+	ZPP_ERROR_WRONG_CALLBACK_OR_NULL,
+	ZPP_ERROR_WRONG_CLASS_NAME,
+	ZPP_ERROR_WRONG_CLASS_NAME_OR_NULL,
 	ZPP_ERROR_WRONG_CLASS,
 	ZPP_ERROR_WRONG_CLASS_OR_NULL,
 	ZPP_ERROR_WRONG_CLASS_OR_STRING,
@@ -1600,7 +1605,6 @@ C23_ENUM(zpp_error, uint8_t) {
 	ZPP_ERROR_WRONG_CLASS_OR_LONG_OR_NULL,
 	ZPP_ERROR_WRONG_ARG,
 	ZPP_ERROR_UNEXPECTED_EXTRA_NAMED,
-	ZPP_ERROR_WRONG_CALLBACK_OR_NULL,
 };
 
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_parameters_none_error(void);
@@ -1773,8 +1777,10 @@ ZEND_API ZEND_COLD void zend_class_redeclaration_error_ex(int type, zend_string 
 /* old "C" */
 #define Z_PARAM_CLASS_EX(dest, check_null, deref) \
 		Z_PARAM_PROLOGUE(deref, 0); \
+		_error = dest ? ZSTR_VAL((dest)->name) : NULL; \
 		if (UNEXPECTED(!zend_parse_arg_class(_arg, &dest, _i, check_null))) { \
-			_error_code = ZPP_ERROR_FAILURE; \
+			_expected_type = check_null ? Z_EXPECTED_CLASS_NAME_OR_NULL : Z_EXPECTED_CLASS_NAME; \
+			_error_code = check_null ? ZPP_ERROR_WRONG_CLASS_NAME_OR_NULL : ZPP_ERROR_WRONG_CLASS_NAME; \
 			break; \
 		}
 

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -1769,8 +1769,9 @@ ZEND_API ZEND_COLD void zend_class_redeclaration_error_ex(int type, zend_string 
 /* old "C" */
 #define Z_PARAM_CLASS_EX(dest, check_null, deref) \
 		Z_PARAM_PROLOGUE(deref, 0); \
-		_error = dest ? ZSTR_VAL((dest)->name) : NULL; \
-		if (UNEXPECTED(!zend_parse_arg_class(_arg, &dest, _i, check_null))) { \
+		const zend_class_entry *_base_ce = dest; \
+		if (UNEXPECTED(!zend_parse_arg_class(_arg, &dest, _base_ce, _i, check_null))) { \
+			_error = _base_ce ? ZSTR_VAL((_base_ce)->name) : NULL; \
 			_expected_type = check_null ? Z_EXPECTED_CLASS_NAME_OR_NULL : Z_EXPECTED_CLASS_NAME; \
 			_error_code = check_null ? ZPP_ERROR_WRONG_CLASS_NAME_OR_NULL : ZPP_ERROR_WRONG_CLASS_NAME; \
 			break; \
@@ -2220,7 +2221,7 @@ typedef enum zpp_parse_bool_status {
 	ZPP_PARSE_BOOL_STATUS_ERROR = 2,
 } zpp_parse_bool_status;
 
-ZEND_API bool ZEND_FASTCALL zend_parse_arg_class(zval *arg, zend_class_entry **pce, uint32_t num, bool check_null);
+ZEND_API bool ZEND_FASTCALL zend_parse_arg_class(zval *arg, zend_class_entry **pce, const zend_class_entry *ce_base, uint32_t num, bool check_null);
 ZEND_API zpp_parse_bool_status ZEND_FASTCALL zend_parse_arg_bool_slow(const zval *arg, uint32_t arg_num);
 ZEND_API zpp_parse_bool_status ZEND_FASTCALL zend_parse_arg_bool_weak(const zval *arg, uint32_t arg_num);
 ZEND_API bool ZEND_FASTCALL zend_parse_arg_long_slow(const zval *arg, zend_long *dest, uint32_t arg_num);

--- a/ext/mysqli/tests/mysqli_fetch_object_oo.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_object_oo.phpt
@@ -116,7 +116,7 @@ require_once 'skipifconnectfailure.inc';
     require_once 'clean_table.inc';
 ?>
 --EXPECT--
-Error: Object of class mysqli could not be converted to string
+TypeError: mysqli_result::fetch_object(): Argument #1 ($class) must be of type string, mysqli given
 ArgumentCountError: mysqli_result::fetch_object() expects at most 2 arguments, 3 given
 TypeError: mysqli_result::fetch_object(): Argument #2 ($constructor_args) must be of type array, null given
 ArgumentCountError: Too few arguments to function mysqli_fetch_object_construct::__construct(), 1 passed and exactly 2 expected


### PR DESCRIPTION
And stop throwing the exceptions directly, fixing quiet mode handling at the same time.

Based on: #23052