### PR TITLE
fix(LiteSpeed): fix return uninitialized value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ config.h.in
 /sapi/fpm/php-fpm
 /sapi/phpdbg/phpdbg
 /sapi/fuzzer/php-fuzz-*
+/sapi/litespeed/lsphp
 /scripts/php-config
 /scripts/phpize
 php

--- a/sapi/litespeed/lsapi_main.c
+++ b/sapi/litespeed/lsapi_main.c
@@ -1443,7 +1443,7 @@ void setArgv0( int argc, char * argv[] )
 #include <fcntl.h>
 int main( int argc, char * argv[] )
 {
-    int ret;
+    int ret = 0;
     int bindFd;
 
     char * php_ini_path = NULL;


### PR DESCRIPTION
While working on #22730 , I found this issue using Valgrind.

The `ret` variable is being returned without being initialized. Additionally, the builded SAPI was not properly excluded from Git.
