### PR TITLE
ext/intl: apply open_basedir restriction to ResourceBundle bundle paths

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -55,6 +55,7 @@ PHP                                                                        NEWS
     after successful calls. (Weilin Du)
   . Fixed IntlNumberRangeFormatter leaving stale global error state after
     successful createFromSkeleton() and format() calls. (Weilin Du)
+  . Fixed ResourceBundle bundle paths to respect open_basedir. (Weilin Du)
   . Implemented GH-20255 (Add a predefined calendar constant in
     IntlDateFormatter for the proleptic gregorian calendar). (David Carlier)
   . Added SpoofChecker::areBidiConfusable(). (David Carlier)

--- a/ext/intl/resourcebundle/resourcebundle_class.cpp
+++ b/ext/intl/resourcebundle/resourcebundle_class.cpp
@@ -20,6 +20,7 @@
 extern "C" {
 #include <zend.h>
 #include <php.h>
+#include "main/fopen_wrappers.h"
 }
 
 #include <Zend/zend_exceptions.h>
@@ -38,6 +39,16 @@ extern "C" {
 zend_class_entry *ResourceBundle_ce_ptr = NULL;
 
 static zend_object_handlers ResourceBundle_object_handlers;
+
+static zend_result resourcebundle_check_open_basedir(const char *bundlename, size_t bundlename_len)
+{
+	if (bundlename != NULL && bundlename_len != 0 && php_check_open_basedir(bundlename)) {
+		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "open_basedir restriction in effect");
+		return FAILURE;
+	}
+
+	return SUCCESS;
+}
 
 /* {{{ ResourceBundle_object_free */
 static void ResourceBundle_object_free( zend_object *object )
@@ -110,6 +121,10 @@ static zend_result resourcebundle_ctor(INTERNAL_FUNCTION_PARAMETERS)
 
 	if (UNEXPECTED(bundlename_len >= MAXPATHLEN)) {
 		zend_argument_value_error(2, "is too long");
+		return FAILURE;
+	}
+
+	if (resourcebundle_check_open_basedir(bundlename, bundlename_len) == FAILURE) {
 		return FAILURE;
 	}
 
@@ -355,6 +370,10 @@ PHP_INTL_FUNCTION_WITH_ERROR_RESET(resourcebundle_locales)
 	if(bundlename_len == 0) {
 		// fetch default locales list
 		bundlename = NULL;
+	}
+
+	if (resourcebundle_check_open_basedir(bundlename, bundlename_len) == FAILURE) {
+		RETURN_FALSE;
 	}
 
 	icuenum = ures_openAvailableLocales( bundlename, &icuerror );

--- a/ext/intl/tests/resourcebundle_open_basedir.phpt
+++ b/ext/intl/tests/resourcebundle_open_basedir.phpt
@@ -1,0 +1,44 @@
+--TEST--
+ResourceBundle bundle paths respect open_basedir
+--EXTENSIONS--
+intl
+--INI--
+open_basedir=.
+display_errors=1
+log_errors=0
+--FILE--
+<?php
+chdir(__DIR__);
+require_once "resourcebundle.inc";
+
+var_dump(ResourceBundle::create('root', BUNDLE) instanceof ResourceBundle);
+var_dump(ResourceBundle::getLocales(BUNDLE));
+
+$outside = dirname(__DIR__);
+
+try {
+    new ResourceBundle('root', $outside);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+var_dump(ResourceBundle::create('root', $outside));
+var_dump(ResourceBundle::getLocales($outside));
+?>
+--EXPECTF--
+bool(true)
+array(2) {
+  [0]=>
+  string(2) "es"
+  [1]=>
+  string(4) "root"
+}
+
+Warning: ResourceBundle::__construct(): open_basedir restriction in effect. File(%s) is not within the allowed path(s): (.) in %s on line %d
+IntlException: ResourceBundle::__construct(): open_basedir restriction in effect
+
+Warning: ResourceBundle::create(): open_basedir restriction in effect. File(%s) is not within the allowed path(s): (.) in %s on line %d
+NULL
+
+Warning: ResourceBundle::getLocales(): open_basedir restriction in effect. File(%s) is not within the allowed path(s): (.) in %s on line %d
+bool(false)


### PR DESCRIPTION
This is inspired by #23213 since ResourceBundle reads local files, and hence this should be restricted under the open_basedir conf