### PR TITLE
Fix GH-23120 test on Windows x86

### DIFF
--- a/ext/dom/tests/gh23120.phpt
+++ b/ext/dom/tests/gh23120.phpt
@@ -12,7 +12,7 @@ if (getenv('SKIP_ASAN')) {
 }
 ?>
 --INI--
-zend.max_allowed_stack_size=512K
+zend.max_allowed_stack_size=256K
 --FILE--
 <?php
 function create_deep_document(): DOMDocument {


### PR DESCRIPTION
Follow-up to GH-23120.

Nightly CI on Windows x86 fails `ext/dom/tests/gh23120.phpt`.
https://github.com/php/php-src/actions/runs/31288567288/job/93181841779#step:6:379

Comparing 10,000 nested nodes does not exhaust the 512K stack limit on Windows x86. Reducing it to 256K should consistently trigger the stack guard across architectures.