### PR TITLE
Zend: Name map ptr chunk size constants

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -746,7 +746,7 @@ static void compiler_globals_ctor(zend_compiler_globals *compiler_globals) /* {{
 	compiler_globals->internal_run_time_cache = NULL;
 	if (compiler_globals->map_ptr_last || zend_map_ptr_static_size) {
 		/* Allocate map_ptr table */
-		compiler_globals->map_ptr_size = ZEND_MM_ALIGNED_SIZE_EX(compiler_globals->map_ptr_last, 4096);
+		compiler_globals->map_ptr_size = ZEND_MM_ALIGNED_SIZE_EX(compiler_globals->map_ptr_last, ZEND_MAP_PTR_CHUNK_SIZE);
 		void *base = pemalloc((zend_map_ptr_static_size + compiler_globals->map_ptr_size) * sizeof(void*), 1);
 		compiler_globals->map_ptr_real_base = base;
 		compiler_globals->map_ptr_base = ZEND_MAP_PTR_BIASED_BASE(base);
@@ -2064,7 +2064,7 @@ ZEND_API void *zend_map_ptr_new(void)
 
 	if (CG(map_ptr_last) >= CG(map_ptr_size)) {
 		/* Grow map_ptr table */
-		CG(map_ptr_size) = ZEND_MM_ALIGNED_SIZE_EX(CG(map_ptr_last) + 1, 4096);
+		CG(map_ptr_size) = ZEND_MM_ALIGNED_SIZE_EX(CG(map_ptr_last) + 1, ZEND_MAP_PTR_CHUNK_SIZE);
 		CG(map_ptr_real_base) = perealloc(CG(map_ptr_real_base), (zend_map_ptr_static_size + CG(map_ptr_size)) * sizeof(void*), 1);
 		CG(map_ptr_base) = ZEND_MAP_PTR_BIASED_BASE(CG(map_ptr_real_base));
 	}
@@ -2079,17 +2079,17 @@ ZEND_API void *zend_map_ptr_new_static(void)
 	void **ptr;
 
 	if (zend_map_ptr_static_last >= zend_map_ptr_static_size) {
-		zend_map_ptr_static_size += 4096;
+		zend_map_ptr_static_size += ZEND_MAP_PTR_CHUNK_SIZE;
 		/* Grow map_ptr table */
 		void *new_base = pemalloc((zend_map_ptr_static_size + CG(map_ptr_size)) * sizeof(void*), 1);
 		if (CG(map_ptr_real_base)) {
-			memcpy((void **)new_base + 4096, CG(map_ptr_real_base), (CG(map_ptr_last) + zend_map_ptr_static_size - 4096) * sizeof(void *));
+			memcpy((void **)new_base + ZEND_MAP_PTR_CHUNK_SIZE, CG(map_ptr_real_base), (CG(map_ptr_last) + zend_map_ptr_static_size - ZEND_MAP_PTR_CHUNK_SIZE) * sizeof(void *));
 			pefree(CG(map_ptr_real_base), 1);
 		}
 		CG(map_ptr_real_base) = new_base;
 		CG(map_ptr_base) = ZEND_MAP_PTR_BIASED_BASE(new_base);
 	}
-	ptr = (void**)CG(map_ptr_real_base) + (zend_map_ptr_static_last & 4095);
+	ptr = (void**)CG(map_ptr_real_base) + (zend_map_ptr_static_last & ZEND_MAP_PTR_CHUNK_MASK);
 	*ptr = NULL;
 	zend_map_ptr_static_last++;
 	return ZEND_MAP_PTR_PTR2OFFSET(ptr);
@@ -2102,7 +2102,7 @@ ZEND_API void zend_map_ptr_extend(size_t last)
 
 		if (last >= CG(map_ptr_size)) {
 			/* Grow map_ptr table */
-			CG(map_ptr_size) = ZEND_MM_ALIGNED_SIZE_EX(last, 4096);
+			CG(map_ptr_size) = ZEND_MM_ALIGNED_SIZE_EX(last, ZEND_MAP_PTR_CHUNK_SIZE);
 			CG(map_ptr_real_base) = perealloc(CG(map_ptr_real_base), (zend_map_ptr_static_size + CG(map_ptr_size)) * sizeof(void*), 1);
 			CG(map_ptr_base) = ZEND_MAP_PTR_BIASED_BASE(CG(map_ptr_real_base));
 		}

--- a/Zend/zend_map_ptr.h
+++ b/Zend/zend_map_ptr.h
@@ -26,6 +26,8 @@ typedef struct _zend_string zend_string;
 #define ZEND_MAP_PTR_KIND_PTR_OR_OFFSET 1
 
 #define ZEND_MAP_PTR_KIND ZEND_MAP_PTR_KIND_PTR_OR_OFFSET
+#define ZEND_MAP_PTR_CHUNK_SIZE 4096
+#define ZEND_MAP_PTR_CHUNK_MASK (ZEND_MAP_PTR_CHUNK_SIZE - 1)
 
 #define ZEND_MAP_PTR(ptr) \
 	ptr ## __ptr
@@ -69,9 +71,11 @@ typedef struct _zend_string zend_string;
 	} while (0)
 # define ZEND_MAP_PTR_BIASED_BASE(real_base) \
 	((void*)(((uintptr_t)(real_base)) + zend_map_ptr_static_size * sizeof(void *) - 1))
-/* Note: chunked like: [8192..12287][4096..8191][0..4095] */
+/* Note: chunked in reverse ZEND_MAP_PTR_CHUNK_SIZE-entry ranges. */
 #define ZEND_MAP_PTR_STATIC_NUM_TO_PTR(num) \
-	((void **)CG(map_ptr_real_base) + zend_map_ptr_static_size - ZEND_MM_ALIGNED_SIZE_EX((num) + 1, 4096) + ((num) & 4095))
+	((void **)CG(map_ptr_real_base) + zend_map_ptr_static_size \
+		- ZEND_MM_ALIGNED_SIZE_EX((num) + 1, ZEND_MAP_PTR_CHUNK_SIZE) \
+		+ ((num) & ZEND_MAP_PTR_CHUNK_MASK))
 #else
 # error "Unknown ZEND_MAP_PTR_KIND"
 #endif

--- a/Zend/zend_map_ptr.h
+++ b/Zend/zend_map_ptr.h
@@ -71,7 +71,7 @@ typedef struct _zend_string zend_string;
 	} while (0)
 # define ZEND_MAP_PTR_BIASED_BASE(real_base) \
 	((void*)(((uintptr_t)(real_base)) + zend_map_ptr_static_size * sizeof(void *) - 1))
-/* Note: chunked in reverse ZEND_MAP_PTR_CHUNK_SIZE-entry ranges. */
+/* Note: chunked like: [8192..12287][4096..8191][0..4095] */
 #define ZEND_MAP_PTR_STATIC_NUM_TO_PTR(num) \
 	((void **)CG(map_ptr_real_base) + zend_map_ptr_static_size \
 		- ZEND_MM_ALIGNED_SIZE_EX((num) + 1, ZEND_MAP_PTR_CHUNK_SIZE) \


### PR DESCRIPTION
Let's prevent writing 4095 and 4096 as a magic number, its indeed confusing, instead use ZEND_MAP_PTR_CHUNK_MASK and ZEND_MAP_PTR_CHUNK_SIZE