### PR TITLE
Fix GH-23244: sync PHP 8.4 m4 file with 8.5

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,10 @@ PHP                                                                        NEWS
   . Fixed bug GH-15375 (Nested "yield from" skips items after a valid() or
     next() call on the inner generator). (iliaal)
 
+- LDAP:
+  . Fixed bug GH-23244 (Can not set LDAP_OPT_NETWORK_TIMEOUT on PHP 8.4).
+    (Weilin Du)
+
 27 Aug 2026, PHP 8.4.25
 
 - Core:

--- a/ext/ldap/config.m4
+++ b/ext/ldap/config.m4
@@ -38,6 +38,7 @@ AC_DEFUN([PHP_LDAP_CHECKS], [
       LDAP_LIBDIR=$1
     fi
   fi
+  PHP_LDAP_PKGCONFIG=false
 ])
 
 PHP_ARG_WITH([ldap],
@@ -59,52 +60,61 @@ if test "$PHP_LDAP" != "no"; then
     [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
 
   AS_VAR_IF([PHP_LDAP], [yes], [
-    for i in /usr/local /usr; do
-      PHP_LDAP_CHECKS([$i])
-    done
-  ], [PHP_LDAP_CHECKS([$PHP_LDAP])])
+    PKG_CHECK_MODULES([LDAP], [lber ldap],
+      PHP_LDAP_PKGCONFIG=true, PHP_LDAP_PKGCONFIG=false)])
 
-  AS_VAR_IF([LDAP_DIR],, [AC_MSG_ERROR([Cannot find ldap.h])])
+  AS_IF([test "$PHP_LDAP_PKGCONFIG" = true], [
+    PHP_EVAL_INCLINE([$LDAP_CFLAGS])
+    PHP_EVAL_LIBLINE([$LDAP_LIBS], [LDAP_SHARED_LIBADD])
+  ], [
+    AS_VAR_IF([PHP_LDAP], [yes], [
+      for i in /usr/local /usr; do
+        PHP_LDAP_CHECKS([$i])
+      done
+    ], [PHP_LDAP_CHECKS([$PHP_LDAP])])
+    AC_MSG_CHECKING([for ldap.h])
+    AS_VAR_IF([LDAP_DIR],, [AC_MSG_ERROR([Cannot find ldap.h])], AC_MSG_RESULT([$LDAP_DIR]))
 
-  dnl -pc removal is a hack for clang
-  MACHINE_INCLUDES=$($CC -dumpmachine | $SED 's/-pc//')
+    dnl -pc removal is a hack for clang
+    MACHINE_INCLUDES=$($CC -dumpmachine | $SED 's/-pc//')
 
-  AH_TEMPLATE([HAVE_ORALDAP],
-    [Define to 1 if the ldap extension uses the Oracle Instant Client.])
+    AH_TEMPLATE([HAVE_ORALDAP],
+      [Define to 1 if the ldap extension uses the Oracle Instant Client.])
 
-  if test -f $LDAP_LIBDIR/liblber.a || test -f $LDAP_LIBDIR/liblber.$SHLIB_SUFFIX_NAME || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/liblber.a || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/liblber.$SHLIB_SUFFIX_NAME; then
-    PHP_ADD_LIBRARY_WITH_PATH([lber], [$LDAP_LIBDIR], [LDAP_SHARED_LIBADD])
-    PHP_ADD_LIBRARY_WITH_PATH([ldap], [$LDAP_LIBDIR], [LDAP_SHARED_LIBADD])
+    if test -f $LDAP_LIBDIR/liblber.a || test -f $LDAP_LIBDIR/liblber.$SHLIB_SUFFIX_NAME || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/liblber.a || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/liblber.$SHLIB_SUFFIX_NAME; then
+      PHP_ADD_LIBRARY_WITH_PATH([lber], [$LDAP_LIBDIR], [LDAP_SHARED_LIBADD])
+      PHP_ADD_LIBRARY_WITH_PATH([ldap], [$LDAP_LIBDIR], [LDAP_SHARED_LIBADD])
 
-  elif test -f $LDAP_LIBDIR/libldap.$SHLIB_SUFFIX_NAME || test -f $LDAP_LIBDIR/libldap.$SHLIB_SUFFIX_NAME.3 || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/libldap.$SHLIB_SUFFIX_NAME || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/libldap.$SHLIB_SUFFIX_NAME.3 || test -f $LDAP_LIBDIR/libldap.3.dylib; then
-    PHP_ADD_LIBRARY_WITH_PATH([ldap], [$LDAP_LIBDIR], [LDAP_SHARED_LIBADD])
+    elif test -f $LDAP_LIBDIR/libldap.$SHLIB_SUFFIX_NAME || test -f $LDAP_LIBDIR/libldap.$SHLIB_SUFFIX_NAME.3 || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/libldap.$SHLIB_SUFFIX_NAME || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/libldap.$SHLIB_SUFFIX_NAME.3 || test -f $LDAP_LIBDIR/libldap.3.dylib; then
+      PHP_ADD_LIBRARY_WITH_PATH([ldap], [$LDAP_LIBDIR], [LDAP_SHARED_LIBADD])
 
-  elif test -f $LDAP_LIBDIR/libclntsh.$SHLIB_SUFFIX_NAME.12.1 || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/libclntsh.$SHLIB_SUFFIX_NAME.12.1; then
-    PHP_ADD_LIBRARY_WITH_PATH([clntsh], [$LDAP_LIBDIR], [LDAP_SHARED_LIBADD])
-    AC_DEFINE([HAVE_ORALDAP], [1])
+    elif test -f $LDAP_LIBDIR/libclntsh.$SHLIB_SUFFIX_NAME.12.1 || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/libclntsh.$SHLIB_SUFFIX_NAME.12.1; then
+      PHP_ADD_LIBRARY_WITH_PATH([clntsh], [$LDAP_LIBDIR], [LDAP_SHARED_LIBADD])
+      AC_DEFINE([HAVE_ORALDAP], [1])
 
-  elif test -f $LDAP_LIBDIR/libclntsh.$SHLIB_SUFFIX_NAME.11.1 || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/libclntsh.$SHLIB_SUFFIX_NAME.11.1; then
-    PHP_ADD_LIBRARY_WITH_PATH([clntsh], [$LDAP_LIBDIR], [LDAP_SHARED_LIBADD])
-    AC_DEFINE([HAVE_ORALDAP], [1])
+    elif test -f $LDAP_LIBDIR/libclntsh.$SHLIB_SUFFIX_NAME.11.1 || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/libclntsh.$SHLIB_SUFFIX_NAME.11.1; then
+      PHP_ADD_LIBRARY_WITH_PATH([clntsh], [$LDAP_LIBDIR], [LDAP_SHARED_LIBADD])
+      AC_DEFINE([HAVE_ORALDAP], [1])
 
-  elif test -f $LDAP_LIBDIR/libclntsh.$SHLIB_SUFFIX_NAME || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/libclntsh.$SHLIB_SUFFIX_NAME; then
-     PHP_ADD_LIBRARY_WITH_PATH([clntsh], [$LDAP_LIBDIR], [LDAP_SHARED_LIBADD])
-     AC_DEFINE([HAVE_ORALDAP], [1])
+    elif test -f $LDAP_LIBDIR/libclntsh.$SHLIB_SUFFIX_NAME || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/libclntsh.$SHLIB_SUFFIX_NAME; then
+      PHP_ADD_LIBRARY_WITH_PATH([clntsh], [$LDAP_LIBDIR], [LDAP_SHARED_LIBADD])
+      AC_DEFINE([HAVE_ORALDAP], [1])
 
-  else
-    AC_MSG_ERROR([Cannot find ldap libraries in $LDAP_LIBDIR.])
-  fi
+    else
+      AC_MSG_ERROR([Cannot find ldap libraries in $LDAP_LIBDIR.])
+    fi
 
-  PHP_ADD_INCLUDE([$LDAP_INCDIR])
-  PHP_SUBST([LDAP_SHARED_LIBADD])
-  AC_DEFINE([HAVE_LDAP], [1],
-    [Define to 1 if the PHP extension 'ldap' is available.])
+    PHP_ADD_INCLUDE([$LDAP_INCDIR])
+
+    LDAP_CFLAGS="-I$LDAP_INCDIR"
+    LDAP_LIBS=$LDAP_SHARED_LIBADD
+  ])
 
   dnl Save original values
-  _SAVE_CPPFLAGS=$CPPFLAGS
+  _SAVE_CFLAGS=$CFLAGS
   _SAVE_LIBS=$LIBS
-  CPPFLAGS="$CPPFLAGS -I$LDAP_INCDIR"
-  LIBS="$LIBS $LDAP_SHARED_LIBADD"
+  CFLAGS="$CFLAGS $LDAP_CFLAGS"
+  LIBS="$LIBS $LDAP_LIBS"
 
   dnl Check for 3 arg ldap_set_rebind_proc
   AC_CACHE_CHECK([for 3 arg ldap_set_rebind_proc],
@@ -132,6 +142,15 @@ if test "$PHP_LDAP" != "no"; then
     ldap_whoami_s
   ]))
 
+  dnl Sanity check
+  AC_CHECK_FUNC([ldap_sasl_bind_s],,
+    [AC_CHECK_FUNC([ldap_simple_bind_s],,
+      [AC_MSG_ERROR([LDAP library build check failed.])])])
+
+  dnl Restore original values
+  CFLAGS=$_SAVE_CFLAGS
+  LIBS=$_SAVE_LIBS
+
   dnl SASL check
   AS_VAR_IF([PHP_LDAP_SASL], [no],, [
     PKG_CHECK_MODULES([SASL], [libsasl2])
@@ -141,12 +160,7 @@ if test "$PHP_LDAP" != "no"; then
       [Define to 1 if the ldap extension has SASL support enabled.])
   ])
 
-  dnl Sanity check
-  AC_CHECK_FUNC([ldap_sasl_bind_s],,
-    [AC_CHECK_FUNC([ldap_simple_bind_s],,
-      [AC_MSG_ERROR([LDAP library build check failed.])])])
-
-  dnl Restore original values
-  CPPFLAGS=$_SAVE_CPPFLAGS
-  LIBS=$_SAVE_LIBS
+  PHP_SUBST([LDAP_SHARED_LIBADD])
+  AC_DEFINE([HAVE_LDAP], [1],
+    [Define to 1 if the PHP extension 'ldap' is available.])
 fi

--- a/ext/ldap/tests/gh23244.phpt
+++ b/ext/ldap/tests/gh23244.phpt
@@ -1,0 +1,29 @@
+--TEST--
+GH-23244 ldap_set_option() fails for LDAP_OPT_NETWORK_TIMEOUT
+--EXTENSIONS--
+ldap
+--SKIPIF--
+<?php
+if (!defined('LDAP_OPT_NETWORK_TIMEOUT')) {
+    die('skip LDAP_OPT_NETWORK_TIMEOUT is not supported');
+}
+?>
+--FILE--
+<?php
+$ldap = ldap_connect("ldap://127.0.0.1");
+
+var_dump(ldap_set_option($ldap, LDAP_OPT_NETWORK_TIMEOUT, 3));
+var_dump(ldap_get_option($ldap, LDAP_OPT_NETWORK_TIMEOUT, $timeout));
+var_dump($timeout);
+
+var_dump(ldap_set_option($ldap, LDAP_OPT_PROTOCOL_VERSION, 3));
+var_dump(ldap_get_option($ldap, LDAP_OPT_PROTOCOL_VERSION, $protocol));
+var_dump($protocol);
+?>
+--EXPECT--
+bool(true)
+bool(true)
+int(3)
+bool(true)
+bool(true)
+int(3)


### PR DESCRIPTION
PHP 8.4 still used the older manual LDAP library detection when `--with-ldap` was passed without an explicit directory, which cause GH-23244 that only occurs on 8.4.
In 8.5 since 3677871, we've implement a better configure logic, here we can directly sync the 8.5 .m4 file to 8.4 to fix the bug (without deprecations that only affects 8.5+).

This cherry-picked:
  367787134761f8c0e90ea2b1dd402b6c5795c687
  Use pkg-config for ext/ldap without a directory (#17441)

  25e8aa5cd22d5d461a5db247cfaedbba6e85e566
  Autotools: Fix ext/ldap shared build (#18673)

  840dc1981f90edca0bbbdace5e19c3118525e75a
  fix ldap.h detection without pkgconfig (#19005)
