### PR TITLE
PFA: Extend local pointer map after loading PFA from SHM

### DIFF
--- a/Zend/tests/partial_application/map_ptr_last.phpt
+++ b/Zend/tests/partial_application/map_ptr_last.phpt
@@ -1,0 +1,58 @@
+--TEST--
+PFA and ZCSG(map_ptr_last)
+--CREDITS--
+Ryan @ Calif.io
+--EXTENSIONS--
+pcntl
+--INI--
+opcache.file_update_protection=0
+--SKIPIF--
+<?php
+if (!function_exists('pcntl_fork')) {
+    die("skip no pcntl_fork");
+}
+?>
+--FILE--
+<?php
+
+function f($a, $b) {
+    return new ReflectionClass($a);
+}
+
+function get_pfa() {
+    return f(?, 0);
+}
+
+$pid = pcntl_fork();
+if ($pid) {
+    pcntl_waitpid($pid, $status, 0);
+
+    /* PFA retrieved from SHM, run_time_cache > CG(map_ptr_last) */
+    var_dump(get_pfa()('ReflectionClass'));
+} else {
+    /* Increment ZSCG(map_ptr_last) enough to mandate a realloc in other processes.
+     * We do so by compiling many functions that are guaranteed to allocate a map_ptr. */
+
+    $fd = fopen(__DIR__ . '/map_ptr_last.inc', 'w');
+    fwrite($fd, "<?php\n");
+    for ($i = 0; $i < 4096; $i++) {
+        fprintf($fd, "function pfa_map_ptr_flood_%05d(\$obj) { return \$obj->prop; }\n", $i);
+    }
+    fclose($fd);
+
+    require __DIR__ . '/map_ptr_last.inc';
+
+    /* Compile a PFA */
+    get_pfa()('ReflectionClass');
+}
+
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/map_ptr_last.inc');
+?>
+--EXPECTF--
+object(ReflectionClass)#%d (1) {
+  ["name"]=>
+  string(15) "ReflectionClass"
+}

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -2073,6 +2073,9 @@ const zend_op_array *zend_accel_pfa_cache_get(
 				zend_emit_recorded_errors_ex(persistent_script->num_warnings,
 						persistent_script->warnings);
 			}
+			if (ZCSG(map_ptr_last) > CG(map_ptr_last)) {
+				zend_map_ptr_extend(ZCSG(map_ptr_last));
+			}
 		}
 	} else {
 		op_array = zend_hash_find_ptr(&EG(partial_function_application_cache), key);


### PR DESCRIPTION
When loading a PFA from SHM we may need to extend the local pointer map because
the PFA may use pointers higher than CG(map_ptr_last). Similar synchronization
happens in inheritance cache [^1] or when loading whole scripts [^2].

The test reproduces under ASAN with Opcache enabled.

Bug found by Ryan @ Calif.io.

[^2]: https://github.com/php/php-src/blob/7a2303f89bffa0ecc4b5877f1a701ce2d844c5a3/ext/opcache/zend_accelerator_util_funcs.c#L373-L375
[^1]: https://github.com/php/php-src/blob/eaac14a17a3d64c52ef1a0778bb65828cfce4eda/ext/opcache/ZendAccelerator.c#L2538-L2545
