### PR TITLE
Add Windows build upgrades to UPGRADING

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -789,6 +789,13 @@ PHP 8.6 UPGRADE NOTES
 12. Windows Support
 ========================================
 
+- Core:
+  . The official Windows builds now use Visual Studio 2026 (VS18).
+
+- OpenSSL:
+  . The OpenSSL library used by the official Windows builds has been upgraded
+    to OpenSSL 4.
+
 ========================================
 13. Other Changes
 ========================================


### PR DESCRIPTION
Document switch to VS18 and OpenSSL 4 for Windows builds.

Follow-up to #22094 and #22267.