### PR TITLE
TSRM: don't use initial-exec on AIX

### DIFF
--- a/TSRM/TSRM.h
+++ b/TSRM/TSRM.h
@@ -152,7 +152,8 @@ TSRM_API bool tsrm_is_managed_thread(void);
 # define __has_attribute(x) 0
 #endif
 
-#if !__has_attribute(tls_model) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__MUSL__) || defined(__HAIKU__)
+#if !__has_attribute(tls_model) || defined(__FreeBSD__) || defined(__NetBSD__) \
+	|| defined(__MUSL__) || defined(__HAIKU__) || defined(_AIX)
 # define TSRM_TLS_MODEL_ATTR
 # define TSRM_TLS_MODEL_DEFAULT
 #elif __PIC__


### PR DESCRIPTION
If building for ZTS, it seems that local-exec can sneak in:

```
PHP Warning:  PHP Startup: Unable to load dynamic library 'intl' (tried: /QOpenSys/pkgs/lib/php-8.6/extensions/intl (   0509-022 Cannot load module /QOpenSys/pkgs/lib/php-8.6/extensions/intl.
        0509-026 System error: A file or directory in the path name does not exist.), /QOpenSys/pkgs/lib/php-8.6/extensions/intl.so (   0509-130 Symbol resolution failed for /QOpenSys/pkgs/lib/php-8.6/extensions/intl.so because:
        0509-189 Module /QOpenSys/pkgs/lib/php-8.6/extensions/intl.so is loaded dynamically,
                  but the initial-exec model is used by the module
                  to refer to its own thread-local variables.
        0509-191 Examine .loader section relocation entries with the
                 'dump -Rv' command.
        0509-192 Examine .loader section symbols with the
                 'dump -Tv' command.)) in Unknown on line 0
```

When inspecting the module for initial-exec:

```
$ dump -Rv /QOpenSys/pkgs/lib/php-8.6/extensions/intl.so | grep TLS_In
        0x20014370  0x000001fb TLS_InExc      0x0003     _tsrm_ls_cache
```

It seems it only was in `ext/intl/timezone/timezone_class.cpp`. However, it seems prudent to just not use local-exec for this case since it seems to be an optimization only really possible on glibc; play it safe elsewhere. (Perhaps this should be really an ifdef GLIBC check?)