### PR TITLE
sapi: Fixes flaky cli server tests

### DIFF
--- a/sapi/cli/tests/php_cli_server.inc
+++ b/sapi/cli/tests/php_cli_server.inc
@@ -16,8 +16,8 @@ function php_cli_server_start(
     $php_executable = getenv('TEST_PHP_EXECUTABLE') ?: PHP_BINARY;
     $error = null;
 
-    // Create dedicated doc root to avoid index.php clashes between tests.
-    $doc_root = __DIR__ . DIRECTORY_SEPARATOR . basename($_SERVER['PHP_SELF'], '.php');
+    // Create dedicated doc root to avoid index.php clashes between processes.
+    $doc_root = __DIR__ . DIRECTORY_SEPARATOR . basename($_SERVER['PHP_SELF'], '.php') . '-' . getmypid();
     @mkdir($doc_root);
 
     if ($code) {

--- a/sapi/cli/tests/php_cli_server_002.phpt
+++ b/sapi/cli/tests/php_cli_server_002.phpt
@@ -13,7 +13,7 @@ php_cli_server_start('var_dump($_SERVER["DOCUMENT_ROOT"], $_SERVER["SERVER_SOFTW
 var_dump(file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS));
 ?>
 --EXPECTF--
-string(%d) "string(%d) "%sphp_cli_server_002"
+string(%d) "string(%d) "%sphp_cli_server_002-%d"
 string(%d) "PHP/%s (Development Server)"
 string(%d) "localhost"
 string(%d) "%s"


### PR DESCRIPTION
[Flake](https://github.com/php/php-src/actions/runs/31602778353/job/94134152293?pr=23230) found in https://github.com/php/php-src/pull/23230.

cc @arnaud-lb

Nothing for this fix, but how do we generally feel about some shared concurrency tooling for such things? Would IMO be convenient to have some neat helpers to handle directories and such.