### PR TITLE
Fix GH-17773: Array element initialised by reference returned from a function

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,10 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 8.6.0beta1
 
+- Core:
+  . Fixed bug GH-17773 (Initializing array elements with references returned by
+    functions was not possible). (Matthias Görgens)
+
 - GMP:
   . Added optional $definitely_prime output parameter to gmp_prevprime().
     (Weilin Du)

--- a/Zend/Optimizer/zend_inference.c
+++ b/Zend/Optimizer/zend_inference.c
@@ -4923,6 +4923,12 @@ ZEND_API zend_result zend_ssa_inference(zend_arena **arena, const zend_op_array 
 
 ZEND_API bool zend_may_throw_ex(const zend_op *opline, const zend_ssa_op *ssa_op, const zend_op_array *op_array, const zend_ssa *ssa, uint32_t t1, uint32_t t2)
 {
+	if (opline->opcode == ZEND_MAKE_REF && opline->extended_value == ZEND_RETURNS_FUNCTION) {
+		/* A by-value function result raises an E_NOTICE, which a userland
+		 * error handler can turn into an exception. */
+		return 1;
+	}
+
 	if (opline->op1_type == IS_CV) {
 		if (t1 & MAY_BE_UNDEF) {
 			switch (opline->opcode) {

--- a/Zend/tests/gh17773.phpt
+++ b/Zend/tests/gh17773.phpt
@@ -1,0 +1,52 @@
+--TEST--
+GH-17773 (Initializing array element with reference returned by function)
+--FILE--
+<?php
+function &get_reference() {
+    static $value = 0;
+    return $value;
+}
+
+$array = [&get_reference()];
+$array[0] = 42;
+var_dump(get_reference());
+
+class Test {
+    public int $value = 0;
+    public static int $staticValue = 0;
+
+    public function &getReference() {
+        return $this->value;
+    }
+
+    public static function &getStaticReference() {
+        return self::$staticValue;
+    }
+}
+
+$test = new Test();
+$array = [&$test->getReference(), &Test::getStaticReference(), [&get_reference()]];
+$unpacked = [...$array];
+$unpacked[0] = 43;
+$unpacked[1] = 44;
+$unpacked[2][0] = 45;
+var_dump($test->value, Test::$staticValue, get_reference());
+
+function get_value() {
+    return 42;
+}
+
+$array = [&get_value()];
+var_dump($array);
+?>
+--EXPECTF--
+int(42)
+int(43)
+int(44)
+int(45)
+
+Notice: Only variables should be assigned by reference in %s on line %d
+array(1) {
+  [0]=>
+  int(42)
+}

--- a/Zend/tests/gh17773_builtin.phpt
+++ b/Zend/tests/gh17773_builtin.phpt
@@ -1,0 +1,8 @@
+--TEST--
+GH-17773 (Cannot initialize array element with reference returned by built-in function)
+--FILE--
+<?php
+$array = [&strlen('value')];
+?>
+--EXPECTF--
+Fatal error: Cannot use result of built-in function in write context in %s on line %d

--- a/Zend/tests/gh17773_exception.phpt
+++ b/Zend/tests/gh17773_exception.phpt
@@ -1,0 +1,23 @@
+--TEST--
+GH-17773 (Exception while reporting by-value function result used by reference)
+--FILE--
+<?php
+function get_value() {
+    return 42;
+}
+
+set_error_handler(function (int $type, string $message) {
+    throw new Exception($message);
+});
+
+try {
+    $array = [&get_value()];
+} catch (Exception $exception) {
+    echo $exception->getMessage(), "\n";
+}
+
+echo "Done\n";
+?>
+--EXPECT--
+Only variables should be assigned by reference
+Done

--- a/Zend/tests/gh17773_globals.phpt
+++ b/Zend/tests/gh17773_globals.phpt
@@ -1,0 +1,8 @@
+--TEST--
+GH-17773 (Cannot initialize array element with reference to $GLOBALS)
+--FILE--
+<?php
+$array = [&$GLOBALS];
+?>
+--EXPECTF--
+Fatal error: Cannot acquire reference to $GLOBALS in %s on line %d

--- a/Zend/tests/gh17773_nullsafe.phpt
+++ b/Zend/tests/gh17773_nullsafe.phpt
@@ -1,0 +1,16 @@
+--TEST--
+GH-17773 (Cannot initialize array element with reference to nullsafe chain)
+--FILE--
+<?php
+class Test {
+    public function &getReference() {
+        static $value = 42;
+        return $value;
+    }
+}
+
+$test = null;
+$array = [&$test?->getReference()];
+?>
+--EXPECTF--
+Fatal error: Cannot take reference of a nullsafe chain in %s on line %d

--- a/Zend/tests/gh17773_uncaught.phpt
+++ b/Zend/tests/gh17773_uncaught.phpt
@@ -1,0 +1,19 @@
+--TEST--
+GH-17773 (Uncaught exception from by-value function result used by reference)
+--FILE--
+<?php
+function get_value() {
+    return 42;
+}
+set_error_handler(function (int $type, string $message) {
+    throw new Exception($message);
+});
+$array = [&get_value()];
+echo "Done\n";
+?>
+--EXPECTF--
+Fatal error: Uncaught Exception: Only variables should be assigned by reference in %s:%d
+Stack trace:
+#0 %s(%d): {closure:%s:%d}(8, 'Only variables ...', '%s', 8)
+#1 {main}
+  thrown in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -11537,8 +11537,19 @@ static void zend_compile_array(znode *result, zend_ast *ast) /* {{{ */
 		}
 
 		if (by_ref) {
-			zend_ensure_writable_variable(value_ast);
+			zend_assert_not_short_circuited(value_ast);
+			if (is_globals_fetch(value_ast)) {
+				zend_error_noreturn(E_COMPILE_ERROR, "Cannot acquire reference to $GLOBALS");
+			}
 			zend_compile_var(&value_node, value_ast, BP_VAR_W, true);
+			if (value_node.op_type != IS_VAR && zend_is_call(value_ast)) {
+				zend_error_noreturn(E_COMPILE_ERROR,
+					"Cannot use result of built-in function in write context");
+			}
+			if (zend_is_call(value_ast)) {
+				opline = zend_emit_op(&value_node, ZEND_MAKE_REF, &value_node, NULL);
+				opline->extended_value = ZEND_RETURNS_FUNCTION;
+			}
 		} else {
 			zend_compile_expr(&value_node, value_ast);
 		}

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -9398,6 +9398,7 @@ ZEND_VM_HANDLER(140, ZEND_MAKE_REF, VAR|CV, UNUSED)
 			zend_error(E_NOTICE, "Only variables should be assigned by reference");
 			if (UNEXPECTED(EG(exception))) {
 				FREE_OP1();
+				ZVAL_UNDEF(EX_VAR(opline->result.var));
 				HANDLE_EXCEPTION();
 			}
 		}

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -9393,6 +9393,14 @@ ZEND_VM_HANDLER(140, ZEND_MAKE_REF, VAR|CV, UNUSED)
 		}
 		ZVAL_REF(EX_VAR(opline->result.var), Z_REF_P(op1));
 	} else {
+		if (UNEXPECTED(opline->extended_value == ZEND_RETURNS_FUNCTION && !Z_ISREF_P(op1))) {
+			SAVE_OPLINE();
+			zend_error(E_NOTICE, "Only variables should be assigned by reference");
+			if (UNEXPECTED(EG(exception))) {
+				FREE_OP1();
+				HANDLE_EXCEPTION();
+			}
+		}
 		ZVAL_COPY_VALUE(EX_VAR(opline->result.var), op1);
 	}
 	ZEND_VM_NEXT_OPCODE();

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -30512,6 +30512,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_MAKE_REF_SPEC
 		}
 		ZVAL_REF(EX_VAR(opline->result.var), Z_REF_P(op1));
 	} else {
+		if (UNEXPECTED(opline->extended_value == ZEND_RETURNS_FUNCTION && !Z_ISREF_P(op1))) {
+			SAVE_OPLINE();
+			zend_error(E_NOTICE, "Only variables should be assigned by reference");
+			if (UNEXPECTED(EG(exception))) {
+				zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
+				HANDLE_EXCEPTION();
+			}
+		}
 		ZVAL_COPY_VALUE(EX_VAR(opline->result.var), op1);
 	}
 	ZEND_VM_NEXT_OPCODE();
@@ -50073,6 +50081,15 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_MAKE_REF_SPEC
 		}
 		ZVAL_REF(EX_VAR(opline->result.var), Z_REF_P(op1));
 	} else {
+		if (UNEXPECTED(opline->extended_value == ZEND_RETURNS_FUNCTION && !Z_ISREF_P(op1))) {
+			SAVE_OPLINE();
+			zend_error(E_NOTICE, "Only variables should be assigned by reference");
+			if (UNEXPECTED(EG(exception))) {
+
+
+				HANDLE_EXCEPTION();
+			}
+		}
 		ZVAL_COPY_VALUE(EX_VAR(opline->result.var), op1);
 	}
 	ZEND_VM_NEXT_OPCODE();
@@ -83142,6 +83159,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_MAKE_REF_SPEC_VAR_
 		}
 		ZVAL_REF(EX_VAR(opline->result.var), Z_REF_P(op1));
 	} else {
+		if (UNEXPECTED(opline->extended_value == ZEND_RETURNS_FUNCTION && !Z_ISREF_P(op1))) {
+			SAVE_OPLINE();
+			zend_error(E_NOTICE, "Only variables should be assigned by reference");
+			if (UNEXPECTED(EG(exception))) {
+				zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
+				HANDLE_EXCEPTION();
+			}
+		}
 		ZVAL_COPY_VALUE(EX_VAR(opline->result.var), op1);
 	}
 	ZEND_VM_NEXT_OPCODE();
@@ -102601,6 +102626,15 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_MAKE_REF_SPEC_CV_U
 		}
 		ZVAL_REF(EX_VAR(opline->result.var), Z_REF_P(op1));
 	} else {
+		if (UNEXPECTED(opline->extended_value == ZEND_RETURNS_FUNCTION && !Z_ISREF_P(op1))) {
+			SAVE_OPLINE();
+			zend_error(E_NOTICE, "Only variables should be assigned by reference");
+			if (UNEXPECTED(EG(exception))) {
+
+
+				HANDLE_EXCEPTION();
+			}
+		}
 		ZVAL_COPY_VALUE(EX_VAR(opline->result.var), op1);
 	}
 	ZEND_VM_NEXT_OPCODE();

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -30517,6 +30517,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_MAKE_REF_SPEC
 			zend_error(E_NOTICE, "Only variables should be assigned by reference");
 			if (UNEXPECTED(EG(exception))) {
 				zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
+				ZVAL_UNDEF(EX_VAR(opline->result.var));
 				HANDLE_EXCEPTION();
 			}
 		}
@@ -50087,6 +50088,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_MAKE_REF_SPEC
 			if (UNEXPECTED(EG(exception))) {
 
 
+				ZVAL_UNDEF(EX_VAR(opline->result.var));
 				HANDLE_EXCEPTION();
 			}
 		}
@@ -83164,6 +83166,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_MAKE_REF_SPEC_VAR_
 			zend_error(E_NOTICE, "Only variables should be assigned by reference");
 			if (UNEXPECTED(EG(exception))) {
 				zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
+				ZVAL_UNDEF(EX_VAR(opline->result.var));
 				HANDLE_EXCEPTION();
 			}
 		}
@@ -102632,6 +102635,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_MAKE_REF_SPEC_CV_U
 			if (UNEXPECTED(EG(exception))) {
 
 
+				ZVAL_UNDEF(EX_VAR(opline->result.var));
 				HANDLE_EXCEPTION();
 			}
 		}


### PR DESCRIPTION
Initialising an array element with a reference returned by a function, e.g.
`[&foo()]`, is rejected at compile time although ordinary reference assignment
accepts it. Allow user-function call results in this source position while
keeping the remaining source-side safeguards of reference assignment.