### PR TITLE
Zend: remove Z_PARAM_FUNC_OR_NULL_WITH_ZVAL()

### DIFF
--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -1698,10 +1698,6 @@ ZEND_API ZEND_COLD void zend_class_redeclaration_error_ex(int type, zend_string 
 		SEPARATE_ZVAL_NOREF(_arg); \
 	}
 
-/* get the zval* for a previously parsed argument */
-#define Z_PARAM_GET_PREV_ZVAL(dest) \
-	zend_parse_arg_zval_deref(_arg, &dest, 0);
-
 /* old "|" */
 #define Z_PARAM_OPTIONAL \
 	_optional = 1;
@@ -1871,10 +1867,6 @@ ZEND_API ZEND_COLD void zend_class_redeclaration_error_ex(int type, zend_string 
 
 #define Z_PARAM_FUNC_NO_TRAMPOLINE_FREE_OR_NULL(dest_fci, dest_fcc) \
 	Z_PARAM_FUNC_EX2(dest_fci, dest_fcc, 1, 0, false)
-
-#define Z_PARAM_FUNC_OR_NULL_WITH_ZVAL(dest_fci, dest_fcc, dest_zp) \
-	Z_PARAM_FUNC_EX2(dest_fci, dest_fcc, 1, 0, true) \
-	Z_PARAM_GET_PREV_ZVAL(dest_zp)
 
 /* old "h" */
 #define Z_PARAM_ARRAY_HT_EX2(dest, check_null, deref, separate) \


### PR DESCRIPTION
And related Z_PARAM_GET_PREV_ZVAL()

These were introduced in https://github.com/php/php-src/commit/11796229f2f047768ee4870328f8dfd7e1a315a6 to simplify memory management.

But this is no longer relevant (well never was as one could have grabbed the zval from the FCI) since the refactoring to only use FCCs in https://github.com/php/php-src/commit/0e5d654409295e19570fb6a7d2e970d736e0f8a5

The following SourceGraph searches confirm there is no usage:
- https://sourcegraph.com/search?q=context:global+Z_PARAM_FUNC_OR_NULL_WITH_ZVAL&patternType=keyword&sm=0
- https://sourcegraph.com/search?q=context:global+Z_PARAM_GET_PREV_ZVAL&patternType=keyword&sm=0