### PR TITLE
Fix GH-23106: mb_strpos() reads past the end of a truncated UTF-8 haystack

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -17,6 +17,8 @@ PHP                                                                        NEWS
     offset in a non-UTF-8 encoding). (Eyüp Can Akman)
   . Fixed bug GH-21036 (mb_ereg_search_getregs() crashes after mb_eregi()
     invalidates the regex cache). (Matthias Goergens)
+  . Fixed bug GH-23106 (mb_strpos() reads past the end of a haystack ending in
+    a truncated UTF-8 sequence). (Lazizbek Ergashev)
 
 - Opcache:
   . Fixed bug GH-22857 (Function JIT emits wrong code for FETCH_OBJ_FUNC_ARG on a

--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -1891,6 +1891,9 @@ static unsigned char* offset_to_pointer_utf8(unsigned char *str, unsigned char *
 			}
 			pos += u8_tbl[*pos];
 		}
+		if (pos > end) {
+			pos = end;
+		}
 		return pos;
 	}
 }

--- a/ext/mbstring/tests/gh23106.phpt
+++ b/ext/mbstring/tests/gh23106.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-23106 (mb_strpos() reads past the end of a haystack ending in a truncated UTF-8 sequence)
+--EXTENSIONS--
+mbstring
+--FILE--
+<?php
+var_dump(mb_strpos("AA\xf0\x90", "xyz", 3));
+var_dump(mb_strpos("AA\xf0\x90", "x", 3));
+var_dump(mb_strrpos("AA\xf0\x90", "A", 3));
+var_dump(mb_strrpos("AA\xf0\x90", "A", -1));
+try {
+    mb_strpos("AA\xf0\x90", "xyz", 4);
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+bool(false)
+bool(false)
+bool(false)
+int(1)
+mb_strpos(): Argument #3 ($offset) must be contained in argument #1 ($haystack)


### PR DESCRIPTION
`offset_to_pointer_utf8()` walks the haystack with the UTF-8 mblen table. If the string ends in a truncated multi-byte sequence, the table length for the lead byte is larger than the bytes actually left, so the walk returns a pointer past the end of the string. `mb_strpos()` passes that pointer to `zend_memnstr()` as the start of the search, which fails the `end >= p` assertion on a debug build.

On a release build it is an out-of-bounds read instead: `mb_strpos("AA\xf0\x90", "x", 3)` returns a different bogus offset on every run, and with a long enough haystack it segfaults.

The clamp is the one `mb_str_split()` already uses for the same mblen table walk.

Fixes GH-23106