### PR TITLE
Fix leaks from unprocessed user filter buckets

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -25,6 +25,10 @@ PHP                                                                        NEWS
     is_writable(), is_readable(), is_executable(), is_file(), is_dir(),
     is_link(), file_exists(), lstat(), stat(). (Girgias)
 
+- Streams:
+  . Fixed memory leaks when a user stream filter returns PSFS_PASS_ON without
+    processing all input buckets. (Matthias Goergens)
+
 30 Jul 2026, PHP 8.6.0alpha3
 
 - Core:

--- a/ext/standard/tests/filters/stream_filter_register_class_coerce_consumed_by_ref_param.phpt
+++ b/ext/standard/tests/filters/stream_filter_register_class_coerce_consumed_by_ref_param.phpt
@@ -1,7 +1,5 @@
 --TEST--
 stream_filter_register() with a class that coerces the $consumed parameter of filter method
---XFAIL--
-This leaks memory
 --FILE--
 <?php
 

--- a/ext/standard/tests/filters/stream_filter_register_filter_always_feed.phpt
+++ b/ext/standard/tests/filters/stream_filter_register_filter_always_feed.phpt
@@ -15,6 +15,10 @@ var_dump(stream_filter_append(STDOUT, "invalid_filter"));
 $out = fwrite(STDOUT, "Hello\n");
 var_dump($out);
 
+$stream = fopen('data://text/plain,Hello', 'r');
+var_dump(stream_filter_append($stream, "invalid_filter"));
+var_dump(stream_get_contents($stream));
+
 ?>
 --EXPECTF--
 bool(true)
@@ -22,3 +26,7 @@ resource(4) of type (stream filter)
 
 Warning: fwrite(): Unprocessed filter buckets remaining on input brigade in %s on line %d
 int(0)
+resource(%d) of type (stream filter)
+
+Warning: stream_get_contents(): Unprocessed filter buckets remaining on input brigade in %s on line %d
+string(0) ""

--- a/ext/standard/tests/filters/stream_filter_register_mock_class_filter.phpt
+++ b/ext/standard/tests/filters/stream_filter_register_mock_class_filter.phpt
@@ -1,7 +1,5 @@
 --TEST--
 stream_filter_register() with a class name exist that mocks php_user_filter with a filter method
---XFAIL--
-This leaks memory
 --FILE--
 <?php
 

--- a/ext/standard/user_filters.c
+++ b/ext/standard/user_filters.c
@@ -229,6 +229,11 @@ static php_stream_filter_status_t userfilter_filter(
 
 	if (buckets_in->head) {
 		php_error_docref(NULL, E_WARNING, "Unprocessed filter buckets remaining on input brigade");
+		php_stream_bucket *bucket;
+		while ((bucket = buckets_in->head)) {
+			php_stream_bucket_unlink(bucket);
+			php_stream_bucket_delref(bucket);
+		}
 	}
 
 	/* filter resources are cleaned up by the stream destructor,


### PR DESCRIPTION
A user filter can return without having processed every bucket in its input
brigade; the stream layer then drops the brigade, orphaning the remaining
buckets. Unlink and release leftover buckets when the filter finishes. This
resolves two XFAILs in ext/standard/tests/filters.