### PR TITLE
ext/gd: Fix two external libgd tests

### DIFF
--- a/ext/gd/tests/bug39780_extern.phpt
+++ b/ext/gd/tests/bug39780_extern.phpt
@@ -16,9 +16,9 @@ $im = imagecreatefrompng(__DIR__ . '/bug39780.png');
 var_dump($im);
 ?>
 --EXPECTF--
-Warning: imagecreatefrompng(): gd-png: fatal libpng error: Read Error: truncated data%win %s on line %d
+Warning: imagecreatefrompng(): gd-png:  fatal libpng error: Read Error: truncated data in %s on line %d
 
-Warning: imagecreatefrompng(): gd-png error: setjmp returns error condition %d%win %s on line %d
+Warning: imagecreatefrompng(): gd-png error: setjmp returns error condition in %s on line %d
 
 Warning: imagecreatefrompng(): "%sbug39780.png" is not a valid PNG file in %s on line %d
 bool(false)

--- a/ext/gd/tests/libgd00086_extern.phpt
+++ b/ext/gd/tests/libgd00086_extern.phpt
@@ -16,9 +16,9 @@ $im = imagecreatefrompng(__DIR__ . '/libgd00086.png');
 var_dump($im);
 ?>
 --EXPECTF--
-Warning: imagecreatefrompng(): gd-png: fatal libpng error: Read Error: truncated data%win %s on line %d
+Warning: imagecreatefrompng(): gd-png:  fatal libpng error: Read Error: truncated data in %s on line %d
 
-Warning: imagecreatefrompng(): gd-png error: setjmp returns error condition %d%win %s on line %d
+Warning: imagecreatefrompng(): gd-png error: setjmp returns error condition in %s on line %d
 
 Warning: imagecreatefrompng(): "%slibgd00086.png" is not a valid PNG file in %s on line %d
 bool(false)


### PR DESCRIPTION
After intruducing

https://github.com/php/php-src/blob/bf5141c5e66b2f93c089fd91ae0d03947fb310f4/ext/gd/gd.c#L302-L306

the expected output of the bundled libgd matches the expected output when using an external libgd.

Without this change, the test suite fails when using external gd.

This leaves us with the following test failures, all with external gd:

```
=====================================================================
FAILED TEST SUMMARY
---------------------------------------------------------------------
Bug #65148 (imagerotate may alter image dimensions) [ext/gd/tests/bug65148.phpt]
Bug #73272 (imagescale() is not affected by, but affects imagesetinterpolation()) [ext/gd/tests/bug73272.phpt]
Bug #73291 (imagecropauto() $threshold differs from external libgd) [ext/gd/tests/bug73291.phpt]
=====================================================================
```

`ext/gd/tests/bug73291.phpt` is related to differences in the algorithm between the current stable libgd-2.3.3 and the bundled 2.4 pre-release, so we either need to split this into a new _external test, which will cause issues when distributions eventually start to ship a future 2.4 release, or we need to guard this behind a version check.

See https://github.com/gentoo/gentoo/pull/46580#issuecomment-5152357813 for more context.

Not sure about the other two failing tests though, but since they also got touched when updating the bundled libgd to 2.4pre, I bet it is the same issue.