### PR TITLE
Fix use-after-free when __clone() retains the stylesheet copy

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -85,6 +85,10 @@ PHP                                                                        NEWS
   . Fixed out-of-bounds write when shm_attach() opens an existing segment with
     a size larger than the segment actually is. (David Carlier)
 
+- XSL:
+  . Fixed use-after-free when a DOMDocument subclass __clone() retains the
+    stylesheet copy made by XSLTProcessor::importStylesheet(). (iliaal)
+
 - Zip:
   . Fixed ZipArchive::addGlob() and ZipArchive::addPattern() ignoring their
     default options when no options array is given. (David Carlier)

--- a/ext/xsl/tests/importStylesheet_clone_retained_document.phpt
+++ b/ext/xsl/tests/importStylesheet_clone_retained_document.phpt
@@ -1,0 +1,47 @@
+--TEST--
+XSLTProcessor::importStylesheet() rejects a stylesheet whose __clone() retains the cloned document
+--EXTENSIONS--
+dom
+xsl
+--FILE--
+<?php
+const STYLESHEET = <<<XML
+<?xml version="1.0"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/"><out/></xsl:template>
+</xsl:stylesheet>
+XML;
+
+class Harmless extends DOMDocument {
+    public function __clone(): void {
+    }
+}
+
+class RetainsDocument extends DOMDocument {
+    public function __clone(): void {
+        $GLOBALS['stash'] = $this;
+    }
+}
+
+$doc = new Harmless;
+$doc->loadXML(STYLESHEET);
+$proc = new XSLTProcessor();
+var_dump($proc->importStylesheet($doc));
+unset($proc, $doc);
+
+$doc = new RetainsDocument;
+$doc->loadXML(STYLESHEET);
+$proc = new XSLTProcessor();
+try {
+    var_dump($proc->importStylesheet($doc));
+} catch (Error $e) {
+    echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+}
+$kept = $GLOBALS['stash'];
+unset($GLOBALS['stash'], $proc, $doc);
+echo get_class($kept), " is still usable: ", $kept->documentElement->nodeName, PHP_EOL;
+?>
+--EXPECT--
+bool(true)
+ValueError: XSLTProcessor::importStylesheet(): Argument #1 ($stylesheet) must not have its clone retained by __clone()
+RetainsDocument is still usable: xsl:stylesheet

--- a/ext/xsl/tests/importStylesheet_clone_retained_node.phpt
+++ b/ext/xsl/tests/importStylesheet_clone_retained_node.phpt
@@ -1,0 +1,34 @@
+--TEST--
+XSLTProcessor::importStylesheet() rejects a stylesheet whose __clone() retains a node of the cloned document
+--EXTENSIONS--
+dom
+xsl
+--FILE--
+<?php
+class RetainsElement extends DOMDocument {
+    public function __clone(): void {
+        $GLOBALS['stash'] = $this->documentElement;
+    }
+}
+
+$doc = new RetainsElement;
+$doc->loadXML(<<<XML
+<?xml version="1.0"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/"><out/></xsl:template>
+</xsl:stylesheet>
+XML);
+
+$proc = new XSLTProcessor();
+try {
+    var_dump($proc->importStylesheet($doc));
+} catch (Error $e) {
+    echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+}
+$kept = $GLOBALS['stash'];
+unset($GLOBALS['stash'], $proc, $doc);
+echo get_class($kept), " is still usable: ", $kept->nodeName, PHP_EOL;
+?>
+--EXPECT--
+ValueError: XSLTProcessor::importStylesheet(): Argument #1 ($stylesheet) must not have its clone retained by __clone()
+DOMElement is still usable: xsl:stylesheet

--- a/ext/xsl/xsltprocessor.c
+++ b/ext/xsl/xsltprocessor.c
@@ -227,6 +227,12 @@ PHP_METHOD(XSLTProcessor, importStylesheet)
 
 	php_libxml_node_object *clone_lxml_obj = Z_LIBXML_NODE_P(&clone_zv);
 
+	if (GC_REFCOUNT(clone) > 1 || clone_lxml_obj->document->refcount > 1) {
+		OBJ_RELEASE(clone);
+		zend_argument_value_error(1, "must not have its clone retained by __clone()");
+		RETURN_THROWS();
+	}
+
 	PHP_LIBXML_SANITIZE_GLOBALS(parse);
 	ZEND_DIAGNOSTIC_IGNORED_START("-Wdeprecated-declarations")
 	xmlSubstituteEntitiesDefault(1);


### PR DESCRIPTION
`XSLTProcessor::importStylesheet()` clones the stylesheet document through the object's clone handler and hands the copy to libxslt, which frees it with the stylesheet. A `DOMDocument` subclass `__clone()` runs while that copy is fully wired up and can stash either the copy itself or a node proxy into it, leaving a dangling pointer once the processor is destroyed. The clone must now be exclusively owned before libxslt takes it.

```php
class D extends DOMDocument {
    public function __clone(): void { $GLOBALS['stash'] = $this; }
}
$d = new D;
$d->loadXML('<?xml version="1.0"?><xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:template match="/"><out/></xsl:template></xsl:stylesheet>');
$p = new XSLTProcessor;
$p->importStylesheet($d);
$esc = $GLOBALS['stash'];
unset($GLOBALS['stash'], $p, $d);
```

That aborts with a double free on 8.4, 8.5 and master. Stashing `$this->documentElement` instead gives a silent read of freed memory in `dom_objects_free_storage`. 8.3 is unaffected because it copies at the libxml level and never builds a PHP object for the copy.
