### PR TITLE
Optimize str_repeat

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -5524,7 +5524,7 @@ PHP_FUNCTION(str_repeat)
 
 		while (e<ee) {
 			l = (e-s) < (ee-e) ? (e-s) : (ee-e);
-			memmove(e, s, l);
+			memcpy(e, s, l);
 			e += l;
 		}
 	}


### PR DESCRIPTION
The memmove got me thinking "can src and dst actually overlap?", and it turns out no:
- e always points to populated data + 1
- l may reach the end of populated data, but will never exceed it

memcpy is safe here, and faster (unless the compiler already spotted it in an optimization pass and replaced it internally, entirely possible)