### PR TITLE
sapi/lsapi: fix returns uninitialized value

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,9 @@ PHP                                                                        NEWS
   . Fixed ZipArchive::extractTo() and ZipArchive::getFrom*() reporting success
     on corrupted entries. (David Carlier)
 
+- SAPI:
+  . Fixed returns uninitialized value on LiteSpeed lsapi SAPI (Go Kudo)
+
 27 Aug 2026, PHP 8.4.25
 
 - Core:

--- a/sapi/litespeed/lsapi_main.c
+++ b/sapi/litespeed/lsapi_main.c
@@ -1443,7 +1443,7 @@ void setArgv0( int argc, char * argv[] )
 #include <fcntl.h>
 int main( int argc, char * argv[] )
 {
-    int ret;
+    int ret = 0;
     int bindFd;
 
     char * php_ini_path = NULL;


### PR DESCRIPTION
Fix: #23275

It’s been a while since I’ve made a fix to Active Support, so please review it.
If it’s approved, I’ll merge up it into 8.5 and master as usual.

This is simply a reference to an uninitialized value, and as there is no way to add tests for it, it is not included in PHPT. Furthermore, it appears that CI does not include any tests relating to the LiteSpeed SAPI either. If CI needs to be built, I will carry out that work on the master branch.