### PR TITLE
session: implement 8.6 deprecation

### DIFF
--- a/ext/session/mod_user_class.c
+++ b/ext/session/mod_user_class.c
@@ -158,3 +158,22 @@ PHP_METHOD(SessionHandler, create_sid)
 
 	RETURN_STR(id);
 }
+
+PHP_METHOD(SessionHandler, validateId)
+{
+	zend_string *id;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S", &id) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	PS_SANITY_CHECK;
+	if (!PS(mod_user_is_open)) {
+		php_error_docref(NULL, E_WARNING, "Parent session handler is not open, ignoring ID validation");
+		RETURN_TRUE;
+	}
+
+	zend_result status = PS(default_mod)->s_validate_sid(&PS(mod_data), id);
+
+	RETURN_BOOL(status == SUCCESS);
+}

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -2158,6 +2158,9 @@ PHP_FUNCTION(session_set_save_handler)
 		} else if (zend_hash_find_ptr(object_methods, create_sid_name)) {
 			/* For BC reasons we accept methods even if the class does not implement the interface */
 			SESSION_SET_USER_HANDLER_OO(ps_create_sid, zend_string_copy(create_sid_name));
+		} else {
+			php_error_docref(NULL, E_DEPRECATED,
+				"Providing an object to argument #1 ($sessionhandler) which does not have the create_sid() method defined is deprecated");
 		}
 		zend_string_release_ex(create_sid_name, false);
 
@@ -2179,6 +2182,9 @@ PHP_FUNCTION(session_set_save_handler)
 			if (zend_hash_find_ptr(object_methods, validate_sid_name)) {
 				/* For BC reasons we accept methods even if the class does not implement the interface */
 				SESSION_SET_USER_HANDLER_OO(ps_validate_sid, zend_string_copy(validate_sid_name));
+			} else {
+				php_error_docref(NULL, E_DEPRECATED,
+					"Providing an object to argument #1 ($sessionhandler) which does not have the validateId() method defined is deprecated");
 			}
 			if (zend_hash_find_ptr(object_methods, update_timestamp_name)) {
 				/* For BC reasons we accept methods even if the class does not implement the interface */
@@ -2929,6 +2935,20 @@ static PHP_GINIT_FUNCTION(ps)
 	ps_globals->random_seeded = false;
 }
 
+static int session_handler_interface_gets_implemented(zend_class_entry *self, zend_class_entry *class) {
+	if (!zend_hash_str_exists(&class->function_table, ZEND_STRL("create_sid"))) {
+		zend_error(E_WARNING,
+			"Class %s implementing SessionHandlerInterface is missing the create_sid() method which will be required in PHP 9.0",
+			ZSTR_VAL(class->name));
+	}
+	if (!zend_hash_str_exists(&class->function_table, ZEND_STRL("validateid"))) {
+		zend_error(E_WARNING,
+			"Class %s implementing SessionHandlerInterface is missing the validateId() method which will be required in PHP 9.0",
+			ZSTR_VAL(class->name));
+	}
+	return SUCCESS;
+}
+
 static PHP_MINIT_FUNCTION(session)
 {
 	zend_register_auto_global(zend_string_init_interned(ZEND_STRL("_SESSION"), true), false, NULL);
@@ -2947,6 +2967,7 @@ static PHP_MINIT_FUNCTION(session)
 
 	/* Register interfaces */
 	php_session_iface_entry = register_class_SessionHandlerInterface();
+	php_session_iface_entry->interface_gets_implemented = session_handler_interface_gets_implemented;
 
 	php_session_id_iface_entry = register_class_SessionIdInterface();
 

--- a/ext/session/session.stub.php
+++ b/ext/session/session.stub.php
@@ -147,4 +147,7 @@ class SessionHandler implements SessionHandlerInterface, SessionIdInterface
 
     /** @tentative-return-type */
     public function create_sid(): string {}
+
+    /** @tentative-return-type */
+    public function validateId(string $id): bool {}
 }

--- a/ext/session/session_arginfo.h
+++ b/ext/session/session_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit session.stub.php instead.
- * Stub hash: 6bbbdc8c4a33d1ff9984b3d81e4f5c9b76efcb14 */
+ * Stub hash: 5109ef5c81733a112fe20d2626b8572d0969973c */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_session_name, 0, 0, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, name, IS_STRING, 1, "null")
@@ -135,6 +135,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_SessionHandler_create_sid arginfo_class_SessionIdInterface_create_sid
 
+#define arginfo_class_SessionHandler_validateId arginfo_class_SessionHandlerInterface_destroy
+
 ZEND_FUNCTION(session_name);
 ZEND_FUNCTION(session_module_name);
 ZEND_FUNCTION(session_save_path);
@@ -164,6 +166,7 @@ ZEND_METHOD(SessionHandler, write);
 ZEND_METHOD(SessionHandler, destroy);
 ZEND_METHOD(SessionHandler, gc);
 ZEND_METHOD(SessionHandler, create_sid);
+ZEND_METHOD(SessionHandler, validateId);
 
 static const zend_function_entry ext_functions[] = {
 	ZEND_FE(session_name, arginfo_session_name)
@@ -221,6 +224,7 @@ static const zend_function_entry class_SessionHandler_methods[] = {
 	ZEND_ME(SessionHandler, destroy, arginfo_class_SessionHandler_destroy, ZEND_ACC_PUBLIC)
 	ZEND_ME(SessionHandler, gc, arginfo_class_SessionHandler_gc, ZEND_ACC_PUBLIC)
 	ZEND_ME(SessionHandler, create_sid, arginfo_class_SessionHandler_create_sid, ZEND_ACC_PUBLIC)
+	ZEND_ME(SessionHandler, validateId, arginfo_class_SessionHandler_validateId, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 

--- a/ext/session/tests/gh12504.phpt
+++ b/ext/session/tests/gh12504.phpt
@@ -34,6 +34,15 @@ class TestSessionHandler implements SessionHandlerInterface
 		echo $data . PHP_EOL;
 		return true;
 	}
+
+    private int $id = 0;
+	public function create_sid(): string {
+	    return ++$this->id;
+	}
+
+	public function validateId(string $id): bool {
+	    return $id > 0 && $id <= $this->id;
+	}
 }
 
 register_shutdown_function(function() {

--- a/ext/session/tests/session_module_name_variation2.phpt
+++ b/ext/session/tests/session_module_name_variation2.phpt
@@ -18,6 +18,14 @@ class MySessionHandler implements SessionHandlerInterface {
     public function write($id, $session_data): bool { return false; }
     public function destroy($id): bool { return false; }
     public function gc($maxlifetime): int { return 1; }
+
+    private int $id = 0;
+	public function create_sid(): string {
+	    return ++$this->id;
+	}
+	public function validateId(string $id): bool {
+	    return $id > 0 && $id <= $this->id;
+	}
 }
 
 var_dump(session_module_name("files"));

--- a/ext/session/tests/session_module_name_variation3.phpt
+++ b/ext/session/tests/session_module_name_variation3.phpt
@@ -24,6 +24,14 @@ class MySessionHandler implements SessionHandlerInterface {
     public function write($id, $session_data): bool { return true; }
     public function destroy($id): bool { return true; }
     public function gc($maxlifetime): int { return 1; }
+
+    private int $id = 0;
+	public function create_sid(): string {
+	    return ++$this->id;
+	}
+	public function validateId(string $id): bool {
+	    return $id > 0 && $id <= $this->id;
+	}
 }
 
 var_dump(session_module_name("files"));

--- a/ext/session/tests/user_session_module/basic_set_save_handler_test.phpt
+++ b/ext/session/tests/user_session_module/basic_set_save_handler_test.phpt
@@ -44,6 +44,14 @@ class handler implements SessionHandlerInterface {
     }
 
     function gc($max_lifetime): int { return 1; }
+
+    private int $id = 0;
+	public function create_sid(): string {
+	    return ++$this->id;
+	}
+	public function validateId(string $id): bool {
+	    return $id > 0 && $id <= $this->id;
+	}
 }
 
 $hnd = new handler;

--- a/ext/session/tests/user_session_module/basic_set_save_handler_test02.phpt
+++ b/ext/session/tests/user_session_module/basic_set_save_handler_test02.phpt
@@ -45,6 +45,14 @@ class handler implements SessionHandlerInterface {
     }
 
     function gc($max_lifetime): int { return 1; }
+
+    private int $id = 0;
+	public function create_sid(): string {
+	    return ++$this->id;
+	}
+	public function validateId(string $id): bool {
+	    return $id > 0 && $id <= $this->id;
+	}
 }
 
 $hnd = new handler;

--- a/ext/session/tests/user_session_module/bug32330.phpt
+++ b/ext/session/tests/user_session_module/bug32330.phpt
@@ -49,6 +49,14 @@ class MySessionHandler implements SessionHandlerInterface {
         echo "gc: maxlifetime = {$maxlifetime}\n";
         return 1;
     }
+
+    private int $id = 0;
+	public function create_sid(): string {
+	    return ++$this->id;
+	}
+	public function validateId(string $id): bool {
+	    return $id > 0 && $id <= $this->id;
+	}
 }
 
 session_set_save_handler(new MySessionHandler());

--- a/ext/session/tests/user_session_module/bug60634.phpt
+++ b/ext/session/tests/user_session_module/bug60634.phpt
@@ -35,6 +35,14 @@ class MySessionHandler implements SessionHandlerInterface {
     function gc($maxlifetime): int {
         return 1;
     }
+
+    private int $id = 0;
+	public function create_sid(): string {
+	    return ++$this->id;
+	}
+	public function validateId(string $id): bool {
+	    return $id > 0 && $id <= $this->id;
+	}
 }
 
 session_set_save_handler(new MySessionHandler());

--- a/ext/session/tests/user_session_module/bug60634_error_1.phpt
+++ b/ext/session/tests/user_session_module/bug60634_error_1.phpt
@@ -37,6 +37,14 @@ class MySessionHandler implements SessionHandlerInterface {
     function gc($maxlifetime): int {
         return 1;
     }
+
+    private int $id = 0;
+	public function create_sid(): string {
+	    return ++$this->id;
+	}
+	public function validateId(string $id): bool {
+	    return $id > 0 && $id <= $this->id;
+	}
 }
 session_set_save_handler(new MySessionHandler());
 session_start();

--- a/ext/session/tests/user_session_module/bug60634_error_2.phpt
+++ b/ext/session/tests/user_session_module/bug60634_error_2.phpt
@@ -37,6 +37,14 @@ class MySessionHandler implements SessionHandlerInterface {
     function gc($maxlifetime): int {
         return true;
     }
+
+    private int $id = 0;
+	public function create_sid(): string {
+	    return ++$this->id;
+	}
+	public function validateId(string $id): bool {
+	    return $id > 0 && $id <= $this->id;
+	}
 }
 
 session_set_save_handler(new MySessionHandler());

--- a/ext/session/tests/user_session_module/bug60634_error_5.phpt
+++ b/ext/session/tests/user_session_module/bug60634_error_5.phpt
@@ -36,6 +36,14 @@ class MySessionHandler implements SessionHandlerInterface {
     function gc($maxlifetime): int {
         return 1;
     }
+
+    private int $id = 0;
+	public function create_sid(): string {
+	    return ++$this->id;
+	}
+	public function validateId(string $id): bool {
+	    return $id > 0 && $id <= $this->id;
+	}
 }
 
 session_set_save_handler(new MySessionHandler());

--- a/ext/session/tests/user_session_module/bug61728.phpt
+++ b/ext/session/tests/user_session_module/bug61728.phpt
@@ -35,6 +35,14 @@ class MySessionHandler implements SessionHandlerInterface {
     function gc ($maxlifetime): int {
         return 1;
     }
+
+    private int $id = 0;
+	public function create_sid(): string {
+	    return ++$this->id;
+	}
+	public function validateId(string $id): bool {
+	    return $id > 0 && $id <= $this->id;
+	}
 }
 
 session_set_save_handler(new MySessionHandler());

--- a/ext/session/tests/user_session_module/bug78624.phpt
+++ b/ext/session/tests/user_session_module/bug78624.phpt
@@ -38,6 +38,14 @@ class MySession implements SessionHandlerInterface {
         echo 'Garbage collect', "\n";
         return 1;
     }
+
+    private int $id = 0;
+	public function create_sid(): string {
+	    return ++$this->id;
+	}
+	public function validateId(string $id): bool {
+	    return $id > 0 && $id <= $this->id;
+	}
 }
 
 $handler = new MySession;

--- a/ext/session/tests/user_session_module/bug80889.phpt
+++ b/ext/session/tests/user_session_module/bug80889.phpt
@@ -25,6 +25,14 @@ class DummyHandler implements SessionHandlerInterface {
     public function gc($maxlifetime): int|false {
         return true;
     }
+
+    private int $id = 0;
+	public function create_sid(): string {
+	    return ++$this->id;
+	}
+	public function validateId(string $id): bool {
+	    return $id > 0 && $id <= $this->id;
+	}
 }
 
 $initHandler = ini_get('session.save_handler');

--- a/ext/session/tests/user_session_module/gh9583-extra.phpt
+++ b/ext/session/tests/user_session_module/gh9583-extra.phpt
@@ -5,6 +5,8 @@ session
 --FILE--
 <?php
 
+ob_start();
+
 class SessionHandlerTester implements \SessionHandlerInterface
 {
 
@@ -42,6 +44,13 @@ echo 'validateId() ', (method_exists($obj, 'validateId') ? ('returns ' . ($obj->
 var_dump($originalSessionId == $newSessionId);
 
 ?>
---EXPECT--
+--EXPECTF--
+Warning: Class SessionHandlerTester implementing SessionHandlerInterface is missing the create_sid() method which will be required in PHP 9.0 in %s on line %d
+
+Warning: Class SessionHandlerTester implementing SessionHandlerInterface is missing the validateId() method which will be required in PHP 9.0 in %s on line %d
+
+Deprecated: session_set_save_handler(): Providing an object to argument #1 ($sessionhandler) which does not have the create_sid() method defined is deprecated in %s on line %d
+
+Deprecated: session_set_save_handler(): Providing an object to argument #1 ($sessionhandler) which does not have the validateId() method defined is deprecated in %s on line %d
 validateId() is commented out
 bool(true)

--- a/ext/session/tests/user_session_module/gh9583.phpt
+++ b/ext/session/tests/user_session_module/gh9583.phpt
@@ -5,6 +5,8 @@ session
 --FILE--
 <?php
 
+ob_start();
+
 class SessionHandlerTester implements \SessionHandlerInterface
 {
 
@@ -38,6 +40,14 @@ echo "\n";
 
 ?>
 --EXPECTF--
+Warning: Class SessionHandlerTester implementing SessionHandlerInterface is missing the create_sid() method which will be required in PHP 9.0 in %s on line %d
+
+Warning: Class SessionHandlerTester implementing SessionHandlerInterface is missing the validateId() method which will be required in PHP 9.0 in %s on line %d
+
+Deprecated: session_set_save_handler(): Providing an object to argument #1 ($sessionhandler) which does not have the create_sid() method defined is deprecated in %s on line %d
+
+Deprecated: session_set_save_handler(): Providing an object to argument #1 ($sessionhandler) which does not have the validateId() method defined is deprecated in %s on line %d
+
 validateId() is commented out
 
 Session ID:%s

--- a/ext/session/tests/user_session_module/session_regenerate_id_destroy_fails.phpt
+++ b/ext/session/tests/user_session_module/session_regenerate_id_destroy_fails.phpt
@@ -31,6 +31,14 @@ class FailingDestroyHandler implements SessionHandlerInterface {
     function gc($maxlifetime): int|false {
         return 0;
     }
+
+    private int $id = 0;
+	public function create_sid(): string {
+	    return ++$this->id;
+	}
+	public function validateId(string $id): bool {
+	    return $id > 0 && $id <= $this->id;
+	}
 }
 
 session_set_save_handler(new FailingDestroyHandler());

--- a/ext/session/tests/user_session_module/session_regenerate_id_write_fails.phpt
+++ b/ext/session/tests/user_session_module/session_regenerate_id_write_fails.phpt
@@ -31,6 +31,14 @@ class FailingWriteHandler implements SessionHandlerInterface {
     function gc($maxlifetime): int|false {
         return 0;
     }
+
+    private int $id = 0;
+	public function create_sid(): string {
+	    return ++$this->id;
+	}
+	public function validateId(string $id): bool {
+	    return $id > 0 && $id <= $this->id;
+	}
 }
 
 session_set_save_handler(new FailingWriteHandler());

--- a/ext/session/tests/user_session_module/session_set_save_handler_class_002.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_class_002.phpt
@@ -48,6 +48,14 @@ class MySession2 extends SessionHandler {
         }
         return true;
     }
+
+    private int $id = 0;
+	public function create_sid(): string {
+	    return ++$this->id;
+	}
+	public function validateId(string $id): bool {
+	    return $id > 0 && $id <= $this->id;
+	}
 }
 
 $handler = new MySession2;

--- a/ext/session/tests/user_session_module/session_set_save_handler_class_016.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_class_016.phpt
@@ -80,6 +80,8 @@ array(1) {
   ["foo"]=>
   string(5) "hello"
 }
+
+Warning: SessionHandler::validateId(): Parent session handler is not open, ignoring ID validation in %s on line %d
 array(1) {
   ["foo"]=>
   string(5) "hello"

--- a/ext/session/tests/user_session_module/session_set_save_handler_class_017.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_class_017.phpt
@@ -71,7 +71,7 @@ var_dump($_SESSION);
 <?php
 @unlink(session_save_path().'/u_sess_PHPSESSIDsession_set_save_handler_class_017');
 ?>
---EXPECT--
+--EXPECTF--
 *** Testing session_set_save_handler() function: class with create_sid ***
 string(34) "session_set_save_handler_class_017"
 string(4) "user"
@@ -79,6 +79,8 @@ array(1) {
   ["foo"]=>
   string(5) "hello"
 }
+
+Warning: SessionHandler::validateId(): Parent session handler is not open, ignoring ID validation in %s on line %d
 array(1) {
   ["foo"]=>
   string(5) "hello"

--- a/ext/session/tests/user_session_module/session_set_save_handler_class_018.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_class_018.phpt
@@ -52,7 +52,7 @@ class MySession2 extends SessionHandler {
         return pathinfo(__FILE__)['filename'];
     }
 
-    public function validate_sid($id): bool {
+    public function validateId($id): bool {
         return pathinfo(__FILE__)['filename']===$id;
     }
 }

--- a/ext/session/tests/user_session_module/session_set_save_handler_iface_001.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_iface_001.phpt
@@ -83,6 +83,10 @@ session_unset();
 --EXPECTF--
 *** Testing session_set_save_handler() function: interface ***
 
+Warning: Class MySession2 implementing SessionHandlerInterface is missing the create_sid() method which will be required in PHP 9.0 in %s on line %d
+
+Warning: Class MySession2 implementing SessionHandlerInterface is missing the validateId() method which will be required in PHP 9.0 in %s on line %d
+
 Deprecated: session_set_save_handler(): Providing individual callbacks instead of an object implementing SessionHandlerInterface is deprecated in %s on line %d
 string(%d) "%s"
 string(4) "user"
@@ -94,6 +98,10 @@ array(1) {
   ["foo"]=>
   string(5) "hello"
 }
+
+Deprecated: session_set_save_handler(): Providing an object to argument #1 ($sessionhandler) which does not have the create_sid() method defined is deprecated in %s on line %d
+
+Deprecated: session_set_save_handler(): Providing an object to argument #1 ($sessionhandler) which does not have the validateId() method defined is deprecated in %s on line %d
 string(%d) "%s"
 string(4) "user"
 array(1) {

--- a/ext/session/tests/user_session_module/session_set_save_handler_iface_003.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_iface_003.phpt
@@ -70,8 +70,12 @@ var_dump($_SESSION);
 <?php
 @unlink(session_save_path().'/u_sess_PHPSESSIDsession_set_save_handler_iface_003');
 ?>
---EXPECT--
+--EXPECTF--
 *** Testing session_set_save_handler() function: id interface ***
+
+Warning: Class MySession2 implementing SessionHandlerInterface is missing the validateId() method which will be required in PHP 9.0 in %s on line %d
+
+Deprecated: session_set_save_handler(): Providing an object to argument #1 ($sessionhandler) which does not have the validateId() method defined is deprecated in %s on line %d
 string(34) "session_set_save_handler_iface_003"
 string(4) "user"
 array(1) {

--- a/ext/session/tests/user_session_module/session_set_save_handler_sid_002.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_sid_002.phpt
@@ -48,6 +48,10 @@ class MySession2 implements SessionHandlerInterface, SessionIdInterface {
     public function create_sid() {
         return false;
     }
+
+	public function validateId(string $id): bool {
+	    return true;
+	}
 }
 
 session_set_save_handler(new MySession2());


### PR DESCRIPTION
session: deprecate passing save handlers without create_sid() and validateId() methods

RFC: https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_passing_a_sessionhandler_object_to_session_set_save_handler_which_does_not_contain_the_create_sid_and_validateid_methods