### PR TITLE
ext/ldap: fix crash in ldap_exop_sync() when $response_data is omitted

### DIFF
--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -4101,10 +4101,12 @@ static void php_ldap_exop(INTERNAL_FUNCTION_PARAMETERS, bool force_sync) {
 		}
 
 		if (lretdata) {
-			ZEND_TRY_ASSIGN_REF_STRINGL(retdata, lretdata->bv_val, lretdata->bv_len);
+			if (retdata) {
+				ZEND_TRY_ASSIGN_REF_STRINGL(retdata, lretdata->bv_val, lretdata->bv_len);
+			}
 			ldap_memfree(lretdata->bv_val);
 			ldap_memfree(lretdata);
-		} else {
+		} else if (retdata) {
 			ZEND_TRY_ASSIGN_REF_EMPTY_STRING(retdata);
 		}
 

--- a/ext/ldap/tests/ldap_exop_sync_without_response_data.phpt
+++ b/ext/ldap/tests/ldap_exop_sync_without_response_data.phpt
@@ -1,0 +1,22 @@
+--TEST--
+ldap_exop_sync() - without the response_data argument
+--EXTENSIONS--
+ldap
+--SKIPIF--
+<?php require_once('skipifbindfailure.inc'); ?>
+--FILE--
+<?php
+require "connect.inc";
+
+$link = ldap_connect_and_bind($uri, $user, $passwd, $protocol_version);
+
+var_dump(
+    ldap_exop_sync($link, LDAP_EXOP_WHO_AM_I),
+    ldap_exop_sync($link, LDAP_EXOP_WHO_AM_I, null, null, $retdata),
+    $retdata
+);
+?>
+--EXPECTF--
+bool(true)
+bool(true)
+string(%d) "dn:%s"


### PR DESCRIPTION
`ldap_exop_sync()` passes `force_sync = true` to `php_ldap_exop()`, so the block that writes back `$response_data` is always entered regardless of whether the argument was supplied. When it is omitted, `retdata` is `NULL`, and both `ZEND_TRY_ASSIGN_REF_STRINGL` and `ZEND_TRY_ASSIGN_REF_EMPTY_STRING` dereference it — `ZEND_ASSERT(Z_ISREF_P(zv))` in debug builds, a NULL dereference crash in release.

`ldap_exop()` is not affected: there `retdata != NULL` is what selects the branch in the first place.

The fix mirrors the existing `if (retoid)` guard a few lines above. `ldap_memfree()` is still called unconditionally so there is no memory leak.

```php
ldap_exop_sync($ld, LDAP_EXOP_WHO_AM_I);  // segfault before, bool(true) after
```

Reproduced on PHP 8.4.22 (exit code 139). Present since `ldap_exop_sync()` was introduced in PHP 8.3.0.