### PR TITLE
ext/pcre: preg_replace() use-after-free when __toString() destroys an…

### DIFF
--- a/ext/pcre/php_pcre.c
+++ b/ext/pcre/php_pcre.c
@@ -2316,6 +2316,16 @@ static void _preg_replace_common(
 		RETURN_THROWS();
 	}
 
+	if (regex_ht) {
+		GC_TRY_ADDREF(regex_ht);
+	}
+	if (replace_ht) {
+		GC_TRY_ADDREF(replace_ht);
+	}
+	if (subject_ht) {
+		GC_TRY_ADDREF(subject_ht);
+	}
+
 	if (subject_str) {
 		old_replace_count = replace_count;
 		result = php_replace_in_subject(regex_str, regex_ht, replace_str, replace_ht,
@@ -2369,6 +2379,16 @@ static void _preg_replace_common(
 
 	if (zcount) {
 		ZEND_TRY_ASSIGN_REF_LONG(zcount, replace_count);
+	}
+
+	if (regex_ht) {
+		GC_TRY_DTOR_NO_REF(regex_ht);
+	}
+	if (replace_ht) {
+		GC_TRY_DTOR_NO_REF(replace_ht);
+	}
+	if (subject_ht) {
+		GC_TRY_DTOR_NO_REF(subject_ht);
 	}
 }
 

--- a/ext/pcre/tests/gh23204.phpt
+++ b/ext/pcre/tests/gh23204.phpt
@@ -1,0 +1,78 @@
+--TEST--
+GH-23204 (Use-after-free when __toString() destroys the array being read)
+--FILE--
+<?php
+class UnsetPatterns implements Stringable {
+    public function __toString(): string {
+        global $patterns;
+        $patterns = null;
+        return "/a/";
+    }
+}
+
+$patterns = [new UnsetPatterns, "/b/", "/c/", "/d/"];
+var_dump(preg_replace($patterns, "z", "abcd"));
+var_dump($patterns);
+
+class UnsetReplacements implements Stringable {
+    public function __toString(): string {
+        global $replacements;
+        $replacements = null;
+        return "z";
+    }
+}
+
+$replacements = [new UnsetReplacements, "y", "y", "y"];
+var_dump(preg_replace(["/a/", "/b/", "/c/", "/d/"], $replacements, "abcd"));
+
+class UnsetSubjects implements Stringable {
+    public function __toString(): string {
+        global $subjects;
+        $subjects = null;
+        return "abcd";
+    }
+}
+
+$subjects = [new UnsetSubjects, "abcd"];
+var_dump(preg_replace("/a/", "z", $subjects));
+
+class AppendPattern implements Stringable {
+    public function __toString(): string {
+        global $appended;
+        $appended[] = "/z/";
+        return "/a/";
+    }
+}
+
+$appended = [new AppendPattern, "/b/"];
+var_dump(preg_replace($appended, "X", "abz"));
+var_dump(count($appended));
+
+class Boom implements Stringable {
+    public function __toString(): string {
+        global $boom;
+        $boom = null;
+        throw new Exception("boom");
+    }
+}
+
+$boom = [new Boom, "/b/"];
+try {
+    preg_replace($boom, "X", "ab");
+} catch (Exception $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+?>
+--EXPECT--
+string(4) "zzzz"
+NULL
+string(4) "zyyy"
+array(2) {
+  [0]=>
+  string(4) "zbcd"
+  [1]=>
+  string(4) "zbcd"
+}
+string(3) "XXz"
+int(3)
+Exception: boom


### PR DESCRIPTION
… array argument.

Fix #23204

Follow-up on GH-23207.

preg_replace() has a frameless handler, so the pattern, replacement and subject arrays reached _preg_replace_common() with a refcount of one. Stringifying an entry runs __toString(), which freed arData under the iterator or rehashed it in place. Taking a reference on each table for the duration of the read keeps it alive and turns a mutation into a separation.