### PR TITLE
Fix GH-7781: CLI server prints HTML in startup warnings

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,10 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 8.6.0beta1
 
+- CLI:
+  . Fixed bug GH-7781 (Built-in web server prints HTML in startup warnings).
+    (Matthias Görgens)
+
 - GMP:
   . Added optional $definitely_prime output parameter to gmp_prevprime().
     (Weilin Du)

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -2797,6 +2797,8 @@ int do_cli_server(int argc, char **argv) /* {{{ */
 	char *php_optarg = NULL;
 	int php_optind = 1;
 	int c, r;
+	bool html_errors;
+	zend_result server_ctor_result;
 	const char *server_bind_address = NULL;
 	extern const opt_struct OPTIONS[];
 	const char *document_root = NULL;
@@ -2868,7 +2870,12 @@ int do_cli_server(int argc, char **argv) /* {{{ */
 		router = argv[php_optind];
 	}
 
-	if (FAILURE == php_cli_server_ctor(&server, server_bind_address, document_root, router)) {
+	/* Startup diagnostics are written to a terminal, not an HTTP response. */
+	html_errors = PG(html_errors);
+	PG(html_errors) = false;
+	server_ctor_result = php_cli_server_ctor(&server, server_bind_address, document_root, router);
+	PG(html_errors) = html_errors;
+	if (FAILURE == server_ctor_result) {
 		return 1;
 	}
 	sapi_module.phpinfo_as_text = 0;

--- a/sapi/cli/tests/gh7781.phpt
+++ b/sapi/cli/tests/gh7781.phpt
@@ -1,0 +1,31 @@
+--TEST--
+GH-7781 (Built-in server startup warnings should not contain HTML)
+--FILE--
+<?php
+$process = proc_open(
+    [PHP_BINARY, '-n', '-S', '0.0..0:8080'],
+    [
+        ['pipe', 'r'],
+        ['pipe', 'w'],
+        ['pipe', 'w'],
+    ],
+    $pipes,
+);
+
+fclose($pipes[0]);
+$stdout = stream_get_contents($pipes[1]);
+$stderr = stream_get_contents($pipes[2]);
+fclose($pipes[1]);
+fclose($pipes[2]);
+$status = proc_close($process);
+
+var_dump($status);
+var_dump(str_contains($stdout, '<br'));
+var_dump(str_contains($stdout, 'Warning: Unknown: php_network_getaddresses:'));
+var_dump(str_contains($stderr, 'Failed to listen on 0.0..0:8080'));
+?>
+--EXPECT--
+int(1)
+bool(false)
+bool(true)
+bool(true)


### PR DESCRIPTION
Startup diagnostics of the built-in server were formatted as HTML because the CLI server keeps `html_errors` on for request handling and used the same setting before the listening socket existed. Suppress the displayed resolver warning around the listen call: its text is already repeated as the reason in the server's own "Failed to listen" message.

Fixes GH-7781.
