### PR TITLE
ext/curl: apply open_basedir restriction to CURLOPT_SSLENGINE

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -1868,7 +1868,6 @@ static zend_result _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue
 		case CURLOPT_PROXYUSERPWD:
 		case CURLOPT_REFERER:
 		case CURLOPT_SSLCERTTYPE:
-		case CURLOPT_SSLENGINE:
 		case CURLOPT_SSLENGINE_DEFAULT:
 		case CURLOPT_SSLKEY:
 		case CURLOPT_SSLKEYPASSWD:
@@ -2228,6 +2227,7 @@ static zend_result _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue
 		case CURLOPT_CRLFILE:
 		case CURLOPT_ISSUERCERT:
 		case CURLOPT_SSH_KNOWNHOSTS:
+		case CURLOPT_SSLENGINE:
 		{
 			zend_string *tmp_str;
 			zend_string *str = zval_get_tmp_string(zvalue, &tmp_str);

--- a/ext/curl/tests/curl_setopt_CURLOPT_SSLENGINE.phpt
+++ b/ext/curl/tests/curl_setopt_CURLOPT_SSLENGINE.phpt
@@ -1,0 +1,35 @@
+--TEST--
+curl_setopt(CURLOPT_SSLENGINE) should respect open_basedir for engine paths
+--EXTENSIONS--
+curl
+--SKIPIF--
+<?php
+if (!defined('CURLOPT_SSLENGINE')) {
+    die('skip CURLOPT_SSLENGINE not available');
+}
+
+$version = curl_version();
+
+if (!isset($version['ssl_version']) ||
+    stripos($version['ssl_version'], 'OpenSSL') === false) {
+    die('skip requires libcurl built against OpenSSL');
+}
+?>
+--INI--
+open_basedir=.
+display_errors=1
+log_errors=0
+--FILE--
+<?php
+
+$ch = curl_init();
+var_dump(curl_setopt($ch, CURLOPT_SSLENGINE, '/dev/null'));
+var_dump(curl_setopt($ch, CURLOPT_SSLENGINE, __FILE__));
+var_dump(curl_setopt($ch, CURLOPT_SSLENGINE, 'someengine:property'));
+
+?>
+--EXPECTF--
+Warning: curl_setopt(): open_basedir restriction in effect. File(/dev/null) is not within the allowed path(s): (.) in %s on line %d
+bool(false)
+bool(false)
+bool(false)


### PR DESCRIPTION
CURLOPT_SSLENGINE normally takes an engine name, but in some cases the passed string is loaded as a shared library. Validate it against open_basedir to restrict the locations the shared library can be loaded from.

Related to https://github.com/php/php-src/issues/22035, but does not solve it.