### PR TITLE
ext/date: Change return type to static

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -335,6 +335,21 @@ PHP 8.6 UPGRADE NOTES
 - Date:
   . Added a new Time\Duration class.
     RFC: https://wiki.php.net/rfc/duration_class
+  . The following DateTime, DateTimeImmutable, DateTimeZone, DateInterval, and DatePeriod methods now have tentative static return types:
+    DateTime::createFromInterface()
+    DateTimeImmutable::__set_state()
+    DateTimeImmutable::modify()
+    DateTimeImmutable::add()
+    DateTimeImmutable::sub()
+    DateTimeImmutable::setTimezone()
+    DateTimeImmutable::setTime()
+    DateTimeImmutable::setDate()
+    DateTimeImmutable::setISODate()
+    DateTimeImmutable::setTimestamp()
+    DateTimeImmutable::createFromInterface()
+    DateTimeZone::__set_state()
+    DateInterval::__set_state()
+    DatePeriod::__set_state()
 
 - Fileinfo:
   . finfo_file() now works with remote streams.

--- a/UPGRADING
+++ b/UPGRADING
@@ -335,21 +335,6 @@ PHP 8.6 UPGRADE NOTES
 - Date:
   . Added a new Time\Duration class.
     RFC: https://wiki.php.net/rfc/duration_class
-  . The following DateTime, DateTimeImmutable, DateTimeZone, DateInterval, and DatePeriod methods now have tentative static return types:
-    DateTime::createFromInterface()
-    DateTimeImmutable::__set_state()
-    DateTimeImmutable::modify()
-    DateTimeImmutable::add()
-    DateTimeImmutable::sub()
-    DateTimeImmutable::setTimezone()
-    DateTimeImmutable::setTime()
-    DateTimeImmutable::setDate()
-    DateTimeImmutable::setISODate()
-    DateTimeImmutable::setTimestamp()
-    DateTimeImmutable::createFromInterface()
-    DateTimeZone::__set_state()
-    DateInterval::__set_state()
-    DatePeriod::__set_state()
 
 - Fileinfo:
   . finfo_file() now works with remote streams.
@@ -617,6 +602,23 @@ PHP 8.6 UPGRADE NOTES
     directive when $details is true. It holds the built-in default value of the
     directive (or null if it has none), independent of values set in php.ini,
     on the command line, or at runtime.
+    
+- Date:
+  . The following DateTime, DateTimeImmutable, DateTimeZone, DateInterval, and DatePeriod methods now have tentative static return types:
+    DateTime::createFromInterface()
+    DateTimeImmutable::__set_state()
+    DateTimeImmutable::modify()
+    DateTimeImmutable::add()
+    DateTimeImmutable::sub()
+    DateTimeImmutable::setTimezone()
+    DateTimeImmutable::setTime()
+    DateTimeImmutable::setDate()
+    DateTimeImmutable::setISODate()
+    DateTimeImmutable::setTimestamp()
+    DateTimeImmutable::createFromInterface()
+    DateTimeZone::__set_state()
+    DateInterval::__set_state()
+    DatePeriod::__set_state()
 
 ========================================
 6. New Functions

--- a/Zend/tests/parameter_default_values/internal_declaration_error_int.phpt
+++ b/Zend/tests/parameter_default_values/internal_declaration_error_int.phpt
@@ -10,4 +10,4 @@ class MyDateTime extends DateTime
 }
 ?>
 --EXPECTF--
-Fatal error: Declaration of MyDateTime::setTime(int $hour, int $minute, int $second = 0, bool $microsecond = false): DateTime must be compatible with DateTime::setTime(int $hour, int $minute, int $second = 0, int $microsecond = 0): static in %s on line %d
+Fatal error: Declaration of MyDateTime::setTime(int $hour, int $minute, int $second = 0, bool $microsecond = false): DateTime must be compatible with DateTime::setTime(int $hour, int $minute, int $second = 0, int $microsecond = 0): DateTime in %s on line %d

--- a/Zend/tests/parameter_default_values/internal_declaration_error_int.phpt
+++ b/Zend/tests/parameter_default_values/internal_declaration_error_int.phpt
@@ -10,4 +10,4 @@ class MyDateTime extends DateTime
 }
 ?>
 --EXPECTF--
-Fatal error: Declaration of MyDateTime::setTime(int $hour, int $minute, int $second = 0, bool $microsecond = false): DateTime must be compatible with DateTime::setTime(int $hour, int $minute, int $second = 0, int $microsecond = 0): DateTime in %s on line %d
+Fatal error: Declaration of MyDateTime::setTime(int $hour, int $minute, int $second = 0, bool $microsecond = false): DateTime must be compatible with DateTime::setTime(int $hour, int $minute, int $second = 0, int $microsecond = 0): static in %s on line %d

--- a/ext/date/php_date.stub.php
+++ b/ext/date/php_date.stub.php
@@ -349,8 +349,8 @@ class DateTime implements DateTimeInterface
     /** @tentative-return-type */
     public static function createFromImmutable(DateTimeImmutable $object): static {}
 
-    /** @return static */
-    public static function createFromInterface(DateTimeInterface $object): DateTime {} // TODO return type should be static
+    /** @tentative-return-type */
+    public static function createFromInterface(DateTimeInterface $object): static {}
 
     /**
      * @tentative-return-type
@@ -400,7 +400,7 @@ class DateTime implements DateTimeInterface
      * @tentative-return-type
      * @alias date_timezone_set
      */
-    public function setTimezone(DateTimeZone $timezone): DateTime {}
+    public function setTimezone(DateTimeZone $timezone): static {}
 
     /**
      * @tentative-return-type
@@ -414,25 +414,25 @@ class DateTime implements DateTimeInterface
      * @tentative-return-type
      * @alias date_time_set
      */
-    public function setTime(int $hour, int $minute, int $second = 0, int $microsecond = 0): DateTime {}
+    public function setTime(int $hour, int $minute, int $second = 0, int $microsecond = 0): static {}
 
     /**
      * @tentative-return-type
      * @alias date_date_set
      */
-    public function setDate(int $year, int $month, int $day): DateTime {}
+    public function setDate(int $year, int $month, int $day): static {}
 
     /**
      * @tentative-return-type
      * @alias date_isodate_set
      */
-    public function setISODate(int $year, int $week, int $dayOfWeek = 1): DateTime {}
+    public function setISODate(int $year, int $week, int $dayOfWeek = 1): static {}
 
     /**
      * @tentative-return-type
      * @alias date_timestamp_set
      */
-    public function setTimestamp(int $timestamp): DateTime {}
+    public function setTimestamp(int $timestamp): static {}
 
     public function setMicrosecond(int $microsecond): static {}
 
@@ -462,13 +462,13 @@ class DateTimeImmutable implements DateTimeInterface
     public function __wakeup(): void {}
 
     /** @tentative-return-type */
-    public static function __set_state(array $array): DateTimeImmutable {}
+    public static function __set_state(array $array): static {}
 
     /**
      * @tentative-return-type
      * @alias date_create_immutable_from_format
      */
-    public static function createFromFormat(string $format, string $datetime, ?DateTimeZone $timezone = null): DateTimeImmutable|false {}
+    public static function createFromFormat(string $format, string $datetime, ?DateTimeZone $timezone = null): static|false {}
 
     /** @tentative-return-type */
     public static function createFromTimestamp(int|float $timestamp): static {}
@@ -517,35 +517,35 @@ class DateTimeImmutable implements DateTimeInterface
 
     /** @tentative-return-type */
     #[\NoDiscard(message: "as DateTimeImmutable::modify() does not modify the object itself")]
-    public function modify(string $modifier): DateTimeImmutable {}
+    public function modify(string $modifier): static {}
 
     /** @tentative-return-type */
     #[\NoDiscard(message: "as DateTimeImmutable::add() does not modify the object itself")]
-    public function add(DateInterval $interval): DateTimeImmutable {}
+    public function add(DateInterval $interval): static {}
 
     /** @tentative-return-type */
     #[\NoDiscard(message: "as DateTimeImmutable::sub() does not modify the object itself")]
-    public function sub(DateInterval $interval): DateTimeImmutable {}
+    public function sub(DateInterval $interval): static {}
 
     /** @tentative-return-type */
     #[\NoDiscard(message: "as DateTimeImmutable::setTimezone() does not modify the object itself")]
-    public function setTimezone(DateTimeZone $timezone): DateTimeImmutable {}
+    public function setTimezone(DateTimeZone $timezone): static {}
 
     /** @tentative-return-type */
     #[\NoDiscard(message: "as DateTimeImmutable::setTime() does not modify the object itself")]
-    public function setTime(int $hour, int $minute, int $second = 0, int $microsecond = 0): DateTimeImmutable {}
+    public function setTime(int $hour, int $minute, int $second = 0, int $microsecond = 0): static {}
 
     /** @tentative-return-type */
     #[\NoDiscard(message: "as DateTimeImmutable::setDate() does not modify the object itself")]
-    public function setDate(int $year, int $month, int $day): DateTimeImmutable {}
+    public function setDate(int $year, int $month, int $day): static {}
 
     /** @tentative-return-type */
     #[\NoDiscard(message: "as DateTimeImmutable::setISODate() does not modify the object itself")]
-    public function setISODate(int $year, int $week, int $dayOfWeek = 1): DateTimeImmutable {}
+    public function setISODate(int $year, int $week, int $dayOfWeek = 1): static {}
 
     /** @tentative-return-type */
     #[\NoDiscard(message: "as DateTimeImmutable::setTimestamp() does not modify the object itself")]
-    public function setTimestamp(int $timestamp): DateTimeImmutable {}
+    public function setTimestamp(int $timestamp): static {}
 
     #[\NoDiscard(message: "as DateTimeImmutable::setMicrosecond() does not modify the object itself")]
     public function setMicrosecond(int $microsecond): static {}
@@ -553,8 +553,8 @@ class DateTimeImmutable implements DateTimeInterface
     /** @tentative-return-type */
     public static function createFromMutable(DateTime $object): static {}
 
-    /** @return static */
-    public static function createFromInterface(DateTimeInterface $object): DateTimeImmutable {} // TODO return type should be static
+    /** @tentative-return-type */
+    public static function createFromInterface(DateTimeInterface $object): static {}
 }
 
 class DateTimeZone
@@ -639,7 +639,7 @@ class DateTimeZone
     public function __wakeup(): void {}
 
     /** @tentative-return-type */
-    public static function __set_state(array $array): DateTimeZone {}
+    public static function __set_state(array $array): static {}
 }
 
 class DateInterval
@@ -649,7 +649,7 @@ class DateInterval
     /**
      * @tentative-return-type
      */
-    public static function createFromDateString(string $datetime): DateInterval {}
+    public static function createFromDateString(string $datetime): static {}
 
     /**
      * @tentative-return-type
@@ -666,7 +666,7 @@ class DateInterval
     public function __wakeup(): void {}
 
     /** @tentative-return-type */
-    public static function __set_state(array $array): DateInterval {}
+    public static function __set_state(array $array): static {}
 }
 
 class DatePeriod implements IteratorAggregate
@@ -743,7 +743,7 @@ class DatePeriod implements IteratorAggregate
     public function __wakeup(): void {}
 
     /** @tentative-return-type */
-    public static function __set_state(array $array): DatePeriod {}
+    public static function __set_state(array $array): static {}
 
     public function getIterator(): Iterator {}
 }

--- a/ext/date/php_date.stub.php
+++ b/ext/date/php_date.stub.php
@@ -400,7 +400,7 @@ class DateTime implements DateTimeInterface
      * @tentative-return-type
      * @alias date_timezone_set
      */
-    public function setTimezone(DateTimeZone $timezone): static {}
+    public function setTimezone(DateTimeZone $timezone): DateTime {}
 
     /**
      * @tentative-return-type
@@ -414,25 +414,25 @@ class DateTime implements DateTimeInterface
      * @tentative-return-type
      * @alias date_time_set
      */
-    public function setTime(int $hour, int $minute, int $second = 0, int $microsecond = 0): static {}
+    public function setTime(int $hour, int $minute, int $second = 0, int $microsecond = 0): DateTime {}
 
     /**
      * @tentative-return-type
      * @alias date_date_set
      */
-    public function setDate(int $year, int $month, int $day): static {}
+    public function setDate(int $year, int $month, int $day): DateTime {}
 
     /**
      * @tentative-return-type
      * @alias date_isodate_set
      */
-    public function setISODate(int $year, int $week, int $dayOfWeek = 1): static {}
+    public function setISODate(int $year, int $week, int $dayOfWeek = 1): DateTime {}
 
     /**
      * @tentative-return-type
      * @alias date_timestamp_set
      */
-    public function setTimestamp(int $timestamp): static {}
+    public function setTimestamp(int $timestamp): DateTime {}
 
     public function setMicrosecond(int $microsecond): static {}
 
@@ -468,7 +468,7 @@ class DateTimeImmutable implements DateTimeInterface
      * @tentative-return-type
      * @alias date_create_immutable_from_format
      */
-    public static function createFromFormat(string $format, string $datetime, ?DateTimeZone $timezone = null): static|false {}
+    public static function createFromFormat(string $format, string $datetime, ?DateTimeZone $timezone = null): DateTimeImmutable|false {}
 
     /** @tentative-return-type */
     public static function createFromTimestamp(int|float $timestamp): static {}

--- a/ext/date/php_date.stub.php
+++ b/ext/date/php_date.stub.php
@@ -649,7 +649,7 @@ class DateInterval
     /**
      * @tentative-return-type
      */
-    public static function createFromDateString(string $datetime): static {}
+    public static function createFromDateString(string $datetime): DateInterval {}
 
     /**
      * @tentative-return-type

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit php_date.stub.php instead.
- * Stub hash: 8556e1b5f05ae9f78200f05f01d9f8e815cba49d */
+ * Stub hash: 90bad5a5d3100d611d237c4aec07b26cf831f52c */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_strtotime, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
@@ -272,7 +272,7 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTime_createF
 	ZEND_ARG_OBJ_INFO(0, object, DateTimeImmutable, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_DateTime_createFromInterface, 0, 1, DateTime, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTime_createFromInterface, 0, 1, IS_STATIC, 0)
 	ZEND_ARG_OBJ_INFO(0, object, DateTimeInterface, 0)
 ZEND_END_ARG_INFO()
 
@@ -303,7 +303,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_DateTime_getTimezone arginfo_class_DateTimeInterface_getTimezone
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTime_setTimezone, 0, 1, DateTime, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTime_setTimezone, 0, 1, IS_STATIC, 0)
 	ZEND_ARG_OBJ_INFO(0, timezone, DateTimeZone, 0)
 ZEND_END_ARG_INFO()
 
@@ -311,26 +311,26 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_DateTime_getMicrosecond arginfo_time
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTime_setTime, 0, 2, DateTime, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTime_setTime, 0, 2, IS_STATIC, 0)
 	ZEND_ARG_TYPE_INFO(0, hour, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, minute, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, second, IS_LONG, 0, "0")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, microsecond, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTime_setDate, 0, 3, DateTime, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTime_setDate, 0, 3, IS_STATIC, 0)
 	ZEND_ARG_TYPE_INFO(0, year, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, month, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, day, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTime_setISODate, 0, 2, DateTime, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTime_setISODate, 0, 2, IS_STATIC, 0)
 	ZEND_ARG_TYPE_INFO(0, year, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, week, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, dayOfWeek, IS_LONG, 0, "1")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTime_setTimestamp, 0, 1, DateTime, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTime_setTimestamp, 0, 1, IS_STATIC, 0)
 	ZEND_ARG_TYPE_INFO(0, timestamp, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
@@ -350,11 +350,11 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_DateTimeImmutable___wakeup arginfo_class_DateTimeInterface___wakeup
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTimeImmutable___set_state, 0, 1, DateTimeImmutable, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTimeImmutable___set_state, 0, 1, IS_STATIC, 0)
 	ZEND_ARG_TYPE_INFO(0, array, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_DateTimeImmutable_createFromFormat, 0, 2, DateTimeImmutable, MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_DateTimeImmutable_createFromFormat, 0, 2, MAY_BE_STATIC|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, format, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, timezone, DateTimeZone, 1, "null")
@@ -376,42 +376,25 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_DateTimeImmutable_diff arginfo_class_DateTimeInterface_diff
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTimeImmutable_modify, 0, 1, DateTimeImmutable, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTimeImmutable_modify, 0, 1, IS_STATIC, 0)
 	ZEND_ARG_TYPE_INFO(0, modifier, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTimeImmutable_add, 0, 1, DateTimeImmutable, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTimeImmutable_add, 0, 1, IS_STATIC, 0)
 	ZEND_ARG_OBJ_INFO(0, interval, DateInterval, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_DateTimeImmutable_sub arginfo_class_DateTimeImmutable_add
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTimeImmutable_setTimezone, 0, 1, DateTimeImmutable, 0)
-	ZEND_ARG_OBJ_INFO(0, timezone, DateTimeZone, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_class_DateTimeImmutable_setTimezone arginfo_class_DateTime_setTimezone
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTimeImmutable_setTime, 0, 2, DateTimeImmutable, 0)
-	ZEND_ARG_TYPE_INFO(0, hour, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, minute, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, second, IS_LONG, 0, "0")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, microsecond, IS_LONG, 0, "0")
-ZEND_END_ARG_INFO()
+#define arginfo_class_DateTimeImmutable_setTime arginfo_class_DateTime_setTime
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTimeImmutable_setDate, 0, 3, DateTimeImmutable, 0)
-	ZEND_ARG_TYPE_INFO(0, year, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, month, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, day, IS_LONG, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_class_DateTimeImmutable_setDate arginfo_class_DateTime_setDate
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTimeImmutable_setISODate, 0, 2, DateTimeImmutable, 0)
-	ZEND_ARG_TYPE_INFO(0, year, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, week, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, dayOfWeek, IS_LONG, 0, "1")
-ZEND_END_ARG_INFO()
+#define arginfo_class_DateTimeImmutable_setISODate arginfo_class_DateTime_setISODate
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTimeImmutable_setTimestamp, 0, 1, DateTimeImmutable, 0)
-	ZEND_ARG_TYPE_INFO(0, timestamp, IS_LONG, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_class_DateTimeImmutable_setTimestamp arginfo_class_DateTime_setTimestamp
 
 #define arginfo_class_DateTimeImmutable_setMicrosecond arginfo_class_DateTime_setMicrosecond
 
@@ -419,9 +402,7 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTimeImmutabl
 	ZEND_ARG_OBJ_INFO(0, object, DateTime, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_DateTimeImmutable_createFromInterface, 0, 1, DateTimeImmutable, 0)
-	ZEND_ARG_OBJ_INFO(0, object, DateTimeInterface, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_class_DateTimeImmutable_createFromInterface arginfo_class_DateTime_createFromInterface
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DateTimeZone___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, timezone, IS_STRING, 0)
@@ -455,15 +436,13 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_DateTimeZone___wakeup arginfo_class_DateTimeInterface___wakeup
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTimeZone___set_state, 0, 1, DateTimeZone, 0)
-	ZEND_ARG_TYPE_INFO(0, array, IS_ARRAY, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_class_DateTimeZone___set_state arginfo_class_DateTimeImmutable___set_state
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DateInterval___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, duration, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateInterval_createFromDateString, 0, 1, DateInterval, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateInterval_createFromDateString, 0, 1, IS_STATIC, 0)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -475,9 +454,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_DateInterval___wakeup arginfo_class_DateTimeInterface___wakeup
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateInterval___set_state, 0, 1, DateInterval, 0)
-	ZEND_ARG_TYPE_INFO(0, array, IS_ARRAY, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_class_DateInterval___set_state arginfo_class_DateTimeImmutable___set_state
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_DatePeriod_createFromISO8601String, 0, 1, IS_STATIC, 0)
 	ZEND_ARG_TYPE_INFO(0, specification, IS_STRING, 0)
@@ -509,9 +486,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_DatePeriod___wakeup arginfo_class_DateTimeInterface___wakeup
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DatePeriod___set_state, 0, 1, DatePeriod, 0)
-	ZEND_ARG_TYPE_INFO(0, array, IS_ARRAY, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_class_DatePeriod___set_state arginfo_class_DateTimeImmutable___set_state
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_DatePeriod_getIterator, 0, 0, Iterator, 0)
 ZEND_END_ARG_INFO()

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit php_date.stub.php instead.
- * Stub hash: 0e01f68589a71eae2f789ef6de330ac27724ba47 */
+ * Stub hash: f82824bc7dc4c7672f03d3c2698c6a958a730fa8 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_strtotime, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
@@ -459,7 +459,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DateInterval___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, duration, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateInterval_createFromDateString, 0, 1, IS_STATIC, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateInterval_createFromDateString, 0, 1, DateInterval, 0)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit php_date.stub.php instead.
- * Stub hash: 90bad5a5d3100d611d237c4aec07b26cf831f52c */
+ * Stub hash: 0e01f68589a71eae2f789ef6de330ac27724ba47 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_strtotime, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
@@ -303,7 +303,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_DateTime_getTimezone arginfo_class_DateTimeInterface_getTimezone
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTime_setTimezone, 0, 1, IS_STATIC, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTime_setTimezone, 0, 1, DateTime, 0)
 	ZEND_ARG_OBJ_INFO(0, timezone, DateTimeZone, 0)
 ZEND_END_ARG_INFO()
 
@@ -311,26 +311,26 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_DateTime_getMicrosecond arginfo_time
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTime_setTime, 0, 2, IS_STATIC, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTime_setTime, 0, 2, DateTime, 0)
 	ZEND_ARG_TYPE_INFO(0, hour, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, minute, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, second, IS_LONG, 0, "0")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, microsecond, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTime_setDate, 0, 3, IS_STATIC, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTime_setDate, 0, 3, DateTime, 0)
 	ZEND_ARG_TYPE_INFO(0, year, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, month, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, day, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTime_setISODate, 0, 2, IS_STATIC, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTime_setISODate, 0, 2, DateTime, 0)
 	ZEND_ARG_TYPE_INFO(0, year, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, week, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, dayOfWeek, IS_LONG, 0, "1")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTime_setTimestamp, 0, 1, IS_STATIC, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTime_setTimestamp, 0, 1, DateTime, 0)
 	ZEND_ARG_TYPE_INFO(0, timestamp, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
@@ -354,7 +354,7 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTimeImmutabl
 	ZEND_ARG_TYPE_INFO(0, array, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_DateTimeImmutable_createFromFormat, 0, 2, MAY_BE_STATIC|MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_DateTimeImmutable_createFromFormat, 0, 2, DateTimeImmutable, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, format, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, timezone, DateTimeZone, 1, "null")
@@ -386,15 +386,32 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_DateTimeImmutable_sub arginfo_class_DateTimeImmutable_add
 
-#define arginfo_class_DateTimeImmutable_setTimezone arginfo_class_DateTime_setTimezone
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTimeImmutable_setTimezone, 0, 1, IS_STATIC, 0)
+	ZEND_ARG_OBJ_INFO(0, timezone, DateTimeZone, 0)
+ZEND_END_ARG_INFO()
 
-#define arginfo_class_DateTimeImmutable_setTime arginfo_class_DateTime_setTime
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTimeImmutable_setTime, 0, 2, IS_STATIC, 0)
+	ZEND_ARG_TYPE_INFO(0, hour, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, minute, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, second, IS_LONG, 0, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, microsecond, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
 
-#define arginfo_class_DateTimeImmutable_setDate arginfo_class_DateTime_setDate
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTimeImmutable_setDate, 0, 3, IS_STATIC, 0)
+	ZEND_ARG_TYPE_INFO(0, year, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, month, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, day, IS_LONG, 0)
+ZEND_END_ARG_INFO()
 
-#define arginfo_class_DateTimeImmutable_setISODate arginfo_class_DateTime_setISODate
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTimeImmutable_setISODate, 0, 2, IS_STATIC, 0)
+	ZEND_ARG_TYPE_INFO(0, year, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, week, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, dayOfWeek, IS_LONG, 0, "1")
+ZEND_END_ARG_INFO()
 
-#define arginfo_class_DateTimeImmutable_setTimestamp arginfo_class_DateTime_setTimestamp
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTimeImmutable_setTimestamp, 0, 1, IS_STATIC, 0)
+	ZEND_ARG_TYPE_INFO(0, timestamp, IS_LONG, 0)
+ZEND_END_ARG_INFO()
 
 #define arginfo_class_DateTimeImmutable_setMicrosecond arginfo_class_DateTime_setMicrosecond
 


### PR DESCRIPTION
Use static return types for DateTime and related methods that preserve the called class.
