### PR TITLE
standard: deprecate passing objects to http_build_query()

### DIFF
--- a/ext/standard/http.c
+++ b/ext/standard/http.c
@@ -158,6 +158,11 @@ PHPAPI void php_url_encode_hash_ex(HashTable *ht, smart_str *formstr,
 		if (Z_TYPE_P(zdata) == IS_ARRAY
 		 || (Z_TYPE_P(zdata) == IS_OBJECT
 		  && !(Z_OBJCE_P(zdata)->ce_flags & ZEND_ACC_ENUM))) {
+			if (Z_TYPE_P(zdata) == IS_OBJECT) {
+				php_error_docref(NULL, E_DEPRECATED,
+					"object values within argument #1 $data to http_build_query() being interpreted as arrays is deprecated,"
+					" instead the $data argument should be preprocessed with get_object_vars()");
+			}
 			zend_string *new_prefix;
 			if (key) {
 				zend_string *encoded_key;
@@ -236,9 +241,13 @@ PHP_FUNCTION(http_build_query)
 		Z_PARAM_LONG(enc_type)
 	ZEND_PARSE_PARAMETERS_END();
 
-	if (UNEXPECTED(Z_TYPE_P(formdata) == IS_OBJECT && (Z_OBJCE_P(formdata)->ce_flags & ZEND_ACC_ENUM))) {
-		zend_argument_type_error(1, "must not be an enum, %s given", zend_zval_value_name(formdata));
-		RETURN_THROWS();
+	if (UNEXPECTED(Z_TYPE_P(formdata) == IS_OBJECT)) {
+		if (Z_OBJCE_P(formdata)->ce_flags & ZEND_ACC_ENUM) {
+			zend_argument_type_error(1, "must not be an enum, %s given", zend_zval_value_name(formdata));
+			RETURN_THROWS();
+		}
+		php_error_docref(NULL, E_DEPRECATED,
+			"Passing an object for argument #1 $data to http_build_query() is deprecated, call get_object_vars() first instead");
 	}
 
 	php_url_encode_hash_ex(HASH_OF(formdata), &formstr, prefix, prefix_len, /* key_prefix */ NULL, (Z_TYPE_P(formdata) == IS_OBJECT ? formdata : NULL), arg_sep, (int)enc_type);

--- a/ext/standard/tests/http/http_build_query/bug26817.phpt
+++ b/ext/standard/tests/http/http_build_query/bug26817.phpt
@@ -21,6 +21,9 @@ $obj = new test();
 $obj->foo();
 var_dump(http_build_query($obj));
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: http_build_query(): Passing an object for argument #1 $data to http_build_query() is deprecated, call get_object_vars() first instead in %s on line %d
 string(27) "foo=lala&bar=meuh&test=test"
+
+Deprecated: http_build_query(): Passing an object for argument #1 $data to http_build_query() is deprecated, call get_object_vars() first instead in %s on line %d
 string(9) "test=test"

--- a/ext/standard/tests/http/http_build_query/http_build_query_object_basic.phpt
+++ b/ext/standard/tests/http/http_build_query/http_build_query_object_basic.phpt
@@ -13,5 +13,6 @@ $o = new KeyVal();
 // Percent encoded "public=input"
 var_dump(http_build_query($o));
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: http_build_query(): Passing an object for argument #1 $data to http_build_query() is deprecated, call get_object_vars() first instead in %s on line %d
 string(12) "public=input"

--- a/ext/standard/tests/http/http_build_query/http_build_query_object_empty.phpt
+++ b/ext/standard/tests/http/http_build_query/http_build_query_object_empty.phpt
@@ -7,5 +7,6 @@ $o = new EmptyObj();
 
 var_dump(http_build_query($o));
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: http_build_query(): Passing an object for argument #1 $data to http_build_query() is deprecated, call get_object_vars() first instead in %s on line %d
 string(0) ""

--- a/ext/standard/tests/http/http_build_query/http_build_query_object_just_stringable.phpt
+++ b/ext/standard/tests/http/http_build_query/http_build_query_object_just_stringable.phpt
@@ -15,8 +15,15 @@ var_dump(http_build_query($o));
 var_dump(http_build_query(['hello', $o], numeric_prefix: 'prefix_'));
 var_dump(http_build_query($o, numeric_prefix: 'prefix_'));
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: http_build_query(): object values within argument #1 $data to http_build_query() being interpreted as arrays is deprecated, instead the $data argument should be preprocessed with get_object_vars() in %s on line %d
 string(7) "0=hello"
+
+Deprecated: http_build_query(): Passing an object for argument #1 $data to http_build_query() is deprecated, call get_object_vars() first instead in %s on line %d
 string(0) ""
+
+Deprecated: http_build_query(): object values within argument #1 $data to http_build_query() being interpreted as arrays is deprecated, instead the $data argument should be preprocessed with get_object_vars() in %s on line %d
 string(14) "prefix_0=hello"
+
+Deprecated: http_build_query(): Passing an object for argument #1 $data to http_build_query() is deprecated, call get_object_vars() first instead in %s on line %d
 string(0) ""

--- a/ext/standard/tests/http/http_build_query/http_build_query_object_key_val_stringable.phpt
+++ b/ext/standard/tests/http/http_build_query/http_build_query_object_key_val_stringable.phpt
@@ -16,5 +16,6 @@ $o = new KeyValStringable();
 
 var_dump(http_build_query($o));
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: http_build_query(): Passing an object for argument #1 $data to http_build_query() is deprecated, call get_object_vars() first instead in %s on line %d
 string(12) "public=input"

--- a/ext/standard/tests/http/http_build_query/http_build_query_object_nested.phpt
+++ b/ext/standard/tests/http/http_build_query/http_build_query_object_nested.phpt
@@ -16,5 +16,8 @@ $o->public = $nested;
 // Percent encoded "public[public]=input"
 var_dump(http_build_query($o));
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: http_build_query(): Passing an object for argument #1 $data to http_build_query() is deprecated, call get_object_vars() first instead in %s on line %d
+
+Deprecated: http_build_query(): object values within argument #1 $data to http_build_query() being interpreted as arrays is deprecated, instead the $data argument should be preprocessed with get_object_vars() in %s on line %d
 string(24) "public%5Bpublic%5D=input"

--- a/ext/standard/tests/http/http_build_query/http_build_query_object_recursif.phpt
+++ b/ext/standard/tests/http/http_build_query/http_build_query_object_recursif.phpt
@@ -13,5 +13,8 @@ $o->public = $o;
 
 var_dump(http_build_query($o));
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: http_build_query(): Passing an object for argument #1 $data to http_build_query() is deprecated, call get_object_vars() first instead in %s on line %d
+
+Deprecated: http_build_query(): object values within argument #1 $data to http_build_query() being interpreted as arrays is deprecated, instead the $data argument should be preprocessed with get_object_vars() in %s on line %d
 string(0) ""

--- a/ext/standard/tests/http/http_build_query/http_build_query_variation1.phpt
+++ b/ext/standard/tests/http/http_build_query/http_build_query_variation1.phpt
@@ -20,6 +20,9 @@ $obj->sort = 'desc,name';
 echo http_build_query($obj) . PHP_EOL;
 echo http_build_query(new UrlBuilder());
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: http_build_query(): Passing an object for argument #1 $data to http_build_query() is deprecated, call get_object_vars() first instead in %s on line %d
 name=homepage&page=1&sort=desc%2Cname
+
+Deprecated: http_build_query(): Passing an object for argument #1 $data to http_build_query() is deprecated, call get_object_vars() first instead in %s on line %d
 name=homepage&page=1


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/deprecations_php_8_6#passing_objects_for_data_parameter_of_http_build_query