### PR TITLE
Fix GH-23232: lone namespace separator asks the autoloader for an empty class name

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,8 @@ PHP                                                                        NEWS
 - Core:
   . Fixed bug GH-15375 (Nested "yield from" skips items after a valid() or
     next() call on the inner generator). (iliaal)
+  . Fixed bug GH-23232 (lone namespace separator asks the autoloader for an
+    empty class name). (spawnia)
   . Fixed bug GH-23301 (Nested "yield from" yields a value twice when the
     middle generator delegates again). (Lazizbek Ergashev)
 

--- a/Zend/tests/gh23232.phpt
+++ b/Zend/tests/gh23232.phpt
@@ -1,0 +1,27 @@
+--TEST--
+GH-23232 (lone namespace separator asks the autoloader for an empty class name)
+--FILE--
+<?php
+spl_autoload_register(function (string $class): void {
+    echo "autoload: '$class'\n";
+});
+
+foreach (['::a', '\::a', '\Foo::a', 'Foo::a'] as $callable) {
+    echo "is_callable(\"$callable\")\n";
+    var_dump(is_callable($callable));
+}
+
+var_dump(class_exists('\\'));
+?>
+--EXPECT--
+is_callable("::a")
+bool(false)
+is_callable("\::a")
+bool(false)
+is_callable("\Foo::a")
+autoload: 'Foo'
+bool(false)
+is_callable("Foo::a")
+autoload: 'Foo'
+bool(false)
+bool(false)

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1180,6 +1180,10 @@ ZEND_API zend_class_entry *zend_lookup_class_ex(zend_string *name, zend_string *
 		}
 
 		if (ZSTR_VAL(name)[0] == '\\') {
+			if (ZSTR_LEN(name) == 1) {
+				/* A lone namespace separator names no class, e.g. is_callable('\::method'). */
+				return NULL;
+			}
 			lc_name = zend_string_alloc(ZSTR_LEN(name) - 1, 0);
 			zend_str_tolower_copy(ZSTR_VAL(lc_name), ZSTR_VAL(name) + 1, ZSTR_LEN(name) - 1);
 		} else {


### PR DESCRIPTION
Fixes GH-23232.

`zend_lookup_class_ex()` rejects an empty class name, but not a name consisting solely of the namespace separator: `"\"` passes the length check, gets its leading `\` stripped, and is then looked up — and autoloaded — as `""`.

That is reachable from userland through any entry point using that lookup:

- `is_callable('\::method')` splits at `::`, takes `"\"` as the class part and hands it to `zend_lookup_class()`. `is_callable('::method')` is rejected as an invalid function name earlier, which is where the asymmetry in the issue comes from.
- `class_exists('\')` passes the name straight through, see https://3v4l.org/Qe3u4.

A lone `\` names no class, so return `NULL` before consulting the class table or the autoloader.

This is observable, not just wasted work: Composer's `ClassLoader::findFileWithExtension()` does `$first = $class[0];` and warns `Uninitialized string offset 0` when handed `''`, which in applications that promote warnings to exceptions aborts the request. We hit it in CI through Laravel's `Factory::expandAttributes()`, which calls `is_callable()` on every string attribute — a randomly generated password starting with `\::` was enough.

Targeting `PHP-8.4` as the lowest branch still receiving bug fixes.

`make test` passes on `Zend/tests` and `ext/standard/tests/general_functions` (5085 passed, 0 failed) in a debug build; the new `.phpt` fails without the patch.
