### PR TITLE
configure.ac: Use 64-bit fibers on AIX without overriding triplet

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1224,7 +1224,15 @@ AS_CASE([$host_cpu],
 
 AS_CASE([$host_os],
   [darwin*], [fiber_os="mac"],
-  [aix*|os400*], [fiber_os="aix"],
+  [aix*|os400*], [
+    fiber_os="aix"
+    dnl AIX triplets start w/ powerpc- even though it may be 64-bit (as AIX
+    dnl has a multiple bitness world). Check if the build is 64-bit, or we
+    dnl end up using the wrong fibre asm (w/o forcing a powerpc64 triplet)
+    AS_IF([test "$ac_cv_sizeof_long" -eq 8], [
+      fiber_cpu="ppc64"
+    ], [])
+  ],
   [freebsd*], [fiber_os="freebsd"],
   [midipix], [fiber_os="midipix"],
   [fiber_os="other"]


### PR DESCRIPTION
AIX/PASE defaults to a powerpc-ibm-(aix|os400) triplet, even though the build may be 64-bit. This causes a problem with fibers, as the 32-bit assembly will be selected, causing a build failure. Detect this case and override the selected assembly ourselves.

Without this, you must override the triplet with i.e. `--build=powerpc64-ibm-aix7.1.0.0`. 

Tested on PASE, which with IBM's provided packages, defaults to a 64-bit build environment.