### PR TITLE
docs: Clarifies `--CREDITS--` section

### DIFF
--- a/docs/source/miscellaneous/writing-tests.rst
+++ b/docs/source/miscellaneous/writing-tests.rst
@@ -596,9 +596,10 @@ Example 1 (full): :ref:`sample001.phpt`
 on the first line. If the test was part of a TestFest event, then # followed by the name of the
 event and the date (YYYY-MM-DD) on the second line.
 
-**Required:** No. For newly created tests this section should no longer be included, as test
-authorship is already accurately tracked by Git. If multiple authors should be credited, the
-`Co-authored-by` tag in the commit message may be used.
+**Required:** No. For newly created tests the section should no longer be used for simple authorship
+claims or listing all contributors who edited the test; as it is already accurately tracked by Git.
+It may be used if more specific attribution is useful, for example to credit the original reporter
+of a bug or a contributor who is not credited via `Co-authored-by` tag.
 
 **Format:** Name Email [Event]
 


### PR DESCRIPTION
Ref: https://github.com/php/php-src/pull/23207#discussion_r3756716935

@ndossche maybe clarifying it for new contributors that do not have all context makes sense?