### PR TITLE
Fix GH-23301: nested "yield from" repeats a value after "yield from []"

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,7 +6,7 @@ PHP                                                                        NEWS
   . Fixed bug GH-15375 (Nested "yield from" skips items after a valid() or
     next() call on the inner generator). (iliaal)
   . Fixed bug GH-23301 (Nested "yield from" yields a value twice when the
-    middle generator ends with "yield from []"). (Lazizbek Ergashev)
+    middle generator delegates again). (Lazizbek Ergashev)
 
 - Opcache:
   . Fixed opcache.protect_memory race under ZTS. (realFlowControl)

--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,8 @@ PHP                                                                        NEWS
 - Core:
   . Fixed bug GH-15375 (Nested "yield from" skips items after a valid() or
     next() call on the inner generator). (iliaal)
+  . Fixed bug GH-23301 (Nested "yield from" yields a value twice when the
+    middle generator ends with "yield from []"). (Lazizbek Ergashev)
 
 - Opcache:
   . Fixed opcache.protect_memory race under ZTS. (realFlowControl)

--- a/Zend/tests/generators/backtrace_multi_yield_from.phpt
+++ b/Zend/tests/generators/backtrace_multi_yield_from.phpt
@@ -25,8 +25,8 @@ var_dump($gen2->current());
 ?>
 --EXPECTF--
 int(1)
-int(1)
 #0 %s(10): gen()
 #1 [internal function]: from(Object(Generator))
-#2 %s(19): Generator->next()
+#2 %s(17): Generator->next()
 int(2)
+NULL

--- a/Zend/tests/generators/gh15375.phpt
+++ b/Zend/tests/generators/gh15375.phpt
@@ -46,9 +46,9 @@ foreach (outer(withNext()) as $s) {
     echo $s, "\n";
 }
 
-// A shared, pre-primed generator consumed through two nested "yield from"
-// levels must still present its current value once to each consumer (the fix
-// must not over-clear the middle level's first-touch).
+// Reading a pre-primed generator through two nested "yield from" levels primes
+// the whole chain but advances nothing. A later next() on a middle level then
+// advances the shared generator, like any other next() would.
 echo "shared primed:\n";
 function counter() {
     yield 1;
@@ -58,11 +58,11 @@ $gen1 = counter();
 $gen1->valid();
 $gen2 = outer($gen1);
 $gen3 = outer($gen2);
-echo "gen3 current: ", $gen3->current(), "\n";
+var_dump($gen3->current());
 $gen2->next();
-echo "gen2 current: ", $gen2->current(), "\n";
+var_dump($gen2->current());
 $gen2->next();
-echo "gen2 current: ", $gen2->current(), "\n";
+var_dump($gen2->current());
 
 ?>
 --EXPECT--
@@ -84,6 +84,6 @@ six
 eight
 nine
 shared primed:
-gen3 current: 1
-gen2 current: 1
-gen2 current: 2
+int(1)
+int(2)
+NULL

--- a/Zend/tests/generators/gh23301.phpt
+++ b/Zend/tests/generators/gh23301.phpt
@@ -1,5 +1,5 @@
 --TEST--
-GH-23301 (Nested "yield from" yields a value twice when the middle generator ends with "yield from []")
+GH-23301 (Nested "yield from" yields a value twice when the middle generator delegates again)
 --FILE--
 <?php
 
@@ -11,19 +11,34 @@ function middle() {
     yield "A";
     yield from inner();
     yield "C";
-    yield from [];
+    yield from ["D"];
 }
 
-function outer() {
-    yield from middle();
+function delegate($gen) {
+    yield from $gen;
 }
 
-foreach (outer() as $value) {
+foreach (delegate(middle()) as $value) {
     echo $value, "\n";
 }
+
+function tail($inner) {
+    yield from $inner;
+    yield from ["E"];
+}
+
+$middle = tail(inner());
+$outer = delegate($middle);
+
+var_dump($outer->current());
+$middle->next();
+var_dump($middle->current());
 
 ?>
 --EXPECT--
 A
 B
 C
+D
+string(1) "B"
+string(1) "E"

--- a/Zend/tests/generators/gh23301.phpt
+++ b/Zend/tests/generators/gh23301.phpt
@@ -1,0 +1,29 @@
+--TEST--
+GH-23301 (Nested "yield from" yields a value twice when the middle generator ends with "yield from []")
+--FILE--
+<?php
+
+function inner() {
+    yield "B";
+}
+
+function middle() {
+    yield "A";
+    yield from inner();
+    yield "C";
+    yield from [];
+}
+
+function outer() {
+    yield from middle();
+}
+
+foreach (outer() as $value) {
+    echo $value, "\n";
+}
+
+?>
+--EXPECT--
+A
+B
+C

--- a/Zend/zend_generators.c
+++ b/Zend/zend_generators.c
@@ -776,15 +776,13 @@ try_again:
 		return;
 	}
 
-	if (UNEXPECTED((delegator->flags & ZEND_GENERATOR_DO_INIT) != 0 && !Z_ISUNDEF(generator->value))) {
-		/* We must not advance Generator if we yield from a Generator being currently run */
-		orig_generator->flags &= ~ZEND_GENERATOR_DO_INIT;
-		return;
+	if (UNEXPECTED((delegator->flags & ZEND_GENERATOR_DO_INIT) != 0)) {
+		delegator->flags &= ~ZEND_GENERATOR_DO_INIT;
+		if (UNEXPECTED(!Z_ISUNDEF(generator->value))) {
+			/* We must not advance an already initialized delegate on first resumption */
+			return;
+		}
 	}
-
-	/* The flag applies to this resume only: if it stays set on a delegating
-	 * generator other than orig_generator, it suppresses a later resume of it */
-	delegator->flags &= ~ZEND_GENERATOR_DO_INIT;
 
 	if (EG(active_fiber)) {
 		orig_generator->flags |= ZEND_GENERATOR_IN_FIBER;

--- a/Zend/zend_generators.c
+++ b/Zend/zend_generators.c
@@ -782,6 +782,10 @@ try_again:
 		return;
 	}
 
+	/* The flag applies to this resume only: if it stays set on a delegating
+	 * generator other than orig_generator, it suppresses a later resume of it */
+	delegator->flags &= ~ZEND_GENERATOR_DO_INIT;
+
 	if (EG(active_fiber)) {
 		orig_generator->flags |= ZEND_GENERATOR_IN_FIBER;
 		generator->flags |= ZEND_GENERATOR_IN_FIBER;
@@ -890,7 +894,7 @@ try_again:
 
 	/* yield from was used, try another resume. */
 	if (UNEXPECTED(generator->execute_data && generator->execute_data->opline->opcode == ZEND_YIELD_FROM)) {
-		delegator = generator->node.parent ? generator : orig_generator;
+		delegator = generator;
 		generator = zend_generator_get_current(orig_generator);
 		goto try_again;
 	}

--- a/Zend/zend_generators.c
+++ b/Zend/zend_generators.c
@@ -823,7 +823,7 @@ try_again:
 			EG(current_execute_data) = original_execute_data;
 			EG(jit_trace_num) = original_jit_trace_num;
 
-			orig_generator->flags &= ~(ZEND_GENERATOR_DO_INIT | ZEND_GENERATOR_IN_FIBER);
+			orig_generator->flags &= ~ZEND_GENERATOR_IN_FIBER;
 			generator->flags &= ~(ZEND_GENERATOR_CURRENTLY_RUNNING | ZEND_GENERATOR_IN_FIBER);
 			return;
 		}
@@ -886,7 +886,6 @@ try_again:
 		} else {
 			generator = zend_generator_get_current(orig_generator);
 			zend_generator_throw_exception(generator, NULL);
-			orig_generator->flags &= ~ZEND_GENERATOR_DO_INIT;
 			delegator = orig_generator;
 			goto try_again;
 		}
@@ -904,7 +903,7 @@ try_again:
 		goto try_again;
 	}
 
-	orig_generator->flags &= ~(ZEND_GENERATOR_DO_INIT | ZEND_GENERATOR_IN_FIBER);
+	orig_generator->flags &= ~ZEND_GENERATOR_IN_FIBER;
 }
 /* }}} */
 

--- a/Zend/zend_generators.c
+++ b/Zend/zend_generators.c
@@ -890,7 +890,7 @@ try_again:
 
 	/* yield from was used, try another resume. */
 	if (UNEXPECTED(generator->execute_data && generator->execute_data->opline->opcode == ZEND_YIELD_FROM)) {
-		delegator = generator;
+		delegator = generator->node.parent ? generator : orig_generator;
 		generator = zend_generator_get_current(orig_generator);
 		goto try_again;
 	}


### PR DESCRIPTION
GH-15375's fix made the `DO_INIT` re-advance guard in `zend_generator_resume()` read the flag from the delegating generator rather than from `orig_generator`. That flag is set by `zend_generator_yield_from()` and only ever cleared on `orig_generator`, so on a middle generator it stays set for the rest of its life.

When such a middle generator then delegates to a non-generator iterable (`yield from []`), it still sits on a `ZEND_YIELD_FROM` opline, so it is picked as the delegator even though no new generator link was established, and its stale `DO_INIT` suppresses the resume. The value it yielded last is presented a second time. Twig hits this on every template, since `doDisplay()` always ends with `yield from [];`.

Only treat the generator as the delegator when it actually delegated to another generator (`node.parent` is set); otherwise keep `orig_generator` as before. The GH-15375 tests still pass.

Fixes GH-23301
