### PR TITLE
Fix stack overflow in count() with COUNT_RECURSIVE and deep arrays

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -78,6 +78,8 @@ PHP                                                                        NEWS
     nested arrays). (Lazizbek Ergashev)
   . Fixed bug GH-23115 (Stack overflow in compact() with deeply nested
     arrays). (Lazizbek Ergashev)
+  . Fixed stack overflow in count() with COUNT_RECURSIVE and deeply nested
+    arrays. (Lazizbek Ergashev)
 
 - Streams:
   . Fixed bug GH-15836 (Use-after-free when a user stream filter accesses

--- a/ext/spl/spl_observer.c
+++ b/ext/spl/spl_observer.c
@@ -679,7 +679,11 @@ PHP_METHOD(SplObjectStorage, count)
 	}
 
 	if (mode == PHP_COUNT_RECURSIVE) {
-		RETURN_LONG(php_count_recursive(&intern->storage));
+		zend_long count = php_count_recursive(&intern->storage);
+		if (UNEXPECTED(count < 0)) {
+			RETURN_THROWS();
+		}
+		RETURN_LONG(count);
 	}
 
 	RETURN_LONG(zend_hash_num_elements(&intern->storage));

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -611,6 +611,13 @@ PHPAPI zend_long php_count_recursive(HashTable *ht) /* {{{ */
 	zend_long cnt = 0;
 	zval *element;
 
+#ifdef ZEND_CHECK_STACK_LIMIT
+	if (UNEXPECTED(zend_call_stack_overflowed(EG(stack_limit)))) {
+		zend_call_stack_size_error();
+		return 0;
+	}
+#endif
+
 	if (!(GC_FLAGS(ht) & GC_IMMUTABLE)) {
 		if (GC_IS_RECURSIVE(ht)) {
 			php_error_docref(NULL, E_WARNING, "Recursion detected");
@@ -624,6 +631,9 @@ PHPAPI zend_long php_count_recursive(HashTable *ht) /* {{{ */
 		ZVAL_DEREF(element);
 		if (Z_TYPE_P(element) == IS_ARRAY) {
 			cnt += php_count_recursive(Z_ARRVAL_P(element));
+			if (UNEXPECTED(EG(exception))) {
+				break;
+			}
 		}
 	} ZEND_HASH_FOREACH_END();
 
@@ -656,6 +666,9 @@ PHP_FUNCTION(count)
 				cnt = zend_hash_num_elements(Z_ARRVAL_P(array));
 			} else {
 				cnt = php_count_recursive(Z_ARRVAL_P(array));
+				if (UNEXPECTED(EG(exception))) {
+					RETURN_THROWS();
+				}
 			}
 			RETURN_LONG(cnt);
 			break;

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -614,14 +614,15 @@ PHPAPI zend_long php_count_recursive(HashTable *ht) /* {{{ */
 #ifdef ZEND_CHECK_STACK_LIMIT
 	if (UNEXPECTED(zend_call_stack_overflowed(EG(stack_limit)))) {
 		zend_call_stack_size_error();
-		return 0;
+		return -1;
 	}
 #endif
 
 	if (!(GC_FLAGS(ht) & GC_IMMUTABLE)) {
 		if (GC_IS_RECURSIVE(ht)) {
 			php_error_docref(NULL, E_WARNING, "Recursion detected");
-			return 0;
+			/* A user error handler may have thrown. */
+			return EG(exception) ? -1 : 0;
 		}
 		GC_PROTECT_RECURSION(ht);
 	}
@@ -630,10 +631,12 @@ PHPAPI zend_long php_count_recursive(HashTable *ht) /* {{{ */
 	ZEND_HASH_FOREACH_VAL(ht, element) {
 		ZVAL_DEREF(element);
 		if (Z_TYPE_P(element) == IS_ARRAY) {
-			cnt += php_count_recursive(Z_ARRVAL_P(element));
-			if (UNEXPECTED(EG(exception))) {
+			zend_long sub_cnt = php_count_recursive(Z_ARRVAL_P(element));
+			if (UNEXPECTED(sub_cnt < 0)) {
+				cnt = -1;
 				break;
 			}
+			cnt += sub_cnt;
 		}
 	} ZEND_HASH_FOREACH_END();
 
@@ -666,7 +669,7 @@ PHP_FUNCTION(count)
 				cnt = zend_hash_num_elements(Z_ARRVAL_P(array));
 			} else {
 				cnt = php_count_recursive(Z_ARRVAL_P(array));
-				if (UNEXPECTED(EG(exception))) {
+				if (UNEXPECTED(cnt < 0)) {
 					RETURN_THROWS();
 				}
 			}

--- a/ext/standard/php_array.h
+++ b/ext/standard/php_array.h
@@ -29,6 +29,7 @@ PHPAPI int php_array_merge(HashTable *dest, HashTable *src);
 PHPAPI int php_array_merge_recursive(HashTable *dest, HashTable *src);
 PHPAPI int php_array_replace_recursive(HashTable *dest, HashTable *src);
 PHPAPI int php_multisort_compare(const void *a, const void *b);
+/* Returns -1 and throws if the array is nested too deeply. */
 PHPAPI zend_long php_count_recursive(HashTable *ht);
 
 PHPAPI bool php_array_data_shuffle(php_random_algo_with_state engine, zval *array);

--- a/ext/standard/tests/array/count_recursive_stack_limit.phpt
+++ b/ext/standard/tests/array/count_recursive_stack_limit.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Stack overflow in count() with COUNT_RECURSIVE and deeply nested arrays
+--SKIPIF--
+<?php
+if (ini_get('zend.max_allowed_stack_size') === false) {
+    die('skip No stack limit support');
+}
+if (getenv('SKIP_ASAN')) {
+    die('skip ASAN needs different stack limit setting due to more stack space usage');
+}
+?>
+--INI--
+zend.max_allowed_stack_size=256K
+--FILE--
+<?php
+/* Two elements per nesting level: the sibling must not be visited once the
+ * stack limit error has been thrown, so only one Error is thrown. */
+$a = [];
+for ($i = 0; $i < 30000; $i++) {
+    $a = [$a, []];
+}
+
+try {
+    count($a, COUNT_RECURSIVE);
+} catch (Throwable $e) {
+    echo $e::class, ": ", $e->getMessage(), "\n";
+    var_dump($e->getPrevious());
+}
+?>
+--EXPECTF--
+Error: Maximum call stack size of %d bytes (zend.max_allowed_stack_size - zend.reserved_stack_size) reached. Infinite recursion?
+NULL


### PR DESCRIPTION
`php_count_recursive()` recurses once per nesting level with no stack check, so `count($array, COUNT_RECURSIVE)` on a deeply nested array exhausts the native stack and the process dies with a segfault.

This is the separate PR offered in #23125, applying the same stack limit check the neighbouring functions in ext/standard use, so the call throws an Error instead of crashing. There is no GitHub issue for it.

The loop over the elements also breaks once the error is thrown, otherwise every remaining sibling recurses again and chains another Error onto the first one, and `count()` returns through `RETURN_THROWS()` in that case.