### PR TITLE
Stop grapheme_strrev from using UBRK_DONE as a byte index

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,10 @@ PHP                                                                        NEWS
     left busy for the next fetch, and rows delivered from a result another
     statement took over. (KentarouTakeda)
 
+- Intl:
+  . Fixed grapheme_strrev() treating UBRK_DONE as a byte index and leaving
+    the result without a terminating NUL. (iliaal)
+
 - Phar:
   . Fixed Phar archives being automatically detected when ".phar" only occurs
     in a directory name or is not a filename extension in an included file's

--- a/ext/intl/grapheme/grapheme_string.cpp
+++ b/ext/intl/grapheme/grapheme_string.cpp
@@ -1175,6 +1175,9 @@ U_CFUNC PHP_FUNCTION(grapheme_strrev)
 	current = ZSTR_LEN(string);
 	for (end = pstr; pos != UBRK_DONE; ) {
 		pos = ubrk_previous(bi);
+		if (pos == UBRK_DONE) {
+			break;
+		}
 		end_len = current - pos;
 		for (int32_t j = 0; j < end_len; j++) {
 			*p++ = *(pstr + pos + j);
@@ -1182,6 +1185,7 @@ U_CFUNC PHP_FUNCTION(grapheme_strrev)
 		current = pos;
 	}
 ubrk_end:
+	ZSTR_VAL(ret)[ZSTR_LEN(ret)] = '\0';
 	RETVAL_NEW_STR(ret);
 	ubrk_close(bi);
 close:

--- a/ext/intl/tests/grapheme_strrev_ubrk_done.phpt
+++ b/ext/intl/tests/grapheme_strrev_ubrk_done.phpt
@@ -1,0 +1,25 @@
+--TEST--
+grapheme_strrev() stops at UBRK_DONE instead of using it as a byte index
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+
+$cases = [
+    'abc',
+    'a',
+    '土下座',
+    "null\x00byte",
+];
+
+foreach ($cases as $s) {
+    $rev = grapheme_strrev($s);
+    echo strlen($s), ' ', strlen($rev), ' ', bin2hex($rev), "\n";
+}
+
+?>
+--EXPECT--
+3 3 636261
+1 1 61
+9 9 e5baa7e4b88be59c9f
+9 9 65747962006c6c756e


### PR DESCRIPTION
grapheme_strrev() called ubrk_previous() inside a loop whose condition still saw the previous position, so UBRK_DONE (-1) was used as a byte offset and overwrote the result NUL. Stop when the iterator is done, and NUL-terminate the zend_string_alloc() buffer.