### PR TITLE
Clamp scale in bc_is_zero_for_scale to n_scale

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,10 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 8.4.25
 
+- BCMath:
+  . Fixed out-of-bounds read in bc_is_zero_for_scale() when scale exceeds
+    n_scale. (iliaal)
+
 - Date:
   . Fixed leak on double DatePeriod::__construct() call. (ilutov)
 

--- a/ext/bcmath/libbcmath/src/zero.c
+++ b/ext/bcmath/libbcmath/src/zero.c
@@ -45,6 +45,10 @@ bool bc_is_zero_for_scale(bc_num num, size_t scale)
 		return true;
 	}
 
+	if (scale > num->n_scale) {
+		scale = num->n_scale;
+	}
+
 	/* Initialize */
 	count = num->n_len + scale;
 	nptr = num->n_value;

--- a/ext/bcmath/tests/bc_is_zero_for_scale_clamp.phpt
+++ b/ext/bcmath/tests/bc_is_zero_for_scale_clamp.phpt
@@ -1,0 +1,12 @@
+--TEST--
+bc_is_zero_for_scale clamps scale to n_scale (Number::compare opposite signs)
+--EXTENSIONS--
+bcmath
+--FILE--
+<?php
+$shortZero = (new BcMath\Number('1.0'))->sub('1.0');
+$longNegative = new BcMath\Number('-0.' . str_repeat('0', 64) . '1');
+var_dump($shortZero->compare($longNegative, 64));
+?>
+--EXPECT--
+int(0)


### PR DESCRIPTION
bc_is_zero_for_scale walked n_len+scale digits without clamping scale to n_scale. Opposite-sign Number::compare with an explicit scale can call it when one operand is shorter, reading past the digit buffer. Match bc_is_near_zero and clamp first.
