### PR TITLE
ext/zip: Fix AES-192 and AES-256 support reporting in phpinfo()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,8 @@ PHP                                                                        NEWS
 - Zip:
   . Fixed ZipArchive::extractTo() and ZipArchive::getFrom*() reporting success
     on corrupted entries. (David Carlier)
+  . Fixed phpinfo() reporting AES-192 and AES-256 encryption support based on
+    AES-128 support. (Weilin Du)
 
 - SAPI:
   . Fixed returns uninitialized value on LiteSpeed lsapi SAPI (Go Kudo)

--- a/NEWS
+++ b/NEWS
@@ -12,8 +12,6 @@ PHP                                                                        NEWS
 - Zip:
   . Fixed ZipArchive::extractTo() and ZipArchive::getFrom*() reporting success
     on corrupted entries. (David Carlier)
-  . Fixed phpinfo() reporting AES-192 and AES-256 encryption support based on
-    AES-128 support. (Weilin Du)
 
 - SAPI:
   . Fixed returns uninitialized value on LiteSpeed lsapi SAPI (Go Kudo)

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -3321,9 +3321,9 @@ static PHP_MINFO_FUNCTION(zip)
 	php_info_print_table_row(2, "AES-128 encryption",
 		zip_encryption_method_supported(ZIP_EM_AES_128, 1) ? "Yes" : "No");
 	php_info_print_table_row(2, "AES-192 encryption",
-		zip_encryption_method_supported(ZIP_EM_AES_128, 1) ? "Yes" : "No");
+		zip_encryption_method_supported(ZIP_EM_AES_192, 1) ? "Yes" : "No");
 	php_info_print_table_row(2, "AES-256 encryption",
-		zip_encryption_method_supported(ZIP_EM_AES_128, 1) ? "Yes" : "No");
+		zip_encryption_method_supported(ZIP_EM_AES_256, 1) ? "Yes" : "No");
 #endif
 
 	php_info_print_table_end();


### PR DESCRIPTION
I am speechless. I firstly thought my environment is broken because I seem to be testing my patch on a libzip implementation that doesn't support some of the aes method, and after hours of researching, I find out that phpinfo() shows the wrong constant. 

```
	php_info_print_table_row(2, "AES-128 encryption",
		zip_encryption_method_supported(ZIP_EM_AES_128, 1) ? "Yes" : "No");
	php_info_print_table_row(2, "AES-192 encryption",
		zip_encryption_method_supported(ZIP_EM_AES_128, 1) ? "Yes" : "No");
	php_info_print_table_row(2, "AES-256 encryption",
		zip_encryption_method_supported(ZIP_EM_AES_128, 1) ? "Yes" : "No");
```

Now, AES-128, AES-192, AES-256 are added in a same version. However, this is still not a robust way to tell if we actually support them. Obviously, using their own macro will be better instead of all using aes-128's. This makes the phpinfo page effectively useless.