### PR TITLE
Keep EG(errors) buffer consistent on erealloc failure

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1486,9 +1486,10 @@ ZEND_API ZEND_COLD void zend_error_zstr_at(
 
 		/* This is very inefficient for a large number of errors.
 		 * Use pow2 realloc if it becomes a problem. */
-		EG(num_errors)++;
-		EG(errors) = erealloc(EG(errors), sizeof(zend_error_info*) * EG(num_errors));
-		EG(errors)[EG(num_errors)-1] = info;
+		uint32_t new_num_errors = EG(num_errors) + 1;
+		EG(errors) = erealloc(EG(errors), sizeof(zend_error_info*) * new_num_errors);
+		EG(errors)[EG(num_errors)] = info;
+		EG(num_errors) = new_num_errors;
 
 		/* Do not process non-fatal recorded error */
 		if (!(type & E_FATAL_ERRORS) || (type & E_DONT_BAIL)) {

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1487,7 +1487,7 @@ ZEND_API ZEND_COLD void zend_error_zstr_at(
 		/* This is very inefficient for a large number of errors.
 		 * Use pow2 realloc if it becomes a problem. */
 		uint32_t new_num_errors = EG(num_errors) + 1;
-		EG(errors) = erealloc(EG(errors), sizeof(zend_error_info*) * new_num_errors);
+		EG(errors) = safe_erealloc(EG(errors), new_num_errors, sizeof(zend_error_info*), 0);
 		EG(errors)[EG(num_errors)] = info;
 		EG(num_errors) = new_num_errors;
 


### PR DESCRIPTION
Update the error count only after the buffer has been resized and the new entry initialized. This prevents fatal error handling from reading past the buffer if reallocating it triggers an OOM bailout.

This zend_bailout path is also present in 8.5, the patch there would look like this?

```diff
-               EG(num_errors)++;
-               EG(errors) = erealloc(EG(errors), sizeof(zend_error_info*) * EG(num_errors));
-               EG(errors)[EG(num_errors)-1] = info;
+               uint32_t new_num_errors = EG(num_errors) + 1;
+               EG(errors) = erealloc(EG(errors), sizeof(zend_error_info*) * new_num_errors);
+               EG(errors)[EG(num_errors)] = info;
+               EG(num_errors) = new_num_errors;
```

---

If this fix is accepted, should I target 8.5 with a different PR, or what's the best workflow for changes that don't cleanly upmerge? I'm inexperienced in this regard.

---

Edit: Retargeting to 8.5 as @DanielEScherzer suggested

Changes for the master upmerge would be:

```diff
diff --git a/Zend/zend.c b/Zend/zend.c
index 07692db85196..e921bed4b812 100644
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1487,13 +1487,14 @@ ZEND_API ZEND_COLD void zend_error_zstr_at(
 		info->lineno = error_lineno;
 		info->filename = zend_string_copy(error_filename);
 		info->message = zend_string_copy(message);
-		EG(errors).size++;
-		if (EG(errors).size > EG(errors).capacity) {
+		uint32_t new_size = EG(errors).size + 1;
+		if (new_size > EG(errors).capacity) {
 			uint32_t capacity = EG(errors).capacity ? EG(errors).capacity + (EG(errors).capacity >> 1) : 2;
 			EG(errors).errors = erealloc(EG(errors).errors, sizeof(zend_error_info *) * capacity);
 			EG(errors).capacity = capacity;
 		}
-		EG(errors).errors[EG(errors).size - 1] = info;
+		EG(errors).errors[EG(errors).size] = info;
+		EG(errors).size = new_size;
 
 		/* Do not process non-fatal recorded error */
 		if (!(type & E_FATAL_ERRORS) || (type & E_DONT_BAIL)) {
```