### PR TITLE
ext/snmp: Put XFAILs under SKIPIF section in tests

### DIFF
--- a/ext/snmp/tests/bug64124.phpt
+++ b/ext/snmp/tests/bug64124.phpt
@@ -6,6 +6,7 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 
 $packed = str_repeat(chr(0), 15) . chr(1);

--- a/ext/snmp/tests/bug64124.phpt
+++ b/ext/snmp/tests/bug64124.phpt
@@ -6,13 +6,13 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 
 $packed = str_repeat(chr(0), 15) . chr(1);
 if (@inet_ntop($packed) === false) {
     die("skip no IPv6 support");
 }
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 ?>
 --FILE--
 <?php

--- a/ext/snmp/tests/bug64124.phpt
+++ b/ext/snmp/tests/bug64124.phpt
@@ -6,7 +6,6 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 
 $packed = str_repeat(chr(0), 15) . chr(1);

--- a/ext/snmp/tests/bug64124.phpt
+++ b/ext/snmp/tests/bug64124.phpt
@@ -6,6 +6,7 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 
 $packed = str_repeat(chr(0), 15) . chr(1);
@@ -13,8 +14,6 @@ if (@inet_ntop($packed) === false) {
     die("skip no IPv6 support");
 }
 ?>
---XFAIL--
-SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/bug64159.phpt
+++ b/ext/snmp/tests/bug64159.phpt
@@ -6,8 +6,8 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 ?>
 --ENV--
 MIBS=noneXistent

--- a/ext/snmp/tests/bug64159.phpt
+++ b/ext/snmp/tests/bug64159.phpt
@@ -6,7 +6,6 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
 --ENV--

--- a/ext/snmp/tests/bug64159.phpt
+++ b/ext/snmp/tests/bug64159.phpt
@@ -6,12 +6,11 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
 --ENV--
 MIBS=noneXistent
---XFAIL--
-SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/bug64159.phpt
+++ b/ext/snmp/tests/bug64159.phpt
@@ -6,6 +6,7 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
 --ENV--

--- a/ext/snmp/tests/generic_timeout_error.phpt
+++ b/ext/snmp/tests/generic_timeout_error.phpt
@@ -6,6 +6,7 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
 --FILE--

--- a/ext/snmp/tests/generic_timeout_error.phpt
+++ b/ext/snmp/tests/generic_timeout_error.phpt
@@ -6,8 +6,8 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 ?>
 --FILE--
 <?php

--- a/ext/snmp/tests/generic_timeout_error.phpt
+++ b/ext/snmp/tests/generic_timeout_error.phpt
@@ -6,10 +6,9 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
---XFAIL--
-SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/generic_timeout_error.phpt
+++ b/ext/snmp/tests/generic_timeout_error.phpt
@@ -6,7 +6,6 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
 --FILE--

--- a/ext/snmp/tests/ipv6.phpt
+++ b/ext/snmp/tests/ipv6.phpt
@@ -6,6 +6,7 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 
 $packed = str_repeat(chr(0), 15) . chr(1);

--- a/ext/snmp/tests/ipv6.phpt
+++ b/ext/snmp/tests/ipv6.phpt
@@ -6,13 +6,13 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 
 $packed = str_repeat(chr(0), 15) . chr(1);
 if (@inet_ntop($packed) === false) {
     die("skip no IPv6 support");
 }
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 ?>
 --FILE--
 <?php

--- a/ext/snmp/tests/ipv6.phpt
+++ b/ext/snmp/tests/ipv6.phpt
@@ -6,7 +6,6 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 
 $packed = str_repeat(chr(0), 15) . chr(1);

--- a/ext/snmp/tests/ipv6.phpt
+++ b/ext/snmp/tests/ipv6.phpt
@@ -6,6 +6,7 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 
 $packed = str_repeat(chr(0), 15) . chr(1);
@@ -13,8 +14,6 @@ if (@inet_ntop($packed) === false) {
     die("skip no IPv6 support");
 }
 ?>
---XFAIL--
-SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmp-object-errno-errstr.phpt
+++ b/ext/snmp/tests/snmp-object-errno-errstr.phpt
@@ -6,6 +6,7 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>

--- a/ext/snmp/tests/snmp-object-errno-errstr.phpt
+++ b/ext/snmp/tests/snmp-object-errno-errstr.phpt
@@ -6,9 +6,9 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 ?>
 --FILE--
 <?php

--- a/ext/snmp/tests/snmp-object-errno-errstr.phpt
+++ b/ext/snmp/tests/snmp-object-errno-errstr.phpt
@@ -6,11 +6,10 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>
---XFAIL--
-SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmp-object-errno-errstr.phpt
+++ b/ext/snmp/tests/snmp-object-errno-errstr.phpt
@@ -6,7 +6,6 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>

--- a/ext/snmp/tests/snmp-object.phpt
+++ b/ext/snmp/tests/snmp-object.phpt
@@ -6,6 +6,7 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
 --FILE--

--- a/ext/snmp/tests/snmp-object.phpt
+++ b/ext/snmp/tests/snmp-object.phpt
@@ -6,8 +6,8 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 ?>
 --FILE--
 <?php

--- a/ext/snmp/tests/snmp-object.phpt
+++ b/ext/snmp/tests/snmp-object.phpt
@@ -6,10 +6,9 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
---XFAIL--
-SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmp-object.phpt
+++ b/ext/snmp/tests/snmp-object.phpt
@@ -6,7 +6,6 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
 --FILE--

--- a/ext/snmp/tests/snmp2_get.phpt
+++ b/ext/snmp/tests/snmp2_get.phpt
@@ -6,11 +6,10 @@ Olivier Doucet & Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>
---XFAIL--
-SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmp2_get.phpt
+++ b/ext/snmp/tests/snmp2_get.phpt
@@ -6,6 +6,7 @@ Olivier Doucet & Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>

--- a/ext/snmp/tests/snmp2_get.phpt
+++ b/ext/snmp/tests/snmp2_get.phpt
@@ -6,9 +6,9 @@ Olivier Doucet & Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 ?>
 --FILE--
 <?php

--- a/ext/snmp/tests/snmp2_get.phpt
+++ b/ext/snmp/tests/snmp2_get.phpt
@@ -6,7 +6,6 @@ Olivier Doucet & Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>

--- a/ext/snmp/tests/snmp2_getnext.phpt
+++ b/ext/snmp/tests/snmp2_getnext.phpt
@@ -6,8 +6,8 @@ Olivier Doucet & Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 ?>
 --FILE--
 <?php

--- a/ext/snmp/tests/snmp2_getnext.phpt
+++ b/ext/snmp/tests/snmp2_getnext.phpt
@@ -6,10 +6,9 @@ Olivier Doucet & Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
---XFAIL--
-SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmp2_getnext.phpt
+++ b/ext/snmp/tests/snmp2_getnext.phpt
@@ -6,6 +6,7 @@ Olivier Doucet & Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
 --FILE--

--- a/ext/snmp/tests/snmp2_getnext.phpt
+++ b/ext/snmp/tests/snmp2_getnext.phpt
@@ -6,7 +6,6 @@ Olivier Doucet & Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
 --FILE--

--- a/ext/snmp/tests/snmp2_real_walk.phpt
+++ b/ext/snmp/tests/snmp2_real_walk.phpt
@@ -6,6 +6,7 @@ Olivier Doucet Olivier Doucet Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
 --FILE--

--- a/ext/snmp/tests/snmp2_real_walk.phpt
+++ b/ext/snmp/tests/snmp2_real_walk.phpt
@@ -6,7 +6,6 @@ Olivier Doucet Olivier Doucet Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
 --FILE--

--- a/ext/snmp/tests/snmp2_real_walk.phpt
+++ b/ext/snmp/tests/snmp2_real_walk.phpt
@@ -6,8 +6,8 @@ Olivier Doucet Olivier Doucet Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 ?>
 --FILE--
 <?php

--- a/ext/snmp/tests/snmp2_real_walk.phpt
+++ b/ext/snmp/tests/snmp2_real_walk.phpt
@@ -6,10 +6,9 @@ Olivier Doucet Olivier Doucet Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
---XFAIL--
-SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmp2_set-nomib.phpt
+++ b/ext/snmp/tests/snmp2_set-nomib.phpt
@@ -6,9 +6,9 @@ Boris Lytockin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 ?>
 --ENV--
 MIBS=

--- a/ext/snmp/tests/snmp2_set-nomib.phpt
+++ b/ext/snmp/tests/snmp2_set-nomib.phpt
@@ -6,13 +6,12 @@ Boris Lytockin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>
 --ENV--
 MIBS=
---XFAIL--
-SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmp2_set-nomib.phpt
+++ b/ext/snmp/tests/snmp2_set-nomib.phpt
@@ -6,6 +6,7 @@ Boris Lytockin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>

--- a/ext/snmp/tests/snmp2_set-nomib.phpt
+++ b/ext/snmp/tests/snmp2_set-nomib.phpt
@@ -6,7 +6,6 @@ Boris Lytockin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>

--- a/ext/snmp/tests/snmp2_set.phpt
+++ b/ext/snmp/tests/snmp2_set.phpt
@@ -6,6 +6,7 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
 --FILE--

--- a/ext/snmp/tests/snmp2_set.phpt
+++ b/ext/snmp/tests/snmp2_set.phpt
@@ -6,8 +6,8 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 ?>
 --FILE--
 <?php

--- a/ext/snmp/tests/snmp2_set.phpt
+++ b/ext/snmp/tests/snmp2_set.phpt
@@ -6,10 +6,9 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
---XFAIL--
-SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmp2_set.phpt
+++ b/ext/snmp/tests/snmp2_set.phpt
@@ -6,7 +6,6 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
 --FILE--

--- a/ext/snmp/tests/snmp2_walk.phpt
+++ b/ext/snmp/tests/snmp2_walk.phpt
@@ -6,9 +6,9 @@ Olivier Doucet Olivier Doucet Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 ?>
 --FILE--
 <?php

--- a/ext/snmp/tests/snmp2_walk.phpt
+++ b/ext/snmp/tests/snmp2_walk.phpt
@@ -6,6 +6,7 @@ Olivier Doucet Olivier Doucet Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>

--- a/ext/snmp/tests/snmp2_walk.phpt
+++ b/ext/snmp/tests/snmp2_walk.phpt
@@ -6,7 +6,6 @@ Olivier Doucet Olivier Doucet Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>

--- a/ext/snmp/tests/snmp2_walk.phpt
+++ b/ext/snmp/tests/snmp2_walk.phpt
@@ -6,11 +6,10 @@ Olivier Doucet Olivier Doucet Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>
---XFAIL--
-SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmp3-error.phpt
+++ b/ext/snmp/tests/snmp3-error.phpt
@@ -6,6 +6,7 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>

--- a/ext/snmp/tests/snmp3-error.phpt
+++ b/ext/snmp/tests/snmp3-error.phpt
@@ -6,9 +6,9 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 ?>
 --FILE--
 <?php

--- a/ext/snmp/tests/snmp3-error.phpt
+++ b/ext/snmp/tests/snmp3-error.phpt
@@ -6,11 +6,10 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>
---XFAIL--
-SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmp3-error.phpt
+++ b/ext/snmp/tests/snmp3-error.phpt
@@ -6,7 +6,6 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>

--- a/ext/snmp/tests/snmp3.phpt
+++ b/ext/snmp/tests/snmp3.phpt
@@ -6,6 +6,7 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
 --FILE--

--- a/ext/snmp/tests/snmp3.phpt
+++ b/ext/snmp/tests/snmp3.phpt
@@ -6,8 +6,8 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 ?>
 --FILE--
 <?php

--- a/ext/snmp/tests/snmp3.phpt
+++ b/ext/snmp/tests/snmp3.phpt
@@ -6,10 +6,9 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
---XFAIL--
-SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmp3.phpt
+++ b/ext/snmp/tests/snmp3.phpt
@@ -6,7 +6,6 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
 --FILE--

--- a/ext/snmp/tests/snmp_getvalue.phpt
+++ b/ext/snmp/tests/snmp_getvalue.phpt
@@ -6,9 +6,9 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === "Windows") die("xfail fails on Windows for unknown reasons");
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
+if (PHP_OS_FAMILY === "Windows") die("xfail fails on Windows for unknown reasons");
 ?>
 --FILE--
 <?php

--- a/ext/snmp/tests/snmp_getvalue.phpt
+++ b/ext/snmp/tests/snmp_getvalue.phpt
@@ -6,6 +6,7 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === "Windows") die("xfail fails on Windows for unknown reasons");
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>

--- a/ext/snmp/tests/snmp_getvalue.phpt
+++ b/ext/snmp/tests/snmp_getvalue.phpt
@@ -6,11 +6,10 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>
---XFAIL--
-SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmp_getvalue.phpt
+++ b/ext/snmp/tests/snmp_getvalue.phpt
@@ -6,7 +6,6 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>

--- a/ext/snmp/tests/snmpget.phpt
+++ b/ext/snmp/tests/snmpget.phpt
@@ -6,11 +6,10 @@ Olivier Doucet & Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>
---XFAIL--
-SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmpget.phpt
+++ b/ext/snmp/tests/snmpget.phpt
@@ -6,6 +6,7 @@ Olivier Doucet & Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>

--- a/ext/snmp/tests/snmpget.phpt
+++ b/ext/snmp/tests/snmpget.phpt
@@ -6,9 +6,9 @@ Olivier Doucet & Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 ?>
 --FILE--
 <?php

--- a/ext/snmp/tests/snmpget.phpt
+++ b/ext/snmp/tests/snmpget.phpt
@@ -6,7 +6,6 @@ Olivier Doucet & Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>

--- a/ext/snmp/tests/snmpgetnext.phpt
+++ b/ext/snmp/tests/snmpgetnext.phpt
@@ -6,8 +6,8 @@ Olivier Doucet & Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 ?>
 --FILE--
 <?php

--- a/ext/snmp/tests/snmpgetnext.phpt
+++ b/ext/snmp/tests/snmpgetnext.phpt
@@ -6,10 +6,9 @@ Olivier Doucet & Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
---XFAIL--
-SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmpgetnext.phpt
+++ b/ext/snmp/tests/snmpgetnext.phpt
@@ -6,6 +6,7 @@ Olivier Doucet & Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
 --FILE--

--- a/ext/snmp/tests/snmpgetnext.phpt
+++ b/ext/snmp/tests/snmpgetnext.phpt
@@ -6,7 +6,6 @@ Olivier Doucet & Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
 --FILE--

--- a/ext/snmp/tests/snmprealwalk.phpt
+++ b/ext/snmp/tests/snmprealwalk.phpt
@@ -6,6 +6,7 @@ Olivier Doucet Olivier Doucet Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
 --FILE--

--- a/ext/snmp/tests/snmprealwalk.phpt
+++ b/ext/snmp/tests/snmprealwalk.phpt
@@ -6,7 +6,6 @@ Olivier Doucet Olivier Doucet Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
 --FILE--

--- a/ext/snmp/tests/snmprealwalk.phpt
+++ b/ext/snmp/tests/snmprealwalk.phpt
@@ -6,8 +6,8 @@ Olivier Doucet Olivier Doucet Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 ?>
 --FILE--
 <?php

--- a/ext/snmp/tests/snmprealwalk.phpt
+++ b/ext/snmp/tests/snmprealwalk.phpt
@@ -6,10 +6,9 @@ Olivier Doucet Olivier Doucet Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
---XFAIL--
-SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmpset-nomib.phpt
+++ b/ext/snmp/tests/snmpset-nomib.phpt
@@ -6,6 +6,7 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>

--- a/ext/snmp/tests/snmpset-nomib.phpt
+++ b/ext/snmp/tests/snmpset-nomib.phpt
@@ -6,9 +6,9 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 ?>
 --ENV--
 MIBS=

--- a/ext/snmp/tests/snmpset-nomib.phpt
+++ b/ext/snmp/tests/snmpset-nomib.phpt
@@ -6,13 +6,12 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>
 --ENV--
 MIBS=
---XFAIL--
-SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmpset-nomib.phpt
+++ b/ext/snmp/tests/snmpset-nomib.phpt
@@ -6,7 +6,6 @@ Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>

--- a/ext/snmp/tests/snmpset.phpt
+++ b/ext/snmp/tests/snmpset.phpt
@@ -6,6 +6,7 @@ Olivier Doucet Olivier Doucet Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
 --FILE--

--- a/ext/snmp/tests/snmpset.phpt
+++ b/ext/snmp/tests/snmpset.phpt
@@ -6,7 +6,6 @@ Olivier Doucet Olivier Doucet Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
 --FILE--

--- a/ext/snmp/tests/snmpset.phpt
+++ b/ext/snmp/tests/snmpset.phpt
@@ -6,8 +6,8 @@ Olivier Doucet Olivier Doucet Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 ?>
 --FILE--
 <?php

--- a/ext/snmp/tests/snmpset.phpt
+++ b/ext/snmp/tests/snmpset.phpt
@@ -6,10 +6,9 @@ Olivier Doucet Olivier Doucet Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 ?>
---XFAIL--
-SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/ext/snmp/tests/snmpwalk.phpt
+++ b/ext/snmp/tests/snmpwalk.phpt
@@ -6,9 +6,9 @@ Olivier Doucet Olivier Doucet Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 ?>
 --FILE--
 <?php

--- a/ext/snmp/tests/snmpwalk.phpt
+++ b/ext/snmp/tests/snmpwalk.phpt
@@ -6,6 +6,7 @@ Olivier Doucet Olivier Doucet Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>

--- a/ext/snmp/tests/snmpwalk.phpt
+++ b/ext/snmp/tests/snmpwalk.phpt
@@ -6,7 +6,6 @@ Olivier Doucet Olivier Doucet Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>

--- a/ext/snmp/tests/snmpwalk.phpt
+++ b/ext/snmp/tests/snmpwalk.phpt
@@ -6,11 +6,10 @@ Olivier Doucet Olivier Doucet Boris Lytochkin
 snmp
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY === 'Windows') die('xfail SNMP tests might possibly fail on Windows');
 require_once(__DIR__.'/skipif.inc');
 if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
 ?>
---XFAIL--
-SNMP tests might possibly fail on Windows
 --FILE--
 <?php
 require_once(__DIR__.'/snmp_include.inc');

--- a/run-tests.php
+++ b/run-tests.php
@@ -2835,7 +2835,6 @@ function is_flaky_output(string $output): bool
         'connection refused',
         'deadlock',
         'mailbox already exists',
-        'no response from',
         'timed out',
     ];
     $regex = '(\b(' . implode('|', $messages) . ')\b)i';

--- a/run-tests.php
+++ b/run-tests.php
@@ -2835,6 +2835,7 @@ function is_flaky_output(string $output): bool
         'connection refused',
         'deadlock',
         'mailbox already exists',
+        'no response from',
         'timed out',
     ];
     $regex = '(\b(' . implode('|', $messages) . ')\b)i';


### PR DESCRIPTION
This adds the SNMP retry pattern to `is_flaky_output` to retry SNMP tests when it fails.

This also removes the XFAIL section in SNMP tests.

Note: only snmp tests use the `No response from ...` prefix