### PR TITLE
chore: add lsphp to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ config.h.in
 /sapi/fpm/php-fpm
 /sapi/phpdbg/phpdbg
 /sapi/fuzzer/php-fuzz-*
+/sapi/litespeed/lsphp
 /scripts/php-config
 /scripts/phpize
 php


### PR DESCRIPTION
LiteSpeed SAPI is not properly added to .gitignore, so it gets tracked during the build.

As with other SAPIs, you can prevent this by excluding the pre-built binaries in .gitignore.