### PR TITLE
Bound the HEIF meta box allocation by the file size

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,10 @@ PHP                                                                        NEWS
   . Fixed bug GH-23120 (Stack overflow when comparing deeply nested DOM nodes
     with DOMNode::isEqualNode()). (Weilin Du)
 
+- Exif:
+  . Fixed exif_read_data() allocating a HEIF meta box larger than the file
+    it came from. (iliaal)
+
 - Intl:
   . Fixed IntlListFormatter::__construct() leaving stale global error state
     after successful calls. (Weilin Du)

--- a/ext/exif/exif.c
+++ b/ext/exif/exif.c
@@ -4415,7 +4415,7 @@ static bool exif_scan_HEIF_header(image_info_type *ImageInfo, unsigned char *buf
 		}
 		if (box.type == FOURCC("meta")) {
 			limit = box.size - box_header_size;
-			if (limit < 36) {
+			if (limit < 36 || limit > ImageInfo->FileSize) {
 				break;
 			}
 			data = (unsigned char *)emalloc(limit);

--- a/ext/exif/tests/heic_meta_box_alloc.phpt
+++ b/ext/exif/tests/heic_meta_box_alloc.phpt
@@ -1,0 +1,23 @@
+--TEST--
+HEIC meta box size must be bounded by the file size
+--EXTENSIONS--
+exif
+--INI--
+memory_limit=32M
+--FILE--
+<?php
+// ftyp box (size 20) followed by a meta box whose size field claims 128MB,
+// in a file that is only 37 bytes. Without an upper bound the meta box
+// allocation exhausts memory_limit before any read is attempted.
+$ftyp = pack("N", 20) . "ftypheic" . str_repeat("\x00", 8);
+$meta = pack("N", 0x08000000) . "meta" . str_repeat("\x00", 8);
+file_put_contents(__DIR__."/heic_meta_box_alloc.heic", $ftyp . $meta . "\x00");
+var_dump(exif_read_data(__DIR__."/heic_meta_box_alloc.heic"));
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__."/heic_meta_box_alloc.heic");
+?>
+--EXPECTF--
+Warning: exif_read_data(heic_meta_box_alloc.heic): Invalid HEIF file in %s on line %d
+bool(false)


### PR DESCRIPTION
`exif_scan_HEIF_header()` takes the meta box size straight from the file and allocates it with only a lower bound of 36, so a 37-byte HEIF claiming a 128MB box forces that allocation before a single byte is read. `memory_limit` stops it, so this is hardening rather than a vulnerability, but the same block already bounds its second allocation by `pos.size < ImageInfo->FileSize` and the first one should match.

```php
$ftyp = pack("N", 20) . "ftypheic" . str_repeat("\x00", 8);
$meta = pack("N", 0x08000000) . "meta" . str_repeat("\x00", 8);
file_put_contents("t.heic", $ftyp . $meta . "\x00");
exif_read_data("t.heic");
```

With memory_limit=32M that is "Allowed memory size of 33554432 bytes exhausted (tried to allocate 134217720 bytes)" from a 37-byte file. PHP-8.4 has no HEIF parser, so this starts at 8.5.
