### PR TITLE
Share the method's runtime cache with fake closures of the same scope

### DIFF
--- a/Zend/zend_closures.c
+++ b/Zend/zend_closures.c
@@ -864,6 +864,16 @@ static void zend_create_closure_ex(
 				ptr = zend_arena_alloc(&CG(arena), func->op_array.cache_size);
 				ZEND_MAP_PTR_SET(func->op_array.run_time_cache, ptr);
 				closure->func.op_array.fn_flags &= ~ZEND_ACC_HEAP_RT_CACHE;
+			} else if (!ptr
+			 && func->common.scope == scope
+			 && !(func->common.fn_flags & (ZEND_ACC_HEAP_RT_CACHE|ZEND_ACC_CALL_VIA_TRAMPOLINE))) {
+				/* Fake closure over a method that has not run yet: initialize
+				 * the method's own shared runtime cache and use it, instead
+				 * of allocating a cold per-closure heap cache on every
+				 * Closure::fromCallable()/first-class callable creation. */
+				ptr = zend_arena_alloc(&CG(arena), func->op_array.cache_size);
+				ZEND_MAP_PTR_SET(func->op_array.run_time_cache, ptr);
+				closure->func.op_array.fn_flags &= ~ZEND_ACC_HEAP_RT_CACHE;
 			} else {
 				/* Otherwise, we use a non-shared runtime cache */
 				ptr = emalloc(func->op_array.cache_size);


### PR DESCRIPTION
disclaimer: this change was generated by claude opus. I have little experience with php-src development

----

Creating a fake closure (Closure::fromCallable(), first-class callable syntax, ReflectionMethod::getClosure()) over a method whose runtime cache was not yet initialized allocated a cold per-closure heap cache on every creation. Initialize the method's own shared cache instead - exactly what the first real call would do - so repeated closure creations reuse one warm cache. Trampolines and heap-cache functions keep the per-closure path.

---

after this PR
```
➜  php-src git:(closure) ✗ hyperfine 'sapi/cli/php -n -d opcache.enable_cli=0 closure_from_callable_runtime_cache_bench.php'
Benchmark 1: sapi/cli/php -n -d opcache.enable_cli=0 closure_from_callable_runtime_cache_bench.php
  Time (mean ± σ):     136.5 ms ±   1.4 ms    [User: 132.8 ms, System: 2.3 ms]
  Range (min … max):   133.4 ms … 138.7 ms    21 runs
```

before this PR
```
➜  php-src git:(closure) ✗ hyperfine 'sapi/cli/php_old -n -d opcache.enable_cli=0 closure_from_callable_runtime_cache_bench.php'
Benchmark 1: sapi/cli/php_old -n -d opcache.enable_cli=0 closure_from_callable_runtime_cache_bench.php
  Time (mean ± σ):     150.6 ms ±   1.3 ms    [User: 147.2 ms, System: 2.3 ms]
  Range (min … max):   148.3 ms … 152.9 ms    19 runs
```


benchmark `closure_from_callable_runtime_cache_bench.php`: https://gist.github.com/staabm/20c082674ed880c8fc097b4775f2d7a7