### PR TITLE
Resolve UConverter callbacks after clone

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,10 @@ PHP                                                                        NEWS
   . Fixed bug GH-15375 (Nested "yield from" skips items after a valid() or
     next() call on the inner generator). (iliaal)
 
+- Intl:
+  . Fixed a crash when converting with a cloned UConverter that uses
+    toUCallback/fromUCallback. (iliaal)
+
 - Opcache:
   . Fixed opcache.protect_memory race under ZTS. (realFlowControl)
 

--- a/ext/intl/converter/converter.c
+++ b/ext/intl/converter/converter.c
@@ -546,8 +546,6 @@ PHP_METHOD(UConverter, __construct) {
 		ZEND_ASSERT(EG(exception));
 		goto cleanup;
 	}
-	php_converter_resolve_callback(&objval->to_cache, Z_OBJ_P(ZEND_THIS), ZEND_STRL("toUCallback"));
-	php_converter_resolve_callback(&objval->from_cache, Z_OBJ_P(ZEND_THIS), ZEND_STRL("fromUCallback"));
 cleanup:
 	INTL_G(use_exceptions) = old_use_exception;
 	INTL_G(error_level) = old_error_level;
@@ -916,6 +914,8 @@ static zend_object *php_converter_object_ctor(zend_class_entry *ce, php_converte
 	zend_object_std_init(&objval->obj, ce);
 	object_properties_init(&objval->obj, ce);
 	intl_error_init(&(objval->error));
+	php_converter_resolve_callback(&objval->to_cache, &objval->obj, ZEND_STRL("toUCallback"));
+	php_converter_resolve_callback(&objval->from_cache, &objval->obj, ZEND_STRL("fromUCallback"));
 
 	*pobjval = objval;
 

--- a/ext/intl/tests/uconverter_clone_callback.phpt
+++ b/ext/intl/tests/uconverter_clone_callback.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Cloned UConverter resolves toUCallback/fromUCallback on the clone
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+
+class MyConverter extends UConverter {
+    public int $hits = 0;
+
+    public function toUCallback($reason, $source, $codeUnits, &$error): string|int|array|null {
+        $this->hits++;
+        return parent::toUCallback($reason, $source, $codeUnits, $error);
+    }
+}
+
+$orig = new MyConverter('ascii', 'utf-8');
+$clone = clone $orig;
+$clone->convert("irregul\xC1\xA1r");
+echo $clone->hits > 0 ? "ok\n" : "no callback\n";
+
+?>
+--EXPECT--
+ok


### PR DESCRIPTION
UConverter::__construct() fills to_cache/from_cache. clone never runs the constructor and only retargeted the ICU C callbacks, so the first callback-worthy convert called zend_call_known_fcc on a NULL handler. Both caches are now resolved in php_converter_object_ctor, covering construct and clone alike.