### PR TITLE
sapi/cli: applied fixers to improve test robustness

### DIFF
--- a/sapi/cli/tests/gh12363.phpt
+++ b/sapi/cli/tests/gh12363.phpt
@@ -36,4 +36,3 @@ Connection: close
 X-Powered-By: %s
 Date: Mon, 25 Mar 1985 00:20:00 GMT
 Content-type: text/html; charset=UTF-8
-


### PR DESCRIPTION
Extracted from: https://github.com/php/php-src/pull/22799 -- just removes the duplicated empty line to follow the "last empty line" rule.