### PR TITLE
Fix parameter name in the convert_uudecode() warning

### DIFF
--- a/ext/standard/tests/strings/bug67252.phpt
+++ b/ext/standard/tests/strings/bug67252.phpt
@@ -8,5 +8,5 @@ var_dump(convert_uudecode($a));
 
 ?>
 --EXPECTF--
-Warning: convert_uudecode(): Argument #1 ($data) is not a valid uuencoded string in %s on line %d
+Warning: convert_uudecode(): Argument #1 ($string) is not a valid uuencoded string in %s on line %d
 bool(false)

--- a/ext/standard/tests/strings/uuencode.phpt
+++ b/ext/standard/tests/strings/uuencode.phpt
@@ -29,9 +29,9 @@ string(36) "6;F]T('9E<GD@<V]P:&ES=&EC871E9```
 "
 string(22) "not very sophisticated"
 
-Warning: convert_uudecode(): Argument #1 ($data) is not a valid uuencoded string in %s on line %d
+Warning: convert_uudecode(): Argument #1 ($string) is not a valid uuencoded string in %s on line %d
 bool(false)
 
-Warning: convert_uudecode(): Argument #1 ($data) is not a valid uuencoded string in %s on line %d
+Warning: convert_uudecode(): Argument #1 ($string) is not a valid uuencoded string in %s on line %d
 bool(false)
 Done

--- a/ext/standard/uuencode.c
+++ b/ext/standard/uuencode.c
@@ -222,7 +222,7 @@ PHP_FUNCTION(convert_uudecode)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if ((dest = php_uudecode(ZSTR_VAL(src), ZSTR_LEN(src))) == NULL) {
-		php_error_docref(NULL, E_WARNING, "Argument #1 ($data) is not a valid uuencoded string");
+		php_error_docref(NULL, E_WARNING, "Argument #1 ($string) is not a valid uuencoded string");
 		RETURN_FALSE;
 	}
 


### PR DESCRIPTION
`convert_uudecode()` declares its parameter as `$string`, but its warning names `$data`:

```
convert_uudecode(): Argument #1 ($data) is not a valid uuencoded string
```

Following the message and calling `convert_uudecode(data: 'x')` raises `Error: Unknown named parameter $data`, while `string:` works. Reproduced on 8.4.22 and 8.5.9.

The message is a literal rather than a generated one, which is why it did not follow the parameter. This is the only place in the tree where a hardcoded `$data` does not match the declared parameter; the other hits (`bzcompress`, `bzdecompress`, `gmp_import`, `http_build_query`) all belong to functions whose parameter really is named `$data`.

Three tests pinned the old wording and are updated in the same commit.

Targeting master rather than a stable branch, since the warning text is observable output.
