### PR TITLE
ext/libxml: Export xmlCtxtSetOptions on Windows

### DIFF
--- a/ext/libxml/php_libxml2.def
+++ b/ext/libxml/php_libxml2.def
@@ -237,6 +237,7 @@ xmlCtxtReadMemory
 xmlCtxtReset
 xmlCtxtResetLastError
 xmlCtxtResetPush
+xmlCtxtSetOptions
 xmlCtxtUseOptions
 xmlCurrentChar
 xmlDebugCheckDocument


### PR DESCRIPTION
Follow-up to #22755
`xmlCtxtSetOptions` is required on master after #20020.