### PR TITLE
ext/curl/config.m4: include string.h for test using strncmp()

### DIFF
--- a/ext/curl/config.m4
+++ b/ext/curl/config.m4
@@ -24,6 +24,7 @@ if test "$PHP_CURL" != "no"; then
 
       AC_RUN_IFELSE([AC_LANG_PROGRAM([
 #include <stdio.h>
+#include <string.h>
 #include <strings.h>
 #include <curl/curl.h>
 ], [


### PR DESCRIPTION
https://github.com/php/php-src/commit/2ecafd41ba updates one of the curl `./configure` tests to use `strncmp()`, but that function may not be defined unless `string.h` is included. We add it here.