### PR TITLE
Fix GH-12171: resolve SimpleXML nodes before equality compare

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,10 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 8.4.25
 
+- SimpleXML:
+  . Fixed bug GH-12171 (SimpleXML property-proxy equality ignores element
+    names). (iliaal)
+
 - Date:
   . Fixed leak on double DatePeriod::__construct() call. (ilutov)
 

--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -1220,8 +1220,11 @@ static int sxe_objects_compare(zval *object1, zval *object2) /* {{{ */
 	sxe2 = Z_SXEOBJ_P(object2);
 
 	if (sxe1->node != NULL && sxe2->node != NULL) {
+		xmlNodePtr node1 = php_sxe_get_first_node_non_destructive(sxe1, sxe1->node->node);
+		xmlNodePtr node2 = php_sxe_get_first_node_non_destructive(sxe2, sxe2->node->node);
+
 		/* Both nodes set: Only support equality comparison between nodes. */
-		if (sxe1->node == sxe2->node) {
+		if (node1 && node1 == node2) {
 			return 0;
 		}
 		return ZEND_UNCOMPARABLE;

--- a/ext/simplexml/tests/gh12171.phpt
+++ b/ext/simplexml/tests/gh12171.phpt
@@ -1,0 +1,23 @@
+--TEST--
+GH-12171 (SimpleXML property-proxy equality must resolve iterator nodes)
+--EXTENSIONS--
+simplexml
+--FILE--
+<?php
+$xml = simplexml_load_string('<root><first/><second/><third/></root>');
+echo "first==second: ";
+var_dump($xml->first == $xml->second);
+echo "first==first: ";
+var_dump($xml->first == $xml->first);
+echo "first==root: ";
+var_dump($xml->first == $xml);
+$a = $xml->first;
+$b = $xml->first;
+echo "proxies equal: ";
+var_dump($a == $b);
+?>
+--EXPECT--
+first==second: bool(false)
+first==first: bool(true)
+first==root: bool(false)
+proxies equal: bool(true)


### PR DESCRIPTION
Property proxies like $xml->first store the parent node plus an element iterator name. sxe_objects_compare compared the parent wrappers, so sibling proxies always compared equal. Resolve each side through php_sxe_get_first_node_non_destructive before comparing.
