### PR TITLE
ext/curl: speed up tests

### DIFF
--- a/ext/curl/tests/curl_setopt_ssl.phpt
+++ b/ext/curl/tests/curl_setopt_ssl.phpt
@@ -74,7 +74,10 @@ if ($process === false) {
 }
 try {
     // Give the server time to start
-    sleep(1);
+    for ($i = 0; $i < 100; $i++) {
+        if (@fsockopen('127.0.0.1', $port)) break;
+        usleep(20000);
+    }
 
     echo "case 1: client cert and key from string\n";
     $ch = curl_init("https://127.0.0.1:$port/");

--- a/ext/curl/tests/server.inc
+++ b/ext/curl/tests/server.inc
@@ -15,7 +15,7 @@ function curl_cli_server_start() {
     // First, wait for the dev server to declare itself ready.
     $bound = null;
     stream_set_blocking($pipes[2], false);
-    for ($i = 0; $i < 60; $i++) {
+    for ($i = 0; $i < 150; $i++) {
         usleep(20000); // 20ms per try
         $status = proc_get_status($handle);
         if (empty($status['running'])) {
@@ -44,7 +44,7 @@ function curl_cli_server_start() {
     // note: even when server prints 'Listening on localhost:8964...Press Ctrl-C to quit.'
     //       it might not be listening yet...need to wait until fsockopen() call returns
     $error = "Unable to connect to server\n";
-    for ($i=0; $i < 60; $i++) {
+    for ($i=0; $i < 150; $i++) {
         $status = proc_get_status($handle);
         $fp = @fsockopen("tcp://$bound");
         // Failure, the server is no longer running
@@ -74,7 +74,7 @@ function curl_cli_server_start() {
         function($handle) {
             proc_terminate($handle);
             /* Wait for server to shutdown */
-            for ($i = 0; $i < 60; $i++) {
+            for ($i = 0; $i < 150; $i++) {
                 $status = proc_get_status($handle);
                 if (!($status && $status['running'])) {
                     break;

--- a/ext/curl/tests/server.inc
+++ b/ext/curl/tests/server.inc
@@ -16,7 +16,7 @@ function curl_cli_server_start() {
     $bound = null;
     stream_set_blocking($pipes[2], false);
     for ($i = 0; $i < 60; $i++) {
-        usleep(50000); // 50ms per try
+        usleep(20000); // 20ms per try
         $status = proc_get_status($handle);
         if (empty($status['running'])) {
             echo "Server is not running\n";
@@ -45,7 +45,6 @@ function curl_cli_server_start() {
     //       it might not be listening yet...need to wait until fsockopen() call returns
     $error = "Unable to connect to server\n";
     for ($i=0; $i < 60; $i++) {
-        usleep(50000); // 50ms per try
         $status = proc_get_status($handle);
         $fp = @fsockopen("tcp://$bound");
         // Failure, the server is no longer running
@@ -58,6 +57,7 @@ function curl_cli_server_start() {
             $error = '';
             break;
         }
+        usleep(20000); // 20ms per try
     }
 
     if ($fp) {
@@ -79,7 +79,7 @@ function curl_cli_server_start() {
                 if (!($status && $status['running'])) {
                     break;
                 }
-                usleep(50000);
+                usleep(20000);
             }
         },
         $handle


### PR DESCRIPTION
By waiting shorter for the server to be ready. In my setup, this takes it from 26 to 15 seconds for all curl tests.

The first check for output on stderr takes approximately 10ms, so we wait 20ms to make sure its ready. The second check for the open port typically succeeds immediately, so move the sleep to after we have tried.

Disable Expect: 100-continue to prevent libcurl's 1-second delay.