### PR TITLE
Fix enabling of opcache in community job for PHP <8.5

### DIFF
--- a/.github/matrix.php
+++ b/.github/matrix.php
@@ -73,7 +73,7 @@ function select_jobs($repository, $trigger, $nightly, $labels, $php_version, $re
         && ($all_jobs || !$no_jobs || $test_benchmarking)
         // push trigger is restricted to official repository.
         && ($repository === 'php/php-src' || $trigger === 'pull_request')) {
-        $jobs['BENCHMARKING']['config']['integrated_opcache'] = version_compare($php_version, '8.5', '>=');
+        $jobs['BENCHMARKING'] = true;
     }
     if ($all_jobs || $test_community) {
         $jobs['COMMUNITY']['matrix'] = version_compare($php_version, '8.4', '>=')
@@ -189,6 +189,7 @@ foreach ($branches as &$branch) {
     $branch['jobs'] = select_jobs($repository, $trigger, $nightly, $labels, $php_version, $branch['ref'], $all_variations);
     $branch['config']['default_run_test_jobs'] = version_compare($php_version, '8.6', '>=') ? '' : '-j2';
     $branch['config']['ubuntu_version'] = version_compare($php_version, '8.5', '>=') ? '24.04' : '22.04';
+    $branch['config']['integrated_opcache'] = version_compare($php_version, '8.5', '>=');
 }
 
 echo "All variations:";

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -472,6 +472,7 @@ jobs:
           mysql -uroot -proot -e "SET GLOBAL local_infile = true"
       - name: Enable Opcache
         run: |
+          ${{ !fromJson(inputs.branch).config.integrated_opcache && 'echo zend_extension=opcache.so >> /etc/php.d/opcache.ini' || '' }}
           echo memory_limit=-1 >> /etc/php.d/opcache.ini
           echo opcache.enable_cli=1 >> /etc/php.d/opcache.ini
           echo opcache.enable=1 >> /etc/php.d/opcache.ini
@@ -966,7 +967,7 @@ jobs:
           sudo mkdir -p /etc/php.d
           sudo chmod 777 /etc/php.d
           echo mysqli.default_socket=/var/run/mysqld/mysqld.sock > /etc/php.d/mysqli.ini
-          ${{ !fromJson(inputs.branch).jobs.BENCHMARKING.config.integrated_opcache && 'echo zend_extension=opcache.so >> /etc/php.d/opcache.ini' || '' }}
+          ${{ !fromJson(inputs.branch).config.integrated_opcache && 'echo zend_extension=opcache.so >> /etc/php.d/opcache.ini' || '' }}
           echo opcache.enable=1 >> /etc/php.d/opcache.ini
           echo opcache.enable_cli=1 >> /etc/php.d/opcache.ini
       - name: Setup


### PR DESCRIPTION
We still need the zend_extension there. This has been broken for a while.