### PR TITLE
ext/snmp: Add XFAIL on several tests in lower branches

### DIFF
--- a/ext/snmp/tests/bug64124.phpt
+++ b/ext/snmp/tests/bug64124.phpt
@@ -13,6 +13,8 @@ if (@inet_ntop($packed) === false) {
     die("skip no IPv6 support");
 }
 ?>
+--XFAIL--
+SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/bug64159.phpt
+++ b/ext/snmp/tests/bug64159.phpt
@@ -10,6 +10,8 @@ require_once(__DIR__.'/skipif.inc');
 ?>
 --ENV--
 MIBS=noneXistent
+--XFAIL--
+SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/generic_timeout_error.phpt
+++ b/ext/snmp/tests/generic_timeout_error.phpt
@@ -8,6 +8,8 @@ snmp
 <?php
 require_once(__DIR__.'/skipif.inc');
 ?>
+--XFAIL--
+SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/ipv6.phpt
+++ b/ext/snmp/tests/ipv6.phpt
@@ -13,6 +13,8 @@ if (@inet_ntop($packed) === false) {
     die("skip no IPv6 support");
 }
 ?>
+--XFAIL--
+SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmp-object-errno-errstr.phpt
+++ b/ext/snmp/tests/snmp-object-errno-errstr.phpt
@@ -9,6 +9,8 @@ snmp
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>
+--XFAIL--
+SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmp-object.phpt
+++ b/ext/snmp/tests/snmp-object.phpt
@@ -8,6 +8,8 @@ snmp
 <?php
 require_once(__DIR__.'/skipif.inc');
 ?>
+--XFAIL--
+SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmp2_get.phpt
+++ b/ext/snmp/tests/snmp2_get.phpt
@@ -9,6 +9,8 @@ snmp
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>
+--XFAIL--
+SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmp2_getnext.phpt
+++ b/ext/snmp/tests/snmp2_getnext.phpt
@@ -8,6 +8,8 @@ snmp
 <?php
 require_once(__DIR__.'/skipif.inc');
 ?>
+--XFAIL--
+SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmp2_real_walk.phpt
+++ b/ext/snmp/tests/snmp2_real_walk.phpt
@@ -8,6 +8,8 @@ snmp
 <?php
 require_once(__DIR__.'/skipif.inc');
 ?>
+--XFAIL--
+SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmp2_set-nomib.phpt
+++ b/ext/snmp/tests/snmp2_set-nomib.phpt
@@ -11,6 +11,8 @@ if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>
 --ENV--
 MIBS=
+--XFAIL--
+SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmp2_set.phpt
+++ b/ext/snmp/tests/snmp2_set.phpt
@@ -8,6 +8,8 @@ snmp
 <?php
 require_once(__DIR__.'/skipif.inc');
 ?>
+--XFAIL--
+SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmp2_walk.phpt
+++ b/ext/snmp/tests/snmp2_walk.phpt
@@ -9,6 +9,8 @@ snmp
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>
+--XFAIL--
+SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmp3-error.phpt
+++ b/ext/snmp/tests/snmp3-error.phpt
@@ -9,6 +9,8 @@ snmp
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>
+--XFAIL--
+SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmp3.phpt
+++ b/ext/snmp/tests/snmp3.phpt
@@ -8,6 +8,8 @@ snmp
 <?php
 require_once(__DIR__.'/skipif.inc');
 ?>
+--XFAIL--
+SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmp_getvalue.phpt
+++ b/ext/snmp/tests/snmp_getvalue.phpt
@@ -7,9 +7,10 @@ snmp
 --SKIPIF--
 <?php
 require_once(__DIR__.'/skipif.inc');
-if (PHP_OS_FAMILY === "Windows") die("xfail fails on Windows for unknown reasons");
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>
+--XFAIL--
+SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmpget.phpt
+++ b/ext/snmp/tests/snmpget.phpt
@@ -9,6 +9,8 @@ snmp
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>
+--XFAIL--
+SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmpgetnext.phpt
+++ b/ext/snmp/tests/snmpgetnext.phpt
@@ -8,6 +8,8 @@ snmp
 <?php
 require_once(__DIR__.'/skipif.inc');
 ?>
+--XFAIL--
+SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmprealwalk.phpt
+++ b/ext/snmp/tests/snmprealwalk.phpt
@@ -8,6 +8,8 @@ snmp
 <?php
 require_once(__DIR__.'/skipif.inc');
 ?>
+--XFAIL--
+SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmpset-nomib.phpt
+++ b/ext/snmp/tests/snmpset-nomib.phpt
@@ -11,6 +11,8 @@ if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>
 --ENV--
 MIBS=
+--XFAIL--
+SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmpset.phpt
+++ b/ext/snmp/tests/snmpset.phpt
@@ -8,6 +8,8 @@ snmp
 <?php
 require_once(__DIR__.'/skipif.inc');
 ?>
+--XFAIL--
+SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmpwalk.phpt
+++ b/ext/snmp/tests/snmpwalk.phpt
@@ -9,6 +9,8 @@ snmp
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>
+--XFAIL--
+SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');


### PR DESCRIPTION
(cherry picked from commit f619e66781d85ad06cc847a0dd5776127a8359bc)

This is approved by 8.5 RM (@edorian) and 8.4 RM (@NattyNarwhal) somewhere else. So I will directly merge this after CI :)