### PR TITLE
ext/mysqli: Deprecate mysqli_stmt_init

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -81,7 +81,9 @@ PHP                                                                        NEWS
   . Passing objects to mb_convert_variables() is now deprecated. (Girgias)
 
 - MySQLi:
-  . The mysqli_get_charset() function is now deprecated. (Kamil Tekiela)
+  . The mysqli_get_charset() function and mysqli::get_charset() method is now deprecated. (Kamil Tekiela)
+  . The mysqli_stmt_init() function and mysqli::stmt_init() method are now deprecated. (Kamil Tekiela)
+  . Instantiation of mysqli_stmt without providing the $query parameter is now deprecated. (Kamil Tekiela)
 
 - PDO:
   . Fixed pdo_raise_impl_error() emitting a warning under ERRMODE_SILENT.

--- a/NEWS
+++ b/NEWS
@@ -81,7 +81,7 @@ PHP                                                                        NEWS
   . Passing objects to mb_convert_variables() is now deprecated. (Girgias)
 
 - MySQLi:
-  . The mysqli_get_charset() function and mysqli::get_charset() method is now deprecated. (Kamil Tekiela)
+  . The mysqli_get_charset() function and mysqli::get_charset() method are now deprecated. (Kamil Tekiela)
   . The mysqli_stmt_init() function and mysqli::stmt_init() method are now deprecated. (Kamil Tekiela)
   . Instantiation of mysqli_stmt without providing the $query parameter is now deprecated. (Kamil Tekiela)
 

--- a/UPGRADING
+++ b/UPGRADING
@@ -473,8 +473,11 @@ PHP 8.6 UPGRADE NOTES
     RFC: https://wiki.php.net/rfc/deprecations_php_8_6#passing_objects_for_vars_parameter_of_mb_convert_variables
 
 - MySQLi:
-  . The mysqli_get_charset() function is now deprecated.
+  . The mysqli_get_charset() function and mysqli::get_charset() method are now deprecated.
     RFC: https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_mysqli_get_charset
+  . The mysqli_stmt_init() function, mysqli::stmt_init() method, and calling mysqli_stmt constructor
+    without providing the $query parameter are now deprecated.
+    RFC: https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_mysqlistmt_init
 
 - SPL:
   . The spl_classes() function is now deprecated, use

--- a/ext/mysqli/mysqli.c
+++ b/ext/mysqli/mysqli.c
@@ -674,6 +674,8 @@ PHP_METHOD(mysqli_stmt, __construct)
 			RETURN_FALSE;
 		}
 		mysqli_resource->status = MYSQLI_STATUS_VALID;
+	} else {
+		zend_error(E_DEPRECATED, "Instantiation of mysqli_stmt without providing the $query parameter is deprecated");
 	}
 }
 

--- a/ext/mysqli/mysqli.stub.php
+++ b/ext/mysqli/mysqli.stub.php
@@ -996,6 +996,7 @@ class mysqli
      * @tentative-return-type
      * @alias mysqli_stmt_init
      */
+    #[\Deprecated(since: '8.6', message: 'use mysqli::prepare() instead')]
     public function stmt_init(): mysqli_stmt|false {}
 
     /**
@@ -1610,6 +1611,7 @@ function mysqli_stmt_get_result(mysqli_stmt $statement): mysqli_result|false {}
 function mysqli_stmt_get_warnings(mysqli_stmt $statement): mysqli_warning|false {}
 
 /** @refcount 1 */
+#[\Deprecated(since: '8.6', message: 'use mysqli_prepare() instead')]
 function mysqli_stmt_init(mysqli $mysql): mysqli_stmt|false {}
 
 /** @refcount 1 */

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit mysqli.stub.php instead.
- * Stub hash: d31c6ff508415337f4536e8e476168882e769158 */
+ * Stub hash: f5327d48b275a5358b740232281478c83bb8a3db */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
 	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
@@ -913,7 +913,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(mysqli_stmt_free_result, arginfo_mysqli_stmt_free_result)
 	ZEND_FE(mysqli_stmt_get_result, arginfo_mysqli_stmt_get_result)
 	ZEND_FE(mysqli_stmt_get_warnings, arginfo_mysqli_stmt_get_warnings)
-	ZEND_FE(mysqli_stmt_init, arginfo_mysqli_stmt_init)
+	ZEND_RAW_FENTRY("mysqli_stmt_init", zif_mysqli_stmt_init, arginfo_mysqli_stmt_init, ZEND_ACC_DEPRECATED, NULL, NULL)
 	ZEND_FE(mysqli_stmt_insert_id, arginfo_mysqli_stmt_insert_id)
 	ZEND_FE(mysqli_stmt_more_results, arginfo_mysqli_stmt_more_results)
 	ZEND_FE(mysqli_stmt_next_result, arginfo_mysqli_stmt_next_result)
@@ -978,7 +978,7 @@ static const zend_function_entry class_mysqli_methods[] = {
 	ZEND_RAW_FENTRY("set_opt", zif_mysqli_options, arginfo_class_mysqli_set_opt, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("ssl_set", zif_mysqli_ssl_set, arginfo_class_mysqli_ssl_set, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("stat", zif_mysqli_stat, arginfo_class_mysqli_stat, ZEND_ACC_PUBLIC, NULL, NULL)
-	ZEND_RAW_FENTRY("stmt_init", zif_mysqli_stmt_init, arginfo_class_mysqli_stmt_init, ZEND_ACC_PUBLIC, NULL, NULL)
+	ZEND_RAW_FENTRY("stmt_init", zif_mysqli_stmt_init, arginfo_class_mysqli_stmt_init, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED, NULL, NULL)
 	ZEND_RAW_FENTRY("store_result", zif_mysqli_store_result, arginfo_class_mysqli_store_result, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("thread_safe", zif_mysqli_thread_safe, arginfo_class_mysqli_thread_safe, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("use_result", zif_mysqli_use_result, arginfo_class_mysqli_use_result, ZEND_ACC_PUBLIC, NULL, NULL)
@@ -1189,6 +1189,13 @@ static void register_mysqli_symbols(int module_number)
 	attribute_Deprecated_func_mysqli_ping_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "mysqli_real_connect", sizeof("mysqli_real_connect") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+
+	zend_attribute *attribute_Deprecated_func_mysqli_stmt_init_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mysqli_stmt_init", sizeof("mysqli_stmt_init") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	ZVAL_STR(&attribute_Deprecated_func_mysqli_stmt_init_0->args[0].value, ZSTR_KNOWN(ZEND_STR_8_DOT_6));
+	attribute_Deprecated_func_mysqli_stmt_init_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zend_string *attribute_Deprecated_func_mysqli_stmt_init_0_arg1_str = zend_string_init("use mysqli_prepare() instead", strlen("use mysqli_prepare() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_mysqli_stmt_init_0->args[1].value, attribute_Deprecated_func_mysqli_stmt_init_0_arg1_str);
+	attribute_Deprecated_func_mysqli_stmt_init_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
 	zend_attribute *attribute_Deprecated_func_mysqli_refresh_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mysqli_refresh", sizeof("mysqli_refresh") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	ZVAL_STR(&attribute_Deprecated_func_mysqli_refresh_0->args[0].value, ZSTR_KNOWN(ZEND_STR_8_DOT_4));
@@ -1502,6 +1509,13 @@ static zend_class_entry *register_class_mysqli(void)
 	attribute_Deprecated_func_ping_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "real_connect", sizeof("real_connect") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+
+	zend_attribute *attribute_Deprecated_func_stmt_init_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "stmt_init", sizeof("stmt_init") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	ZVAL_STR(&attribute_Deprecated_func_stmt_init_0->args[0].value, ZSTR_KNOWN(ZEND_STR_8_DOT_6));
+	attribute_Deprecated_func_stmt_init_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zend_string *attribute_Deprecated_func_stmt_init_0_arg1_str = zend_string_init("use mysqli::prepare() instead", strlen("use mysqli::prepare() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_stmt_init_0->args[1].value, attribute_Deprecated_func_stmt_init_0_arg1_str);
+	attribute_Deprecated_func_stmt_init_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
 	zend_attribute *attribute_Deprecated_func_refresh_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "refresh", sizeof("refresh") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	ZVAL_STR(&attribute_Deprecated_func_refresh_0->args[0].value, ZSTR_KNOWN(ZEND_STR_8_DOT_4));

--- a/ext/mysqli/tests/bug38710.phpt
+++ b/ext/mysqli/tests/bug38710.phpt
@@ -11,8 +11,7 @@ require_once 'skipifconnectfailure.inc';
 require_once 'connect.inc';
 
 $db = new my_mysqli($host, $user, $passwd, $db, $port, $socket);
-$qry=$db->stmt_init();
-$qry->prepare("SELECT REPEAT('a',100000)");
+$qry=$db->prepare("SELECT REPEAT('a',100000)");
 $qry->execute();
 $qry->bind_result($text);
 $qry->fetch();

--- a/ext/mysqli/tests/bug42378.phpt
+++ b/ext/mysqli/tests/bug42378.phpt
@@ -50,12 +50,6 @@ memory_limit=83886080
 
     function test_format($link, $format, $from, $order_by, $expected, $offset) {
 
-        if (!$stmt = mysqli_stmt_init($link)) {
-            printf("[%03d] Cannot create PS, [%d] %s\n",
-                $offset,
-                mysqli_errno($link), mysqli_error($link));
-            return false;
-        }
         print "$format\n";
 
         if ($order_by)
@@ -63,10 +57,10 @@ memory_limit=83886080
         else
             $sql = sprintf('SELECT %s AS _format FROM %s', $format, $from);
 
-        if (!mysqli_stmt_prepare($stmt, $sql)) {
+        if (!$stmt = mysqli_prepare($link, $sql)) {
             printf("[%03d] Cannot prepare PS, [%d] %s\n",
                 $offset + 1,
-                mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
+                mysqli_errno($link), mysqli_error($link));
             return false;
         }
 

--- a/ext/mysqli/tests/bug55653.phpt
+++ b/ext/mysqli/tests/bug55653.phpt
@@ -16,11 +16,10 @@ require_once 'skipifconnectfailure.inc';
 
     $in_and_out = "a";
 
-    if (!($stmt = $link->stmt_init()))
+    if (!($stmt = $link->prepare("SELECT ?")))
         printf("[002] [%d] %s\n", $link->errno, $link->error);
 
-    if (!($stmt->prepare("SELECT ?")) ||
-        !($stmt->bind_param("s", $in_and_out)) ||
+    if (!($stmt->bind_param("s", $in_and_out)) ||
         !($stmt->execute()) ||
         !($stmt->bind_result($in_and_out)))
         printf("[003] [%d] %s\n", $stmt->errno, $stmt->error);

--- a/ext/mysqli/tests/bug66043.phpt
+++ b/ext/mysqli/tests/bug66043.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug #66043 (Segfault calling bind_param() on mysqli)
+Bug #66043 (Segfault calling bind_param() on mysqli) - Calling mysql_stmt::bind_result() without storing it's result value in a variable is causing a segfault.
 --EXTENSIONS--
 mysqli
 --SKIPIF--
@@ -9,38 +9,13 @@ require_once 'skipifconnectfailure.inc';
 --FILE--
 <?php
 require 'connect.inc';
-if (!$db = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
-    printf("[001] Connect failed, [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());
-}
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+$db = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket);
 
-if (!$db->query("DROP TABLE IF EXISTS test")) {
-    printf("[002] [%d] %s\n", mysqli_errno($db), mysqli_error($db));
-    die();
-}
-
-if (!$db->query("CREATE TABLE test(str TEXT)")) {
-    printf("[003] [%d] %s\n", mysqli_errno($db), mysqli_error($db));
-    die();
-}
-
-if (!$db->query("INSERT INTO test(str) VALUES ('Test')")) {
-    printf("[004] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-    die();
-}
-
-$stmt = $db->stmt_init();
-if (!$stmt->prepare("SELECT str FROM test")) {
-    printf("[004] [%d] %s\n", mysqli_errno($db), mysqli_error($db));
-    die();
-}
-
+$stmt = $db->prepare("SELECT 'Test'");
 $stmt->execute();
 $stmt->bind_result($testArg);
 echo "Okey";
-?>
---CLEAN--
-<?php
-require_once 'clean_table.inc';
 ?>
 --EXPECT--
 Okey

--- a/ext/mysqli/tests/mysqli_class_mysqli_stmt_interface.phpt
+++ b/ext/mysqli/tests/mysqli_class_mysqli_stmt_interface.phpt
@@ -132,6 +132,7 @@ printf("stmt->unknown = '%s'\n", @$stmt->unknown);
 print "done!";
 ?>
 --EXPECTF--
+Deprecated: Instantiation of mysqli_stmt without providing the $query parameter is deprecated in %s on line %d
 Parent class:
 bool(false)
 

--- a/ext/mysqli/tests/mysqli_explain_metadata.phpt
+++ b/ext/mysqli/tests/mysqli_explain_metadata.phpt
@@ -59,9 +59,8 @@ require_once 'skipifconnectfailure.inc';
 
     mysqli_free_result($res);
 
-    $stmt = mysqli_stmt_init($link);
-    /* Depending on your version, the MySQL server migit not support this */
-    if ($stmt->prepare('EXPLAIN SELECT t1.*, t2.* FROM test AS t1, test AS t2') && $stmt->execute()) {
+    /* Depending on your version, the MySQL server might not support this */
+    if (($stmt = $link->prepare('EXPLAIN SELECT t1.*, t2.* FROM test AS t1, test AS t2')) && $stmt->execute()) {
         if (!mysqli_stmt_store_result($stmt))
             printf("[008] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 

--- a/ext/mysqli/tests/mysqli_get_client_stats.phpt
+++ b/ext/mysqli/tests/mysqli_get_client_stats.phpt
@@ -310,13 +310,12 @@ mysqli.allow_local_infile=1
     mysqli_get_client_stats_assert_eq('flushed_normal_sets', $info, $expected, $test_counter);
 
     print "Testing buffered Prepared Statements...\n";
-    if (!$stmt = mysqli_stmt_init($link))
-        printf("[%03d] stmt_init() failed, [%d] %s\n",
+    if (!$stmt = mysqli_prepare($link, 'SELECT id, label FROM test'))
+        printf("[%03d] mysqli_prepare() failed, [%d] %s\n",
             ++$test_counter, mysqli_errno($link), mysqli_error($link));
 
-    if (!mysqli_stmt_prepare($stmt, 'SELECT id, label FROM test') ||
-            !mysqli_stmt_execute($stmt))
-        printf("[%03d] prepare/execute failed, [%d] %s\n",
+    if (!mysqli_stmt_execute($stmt))
+        printf("[%03d] mysqli_stmt_execute() failed, [%d] %s\n",
             ++$test_counter, mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     /* by default PS is unbuffered - no change */

--- a/ext/mysqli/tests/mysqli_get_client_stats_ps.phpt
+++ b/ext/mysqli/tests/mysqli_get_client_stats_ps.phpt
@@ -19,12 +19,11 @@ mysqlnd.collect_memory_statistics=1
     printf("BEGINNING: rows_fetched_from_client_ps_buffered = %d\n",	$stats['rows_fetched_from_client_ps_buffered']);
     printf("BEGINNING: rows_fetched_from_client_ps_cursor = %d\n",	$stats['rows_fetched_from_client_ps_cursor']);
 
-    if (!$stmt = mysqli_stmt_init($link))
+    if (!$stmt = mysqli_prepare($link, 'SELECT id FROM test'))
         printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
     $id = null;
-    if (!mysqli_stmt_prepare($stmt, 'SELECT id FROM test') ||
-            !mysqli_stmt_execute($stmt) ||
+    if (!mysqli_stmt_execute($stmt) ||
             !mysqli_stmt_store_result($stmt) ||
             !mysqli_stmt_bind_result($stmt, $id))
         printf("[002] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));

--- a/ext/mysqli/tests/mysqli_report.phpt
+++ b/ext/mysqli/tests/mysqli_report.phpt
@@ -33,6 +33,7 @@ require_once 'skipifconnectfailure.inc';
     */
     mysqli_report(MYSQLI_REPORT_ERROR);
 
+    $stmt = mysqli_prepare($link, "DO 1");
     mysqli_multi_query($link, "BAR; FOO;");
     mysqli_query($link, "FOO");
     try {
@@ -51,7 +52,6 @@ require_once 'skipifconnectfailure.inc';
     mysqli_autocommit($link, true);
     mysqli_commit($link);
     mysqli_rollback($link);
-    $stmt = mysqli_stmt_init($link);
     mysqli_stmt_prepare($stmt, "SELECT id FROM test WHERE id > ?");
     while(mysqli_more_results($link)) {
         mysqli_next_result($link);
@@ -63,6 +63,7 @@ require_once 'skipifconnectfailure.inc';
     // not have been set. If that would be the case, the test would be broken.
     mysqli_report(MYSQLI_REPORT_OFF);
 
+    $stmt = mysqli_prepare($link, "DO 1");
     mysqli_multi_query($link, "BAR; FOO;");
     mysqli_query($link, "FOO");
     try {
@@ -78,7 +79,6 @@ require_once 'skipifconnectfailure.inc';
     mysqli_autocommit($link, true);
     mysqli_commit($link);
     mysqli_rollback($link);
-    $stmt = mysqli_stmt_init($link);
     mysqli_stmt_prepare($stmt, "SELECT id FROM test WHERE id > ?");
     while(mysqli_more_results($link)) {
         mysqli_next_result($link);
@@ -92,11 +92,10 @@ require_once 'skipifconnectfailure.inc';
 
     mysqli_report(MYSQLI_REPORT_ERROR);
 
-    $stmt = mysqli_stmt_init($link);
+    $stmt = mysqli_prepare($link, "DO 1");
     mysqli_stmt_prepare($stmt, "FOO");
 
-    $stmt = mysqli_stmt_init($link);
-    mysqli_stmt_prepare($stmt, "SELECT id FROM test WHERE id > ?");
+    $stmt = mysqli_prepare($link, "SELECT id FROM test WHERE id > ?");
     $id = 1;
     mysqli_kill($link, mysqli_thread_id($link));
     mysqli_stmt_bind_param($stmt, "i", $id);
@@ -106,11 +105,10 @@ require_once 'skipifconnectfailure.inc';
     /* mysqli_stmt_execute() = mysql_stmt_execute cannot be tested from PHP */
     if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
             printf("[008] [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());
-    $stmt = mysqli_stmt_init($link);
-    mysqli_stmt_prepare($stmt, "SELECT id FROM test WHERE id > ?");
+    $stmt = mysqli_prepare($link, "SELECT id FROM test WHERE id > ?");
     $id = 1;
     mysqli_stmt_bind_param($stmt, "i", $id);
-    // mysqli_kill($link, mysqli_thread_id($link));
+    mysqli_kill($link, mysqli_thread_id($link));
     mysqli_stmt_execute($stmt);
     mysqli_stmt_close($stmt);
     mysqli_close($link);
@@ -126,11 +124,10 @@ require_once 'skipifconnectfailure.inc';
 
     if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
         printf("[010] [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());
-    $stmt = mysqli_stmt_init($link);
+    $stmt = mysqli_prepare($link, "DO 1");
     mysqli_stmt_prepare($stmt, "FOO");
 
-    $stmt = mysqli_stmt_init($link);
-    mysqli_stmt_prepare($stmt, "SELECT id FROM test WHERE id > ?");
+    $stmt = mysqli_prepare($link, "SELECT id FROM test WHERE id > ?");
     $id = 1;
     mysqli_kill($link, mysqli_thread_id($link));
     mysqli_stmt_bind_param($stmt, "i", $id);
@@ -139,8 +136,7 @@ require_once 'skipifconnectfailure.inc';
 
     if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
         printf("[011] [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());
-    $stmt = mysqli_stmt_init($link);
-    mysqli_stmt_prepare($stmt, "SELECT id FROM test WHERE id > ?");
+    $stmt = mysqli_prepare($link, "SELECT id FROM test WHERE id > ?");
     $id = 1;
     mysqli_stmt_bind_param($stmt, "i", $id);
     mysqli_kill($link, mysqli_thread_id($link));
@@ -257,7 +253,7 @@ require_once 'skipifconnectfailure.inc';
     if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
         printf("[024] [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());
 
-    if (!$stmt = mysqli_stmt_init($link))
+    if (!$stmt = mysqli_prepare($link, 'SELECT id * 3 FROM test'))
         printf("[025] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
     if (!mysqli_stmt_prepare($stmt, 'SELECT id, label FROM test'))
@@ -283,11 +279,6 @@ require_once 'skipifconnectfailure.inc';
         printf("[031]  [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
     mysqli_free_result($res);
-
-    if (!$stmt = mysqli_prepare($link, 'SELECT id * 3 FROM test'))
-        printf("[032] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-    else
-        mysqli_stmt_close($stmt);
 
     if (!mysqli_query($link, "INSERT INTO test(id, label) VALUES (100, 'z')", MYSQLI_USE_RESULT) ||
             !mysqli_query($link, 'DELETE FROM test WHERE id > 50', MYSQLI_USE_RESULT))
@@ -330,6 +321,10 @@ mysqli_kill(): Argument #2 ($process_id) must be greater than 0
 Warning: mysqli_stmt_prepare(): (%d/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'FOO' at line 1 in %s on line %d
 
 Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s
+
+Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s
+
+Warning: mysqli_stmt_execute(): (HY000/2006): MySQL server has gone away in %s on line %d
 
 Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s
 

--- a/ext/mysqli/tests/mysqli_stmt_affected_rows.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_affected_rows.phpt
@@ -14,10 +14,12 @@ require_once 'skipifconnectfailure.inc';
         printf("Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
             $host, $user, $db, $port, $socket);
     }
-    $stmt = mysqli_stmt_init($link);
 
-    if (!mysqli_stmt_prepare($stmt, 'DROP TABLE IF EXISTS test') ||
-        !mysqli_stmt_execute($stmt)) {
+    if (!$stmt = mysqli_prepare($link, 'DROP TABLE IF EXISTS test')) {
+        printf("[000] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+    }
+
+    if (!mysqli_stmt_execute($stmt)) {
         printf("[003] Failed to drop old test table: [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
     }
 
@@ -30,59 +32,71 @@ require_once 'skipifconnectfailure.inc';
         printf("[005] Expecting int/0, got %s/'%s'\n", gettype($tmp), $tmp);
 
     mysqli_stmt_close($stmt);
-    $stmt = mysqli_stmt_init($link);
 
-    if (!mysqli_stmt_prepare($stmt, "INSERT INTO test(id, label) VALUES (1, 'a')") ||
-        !mysqli_stmt_execute($stmt))
+    if (!$stmt = mysqli_prepare($link, "INSERT INTO test(id, label) VALUES (1, 'a')")) {
+        printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+    }
+
+    if (!mysqli_stmt_execute($stmt))
         printf("[006] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     mysqli_stmt_close($stmt);
-    $stmt = mysqli_stmt_init($link);
 
-    if (!mysqli_stmt_prepare($stmt, "INSERT INTO test(id, label) VALUES (100, 'z')") ||
-        !mysqli_stmt_execute($stmt))
+    if (!$stmt = mysqli_prepare($link, "INSERT INTO test(id, label) VALUES (100, 'z')")) {
+        printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+    }
+
+    if (!mysqli_stmt_execute($stmt))
         printf("[007] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     if (1 !== ($tmp = mysqli_stmt_affected_rows($stmt)))
         printf("[008] Expecting int/1, got %s/%s\n", gettype($tmp), $tmp);
 
     mysqli_stmt_close($stmt);
-    $stmt = mysqli_stmt_init($link);
 
-    if (!mysqli_stmt_prepare($stmt, "INSERT INTO test(id, label) VALUES (100, 'z')") ||
-        !mysqli_stmt_execute($stmt))
+    if (!$stmt = mysqli_prepare($link, "INSERT INTO test(id, label) VALUES (100, 'z')")) {
+        printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+    }
+
+    if (!mysqli_stmt_execute($stmt))
         // NOTE: the error message varies with the MySQL Server version, dump only the error code!
         printf("[009] [%d] (error message varies with the MySQL Server version, check the error code)\n", mysqli_stmt_errno($stmt));
 
     /* an error occurred: affected rows should return -1 */
     if (-1 !== ($tmp = mysqli_stmt_affected_rows($stmt)))
-        printf("[010] Expecting int/0, got %s/%s\n", gettype($tmp), $tmp);
+        printf("[010] Expecting int/-1, got %s/%s\n", gettype($tmp), $tmp);
 
     mysqli_stmt_close($stmt);
-    $stmt = mysqli_stmt_init($link);
 
-    if (!mysqli_stmt_prepare($stmt, "INSERT INTO test(id, label) VALUES (1, 'a') ON DUPLICATE KEY UPDATE id = 4") ||
-        !mysqli_stmt_execute($stmt))
+    if (!$stmt = mysqli_prepare($link, "INSERT INTO test(id, label) VALUES (1, 'a') ON DUPLICATE KEY UPDATE id = 4")) {
+        printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+    }
+
+    if (!mysqli_stmt_execute($stmt))
         printf("[011] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     if (2 !== ($tmp = mysqli_stmt_affected_rows($stmt)))
         printf("[012] Expecting int/2, got %s/%s\n", gettype($tmp), $tmp);
 
     mysqli_stmt_close($stmt);
-    $stmt = mysqli_stmt_init($link);
 
-    if (!mysqli_stmt_prepare($stmt, "INSERT INTO test(id, label) VALUES (2, 'b'), (3, 'c')") ||
-        !mysqli_stmt_execute($stmt))
+    if (!$stmt = mysqli_prepare($link, "INSERT INTO test(id, label) VALUES (2, 'b'), (3, 'c')")) {
+        printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+    }
+
+    if (!mysqli_stmt_execute($stmt))
         printf("[013] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     if (2 !== ($tmp = mysqli_stmt_affected_rows($stmt)))
         printf("[014] Expecting int/2, got %s/%s\n", gettype($tmp), $tmp);
 
     mysqli_stmt_close($stmt);
-    $stmt = mysqli_stmt_init($link);
 
-    if (!mysqli_stmt_prepare($stmt, "INSERT IGNORE INTO test(id, label) VALUES (1, 'a')") ||
-        !mysqli_stmt_execute($stmt))
+    if (!$stmt = mysqli_prepare($link, "INSERT IGNORE INTO test(id, label) VALUES (1, 'a')")) {
+        printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+    }
+
+    if (!mysqli_stmt_execute($stmt))
         printf("[015] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     if (1 !== ($tmp = mysqli_stmt_affected_rows($stmt)))
@@ -95,40 +109,48 @@ require_once 'skipifconnectfailure.inc';
     mysqli_free_result($res);
 
     mysqli_stmt_close($stmt);
-    $stmt = mysqli_stmt_init($link);
 
-    if (!mysqli_stmt_prepare($stmt, "INSERT INTO test(id, label) SELECT id + 10, label FROM test") ||
-        !mysqli_stmt_execute($stmt))
+    if (!$stmt = mysqli_prepare($link, "INSERT INTO test(id, label) SELECT id + 10, label FROM test")) {
+        printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+    }
+
+    if (!mysqli_stmt_execute($stmt))
         printf("[018] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     if ($num !== ($tmp = mysqli_stmt_affected_rows($stmt)))
         printf("[019] Expecting int/%d, got %s/%s\n", $num, gettype($tmp), $tmp);
 
     mysqli_stmt_close($stmt);
-    $stmt = mysqli_stmt_init($link);
 
-    if (!mysqli_stmt_prepare($stmt, "REPLACE INTO test(id, label) values (4, 'd')") ||
-        !mysqli_stmt_execute($stmt))
+    if (!$stmt = mysqli_prepare($link, "REPLACE INTO test(id, label) values (4, 'd')")) {
+        printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+    }
+
+    if (!mysqli_stmt_execute($stmt))
         printf("[020] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     if (2 !== ($tmp = mysqli_stmt_affected_rows($stmt)))
         printf("[021] Expecting int/2, got %s/%s\n", gettype($tmp), $tmp);
 
     mysqli_stmt_close($stmt);
-    $stmt = mysqli_stmt_init($link);
 
-    if (!mysqli_stmt_prepare($stmt, "REPLACE INTO test(id, label) values (5, 'e')") ||
-        !mysqli_stmt_execute($stmt))
+    if (!$stmt = mysqli_prepare($link, "REPLACE INTO test(id, label) values (5, 'e')")) {
+        printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+    }
+
+    if (!mysqli_stmt_execute($stmt))
         printf("[022] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     if (1 !== ($tmp = mysqli_stmt_affected_rows($stmt)))
         printf("[023] Expecting int/1, got %s/%s\n", gettype($tmp), $tmp);
 
     mysqli_stmt_close($stmt);
-    $stmt = mysqli_stmt_init($link);
 
-    if (!mysqli_stmt_prepare($stmt, "UPDATE test SET label = 'a' WHERE id = 2") ||
-        !mysqli_stmt_execute($stmt))
+    if (!$stmt = mysqli_prepare($link, "UPDATE test SET label = 'a' WHERE id = 2")) {
+        printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+    }
+
+    if (!mysqli_stmt_execute($stmt))
         printf("[024] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     if (1 !== ($tmp = mysqli_stmt_affected_rows($stmt)))
@@ -142,10 +164,12 @@ require_once 'skipifconnectfailure.inc';
         printf("[027] Expecting int/0, got %s/%s\n", gettype($tmp), $tmp);
 
     mysqli_stmt_close($stmt);
-    $stmt = mysqli_stmt_init($link);
 
-    if (!mysqli_stmt_prepare($stmt, "UPDATE test SET label = 'a' WHERE id = 100") ||
-        !mysqli_stmt_execute($stmt))
+    if (!$stmt = mysqli_prepare($link, "UPDATE test SET label = 'a' WHERE id = 100")) {
+        printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+    }
+
+    if (!mysqli_stmt_execute($stmt))
         printf("[028] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     if (1 !== ($tmp = mysqli_stmt_affected_rows($stmt)))
@@ -174,10 +198,12 @@ require_once 'skipifconnectfailure.inc';
 
     mysqli_stmt_free_result($stmt);
     mysqli_stmt_close($stmt);
-    $stmt = mysqli_stmt_init($link);
 
-    if (!mysqli_stmt_prepare($stmt, 'SELECT label FROM test WHERE 1 = 2') ||
-        !mysqli_stmt_execute($stmt))
+    if (!$stmt = mysqli_prepare($link, 'SELECT label FROM test WHERE 1 = 2')) {
+        printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+    }
+
+    if (!mysqli_stmt_execute($stmt))
         printf("[036] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     /* use it like num_rows */
@@ -212,10 +238,12 @@ require_once 'skipifconnectfailure.inc';
         printf("[045] Expecting int/-1, got %s/%s\n", gettype($tmp), $tmp);
 
     mysqli_stmt_close($stmt);
-    $stmt = mysqli_stmt_init($link);
 
-    if (!mysqli_stmt_prepare($stmt, "DROP TABLE IF EXISTS test") ||
-        !mysqli_stmt_execute($stmt))
+    if (!$stmt = mysqli_prepare($link, "DROP TABLE IF EXISTS test")) {
+        printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+    }
+
+    if (!mysqli_stmt_execute($stmt))
         printf("[046] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     mysqli_stmt_close($stmt);

--- a/ext/mysqli/tests/mysqli_stmt_attr_get.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_attr_get.phpt
@@ -15,8 +15,7 @@ require_once 'skipifconnectfailure.inc';
         MYSQLI_STMT_ATTR_CURSOR_TYPE,
     );
 
-    $stmt = mysqli_stmt_init($link);
-    mysqli_stmt_prepare($stmt, 'SELECT * FROM test');
+    $stmt = mysqli_prepare($link, 'SELECT * FROM test');
 
     try {
         mysqli_stmt_attr_get($stmt, -100);

--- a/ext/mysqli/tests/mysqli_stmt_attr_set.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_attr_set.phpt
@@ -36,8 +36,7 @@ require_once 'skipifconnectfailure.inc';
     // MYSQLI_STMT_ATTR_UPDATE_MAX_LENGTH
     //
     // expecting max_length not to be set and be 0 in all cases
-    $stmt = mysqli_stmt_init($link);
-    $stmt->prepare("SELECT label FROM test");
+    $stmt = $link->prepare("SELECT label FROM test");
     $stmt->execute();
     $stmt->store_result();
     $res = $stmt->result_metadata();
@@ -50,8 +49,7 @@ require_once 'skipifconnectfailure.inc';
     $stmt->close();
 
     // MYSQLI_STMT_ATTR_UPDATE_MAX_LENGTH is no longer supported, expect no change in behavior.
-    $stmt = mysqli_stmt_init($link);
-    $stmt->prepare("SELECT label FROM test");
+    $stmt = $link->prepare("SELECT label FROM test");
     var_dump($stmt->attr_set(MYSQLI_STMT_ATTR_UPDATE_MAX_LENGTH, 1));
     $res = $stmt->attr_get(MYSQLI_STMT_ATTR_UPDATE_MAX_LENGTH);
     if ($res !== 1)
@@ -68,8 +66,7 @@ require_once 'skipifconnectfailure.inc';
     $stmt->close();
 
     // expecting max_length not to be set
-    $stmt = mysqli_stmt_init($link);
-    $stmt->prepare("SELECT label FROM test");
+    $stmt = $link->prepare("SELECT label FROM test");
     $stmt->attr_set(MYSQLI_STMT_ATTR_UPDATE_MAX_LENGTH, 0);
     $res = $stmt->attr_get(MYSQLI_STMT_ATTR_UPDATE_MAX_LENGTH);
     if ($res !== 0)
@@ -90,8 +87,7 @@ require_once 'skipifconnectfailure.inc';
     //
 
 
-    $stmt = mysqli_stmt_init($link);
-    $stmt->prepare("SELECT id, label FROM test");
+    $stmt = $link->prepare("SELECT id, label FROM test");
 
     // Invalid cursor type
     try {
@@ -108,8 +104,7 @@ require_once 'skipifconnectfailure.inc';
 
     $stmt->close();
 
-    $stmt = mysqli_stmt_init($link);
-    $stmt->prepare("SELECT id, label FROM test");
+    $stmt = $link->prepare("SELECT id, label FROM test");
     $stmt->execute();
     $id = $label = NULL;
     $stmt->bind_result($id, $label);
@@ -120,8 +115,7 @@ require_once 'skipifconnectfailure.inc';
     if (empty($results))
         printf("[015] Results should not be empty, subsequent tests will probably fail!\n");
 
-    $stmt = mysqli_stmt_init($link);
-    $stmt->prepare("SELECT id, label FROM test");
+    $stmt = $link->prepare("SELECT id, label FROM test");
     if (true !== ($tmp = $stmt->attr_set(MYSQLI_STMT_ATTR_CURSOR_TYPE, MYSQLI_CURSOR_TYPE_NO_CURSOR)))
         printf("[016] Expecting boolean/true, got %s/%s\n", gettype($tmp), $tmp);
     $stmt->execute();
@@ -137,8 +131,7 @@ require_once 'skipifconnectfailure.inc';
         var_dump($results2);
     }
 
-    $stmt = mysqli_stmt_init($link);
-    $stmt->prepare("SELECT id, label FROM test");
+    $stmt = $link->prepare("SELECT id, label FROM test");
     if (true !== ($tmp = $stmt->attr_set(MYSQLI_STMT_ATTR_CURSOR_TYPE, MYSQLI_CURSOR_TYPE_READ_ONLY)))
         printf("[018] Expecting boolean/true, got %s/%s\n", gettype($tmp), $tmp);
     $stmt->execute();
@@ -161,7 +154,8 @@ require_once 'skipifconnectfailure.inc';
 <?php
     require_once 'clean_table.inc';
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function mysqli_stmt_init() is deprecated since 8.6, use mysqli_prepare() instead in %s on line %d
 Error: mysqli_stmt object is not fully initialized
 mysqli_stmt_attr_set(): Argument #2 ($attribute) must be either MYSQLI_STMT_ATTR_UPDATE_MAX_LENGTH or MYSQLI_STMT_ATTR_CURSOR_TYPE
 mysqli_stmt::attr_set(): Argument #2 ($value) must be 0 or 1 for attribute MYSQLI_STMT_ATTR_UPDATE_MAX_LENGTH

--- a/ext/mysqli/tests/mysqli_stmt_bind_param.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_bind_param.phpt
@@ -19,9 +19,8 @@ require_once 'skipifconnectfailure.inc';
     */
     require 'table.inc';
 
-    $stmt = mysqli_stmt_init($link);
-    if (!mysqli_stmt_prepare($stmt, "INSERT INTO test(id, label) VALUES (?, ?)"))
-        printf("[003] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
+    if (!$stmt = mysqli_prepare($link, "INSERT INTO test(id, label) VALUES (?, ?)"))
+        printf("[003] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
     $id = null;
     $label = null;
@@ -136,13 +135,8 @@ require_once 'skipifconnectfailure.inc';
             return false;
         }
 
-        if (!$stmt = mysqli_stmt_init($link)) {
+        if (!$stmt = mysqli_prepare($link, "INSERT INTO test(id, label) VALUE (?, ?)")) {
             printf("[%03d] [%d] %s\n", $offset + 1, mysqli_errno($link), mysqli_error($link));
-            return false;
-        }
-
-        if (!mysqli_stmt_prepare($stmt, "INSERT INTO test(id, label) VALUE (?, ?)")) {
-            printf("[%03d] [%d] %s\n", $offset + 2, mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
             return false;
         }
 
@@ -333,9 +327,8 @@ require_once 'skipifconnectfailure.inc';
     if (mysqli_get_server_version($link) >= 50600)
         func_mysqli_stmt_bind_datatype($link, $engine, "s", "TIME", "13:27:34.123456", 890, "13:27:34");
 
-    $stmt = mysqli_stmt_init($link);
-    if (!mysqli_stmt_prepare($stmt, "INSERT INTO test(id, label) VALUES (?, ?)"))
-        printf("[2000] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
+    if (!$stmt = mysqli_prepare($link, "INSERT INTO test(id, label) VALUES (?, ?)"))
+        printf("[2000] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
     $id = null;
     $label = null;
@@ -350,11 +343,8 @@ require_once 'skipifconnectfailure.inc';
     mysqli_stmt_close($stmt);
     include 'table.inc';
 
-    if (!$stmt = mysqli_stmt_init($link))
+    if (!$stmt = mysqli_prepare($link, "INSERT INTO test(id, label) VALUES (?, ?)"))
         printf("[2003] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
-    if (!mysqli_stmt_prepare($stmt, "INSERT INTO test(id, label) VALUES (?, ?)"))
-        printf("[2004] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     $id = $label = null;
     if (true !== ($tmp = $stmt->bind_param('is', $id, $label)))

--- a/ext/mysqli/tests/mysqli_stmt_bind_param_call_user_func.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_bind_param_call_user_func.phpt
@@ -11,11 +11,8 @@ require_once 'skipifconnectfailure.inc';
     require 'connect.inc';
     require 'table.inc';
 
-    if (!$stmt = mysqli_stmt_init($link))
+    if (!$stmt = mysqli_prepare($link, 'SELECT id, label FROM test WHERE id = ?'))
         printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
-    if (!mysqli_stmt_prepare($stmt, 'SELECT id, label FROM test WHERE id = ?'))
-        printf("[002] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     $id = 1;
     if (!mysqli_stmt_bind_param($stmt, 'i', $id) ||
@@ -32,11 +29,8 @@ require_once 'skipifconnectfailure.inc';
     var_dump($label);
 
     mysqli_stmt_close($stmt);
-    if (!$stmt = mysqli_stmt_init($link))
+    if (!$stmt = mysqli_prepare($link, 'SELECT id, label FROM test WHERE id = ?'))
         printf("[005] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
-    if (!mysqli_stmt_prepare($stmt, 'SELECT id, label FROM test WHERE id = ?'))
-        printf("[006] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     $types = 'i';
     $id = 1;
@@ -61,11 +55,8 @@ require_once 'skipifconnectfailure.inc';
     var_dump($label);
 
     mysqli_stmt_close($stmt);
-    if (!$stmt = mysqli_stmt_init($link))
+    if (!$stmt = mysqli_prepare($link, 'SELECT id, label FROM test WHERE id = ?'))
         printf("[010] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
-    if (!mysqli_stmt_prepare($stmt, 'SELECT id, label FROM test WHERE id = ?'))
-        printf("[011] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     $types = 'i';
     $id = 1;
@@ -89,11 +80,8 @@ require_once 'skipifconnectfailure.inc';
     var_dump($label);
 
     mysqli_stmt_close($stmt);
-    if (!$stmt = mysqli_stmt_init($link))
+    if (!$stmt = mysqli_prepare($link, 'SELECT id, label FROM test WHERE id = ?'))
         printf("[015] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
-    if (!mysqli_stmt_prepare($stmt, 'SELECT id, label FROM test WHERE id = ?'))
-        printf("[016] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     $types = 'i';
     $id = 1;
@@ -117,11 +105,8 @@ require_once 'skipifconnectfailure.inc';
     var_dump($label);
 
     mysqli_stmt_close($stmt);
-    if (!$stmt = mysqli_stmt_init($link))
+    if (!$stmt = mysqli_prepare($link, 'SELECT id, label FROM test WHERE id = ?'))
         printf("[020] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
-    if (!mysqli_stmt_prepare($stmt, 'SELECT id, label FROM test WHERE id = ?'))
-        printf("[021] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     $id = 1;
     $params = array(
@@ -144,11 +129,8 @@ require_once 'skipifconnectfailure.inc';
     var_dump($label);
 
     mysqli_stmt_close($stmt);
-    if (!$stmt = mysqli_stmt_init($link))
+    if (!$stmt = mysqli_prepare($link, 'SELECT id, label FROM test WHERE id = ?'))
         printf("[025] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
-    if (!mysqli_stmt_prepare($stmt, 'SELECT id, label FROM test WHERE id = ?'))
-        printf("[026] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     $types = 'i';
     $id = 1;
@@ -173,11 +155,8 @@ require_once 'skipifconnectfailure.inc';
     var_dump($label);
 
     mysqli_stmt_close($stmt);
-    if (!$stmt = mysqli_stmt_init($link))
+    if (!$stmt = mysqli_prepare($link, 'SELECT id, label FROM test WHERE id = ?'))
         printf("[025] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
-    if (!mysqli_stmt_prepare($stmt, 'SELECT id, label FROM test WHERE id = ?'))
-        printf("[026] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     $types = 'i';
     $id = 1;
@@ -202,11 +181,8 @@ require_once 'skipifconnectfailure.inc';
     var_dump($label);
 
     mysqli_stmt_close($stmt);
-    if (!$stmt = mysqli_stmt_init($link))
+    if (!$stmt = mysqli_prepare($link, 'SELECT id, label FROM test WHERE id = ?'))
         printf("[030] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
-    if (!mysqli_stmt_prepare($stmt, 'SELECT id, label FROM test WHERE id = ?'))
-        printf("[031] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     $types = 'i';
     $id = 1;
@@ -231,11 +207,8 @@ require_once 'skipifconnectfailure.inc';
     var_dump($label);
 
     mysqli_stmt_close($stmt);
-    if (!$stmt = mysqli_stmt_init($link))
+    if (!$stmt = mysqli_prepare($link, 'SELECT id, label FROM test WHERE id = ?'))
         printf("[035] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
-    if (!mysqli_stmt_prepare($stmt, 'SELECT id, label FROM test WHERE id = ?'))
-        printf("[036] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     $id = 1;
     $params = array(
@@ -259,11 +232,8 @@ require_once 'skipifconnectfailure.inc';
     var_dump($label);
 
     mysqli_stmt_close($stmt);
-    if (!$stmt = mysqli_stmt_init($link))
+    if (!$stmt = mysqli_prepare($link, 'SELECT id, label FROM test WHERE id = ?'))
         printf("[040] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
-    if (!mysqli_stmt_prepare($stmt, 'SELECT id, label FROM test WHERE id = ?'))
-        printf("[041] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     $id = 1;
     if (!call_user_func_array('mysqli_stmt_bind_param', array($stmt, 'i', &$id)))
@@ -285,11 +255,8 @@ require_once 'skipifconnectfailure.inc';
     // Any of those shall fail - see also bugs.php.net/43568
     //
     mysqli_stmt_close($stmt);
-    if (!$stmt = mysqli_stmt_init($link))
+    if (!$stmt = mysqli_prepare($link, 'SELECT id, label FROM test WHERE id = ?'))
         printf("[045] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
-    if (!mysqli_stmt_prepare($stmt, 'SELECT id, label FROM test WHERE id = ?'))
-        printf("[046] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     $id = 1;
     $params = array(
@@ -303,11 +270,8 @@ require_once 'skipifconnectfailure.inc';
         printf("[048] [%d] (Message might vary with MySQL Server version, e.g. No data supplied for parameters in prepared statement)\n", mysqli_stmt_errno($stmt));
 
     mysqli_stmt_close($stmt);
-    if (!$stmt = mysqli_stmt_init($link))
+    if (!$stmt = mysqli_prepare($link, 'SELECT id, label FROM test WHERE id = ?'))
         printf("[049] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
-    if (!mysqli_stmt_prepare($stmt, 'SELECT id, label FROM test WHERE id = ?'))
-        printf("[050] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     $id = 1;
     $params = array(

--- a/ext/mysqli/tests/mysqli_stmt_bind_param_references.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_bind_param_references.phpt
@@ -55,14 +55,13 @@ require_once 'skipifconnectfailure.inc';
     // or we will get dups around [28]
     mysqli_query($link, "ALTER TABLE test DROP PRIMARY KEY");
 
-    $stmt = mysqli_stmt_init($link);
-    if (!mysqli_stmt_prepare($stmt, "INSERT INTO test(id, label) VALUES (?, ?)"))
-        printf("[001] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
+    if (!($stmt = mysqli_prepare($link, "INSERT INTO test(id, label) VALUES (?, ?)")))
+        printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
     $id = 100;
     $label = 'v';
     if (true !== ($tmp = mysqli_stmt_bind_param($stmt, "is", $id, $label)))
-        printf("[002] Expecting boolean/false, got %s/%s\n", gettype($tmp), $tmp);
+        printf("[002] Expecting boolean/true, got %s/%s\n", gettype($tmp), $tmp);
 
     if (true !== mysqli_stmt_execute($stmt))
         printf("[003] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));

--- a/ext/mysqli/tests/mysqli_stmt_bind_param_type_juggling.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_bind_param_type_juggling.phpt
@@ -24,13 +24,8 @@ require_once 'skipifconnectfailure.inc';
             return false;
         }
 
-        if (!$stmt = mysqli_stmt_init($link)) {
+        if (!$stmt = mysqli_prepare($link, "INSERT INTO test(col1, col2) VALUES (?, ?)")) {
             printf("[%03d + 3] [%d] %s\n", $offset, mysqli_errno($link), mysqli_error($link));
-            return false;
-        }
-
-        if (!mysqli_stmt_prepare($stmt, "INSERT INTO test(col1, col2) VALUES (?, ?)")) {
-            printf("[%03d + 4] [%d] %s\n", $offset, mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
             return false;
         }
 

--- a/ext/mysqli/tests/mysqli_stmt_bind_result.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_bind_result.phpt
@@ -10,9 +10,11 @@ require_once 'skipifconnectfailure.inc';
 <?php
     require 'table.inc';
 
-    $stmt = mysqli_stmt_init($link);
-    if (!mysqli_stmt_prepare($stmt, "SELECT id, label FROM test ORDER BY id LIMIT 1"))
-        printf("[002a] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
+    if (!($stmt = mysqli_prepare($link, "SELECT id, label FROM test ORDER BY id LIMIT 1")))
+        printf("[002a] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+
+    if (!mysqli_stmt_bind_result($stmt, $id, $label))
+        printf("[002b] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     mysqli_stmt_close($stmt);
     $stmt = mysqli_stmt_init($link);
@@ -67,13 +69,8 @@ require_once 'skipifconnectfailure.inc';
             return false;
         }
 
-        if (!$stmt = mysqli_stmt_init($link)) {
+        if (!$stmt = mysqli_prepare($link, "INSERT INTO test(id, label) VALUES (?, ?)")) {
             printf("[%04d] [%d] %s\n", $offset + 1, mysqli_errno($link), mysqli_error($link));
-            return false;
-        }
-
-        if (!mysqli_stmt_prepare($stmt, "INSERT INTO test(id, label) VALUES (?, ?)")) {
-            printf("[%04d] [%d] %s\n", $offset + 2, mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
             return false;
         }
 
@@ -91,10 +88,8 @@ require_once 'skipifconnectfailure.inc';
         }
         mysqli_stmt_close($stmt);
 
-        $stmt = mysqli_stmt_init($link);
-
-        if (!mysqli_stmt_prepare($stmt, "SELECT id, label FROM test")) {
-            printf("[%04d] [%d] %s\n", $offset + 7, mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
+        if (!($stmt = mysqli_prepare($link, "SELECT id, label FROM test"))) {
+            printf("[%04d] [%d] %s\n", $offset + 7, mysqli_errno($link), mysqli_error($link));
             return false;
         }
 
@@ -267,9 +262,8 @@ require_once 'skipifconnectfailure.inc';
     if (mysqli_get_server_version($link) >= 50600)
         func_mysqli_stmt_bind_result($link, $engine, "s", "TIME(6)", "13:31:34.123456", 1770);
 
-    $stmt = mysqli_stmt_init($link);
-    if (!mysqli_stmt_prepare($stmt, "INSERT INTO test(id, label) VALUES (1000, 'z')"))
-        printf("[3001] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
+    if (!($stmt = mysqli_prepare($link, "INSERT INTO test(id, label) VALUES (1000, 'z')")))
+        printf("[3001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
     $id = null;
     try {
@@ -288,6 +282,7 @@ require_once 'skipifconnectfailure.inc';
     require_once 'clean_table.inc';
 ?>
 --EXPECTF--
+Deprecated: Function mysqli_stmt_init() is deprecated since 8.6, use mysqli_prepare() instead in %s on line %d
 mysqli_stmt object is not fully initialized
 Number of bind variables doesn't match number of fields in prepared statement
 Number of bind variables doesn't match number of fields in prepared statement

--- a/ext/mysqli/tests/mysqli_stmt_bind_result_bit.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_bind_result_bit.phpt
@@ -48,21 +48,9 @@ require_once 'skipifconnectfailure.inc';
             // don't bail - column type might not be supported by the server, ignore this
             continue;
         }
-        if (!$stmt_ins = mysqli_stmt_init($link_ins)) {
+        if (!$stmt_ins = mysqli_prepare($link_ins, "INSERT INTO test(id, bit_value) VALUES (?, ?)")) {
             printf("[004 - %d] [%d] %s\n", $bits, mysqli_errno($link_ins), mysqli_error($link_ins));
             continue;
-        }
-
-        if (!mysqli_stmt_prepare($stmt_ins, "INSERT INTO test(id, bit_value) VALUES (?, ?)")) {
-            printf("[005 - %d] [%d] %s\n", $bits, mysqli_stmt_errno($stmt_ins), mysqli_stmt_error($stmt_ins));
-            mysqli_stmt_close($stmt_ins);
-            continue;
-        }
-
-        if (!($stmt_sel = mysqli_stmt_init($link_sel))) {
-            printf("[006 - %d] [%d] %s\n", $bits, mysqli_errno($link_sel), mysqli_error($link_sel));
-            mysqli_stmt_close($stmt_ins);
-                continue;
         }
 
         $tests = 0;
@@ -101,8 +89,12 @@ require_once 'skipifconnectfailure.inc';
                 break;
             }
             $sql = sprintf("SELECT id, BIN(bit_value) AS _bin, bit_value, bit_value + 0 AS _bit_value0, bit_null FROM test WHERE id = %s", $value);
-            if ((!mysqli_stmt_prepare($stmt_sel, $sql)) ||
-                (!mysqli_stmt_execute($stmt_sel))) {
+            unset($stmt_sel); // Unset the variable first, otherwise we would get Out of sync error
+            if (!($stmt_sel = mysqli_prepare($link_sel, $sql))) {
+                printf("[009 - %d] [%d] %s\n", $bits, mysqli_errno($link_sel), mysqli_error($link_sel));
+                break;
+            }
+            if (!mysqli_stmt_execute($stmt_sel)) {
                 printf("[009 - %d] [%d] %s\n", $bits, mysqli_stmt_errno($stmt_sel), mysqli_stmt_error($stmt_sel));
                 break;
             }

--- a/ext/mysqli/tests/mysqli_stmt_bind_result_format.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_bind_result_format.phpt
@@ -49,22 +49,15 @@ memory_limit=83886080
 
     function test_format($link, $format, $from, $order_by, $expected, $offset) {
 
-        if (!$stmt = mysqli_stmt_init($link)) {
-            printf("[%03d] Cannot create PS, [%d] %s\n",
-                $offset,
-                mysqli_errno($link), mysqli_error($link));
-            return false;
-        }
-
         if ($order_by)
             $sql = sprintf('SELECT %s AS _format FROM %s ORDER BY %s', $format, $from, $order_by);
         else
             $sql = sprintf('SELECT %s AS _format FROM %s', $format, $from);
 
-        if (!mysqli_stmt_prepare($stmt, $sql)) {
+        if (!$stmt = mysqli_prepare($link, $sql)) {
             printf("[%03d] Cannot prepare PS, [%d] %s\n",
                 $offset + 1,
-                mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
+                mysqli_errno($link), mysqli_error($link));
             return false;
         }
 
@@ -244,13 +237,8 @@ memory_limit=83886080
             }
             krsort($values);
 
-            if (!$stmt = mysqli_stmt_init($link)) {
+            if (!$stmt = mysqli_prepare($link, 'SELECT trend, targetport, FORMAT(trend, 2) FROM test WHERE current_targets > 0 AND trend IS NOT NULL ORDER BY trend DESC LIMIT 100')) {
                 printf("[302] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-                break;
-            }
-
-            if (!mysqli_stmt_prepare($stmt, 'SELECT trend, targetport, FORMAT(trend, 2) FROM test WHERE current_targets > 0 AND trend IS NOT NULL ORDER BY trend DESC LIMIT 100')) {
-                printf("[303] [%d] %s\n", mysqli_stmt_errno($link), mysqli_stmt_error($link));
                 break;
             }
 
@@ -284,13 +272,8 @@ memory_limit=83886080
             mysqli_stmt_close($stmt);
 
             // same but OO interface
-            if (!$stmt = mysqli_stmt_init($link)) {
+            if (!$stmt = $link->prepare('SELECT trend, targetport, FORMAT(trend, 2) FROM test WHERE current_targets > 0 AND trend IS NOT NULL ORDER BY trend DESC LIMIT 100')) {
                 printf("[307] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-                break;
-            }
-
-            if (!$stmt->prepare('SELECT trend, targetport, FORMAT(trend, 2) FROM test WHERE current_targets > 0 AND trend IS NOT NULL ORDER BY trend DESC LIMIT 100')) {
-                printf("[308] [%d] %s\n", mysqli_stmt_errno($link), mysqli_stmt_error($link));
                 break;
             }
 

--- a/ext/mysqli/tests/mysqli_stmt_bind_result_references.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_bind_result_references.phpt
@@ -10,12 +10,8 @@ require_once 'skipifconnectfailure.inc';
 <?php
     require 'table.inc';
 
-    $stmt = mysqli_stmt_init($link);
-    if (!mysqli_stmt_prepare($stmt, "SELECT id, label FROM test ORDER BY id LIMIT 1"))
-        printf("[001] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
-
-    if (!mysqli_stmt_prepare($stmt, "SELECT id, label FROM test ORDER BY id LIMIT 1"))
-        printf("[001] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
+    if (!$stmt = mysqli_prepare($link, "SELECT id, label FROM test ORDER BY id LIMIT 1"))
+        printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
 
     print "plain vanilla...\n";

--- a/ext/mysqli/tests/mysqli_stmt_close.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_close.phpt
@@ -13,7 +13,6 @@ require_once 'skipifconnectfailure.inc';
     if (!$stmt = mysqli_stmt_init($link))
         printf("[003] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
-    // Yes, amazing, eh? AFAIK a workaround of a constructor bug...
     try {
         mysqli_stmt_close($stmt);
     } catch (Error $exception) {
@@ -31,11 +30,8 @@ require_once 'skipifconnectfailure.inc';
         echo $exception->getMessage() . "\n";
     }
 
-    if (!$stmt = mysqli_stmt_init($link))
+    if (!$stmt = mysqli_prepare($link, "INSERT INTO test(id, label) VALUES (?, ?)"))
         printf("[008] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
-    if (!mysqli_stmt_prepare($stmt, "INSERT INTO test(id, label) VALUES (?, ?)"))
-        printf("[009] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     $id = $label = null;
     if (!mysqli_stmt_bind_param($stmt, "is", $id, $label))
@@ -52,11 +48,8 @@ require_once 'skipifconnectfailure.inc';
     mysqli_close($link);
 
     require 'table.inc';
-    if (!$stmt = mysqli_stmt_init($link))
+    if (!$stmt = mysqli_prepare($link, "SELECT id, label FROM test"))
         printf("[013] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
-    if (!mysqli_stmt_prepare($stmt, "SELECT id, label FROM test"))
-        printf("[014] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     $id = $label = null;
     if (!mysqli_stmt_bind_result($stmt, $id, $label))
@@ -75,7 +68,8 @@ require_once 'skipifconnectfailure.inc';
 <?php
     require_once 'clean_table.inc';
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function mysqli_stmt_init() is deprecated since 8.6, use mysqli_prepare() instead in %s on line %d
 mysqli_stmt object is not fully initialized
 mysqli_stmt object is already closed
 done!

--- a/ext/mysqli/tests/mysqli_stmt_data_seek.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_data_seek.phpt
@@ -85,7 +85,8 @@ require_once 'skipifconnectfailure.inc';
 <?php
     require_once 'clean_table.inc';
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function mysqli_stmt_init() is deprecated since 8.6, use mysqli_prepare() instead in %s on line %d
 mysqli_stmt object is not fully initialized
 mysqli_stmt_data_seek(): No result set associated with the statement
 int(3)

--- a/ext/mysqli/tests/mysqli_stmt_errno.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_errno.phpt
@@ -55,6 +55,7 @@ require_once 'skipifconnectfailure.inc';
 <?php
     require_once 'clean_table.inc';
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function mysqli_stmt_init() is deprecated since 8.6, use mysqli_prepare() instead in %s on line %d
 mysqli_stmt object is already closed
 done!

--- a/ext/mysqli/tests/mysqli_stmt_error.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_error.phpt
@@ -55,6 +55,7 @@ require_once 'skipifconnectfailure.inc';
 <?php
     require_once 'clean_table.inc';
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function mysqli_stmt_init() is deprecated since 8.6, use mysqli_prepare() instead in %s on line %d
 mysqli_stmt object is already closed
 done!

--- a/ext/mysqli/tests/mysqli_stmt_execute.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_execute.phpt
@@ -54,11 +54,8 @@ require_once 'skipifconnectfailure.inc';
 
     // calling reset between executions
     mysqli_stmt_close($stmt);
-    if (!$stmt = mysqli_stmt_init($link))
+    if (!$stmt = mysqli_prepare($link, "SELECT id FROM test ORDER BY id LIMIT ?"))
         printf("[013] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
-    if (!mysqli_stmt_prepare($stmt, "SELECT id FROM test ORDER BY id LIMIT ?"))
-        printf("[014] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     $limit = 1;
     if (!mysqli_stmt_bind_param($stmt, "i", $limit))
@@ -91,11 +88,8 @@ require_once 'skipifconnectfailure.inc';
         printf("[022] Expecting int/1 got %s/%s\n", gettype($id), $id);
 
     mysqli_stmt_close($stmt);
-    if (!$stmt = mysqli_stmt_init($link))
+    if (!$stmt = mysqli_prepare($link, "SELECT id FROM test ORDER BY id LIMIT 1"))
         printf("[023] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
-    if (!mysqli_stmt_prepare($stmt, "SELECT id FROM test ORDER BY id LIMIT 1"))
-        printf("[024] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     if (true !== ($tmp = mysqli_stmt_execute($stmt)))
         printf("[025] Expecting boolean/true, got %s/%s. [%d] %s\n",
@@ -128,7 +122,8 @@ require_once 'skipifconnectfailure.inc';
 <?php
 require_once 'clean_table.inc';
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function mysqli_stmt_init() is deprecated since 8.6, use mysqli_prepare() instead in %s on line %d
 mysqli_stmt object is not fully initialized
 mysqli_stmt object is not fully initialized
 bool(true)

--- a/ext/mysqli/tests/mysqli_stmt_fetch.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_fetch.phpt
@@ -39,11 +39,8 @@ require_once 'skipifconnectfailure.inc';
         printf("[008] NULL, got %s/%s\n", gettype($tmp), $tmp);
 
     mysqli_stmt_close($stmt);
-    if (!$stmt = mysqli_stmt_init($link))
+    if (!$stmt = mysqli_prepare($link, "SELECT id, label FROM test ORDER BY id LIMIT 2"))
         printf("[009] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
-    if (!mysqli_stmt_prepare($stmt, "SELECT id, label FROM test ORDER BY id LIMIT 2"))
-        printf("[010] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     if (!mysqli_stmt_execute($stmt))
         printf("[011] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
@@ -80,6 +77,7 @@ require_once 'skipifconnectfailure.inc';
     require_once 'clean_table.inc';
 ?>
 --EXPECTF--
+Deprecated: Function mysqli_stmt_init() is deprecated since 8.6, use mysqli_prepare() instead in %s on line %d
 mysqli_stmt object is not fully initialized
 [014] [%d] Commands out of sync; you can't run this command now
 mysqli_stmt object is already closed

--- a/ext/mysqli/tests/mysqli_stmt_fetch_bit.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_fetch_bit.phpt
@@ -29,16 +29,16 @@ if (mysqli_get_server_version($link) < 50003) {
             !mysqli_query($link, $sql = sprintf('CREATE TABLE test(id INT, label BIT(%d)) ENGINE="%s"', $bits, $engine)))
             printf("[002 - %d] [%d] %s\n",$bits, mysqli_errno($link), mysqli_error($link));
 
-        if (!$stmt = mysqli_stmt_init($link))
-            printf("[003 - %d] [%d] %s\n", $bits, mysqli_errno($link), mysqli_error($link));
-
         while ($tests < min($max_value, 20)) {
             $tests++;
             $value = mt_rand(0, $max_value);
             $sql = sprintf("INSERT INTO test(id, label) VALUES (%d, b'%s')", $value, decbin($value));
 
-            if (!mysqli_stmt_prepare($stmt, $sql) ||
-                    !mysqli_stmt_execute($stmt))
+            unset($stmt); // Unset the variable first, otherwise we would get Out of sync error
+            if (!$stmt = mysqli_prepare($link, $sql))
+                printf("[003 - %d] [%d] %s\n", $bits, mysqli_errno($link), mysqli_error($link));
+
+            if (!mysqli_stmt_execute($stmt))
                 printf("[004 - %d] [%d] %s\n", $bits, mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
             $id = $_label0 = $label = null;

--- a/ext/mysqli/tests/mysqli_stmt_fetch_fields_win32_unicode.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_fetch_fields_win32_unicode.phpt
@@ -12,8 +12,7 @@ require_once 'skipifconnectfailure.inc';
     require_once 'table.inc';
 
     $bind_res = $id = null;
-    if (!($stmt = mysqli_stmt_init($link)) ||
-        !mysqli_stmt_prepare($stmt, "SELECT id, label FROM test") ||
+    if (!($stmt = mysqli_prepare($link, "SELECT id, label FROM test")) ||
         !mysqli_stmt_execute($stmt) ||
         !($result = mysqli_stmt_result_metadata($stmt)) ||
         !mysqli_stmt_bind_result($stmt, $id, $bind_res) ||
@@ -26,8 +25,7 @@ require_once 'skipifconnectfailure.inc';
     mysqli_free_result($result);
     mysqli_stmt_close($stmt);
 
-    if (!($stmt = mysqli_stmt_init($link)) ||
-        !mysqli_stmt_prepare($stmt, "SELECT id, label FROM test") ||
+    if (!($stmt = mysqli_prepare($link, "SELECT id, label FROM test")) ||
         !mysqli_stmt_execute($stmt) ||
         !($result = mysqli_stmt_result_metadata($stmt)) ||
         !mysqli_stmt_bind_result($stmt, $id, $bind_res)) {

--- a/ext/mysqli/tests/mysqli_stmt_fetch_geom.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_fetch_geom.phpt
@@ -34,14 +34,8 @@ mysqli
             }
         }
 
-        if (!$stmt = mysqli_stmt_init($link)) {
+        if (!$stmt = mysqli_prepare($link, "SELECT id, label FROM test")) {
             printf("[%04d] [%d] %s\n", $offset + 6, mysqli_errno($link), mysqli_error($link));
-            return false;
-        }
-
-        if (!mysqli_stmt_prepare($stmt, "SELECT id, label FROM test")) {
-            printf("[%04d] [%d] %s\n", $offset + 7, mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
-            mysqli_stmt_close($stmt);
             return false;
         }
 
@@ -78,13 +72,8 @@ mysqli
         mysqli_stmt_close($stmt);
 
         foreach ($rows as $row) {
-            if (!$stmt = mysqli_stmt_init($link)) {
+            if (!$stmt = mysqli_prepare($link, "INSERT INTO test(id, label) VALUES (?, ?)")) {
                 printf("[%04d] [%d] %s\n", $offset + 10, mysqli_errno($link), mysqli_error($link));
-                return false;
-            }
-
-            if (!mysqli_stmt_prepare($stmt, "INSERT INTO test(id, label) VALUES (?, ?)")) {
-                printf("[%04d] [%d] %s\n", $offset + 11, mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
                 return false;
             }
 

--- a/ext/mysqli/tests/mysqli_stmt_field_count.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_field_count.phpt
@@ -93,7 +93,8 @@ require_once 'skipifconnectfailure.inc';
 <?php
     require_once 'clean_table.inc';
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function mysqli_stmt_init() is deprecated since 8.6, use mysqli_prepare() instead in %s on line %d
 mysqli_stmt object is not fully initialized
 mysqli_stmt object is not fully initialized
 The number of variables must match the number of parameters in the prepared statement

--- a/ext/mysqli/tests/mysqli_stmt_free_result.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_free_result.phpt
@@ -40,11 +40,8 @@ require_once 'skipifconnectfailure.inc';
 
     mysqli_stmt_close($stmt);
 
-    if (!$stmt = mysqli_stmt_init($link))
+    if (!$stmt = mysqli_prepare($link, "SELECT id, label FROM test ORDER BY id"))
         printf("[010] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
-    if (!mysqli_stmt_prepare($stmt, "SELECT id, label FROM test ORDER BY id"))
-        printf("[011] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     if (!mysqli_stmt_execute($stmt))
         printf("[012] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
@@ -70,7 +67,8 @@ require_once 'skipifconnectfailure.inc';
 <?php
     require_once 'clean_table.inc';
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function mysqli_stmt_init() is deprecated since 8.6, use mysqli_prepare() instead in %s on line %d
 mysqli_stmt object is not fully initialized
 mysqli_stmt object is already closed
 done!

--- a/ext/mysqli/tests/mysqli_stmt_get_result.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_get_result.phpt
@@ -104,11 +104,8 @@ require_once 'skipifconnectfailure.inc';
     mysqli_stmt_close($stmt);
 
     // get_result can be used in PS cursor mode
-    if (!$stmt = mysqli_stmt_init($link))
+    if (!$stmt = mysqli_prepare($link, "SELECT id, label FROM test ORDER BY id LIMIT 2"))
         printf("[030] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
-    if (!mysqli_stmt_prepare($stmt, "SELECT id, label FROM test ORDER BY id LIMIT 2"))
-        printf("[031] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     if (!mysqli_stmt_attr_set($stmt, MYSQLI_STMT_ATTR_CURSOR_TYPE, MYSQLI_CURSOR_TYPE_READ_ONLY))
         printf("[032] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
@@ -121,11 +118,8 @@ require_once 'skipifconnectfailure.inc';
         var_dump($row);
     }
 
-    if (!$stmt = mysqli_stmt_init($link))
+    if (!$stmt = mysqli_prepare($link, "SELECT id, label FROM test ORDER BY id LIMIT 2"))
         printf("[034] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
-    if (!mysqli_stmt_prepare($stmt, "SELECT id, label FROM test ORDER BY id LIMIT 2"))
-        printf("[035] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     if (!mysqli_stmt_execute($stmt))
         printf("[036] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
@@ -176,8 +170,13 @@ require_once 'skipifconnectfailure.inc';
     require_once 'clean_table.inc';
 ?>
 --EXPECTF--
+Deprecated: Function mysqli_stmt_init() is deprecated since 8.6, use mysqli_prepare() instead in %s on line %d
 mysqli_stmt object is not fully initialized
+
+Deprecated: Function mysqli_stmt_init() is deprecated since 8.6, use mysqli_prepare() instead in %s on line %d
 mysqli_stmt object is not fully initialized
+
+Deprecated: Function mysqli_stmt_init() is deprecated since 8.6, use mysqli_prepare() instead in %s on line %d
 mysqli_stmt object is not fully initialized
 array(2) {
   ["id"]=>

--- a/ext/mysqli/tests/mysqli_stmt_get_result2.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_get_result2.phpt
@@ -15,44 +15,42 @@ require_once 'skipifconnectfailure.inc';
     */
     require 'table.inc';
 
-    if (!$stmt = mysqli_stmt_init($link))
+    if (!$stmt = mysqli_prepare($link, "SELECT id, label FROM test ORDER BY id ASC LIMIT 1"))
         printf("[003] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
-    if (!mysqli_stmt_prepare($stmt, "SELECT id, label FROM test ORDER BY id ASC LIMIT 1"))
-        printf("[005] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
+    if (!mysqli_stmt_execute($stmt))
+        printf("[006] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
-        if (!mysqli_stmt_execute($stmt))
-            printf("[006] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
+    if (!is_object($res = mysqli_stmt_get_result($stmt)) || 'mysqli_result' != get_class($res)) {
+        printf("[007] Expecting object/mysqli_result got %s/%s, [%d] %s\n",
+            gettype($res), $res, mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
+    }
+    while ($row = mysqli_fetch_assoc($res))
+        var_dump($row);
+    var_dump(mysqli_fetch_assoc($res));
+    mysqli_free_result($res);
 
-        if (!is_object($res = mysqli_stmt_get_result($stmt)) || 'mysqli_result' != get_class($res)) {
-            printf("[007] Expecting object/mysqli_result got %s/%s, [%d] %s\n",
-                gettype($res), $res, mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
-        }
-        while ($row = mysqli_fetch_assoc($res))
-            var_dump($row);
-        var_dump(mysqli_fetch_assoc($res));
-        mysqli_free_result($res);
+    if (false !== ($res = mysqli_stmt_get_result($stmt))) {
+        printf("[008] boolean/false got %s/%s, [%d] %s\n",
+            gettype($res), $res, mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
+    }
 
-        if (false !== ($res = mysqli_stmt_get_result($stmt))) {
-            printf("[008] boolean/false got %s/%s, [%d] %s\n",
-                gettype($res), $res, mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
-        }
-
-        mysqli_stmt_execute($stmt);
-        if (!is_object($res = mysqli_stmt_get_result($stmt)) || 'mysqli_result' != get_class($res)) {
-            printf("[009] Expecting object/mysqli_result got %s/%s, [%d] %s\n",
-                gettype($res), $res, mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
-        }
-        while ($row = mysqli_fetch_assoc($res))
-            var_dump($row);
-        var_dump(mysqli_fetch_assoc($res));
-        mysqli_free_result($res);
+    mysqli_stmt_execute($stmt);
+    if (!is_object($res = mysqli_stmt_get_result($stmt)) || 'mysqli_result' != get_class($res)) {
+        printf("[009] Expecting object/mysqli_result got %s/%s, [%d] %s\n",
+            gettype($res), $res, mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
+    }
+    while ($row = mysqli_fetch_assoc($res))
+        var_dump($row);
+    var_dump(mysqli_fetch_assoc($res));
+    mysqli_free_result($res);
 
     mysqli_stmt_close($stmt);
 
-    if (!($stmt = mysqli_stmt_init($link)) ||
-        !mysqli_stmt_prepare($stmt, "SELECT id, label FROM test ORDER BY id ASC LIMIT 2") ||
-        !mysqli_stmt_execute($stmt))
+    if (!$stmt = mysqli_prepare($link, "SELECT id, label FROM test ORDER BY id ASC LIMIT 2"))
+        printf("[010] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+
+    if (!mysqli_stmt_execute($stmt))
         printf("[010] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     $id = $label = null;
@@ -69,9 +67,10 @@ require_once 'skipifconnectfailure.inc';
 
     mysqli_stmt_close($stmt);
 
-    if (!($stmt = mysqli_stmt_init($link)) ||
-        !mysqli_stmt_prepare($stmt, "SELECT id, label FROM test ORDER BY id ASC LIMIT 2") ||
-        !mysqli_stmt_execute($stmt))
+    if (!$stmt = mysqli_prepare($link, "SELECT id, label FROM test ORDER BY id ASC LIMIT 2"))
+        printf("[014] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+
+    if (!mysqli_stmt_execute($stmt))
         printf("[014] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     if (!is_object($res = mysqli_stmt_get_result($stmt)) || 'mysqli_result' != get_class($res)) {
@@ -88,9 +87,10 @@ require_once 'skipifconnectfailure.inc';
 
     mysqli_stmt_close($stmt);
 
-    if (!($stmt = mysqli_stmt_init($link)) ||
-        !mysqli_stmt_prepare($stmt, "SELECT id, label FROM test ORDER BY id ASC LIMIT 2") ||
-        !mysqli_stmt_execute($stmt))
+    if (!$stmt = mysqli_prepare($link, "SELECT id, label FROM test ORDER BY id ASC LIMIT 2"))
+        printf("[018] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+
+    if (!mysqli_stmt_execute($stmt))
         printf("[018] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     if (!is_object($res = mysqli_stmt_get_result($stmt)) || 'mysqli_result' != get_class($res)) {
@@ -109,9 +109,10 @@ require_once 'skipifconnectfailure.inc';
 
     mysqli_stmt_close($stmt);
 
-    if (!($stmt = mysqli_stmt_init($link)) ||
-        !mysqli_stmt_prepare($stmt, "SELECT id, label FROM test ORDER BY id ASC LIMIT 2") ||
-        !mysqli_stmt_execute($stmt))
+    if (!$stmt = mysqli_prepare($link, "SELECT id, label FROM test ORDER BY id ASC LIMIT 2"))
+        printf("[022] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+
+    if (!mysqli_stmt_execute($stmt))
         printf("[022] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     if (!is_object($res = mysqli_stmt_get_result($stmt)) || 'mysqli_result' != get_class($res)) {

--- a/ext/mysqli/tests/mysqli_stmt_get_result_bit.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_get_result_bit.phpt
@@ -47,9 +47,6 @@ if (mysqli_get_server_version($link) < 50003) {
             !mysqli_query($link, $sql = sprintf('CREATE TABLE test(id BIGINT UNSIGNED, bit_value BIT(%d) NOT NULL, bit_null BIT(%d) DEFAULT NULL) ENGINE="%s"', $bits, $bits, $engine)))
             printf("[002 - %d] [%d] %s\n",$bits, mysqli_errno($link), mysqli_error($link));
 
-        if (!$stmt = mysqli_stmt_init($link))
-            printf("[003 - %d] [%d] %s\n", $bits, mysqli_errno($link), mysqli_error($link));
-
         $tests = 0;
         $rand_max = mt_getrandmax();
         while ($tests < 10) {
@@ -77,13 +74,17 @@ if (mysqli_get_server_version($link) < 50003) {
                 ;
             $bin2 = substr($bin, $i, strlen($bin));
 
-            if (!mysqli_stmt_prepare($stmt, $sql) ||
-                    !mysqli_stmt_execute($stmt))
+            if (!$stmt = mysqli_prepare($link, $sql))
+                printf("[003 - %d] [%d] %s\n", $bits, mysqli_errno($link), mysqli_error($link));
+
+            if(!mysqli_stmt_execute($stmt))
                 printf("[004 - %d] [%d] %s\n", $bits, mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
             $sql = sprintf("SELECT bin(bit_value) AS _bin, id, bit_value, bit_null FROM test WHERE id = %s", $value);
-            if (!mysqli_stmt_prepare($stmt, $sql) ||
-                    !mysqli_stmt_execute($stmt))
+            if (!$stmt = mysqli_prepare($link, $sql))
+                printf("[005 - %d] [%d] %s\n", $bits, mysqli_errno($link), mysqli_error($link));
+
+            if(!mysqli_stmt_execute($stmt))
                 printf("[005 - %d] [%d] %s\n", $bits, mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
             if (!$res = mysqli_stmt_get_result($stmt))

--- a/ext/mysqli/tests/mysqli_stmt_get_result_field_count.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_get_result_field_count.phpt
@@ -10,11 +10,8 @@ mysqli
 <?php
     require 'table.inc';
 
-    if (!$stmt = mysqli_stmt_init($link))
+    if (!$stmt = mysqli_prepare($link, "SELECT id, label FROM test ORDER BY id ASC LIMIT 3"))
         printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
-    if (!mysqli_stmt_prepare($stmt, "SELECT id, label FROM test ORDER BY id ASC LIMIT 3"))
-        printf("[002] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     if (!mysqli_stmt_execute($stmt))
         printf("[003] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));

--- a/ext/mysqli/tests/mysqli_stmt_get_result_geom.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_get_result_geom.phpt
@@ -34,14 +34,8 @@ mysqli
             }
         }
 
-        if (!$stmt = mysqli_stmt_init($link)) {
-            printf("[%04d] [%d] %s\n", $offset + 6, mysqli_errno($link), mysqli_error($link));
-            return false;
-        }
-
-        if (!mysqli_stmt_prepare($stmt, "SELECT id, label FROM test")) {
-            printf("[%04d] [%d] %s\n", $offset + 7, mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
-            mysqli_stmt_close($stmt);
+        if (!($stmt = mysqli_prepare($link, "SELECT id, label FROM test"))) {
+            printf("[%04d] [%d] %s\n", $offset + 7, mysqli_errno($link), mysqli_error($link));
             return false;
         }
 
@@ -66,13 +60,8 @@ mysqli
         while ($row = mysqli_fetch_assoc($res)) {
             $bind_res = &$row['label'];
 
-            if (!$stmt2 = mysqli_stmt_init($link)) {
+            if (!($stmt2 = mysqli_prepare($link, "INSERT INTO test(id, label) VALUES (?, ?)"))) {
                 printf("[%04d] [%d] %s\n", $offset + 11, mysqli_errno($link), mysqli_error($link));
-                return false;
-            }
-
-            if (!mysqli_stmt_prepare($stmt2, "INSERT INTO test(id, label) VALUES (?, ?)")) {
-                printf("[%04d] [%d] %s\n", $offset + 12, mysqli_stmt_errno($stmt2), mysqli_stmt_error($stmt2));
                 return false;
             }
 

--- a/ext/mysqli/tests/mysqli_stmt_get_result_metadata.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_get_result_metadata.phpt
@@ -10,11 +10,8 @@ require_once 'skipifconnectfailure.inc';
 <?php
     require 'table.inc';
 
-    if (!$stmt = mysqli_stmt_init($link))
-        printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
-    if (!mysqli_stmt_prepare($stmt, "SELECT id, label FROM test ORDER BY id ASC LIMIT 3"))
-        printf("[002] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
+    if (!$stmt = mysqli_prepare($link, "SELECT id, label FROM test ORDER BY id ASC LIMIT 3"))
+        printf("[002] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
     if (!mysqli_stmt_execute($stmt))
         printf("[003] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
@@ -38,9 +35,10 @@ require_once 'skipifconnectfailure.inc';
     mysqli_stmt_close($stmt);
 
     // !mysqli_stmt_prepare($stmt, "SELECT id, label, id + 1 as _id,  concat(label, '_') _label FROM test as _test ORDER BY id ASC LIMIT 3") ||
-    if (!($stmt = mysqli_stmt_init($link)) ||
-        !mysqli_stmt_prepare($stmt, "SELECT id , label, id + 1 AS _id, label AS _label, null AS _null, CONCAT(label, '_') _label_concat  FROM test _test ORDER BY id ASC LIMIT 3") ||
-        !mysqli_stmt_execute($stmt))
+    if (!$stmt = mysqli_prepare($link, "SELECT id , label, id + 1 AS _id, label AS _label, null AS _null, CONCAT(label, '_') _label_concat  FROM test _test ORDER BY id ASC LIMIT 3"))
+        printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+
+    if(!mysqli_stmt_execute($stmt))
         printf("[006] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     if (!is_object($res = mysqli_stmt_get_result($stmt)) || 'mysqli_result' != get_class($res)) {

--- a/ext/mysqli/tests/mysqli_stmt_get_result_metadata_fetch_field.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_get_result_metadata_fetch_field.phpt
@@ -15,9 +15,10 @@ require_once 'skipifconnectfailure.inc';
     if (!mysqli_set_charset($link, 'utf8'))
         printf("[%d] %s\n", mysqli_errno($link), mysqli_errno($link));
 
-    if (!($stmt = mysqli_stmt_init($link)) ||
-        !mysqli_stmt_prepare($stmt, "SELECT id, label, id + 1 as _id,  concat(label, '_') ___label FROM test ORDER BY id ASC LIMIT 3") ||
-        !mysqli_stmt_execute($stmt))
+    if (!$stmt = mysqli_prepare($link, "SELECT id, label, id + 1 as _id,  concat(label, '_') ___label FROM test ORDER BY id ASC LIMIT 3"))
+        printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+
+    if(!mysqli_stmt_execute($stmt))
         printf("[001] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     if (!is_object($res = mysqli_stmt_get_result($stmt)) || 'mysqli_result' != get_class($res)) {

--- a/ext/mysqli/tests/mysqli_stmt_get_result_non_select.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_get_result_non_select.phpt
@@ -15,14 +15,13 @@ require_once 'skipifconnectfailure.inc';
     */
     require 'table.inc';
 
-    if (!$stmt = mysqli_stmt_init($link))
-        printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
     if (mysqli_query($link, 'PREPARE mystmt FROM "SHOW ENGINES"')) {
         mysqli_query($link, 'DEALLOCATE PREPARE mystmt');
 
-        if (!$stmt->prepare('SHOW ENGINES') ||
-            !$stmt->execute())
+        if (!$stmt = mysqli_prepare($link, "SHOW ENGINES"))
+            printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+
+        if (!$stmt->execute())
             printf("[002] [%d] %s\n", $stmt->errno, $stmt->error);
 
         if (!$res = $stmt->get_result())
@@ -48,8 +47,10 @@ require_once 'skipifconnectfailure.inc';
     if (mysqli_query($link, 'PREPARE mystmt FROM "DESCRIBE test id"')) {
         mysqli_query($link, 'DEALLOCATE PREPARE mystmt');
 
-        if (!$stmt->prepare('DESCRIBE test id') ||
-            !$stmt->execute())
+        if (!$stmt = mysqli_prepare($link, "DESCRIBE test id"))
+            printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+
+        if (!mysqli_stmt_execute($stmt))
             printf("[006] [%d] %s\n", $stmt->errno, $stmt->error);
 
         if (!$res = $stmt->get_result())
@@ -67,8 +68,10 @@ require_once 'skipifconnectfailure.inc';
     if (mysqli_query($link, 'PREPARE mystmt FROM "EXPLAIN SELECT id FROM test"')) {
         mysqli_query($link, 'DEALLOCATE PREPARE mystmt');
 
-        if (!$stmt->prepare('EXPLAIN SELECT id FROM test') ||
-            !$stmt->execute())
+        if (!$stmt = mysqli_prepare($link, "EXPLAIN SELECT id FROM test"))
+            printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+
+        if (!$stmt->execute())
             printf("[009] [%d] %s\n", $stmt->errno, $stmt->error);
 
         if (!$res = $stmt->get_result())

--- a/ext/mysqli/tests/mysqli_stmt_get_result_seek.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_get_result_seek.phpt
@@ -10,11 +10,8 @@ require_once 'skipifconnectfailure.inc';
 <?php
     require 'table.inc';
 
-    if (!$stmt = mysqli_stmt_init($link))
-        printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
-    if (!mysqli_stmt_prepare($stmt, "SELECT id, label FROM test ORDER BY id ASC LIMIT 3"))
-        printf("[002] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
+    if (!$stmt = mysqli_prepare($link, "SELECT id, label FROM test ORDER BY id ASC LIMIT 3"))
+        printf("[002] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
     if (!mysqli_stmt_execute($stmt))
         printf("[003] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
@@ -36,7 +33,7 @@ require_once 'skipifconnectfailure.inc';
     for ($i = 2; $i > 0; $i--) {
         if (!$res->data_seek($i))
             printf("[007] Cannot seek to position %d, [%d] %s\n",
-                $i, mysqli_stmt_errno($stmt), $stmt->error);
+                $i, mysqli_errno($link), mysqli_error($link));
         $row = $res->fetch_array(MYSQLI_BOTH);
         if (($row[0] !== $row['id']) || ($row[0] !== $i + 1)) {
             printf("[008] Record looks wrong, dumping data\n");

--- a/ext/mysqli/tests/mysqli_stmt_get_result_types.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_get_result_types.phpt
@@ -24,13 +24,8 @@ mysqli
             return false;
         }
 
-        if (!$stmt = mysqli_stmt_init($link)) {
-            printf("[%04d] [%d] %s\n", $offset + 1, mysqli_errno($link), mysqli_error($link));
-            return false;
-        }
-
-        if (!mysqli_stmt_prepare($stmt, "INSERT INTO test(id, label) VALUES (?, ?)")) {
-            printf("[%04d] [%d] %s\n", $offset + 2, mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
+        if (!$stmt = mysqli_prepare($link, "INSERT INTO test(id, label) VALUES (?, ?)")) {
+            printf("[%04d] [%d] %s\n", $offset + 2, mysqli_errno($link), mysqli_error($link));
             return false;
         }
 
@@ -48,10 +43,8 @@ mysqli
         }
         mysqli_stmt_close($stmt);
 
-        $stmt = mysqli_stmt_init($link);
-
-        if (!mysqli_stmt_prepare($stmt, "SELECT id, label FROM test")) {
-            printf("[%04d] [%d] %s\n", $offset + 7, mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
+        if (!($stmt = mysqli_prepare($link, "SELECT id, label FROM test"))) {
+            printf("[%04d] [%d] %s\n", $offset + 7, mysqli_errno($link), mysqli_error($link));
             return false;
         }
 

--- a/ext/mysqli/tests/mysqli_stmt_get_warnings.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_get_warnings.phpt
@@ -95,7 +95,8 @@ mysqli_query($link, "DROP TABLE IF EXISTS test");
 <?php
 require_once 'clean_table.inc';
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function mysqli_stmt_init() is deprecated since 8.6, use mysqli_prepare() instead in %s on line %d
 mysqli_stmt object is not fully initialized
 mysqli_stmt object is already closed
 done!

--- a/ext/mysqli/tests/mysqli_stmt_init.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_init.phpt
@@ -20,10 +20,13 @@ require_once 'skipifconnectfailure.inc';
         exit(1);
     }
 
+    if (!is_object($stmt = $link->stmt_init()))
+        printf("[003] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+
     if (!is_object($stmt = mysqli_stmt_init($link)))
         printf("[003] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
-    if (!is_object($stmt2 = @mysqli_stmt_init($link)))
+    if (!is_object($stmt2 = mysqli_stmt_init($link)))
         printf("[003a] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
     try {
@@ -42,7 +45,14 @@ require_once 'skipifconnectfailure.inc';
 
     print "done!";
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Method mysqli::stmt_init() is deprecated since 8.6, use mysqli::prepare() instead in %s on line %d
+
+Deprecated: Function mysqli_stmt_init() is deprecated since 8.6, use mysqli_prepare() instead in %s on line %d
+
+Deprecated: Function mysqli_stmt_init() is deprecated since 8.6, use mysqli_prepare() instead in %s on line %d
 mysqli_stmt object is not fully initialized
+
+Deprecated: Function mysqli_stmt_init() is deprecated since 8.6, use mysqli_prepare() instead in %s on line %d
 mysqli object is already closed
 done!

--- a/ext/mysqli/tests/mysqli_stmt_insert_id.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_insert_id.phpt
@@ -28,9 +28,11 @@ require_once 'skipifconnectfailure.inc';
     mysqli_stmt_close($stmt);
 
     // no auto_increment column
-    $stmt = mysqli_stmt_init($link);
-    if (!mysqli_stmt_prepare($stmt, "INSERT INTO test(id, label) VALUES (100, 'a')") ||
-        !mysqli_stmt_execute($stmt)) {
+    if(!$stmt = mysqli_prepare($link, "INSERT INTO test(id, label) VALUES (100, 'a')")) {
+        printf("[006] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+    }
+
+    if (!mysqli_stmt_execute($stmt)) {
         printf("[006] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
     }
 
@@ -67,7 +69,8 @@ require_once 'skipifconnectfailure.inc';
 <?php
     require_once 'clean_table.inc';
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function mysqli_stmt_init() is deprecated since 8.6, use mysqli_prepare() instead in %s on line %d
 mysqli_stmt object is not fully initialized
 mysqli_stmt object is already closed
 done!

--- a/ext/mysqli/tests/mysqli_stmt_num_rows.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_num_rows.phpt
@@ -103,7 +103,8 @@ require_once 'skipifconnectfailure.inc';
 <?php
     require_once 'clean_table.inc';
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function mysqli_stmt_init() is deprecated since 8.6, use mysqli_prepare() instead in %s on line %d
 run_tests.php don't fool me with your 'ungreedy' expression '.+?'!
 mysqli_stmt object is already closed
 done!

--- a/ext/mysqli/tests/mysqli_stmt_param_count.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_param_count.phpt
@@ -54,7 +54,8 @@ require_once 'skipifconnectfailure.inc';
 <?php
     require_once 'clean_table.inc';
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function mysqli_stmt_init() is deprecated since 8.6, use mysqli_prepare() instead in %s on line %d
 mysqli_stmt object is not fully initialized
 mysqli_stmt object is already closed
 done!

--- a/ext/mysqli/tests/mysqli_stmt_prepare.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_prepare.phpt
@@ -16,7 +16,7 @@ require_once 'skipifconnectfailure.inc';
 
     require 'table.inc';
 
-    if (!$stmt = mysqli_stmt_init($link))
+    if (!$stmt = mysqli_prepare($link, 'DO 1'))
         printf("[003] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
     if (false !== ($tmp = mysqli_stmt_prepare($stmt, '')))

--- a/ext/mysqli/tests/mysqli_stmt_reset.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_reset.phpt
@@ -44,8 +44,6 @@ require_once 'skipifconnectfailure.inc';
 
     var_dump($id);
     mysqli_stmt_close($stmt);
-    if (!$stmt = mysqli_stmt_init($link))
-        printf("[010] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
     if (!mysqli_query($link, "DROP TABLE IF EXISTS test"))
         printf("[011] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
@@ -53,8 +51,8 @@ require_once 'skipifconnectfailure.inc';
     if (!mysqli_query($link, "CREATE TABLE test(id INT NOT NULL AUTO_INCREMENT, label BLOB, PRIMARY KEY(id))"))
         printf("[012] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
-    if (!mysqli_stmt_prepare($stmt, "INSERT INTO test(label) VALUES (?)"))
-        printf("[013] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
+    if (!($stmt = mysqli_prepare($link, "INSERT INTO test(label) VALUES (?)")))
+        printf("[013] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
     $label = null;
     if (!mysqli_stmt_bind_param($stmt, "b", $label))
@@ -98,7 +96,8 @@ require_once 'skipifconnectfailure.inc';
 <?php
     require_once 'clean_table.inc';
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function mysqli_stmt_init() is deprecated since 8.6, use mysqli_prepare() instead in %s on line %d
 mysqli_stmt object is not fully initialized
 int(1)
 mysqli_stmt object is already closed

--- a/ext/mysqli/tests/mysqli_stmt_result_metadata.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_result_metadata.phpt
@@ -86,6 +86,7 @@ require_once 'skipifconnectfailure.inc';
     require_once 'clean_table.inc';
 ?>
 --EXPECTF--
+Deprecated: Function mysqli_stmt_init() is deprecated since 8.6, use mysqli_prepare() instead in %s on line %d
 mysqli_stmt object is not fully initialized
 object(stdClass)#%d (13) {
   ["name"]=>

--- a/ext/mysqli/tests/mysqli_stmt_send_long_data.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_send_long_data.phpt
@@ -11,17 +11,14 @@ require_once 'skipifconnectfailure.inc';
 <?php
     require 'table.inc';
 
-    if (!$stmt = mysqli_stmt_init($link))
-        printf("[003] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
     if (!mysqli_query($link, "DROP TABLE IF EXISTS test"))
         printf("[005] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
     if (!mysqli_query($link, sprintf("CREATE TABLE test(id INT NOT NULL AUTO_INCREMENT, label LONGBLOB, PRIMARY KEY(id)) ENGINE = %s", $engine)))
         printf("[006] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
-    if (!mysqli_stmt_prepare($stmt, "INSERT INTO test(id, label) VALUES (?, ?)"))
-        printf("[007] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
+    if (!$stmt = mysqli_prepare($link, "INSERT INTO test(id, label) VALUES (?, ?)"))
+        printf("[007] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
     $id = null;
     $label = null;

--- a/ext/mysqli/tests/mysqli_stmt_send_long_data_packet_size_mysqlnd.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_send_long_data_packet_size_mysqlnd.phpt
@@ -10,17 +10,14 @@ require_once 'skipifconnectfailure.inc';
 <?php
     require 'table.inc';
 
-    if (!$stmt = mysqli_stmt_init($link))
-        printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
     if (!mysqli_query($link, "DROP TABLE IF EXISTS test"))
         printf("[002] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
     if (!mysqli_query($link, sprintf("CREATE TABLE test(id INT NOT NULL AUTO_INCREMENT, label LONGBLOB, PRIMARY KEY(id)) ENGINE = %s", $engine)))
         printf("[003] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
-    if (!mysqli_stmt_prepare($stmt, "INSERT INTO test(id, label) VALUES (?, ?)"))
-        printf("[004] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
+    if (!$stmt = mysqli_prepare($link, "INSERT INTO test(id, label) VALUES (?, ?)"))
+        printf("[004] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
     $id = null;
     $label = null;

--- a/ext/mysqli/tests/mysqli_stmt_sqlstate.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_sqlstate.phpt
@@ -47,7 +47,8 @@ require_once 'skipifconnectfailure.inc';
 <?php
     require_once 'clean_table.inc';
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function mysqli_stmt_init() is deprecated since 8.6, use mysqli_prepare() instead in %s on line %d
 mysqli_stmt object is not fully initialized
 mysqli_stmt object is already closed
 done!

--- a/ext/mysqli/tests/mysqli_stmt_store_result.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_store_result.phpt
@@ -34,11 +34,10 @@ require_once 'skipifconnectfailure.inc';
     if (!$link_buf = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
         printf("[009] [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());
 
-    if (!$stmt_buf = mysqli_stmt_init($link_buf))
+    if (!$stmt_buf = mysqli_prepare($link_buf, "SELECT id, label FROM test ORDER BY id"))
         printf("[010] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
-    if (!mysqli_stmt_prepare($stmt_buf, "SELECT id, label FROM test ORDER BY id") ||
-        !mysqli_stmt_execute($stmt_buf))
+    if (!mysqli_stmt_execute($stmt_buf))
         printf("[011] [%d] %s\n", mysqli_stmt_errno($stmt_buf), mysqli_stmt_error($stmt_buf));
 
     $id = $label = $id_buf = $label_buf = null;
@@ -78,7 +77,8 @@ require_once 'skipifconnectfailure.inc';
 <?php
     require_once 'clean_table.inc';
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function mysqli_stmt_init() is deprecated since 8.6, use mysqli_prepare() instead in %s on line %d
 mysqli_stmt object is not fully initialized
 mysqli_stmt object is already closed
 done!

--- a/ext/mysqli/tests/mysqli_stmt_unclonable.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_unclonable.phpt
@@ -14,7 +14,7 @@ require_once 'skipifconnectfailure.inc';
         printf("[001] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
             $host, $user, $db, $port, $socket);
 
-    if (!$stmt = mysqli_stmt_init($link))
+    if (!$stmt = mysqli_prepare($link, "DO 1"))
         printf("[002] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
     try {


### PR DESCRIPTION
This was mostly replacing `mysqli_stmt_init` + `mysqli_stmt_prepare` with `mysqli_prepare`. 

The unrelated changes are either fixing typos or removing dead code. 