### PR TITLE
ext/uri: Increases test coverage

### DIFF
--- a/ext/uri/tests/general/http_stream_error_invalid_uri.phpt
+++ b/ext/uri/tests/general/http_stream_error_invalid_uri.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Test HTTP stream URI parsing - error - invalid URI
+--INI--
+allow_url_fopen=1
+--FILE--
+<?php
+
+// hits ext/uri parsing and fails
+// before connection is attempted
+var_dump(@fopen("http://", "r"));
+
+?>
+--EXPECT--
+bool(false)

--- a/ext/uri/tests/general/phpinfo_module_info.phpt
+++ b/ext/uri/tests/general/phpinfo_module_info.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test phpinfo() - URI module information
+--FILE--
+<?php
+
+ob_start();
+phpinfo(INFO_MODULES);
+$info = ob_get_clean();
+
+var_dump(str_contains($info, "URI support => active"));
+var_dump(
+    str_contains($info, "uriparser bundled version") ||
+    (
+        str_contains($info, "uriparser compiled version")
+        &&
+        str_contains($info, "uriparser loaded version")
+    )
+);
+
+?>
+--EXPECT--
+bool(true)
+bool(true)

--- a/ext/uri/tests/rfc3986/builder/build_error_invalid_internal_fragment.phpt
+++ b/ext/uri/tests/rfc3986/builder/build_error_invalid_internal_fragment.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Test Uri\Rfc3986\UriBuilder::build() - error - invalid internal fragment
+--EXTENSIONS--
+reflection
+--FILE--
+<?php
+
+$builder = new Uri\Rfc3986\UriBuilder();
+new ReflectionProperty($builder, 'fragment')->setValue($builder, '<');
+
+try {
+    $builder->build();
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Uri\InvalidUriException: The specified fragment is malformed

--- a/ext/uri/tests/rfc3986/builder/build_error_invalid_internal_host.phpt
+++ b/ext/uri/tests/rfc3986/builder/build_error_invalid_internal_host.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Test Uri\Rfc3986\UriBuilder::build() - error - invalid internal host
+--EXTENSIONS--
+reflection
+--FILE--
+<?php
+
+$builder = new Uri\Rfc3986\UriBuilder();
+new ReflectionProperty($builder, 'host')->setValue($builder, '[');
+
+try {
+    $builder->build();
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Uri\InvalidUriException: The specified host is malformed

--- a/ext/uri/tests/rfc3986/builder/build_error_invalid_internal_query.phpt
+++ b/ext/uri/tests/rfc3986/builder/build_error_invalid_internal_query.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Test Uri\Rfc3986\UriBuilder::build() - error - invalid internal query
+--EXTENSIONS--
+reflection
+--FILE--
+<?php
+
+$builder = new Uri\Rfc3986\UriBuilder();
+new ReflectionProperty($builder, 'query')->setValue($builder, '<');
+
+try {
+    $builder->build();
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Uri\InvalidUriException: The specified query is malformed

--- a/ext/uri/tests/rfc3986/builder/build_error_invalid_internal_scheme.phpt
+++ b/ext/uri/tests/rfc3986/builder/build_error_invalid_internal_scheme.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Test Uri\Rfc3986\UriBuilder::build() - error - invalid internal scheme
+--EXTENSIONS--
+reflection
+--FILE--
+<?php
+
+$builder = new Uri\Rfc3986\UriBuilder();
+new ReflectionProperty($builder, 'scheme')->setValue($builder, ':');
+
+try {
+    $builder->build();
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Uri\InvalidUriException: The specified scheme is malformed

--- a/ext/uri/tests/rfc3986/builder/build_success_referenced_component.phpt
+++ b/ext/uri/tests/rfc3986/builder/build_success_referenced_component.phpt
@@ -1,0 +1,62 @@
+--TEST--
+Test Uri\Rfc3986\UriBuilder::build() - success - referenced component
+--FILE--
+<?php
+
+$scope = "\0Uri\\Rfc3986\\UriBuilder\0";
+
+$serialised = serialize(new Uri\Rfc3986\UriBuilder());
+
+$serialised = str_replace(
+    "s:30:\"{$scope}scheme\";N;",
+    "s:30:\"{$scope}scheme\";s:5:\"https\";",
+    $serialised,
+);
+
+$serialised = str_replace(
+    "s:28:\"{$scope}host\";N;",
+    "s:28:\"{$scope}host\";s:11:\"example.com\";",
+    $serialised,
+);
+
+$serialised = str_replace(
+    "s:28:\"{$scope}path\";s:0:\"\";",
+    "s:28:\"{$scope}path\";s:5:\"/path\";",
+    $serialised,
+);
+
+// make fragment share path value
+$serialised = str_replace(
+    "s:32:\"{$scope}fragment\";N;",
+    "s:32:\"{$scope}fragment\";R:6;",
+    $serialised,
+);
+
+$uri = unserialize($serialised)->build();
+
+var_dump($uri->toRawString());
+var_dump($uri);
+var_dump($uri->equals(new Uri\Rfc3986\Uri($uri->toRawString())));
+
+?>
+--EXPECTF--
+string(30) "https://example.com/path#/path"
+object(Uri\Rfc3986\Uri)#%d (%d) {
+  ["scheme"]=>
+  string(5) "https"
+  ["username"]=>
+  NULL
+  ["password"]=>
+  NULL
+  ["host"]=>
+  string(11) "example.com"
+  ["port"]=>
+  NULL
+  ["path"]=>
+  string(5) "/path"
+  ["query"]=>
+  NULL
+  ["fragment"]=>
+  string(5) "/path"
+}
+bool(true)

--- a/ext/uri/tests/rfc3986/builder/host_success_empty.phpt
+++ b/ext/uri/tests/rfc3986/builder/host_success_empty.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Test Uri\Rfc3986\UriBuilder::setHost() - success - empty string
+--FILE--
+<?php
+
+$builder = new Uri\Rfc3986\UriBuilder();
+$builder->setHost('');
+$uri = $builder->build();
+
+var_dump($uri->toRawString());
+var_dump($uri);
+var_dump($uri->equals(new Uri\Rfc3986\Uri($uri->toRawString())));
+
+?>
+--EXPECTF--
+string(2) "//"
+object(Uri\Rfc3986\Uri)#%d (%d) {
+  ["scheme"]=>
+  NULL
+  ["username"]=>
+  NULL
+  ["password"]=>
+  NULL
+  ["host"]=>
+  string(0) ""
+  ["port"]=>
+  NULL
+  ["path"]=>
+  string(0) ""
+  ["query"]=>
+  NULL
+  ["fragment"]=>
+  NULL
+}
+bool(true)

--- a/ext/uri/tests/rfc3986/getters/userinfo_success_without_password_separator.phpt
+++ b/ext/uri/tests/rfc3986/getters/userinfo_success_without_password_separator.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test Uri\Rfc3986\Uri component retrieval - userinfo - without password separator
+--FILE--
+<?php
+
+$uri = new Uri\Rfc3986\Uri('https://user@example.com');
+
+var_dump($uri->getUserInfo());
+var_dump($uri->getUsername());
+var_dump($uri->getPassword());
+
+?>
+--EXPECT--
+string(4) "user"
+string(4) "user"
+string(0) ""

--- a/ext/uri/tests/rfc3986/modification/host_error_unset_with_port.phpt
+++ b/ext/uri/tests/rfc3986/modification/host_error_unset_with_port.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test Uri\Rfc3986\Uri::withHost() - error - unsetting with port
+--FILE--
+<?php
+
+$uri = new Uri\Rfc3986\Uri('https://example.com:8080');
+
+try {
+    $uri->withHost(null);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Uri\InvalidUriException: Cannot remove the host from a URI that has a port

--- a/ext/uri/tests/rfc3986/parsing/port_error_excessive_digits.phpt
+++ b/ext/uri/tests/rfc3986/parsing/port_error_excessive_digits.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Test Uri\Rfc3986\Uri parsing - port - excessive number of digits
+--FILE--
+<?php
+
+try {
+    new \Uri\Rfc3986\Uri('https://example.com:4242424269424242426942424242694242424269');
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Uri\InvalidUriException: The port is out of range

--- a/ext/uri/tests/rfc3986/parsing/port_error_overflow.phpt
+++ b/ext/uri/tests/rfc3986/parsing/port_error_overflow.phpt
@@ -3,16 +3,6 @@ Test Uri\Rfc3986\Uri parsing - port - integer overflow
 --FILE--
 <?php
 
-if (PHP_INT_SIZE == 8) {
-    $uri = new \Uri\Rfc3986\Uri('https://example.com:9223372036854775807');
-    echo $uri->getPort(), "\n";
-    echo "2147483647", "\n";
-} else {
-    $uri = new \Uri\Rfc3986\Uri('https://example.com:2147483647');
-    echo "9223372036854775807", "\n";
-    echo $uri->getPort(), "\n";
-}
-
 try {
     if (PHP_INT_SIZE == 8) {
         new \Uri\Rfc3986\Uri('https://example.com:9223372036854775808');
@@ -25,6 +15,4 @@ try {
 
 ?>
 --EXPECT--
-9223372036854775807
-2147483647
 Uri\InvalidUriException: The port is out of range

--- a/ext/uri/tests/rfc3986/parsing/port_success_maximum_integer.phpt
+++ b/ext/uri/tests/rfc3986/parsing/port_success_maximum_integer.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Test Uri\Rfc3986\Uri parsing - port - maximum integer
+--FILE--
+<?php
+
+if (PHP_INT_SIZE == 8) {
+    $uri = new \Uri\Rfc3986\Uri('https://example.com:9223372036854775807');
+    echo $uri->getPort(), "\n";
+    echo "2147483647", "\n";
+} else {
+    $uri = new \Uri\Rfc3986\Uri('https://example.com:2147483647');
+    echo "9223372036854775807", "\n";
+    echo $uri->getPort(), "\n";
+}
+
+?>
+--EXPECT--
+9223372036854775807
+2147483647

--- a/ext/uri/tests/whatwg/builder/build_success_multiple_validation_warnings.phpt
+++ b/ext/uri/tests/whatwg/builder/build_success_multiple_validation_warnings.phpt
@@ -1,0 +1,51 @@
+--TEST--
+Test Uri\WhatWg\UrlBuilder::build() - success - multiple validation warnings
+--EXTENSIONS--
+reflection
+--FILE--
+<?php
+
+$builder = new Uri\WhatWg\UrlBuilder();
+
+foreach ([
+    "scheme" => "https",
+    "host" => "127.0.0.1.",
+    "path" => "\\foo",
+] as $property => $value) {
+    new ReflectionProperty($builder, $property)->setValue($builder, $value);
+}
+
+$url = $builder->build(errors: $errors);
+
+var_dump($url->toAsciiString());
+var_dump($url);
+foreach ($errors as $error) {
+    echo $error->type->name, ': ', $error->context, ': ';
+    var_dump($error->failure);
+}
+var_dump($url->equals(new Uri\WhatWg\Url($url->toAsciiString())));
+
+?>
+--EXPECTF--
+string(21) "https://127.0.0.1/foo"
+object(Uri\WhatWg\Url)#%d (%d) {
+  ["scheme"]=>
+  string(5) "https"
+  ["username"]=>
+  NULL
+  ["password"]=>
+  NULL
+  ["host"]=>
+  string(9) "127.0.0.1"
+  ["port"]=>
+  NULL
+  ["path"]=>
+  string(4) "/foo"
+  ["query"]=>
+  NULL
+  ["fragment"]=>
+  NULL
+}
+Ipv4EmptyPart: : bool(false)
+InvalidReverseSoldius: \foo: bool(false)
+bool(true)

--- a/ext/uri/tests/whatwg/builder/build_success_scheme_classification_ftp.phpt
+++ b/ext/uri/tests/whatwg/builder/build_success_scheme_classification_ftp.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Test Uri\WhatWg\UrlBuilder::build() - success - ftp scheme classification
+--FILE--
+<?php
+
+$url = new Uri\WhatWg\UrlBuilder()
+    ->setScheme("ftp")
+    ->setHost("example.com")
+    ->build();
+
+var_dump($url->toAsciiString());
+var_dump($url);
+var_dump($url->equals(new Uri\WhatWg\Url($url->toAsciiString())));
+var_dump($url->isSpecialScheme());
+
+?>
+--EXPECTF--
+string(18) "ftp://example.com/"
+object(Uri\WhatWg\Url)#%d (%d) {
+  ["scheme"]=>
+  string(3) "ftp"
+  ["username"]=>
+  NULL
+  ["password"]=>
+  NULL
+  ["host"]=>
+  string(11) "example.com"
+  ["port"]=>
+  NULL
+  ["path"]=>
+  string(1) "/"
+  ["query"]=>
+  NULL
+  ["fragment"]=>
+  NULL
+}
+bool(true)
+bool(true)

--- a/ext/uri/tests/whatwg/builder/build_success_scheme_classification_http.phpt
+++ b/ext/uri/tests/whatwg/builder/build_success_scheme_classification_http.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Test Uri\WhatWg\UrlBuilder::build() - success - http scheme classification
+--FILE--
+<?php
+
+$url = new Uri\WhatWg\UrlBuilder()
+    ->setScheme("http")
+    ->setHost("example.com")
+    ->build();
+
+var_dump($url->toAsciiString());
+var_dump($url);
+var_dump($url->equals(new Uri\WhatWg\Url($url->toAsciiString())));
+var_dump($url->isSpecialScheme());
+
+?>
+--EXPECTF--
+string(19) "http://example.com/"
+object(Uri\WhatWg\Url)#%d (%d) {
+  ["scheme"]=>
+  string(4) "http"
+  ["username"]=>
+  NULL
+  ["password"]=>
+  NULL
+  ["host"]=>
+  string(11) "example.com"
+  ["port"]=>
+  NULL
+  ["path"]=>
+  string(1) "/"
+  ["query"]=>
+  NULL
+  ["fragment"]=>
+  NULL
+}
+bool(true)
+bool(true)

--- a/ext/uri/tests/whatwg/builder/build_success_scheme_classification_non_special_five_characters.phpt
+++ b/ext/uri/tests/whatwg/builder/build_success_scheme_classification_non_special_five_characters.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Test Uri\WhatWg\UrlBuilder::build() - success - five-character non-special scheme classification
+--FILE--
+<?php
+
+$url = new Uri\WhatWg\UrlBuilder()
+    ->setScheme("about")
+    ->setHost("example.com")
+    ->build();
+
+var_dump($url->toAsciiString());
+var_dump($url);
+var_dump($url->equals(new Uri\WhatWg\Url($url->toAsciiString())));
+var_dump($url->isSpecialScheme());
+
+?>
+--EXPECTF--
+string(19) "about://example.com"
+object(Uri\WhatWg\Url)#%d (%d) {
+  ["scheme"]=>
+  string(5) "about"
+  ["username"]=>
+  NULL
+  ["password"]=>
+  NULL
+  ["host"]=>
+  string(11) "example.com"
+  ["port"]=>
+  NULL
+  ["path"]=>
+  string(0) ""
+  ["query"]=>
+  NULL
+  ["fragment"]=>
+  NULL
+}
+bool(true)
+bool(false)

--- a/ext/uri/tests/whatwg/builder/build_success_scheme_classification_non_special_four_characters.phpt
+++ b/ext/uri/tests/whatwg/builder/build_success_scheme_classification_non_special_four_characters.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Test Uri\WhatWg\UrlBuilder::build() - success - four-character non-special scheme classification
+--FILE--
+<?php
+
+$url = new Uri\WhatWg\UrlBuilder()
+    ->setScheme("news")
+    ->setHost("example.com")
+    ->build();
+
+var_dump($url->toAsciiString());
+var_dump($url);
+var_dump($url->equals(new Uri\WhatWg\Url($url->toAsciiString())));
+var_dump($url->isSpecialScheme());
+
+?>
+--EXPECTF--
+string(18) "news://example.com"
+object(Uri\WhatWg\Url)#%d (%d) {
+  ["scheme"]=>
+  string(4) "news"
+  ["username"]=>
+  NULL
+  ["password"]=>
+  NULL
+  ["host"]=>
+  string(11) "example.com"
+  ["port"]=>
+  NULL
+  ["path"]=>
+  string(0) ""
+  ["query"]=>
+  NULL
+  ["fragment"]=>
+  NULL
+}
+bool(true)
+bool(false)

--- a/ext/uri/tests/whatwg/builder/build_success_scheme_classification_non_special_two_characters.phpt
+++ b/ext/uri/tests/whatwg/builder/build_success_scheme_classification_non_special_two_characters.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Test Uri\WhatWg\UrlBuilder::build() - success - two-character non-special scheme classification
+--FILE--
+<?php
+
+$url = new Uri\WhatWg\UrlBuilder()
+    ->setScheme("id")
+    ->setHost("example.com")
+    ->build();
+
+var_dump($url->toAsciiString());
+var_dump($url);
+var_dump($url->equals(new Uri\WhatWg\Url($url->toAsciiString())));
+var_dump($url->isSpecialScheme());
+
+?>
+--EXPECTF--
+string(16) "id://example.com"
+object(Uri\WhatWg\Url)#%d (%d) {
+  ["scheme"]=>
+  string(2) "id"
+  ["username"]=>
+  NULL
+  ["password"]=>
+  NULL
+  ["host"]=>
+  string(11) "example.com"
+  ["port"]=>
+  NULL
+  ["path"]=>
+  string(0) ""
+  ["query"]=>
+  NULL
+  ["fragment"]=>
+  NULL
+}
+bool(true)
+bool(false)

--- a/ext/uri/tests/whatwg/builder/build_success_scheme_classification_ws.phpt
+++ b/ext/uri/tests/whatwg/builder/build_success_scheme_classification_ws.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Test Uri\WhatWg\UrlBuilder::build() - success - ws scheme classification
+--FILE--
+<?php
+
+$url = new Uri\WhatWg\UrlBuilder()
+    ->setScheme("ws")
+    ->setHost("example.com")
+    ->build();
+
+var_dump($url->toAsciiString());
+var_dump($url);
+var_dump($url->equals(new Uri\WhatWg\Url($url->toAsciiString())));
+var_dump($url->isSpecialScheme());
+
+?>
+--EXPECTF--
+string(17) "ws://example.com/"
+object(Uri\WhatWg\Url)#%d (%d) {
+  ["scheme"]=>
+  string(2) "ws"
+  ["username"]=>
+  NULL
+  ["password"]=>
+  NULL
+  ["host"]=>
+  string(11) "example.com"
+  ["port"]=>
+  NULL
+  ["path"]=>
+  string(1) "/"
+  ["query"]=>
+  NULL
+  ["fragment"]=>
+  NULL
+}
+bool(true)
+bool(true)

--- a/ext/uri/tests/whatwg/builder/build_success_scheme_classification_wss.phpt
+++ b/ext/uri/tests/whatwg/builder/build_success_scheme_classification_wss.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Test Uri\WhatWg\UrlBuilder::build() - success - wss scheme classification
+--FILE--
+<?php
+
+$url = new Uri\WhatWg\UrlBuilder()
+    ->setScheme("wss")
+    ->setHost("example.com")
+    ->build();
+
+var_dump($url->toAsciiString());
+var_dump($url);
+var_dump($url->equals(new Uri\WhatWg\Url($url->toAsciiString())));
+var_dump($url->isSpecialScheme());
+
+?>
+--EXPECTF--
+string(18) "wss://example.com/"
+object(Uri\WhatWg\Url)#%d (%d) {
+  ["scheme"]=>
+  string(3) "wss"
+  ["username"]=>
+  NULL
+  ["password"]=>
+  NULL
+  ["host"]=>
+  string(11) "example.com"
+  ["port"]=>
+  NULL
+  ["path"]=>
+  string(1) "/"
+  ["query"]=>
+  NULL
+  ["fragment"]=>
+  NULL
+}
+bool(true)
+bool(true)

--- a/ext/uri/tests/whatwg/builder/host_success_ipv6_leading_tab.phpt
+++ b/ext/uri/tests/whatwg/builder/host_success_ipv6_leading_tab.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Test Uri\WhatWg\UrlBuilder::setHost() - success - IPv6 address with a leading tab
+--FILE--
+<?php
+
+$url = new Uri\WhatWg\UrlBuilder()
+    ->setScheme("https")
+    ->setHost("\t[::1]")
+    ->build();
+
+var_dump($url->toAsciiString());
+var_dump($url);
+var_dump($url->equals(new Uri\WhatWg\Url($url->toAsciiString())));
+
+?>
+--EXPECTF--
+string(14) "https://[::1]/"
+object(Uri\WhatWg\Url)#%d (%d) {
+  ["scheme"]=>
+  string(5) "https"
+  ["username"]=>
+  NULL
+  ["password"]=>
+  NULL
+  ["host"]=>
+  string(5) "[::1]"
+  ["port"]=>
+  NULL
+  ["path"]=>
+  string(1) "/"
+  ["query"]=>
+  NULL
+  ["fragment"]=>
+  NULL
+}
+bool(true)

--- a/ext/uri/tests/whatwg/exceptions/invalid_url_exception_constructor_error_invalid_errors_element.phpt
+++ b/ext/uri/tests/whatwg/exceptions/invalid_url_exception_constructor_error_invalid_errors_element.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Test Uri\WhatWg\InvalidUrlException::__construct() - error - invalid errors element
+--FILE--
+<?php
+
+try {
+    new Uri\WhatWg\InvalidUrlException('message', [new stdClass()]);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+ValueError: Uri\WhatWg\InvalidUrlException::__construct(): Argument #2 ($errors) must be a list of Uri\WhatWg\UrlValidationError

--- a/ext/uri/tests/whatwg/exceptions/url_validation_error_constructor_reentry_failure.phpt
+++ b/ext/uri/tests/whatwg/exceptions/url_validation_error_constructor_reentry_failure.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test Uri\WhatWg\UrlValidationError::__construct() - error - reentry with initialized failure
+--FILE--
+<?php
+
+$error = unserialize(
+    'O:29:"Uri\\WhatWg\\UrlValidationError":1:{s:7:"failure";b:1;}'
+);
+
+try {
+    $error->__construct('foo', Uri\WhatWg\UrlValidationErrorType::HostMissing, false);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Error: Cannot modify readonly property Uri\WhatWg\UrlValidationError::$failure

--- a/ext/uri/tests/whatwg/exceptions/url_validation_error_constructor_reentry_type.phpt
+++ b/ext/uri/tests/whatwg/exceptions/url_validation_error_constructor_reentry_type.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test Uri\WhatWg\UrlValidationError::__construct() - error - reentry with initialized type
+--FILE--
+<?php
+
+$error = unserialize(
+    'O:29:"Uri\\WhatWg\\UrlValidationError":1:{s:4:"type";E:45:"Uri\\WhatWg\\UrlValidationErrorType:HostMissing";}'
+);
+
+try {
+    $error->__construct('foo', Uri\WhatWg\UrlValidationErrorType::HostMissing, false);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Error: Cannot modify readonly property Uri\WhatWg\UrlValidationError::$type

--- a/ext/uri/tests/whatwg/parsing/errors_error_typed_property_reference_invalid_url.phpt
+++ b/ext/uri/tests/whatwg/parsing/errors_error_typed_property_reference_invalid_url.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test Uri\WhatWg\Url parsing - errors - assignment to a typed property reference for an invalid URL
+--FILE--
+<?php
+
+class Foo {
+    public string $x = '';
+}
+
+$foo = new Foo();
+
+try {
+    Uri\WhatWg\Url::parse('invalid uri', errors: $foo->x);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+TypeError: Cannot assign array to reference held by property Foo::$x of type string

--- a/ext/uri/tests/whatwg/parsing/host_error_ipv4_in_ipv6_invalid_code_point.phpt
+++ b/ext/uri/tests/whatwg/parsing/host_error_ipv4_in_ipv6_invalid_code_point.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test Uri\WhatWg\Url parsing - host - IPv4-in-IPv6 invalid code point
+--FILE--
+<?php
+
+$errors = [];
+$url = Uri\WhatWg\Url::parse('http://[::ffff:1.2.3.a]/', errors: $errors);
+
+var_dump($url);
+foreach ($errors as $error) {
+    echo $error->type->name, ': ', $error->context, ': ';
+    var_dump($error->failure);
+}
+
+?>
+--EXPECT--
+NULL
+Ipv4InIpv6InvalidCodePoint: a]/: bool(true)

--- a/ext/uri/tests/whatwg/parsing/host_error_ipv4_in_ipv6_out_of_range_part.phpt
+++ b/ext/uri/tests/whatwg/parsing/host_error_ipv4_in_ipv6_out_of_range_part.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test Uri\WhatWg\Url parsing - host - IPv4-in-IPv6 out-of-range part
+--FILE--
+<?php
+
+$errors = [];
+$url = Uri\WhatWg\Url::parse('http://[::ffff:256.2.3.4]/', errors: $errors);
+
+var_dump($url);
+foreach ($errors as $error) {
+    echo $error->type->name, ': ', $error->context, ': ';
+    var_dump($error->failure);
+}
+
+?>
+--EXPECT--
+NULL
+Ipv4InIpv6OutOfRangePart: 6.2.3.4]/: bool(true)

--- a/ext/uri/tests/whatwg/parsing/host_error_ipv4_in_ipv6_too_few_parts.phpt
+++ b/ext/uri/tests/whatwg/parsing/host_error_ipv4_in_ipv6_too_few_parts.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test Uri\WhatWg\Url parsing - host - IPv4-in-IPv6 too few parts
+--FILE--
+<?php
+
+$errors = [];
+$url = Uri\WhatWg\Url::parse('http://[::ffff:1.2.3]/', errors: $errors);
+
+var_dump($url);
+foreach ($errors as $error) {
+    echo $error->type->name, ': ', $error->context, ': ';
+    var_dump($error->failure);
+}
+
+?>
+--EXPECT--
+NULL
+Ipv4InIpv6TooFewParts: ]/: bool(true)

--- a/ext/uri/tests/whatwg/parsing/host_error_ipv4_in_ipv6_too_many_pieces.phpt
+++ b/ext/uri/tests/whatwg/parsing/host_error_ipv4_in_ipv6_too_many_pieces.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test Uri\WhatWg\Url parsing - host - IPv4-in-IPv6 too many pieces
+--FILE--
+<?php
+
+$errors = [];
+$url = Uri\WhatWg\Url::parse('http://[1:2:3:4:5:6:7:1.2.3.4]/', errors: $errors);
+
+var_dump($url);
+foreach ($errors as $error) {
+    echo $error->type->name, ': ', $error->context, ': ';
+    var_dump($error->failure);
+}
+
+?>
+--EXPECT--
+NULL
+Ipv4InIpv6TooManyPieces: 1.2.3.4]/: bool(true)

--- a/ext/uri/tests/whatwg/parsing/host_error_ipv4_non_numeric_part.phpt
+++ b/ext/uri/tests/whatwg/parsing/host_error_ipv4_non_numeric_part.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test Uri\WhatWg\Url parsing - host - IPv4 non-numeric part
+--FILE--
+<?php
+
+$errors = [];
+$url = Uri\WhatWg\Url::parse('http://1.a.2.3/', errors: $errors);
+
+var_dump($url);
+foreach ($errors as $error) {
+    echo $error->type->name, ': ', $error->context, ': ';
+    var_dump($error->failure);
+}
+
+?>
+--EXPECT--
+NULL
+Ipv4NonNumericPart: a.2.3: bool(true)

--- a/ext/uri/tests/whatwg/parsing/host_error_ipv4_out_of_range_part.phpt
+++ b/ext/uri/tests/whatwg/parsing/host_error_ipv4_out_of_range_part.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test Uri\WhatWg\Url parsing - host - IPv4 out-of-range part
+--FILE--
+<?php
+
+$errors = [];
+$url = Uri\WhatWg\Url::parse('http://256.0.0.1/', errors: $errors);
+
+var_dump($url);
+foreach ($errors as $error) {
+    echo $error->type->name, ': ', $error->context, ': ';
+    var_dump($error->failure);
+}
+
+?>
+--EXPECT--
+NULL
+Ipv4OutOfRangePart: 256.0.0.1: bool(true)

--- a/ext/uri/tests/whatwg/parsing/host_error_ipv6_invalid_compression.phpt
+++ b/ext/uri/tests/whatwg/parsing/host_error_ipv6_invalid_compression.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test Uri\WhatWg\Url parsing - host - IPv6 invalid compression
+--FILE--
+<?php
+
+$errors = [];
+$url = Uri\WhatWg\Url::parse('http://[:1]/', errors: $errors);
+
+var_dump($url);
+foreach ($errors as $error) {
+    echo $error->type->name, ': ', $error->context, ': ';
+    var_dump($error->failure);
+}
+
+?>
+--EXPECT--
+NULL
+Ipv6InvalidCompression: 1]/: bool(true)

--- a/ext/uri/tests/whatwg/parsing/host_error_ipv6_multiple_compression.phpt
+++ b/ext/uri/tests/whatwg/parsing/host_error_ipv6_multiple_compression.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test Uri\WhatWg\Url parsing - host - IPv6 multiple compression
+--FILE--
+<?php
+
+$errors = [];
+$url = Uri\WhatWg\Url::parse('http://[1::1::1]/', errors: $errors);
+
+var_dump($url);
+foreach ($errors as $error) {
+    echo $error->type->name, ': ', $error->context, ': ';
+    var_dump($error->failure);
+}
+
+?>
+--EXPECT--
+NULL
+Ipv6MultipleCompression: :1]/: bool(true)

--- a/ext/uri/tests/whatwg/parsing/host_error_ipv6_too_few_pieces.phpt
+++ b/ext/uri/tests/whatwg/parsing/host_error_ipv6_too_few_pieces.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test Uri\WhatWg\Url parsing - host - IPv6 too few pieces
+--FILE--
+<?php
+
+$errors = [];
+$url = Uri\WhatWg\Url::parse('http://[1:2:3]/', errors: $errors);
+
+var_dump($url);
+foreach ($errors as $error) {
+    echo $error->type->name, ': ', $error->context, ': ';
+    var_dump($error->failure);
+}
+
+?>
+--EXPECT--
+NULL
+Ipv6TooFewPieces: ]/: bool(true)

--- a/ext/uri/tests/whatwg/parsing/host_error_ipv6_too_many_pieces.phpt
+++ b/ext/uri/tests/whatwg/parsing/host_error_ipv6_too_many_pieces.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test Uri\WhatWg\Url parsing - host - IPv6 too many pieces
+--FILE--
+<?php
+
+$errors = [];
+$url = Uri\WhatWg\Url::parse('http://[1:2:3:4:5:6:7:8:9]/', errors: $errors);
+
+var_dump($url);
+foreach ($errors as $error) {
+    echo $error->type->name, ': ', $error->context, ': ';
+    var_dump($error->failure);
+}
+
+?>
+--EXPECT--
+NULL
+Ipv6TooManyPieces: 9]/: bool(true)

--- a/ext/uri/tests/whatwg/parsing/host_success_file_invalid_windows_drive_letter_host_warning.phpt
+++ b/ext/uri/tests/whatwg/parsing/host_success_file_invalid_windows_drive_letter_host_warning.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Test Uri\WhatWg\Url parsing - host - file invalid Windows drive letter host warning
+--FILE--
+<?php
+
+$errors = [];
+$url = Uri\WhatWg\Url::parse('file://c:/foo', errors: $errors);
+
+var_dump($url);
+var_dump($url->toAsciiString());
+foreach ($errors as $error) {
+    echo $error->type->name, ': ', $error->context, ': ';
+    var_dump($error->failure);
+}
+
+?>
+--EXPECTF--
+object(Uri\WhatWg\Url)#%d (%d) {
+  ["scheme"]=>
+  string(4) "file"
+  ["username"]=>
+  NULL
+  ["password"]=>
+  NULL
+  ["host"]=>
+  string(0) ""
+  ["port"]=>
+  NULL
+  ["path"]=>
+  string(7) "/c:/foo"
+  ["query"]=>
+  NULL
+  ["fragment"]=>
+  NULL
+}
+string(14) "file:///c:/foo"
+FileInvalidWindowsDriveLetterHost: c:/foo: bool(false)

--- a/ext/uri/tests/whatwg/parsing/host_success_ipv4_empty_part_warning.phpt
+++ b/ext/uri/tests/whatwg/parsing/host_success_ipv4_empty_part_warning.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Test Uri\WhatWg\Url parsing - host - IPv4 empty part warning
+--FILE--
+<?php
+
+$errors = [];
+$url = Uri\WhatWg\Url::parse('http://1.2.3./', errors: $errors);
+
+var_dump($url);
+var_dump($url->toAsciiString());
+foreach ($errors as $error) {
+    echo $error->type->name, ': ', $error->context, ': ';
+    var_dump($error->failure);
+}
+
+?>
+--EXPECTF--
+object(Uri\WhatWg\Url)#%d (%d) {
+  ["scheme"]=>
+  string(4) "http"
+  ["username"]=>
+  NULL
+  ["password"]=>
+  NULL
+  ["host"]=>
+  string(7) "1.2.0.3"
+  ["port"]=>
+  NULL
+  ["path"]=>
+  string(1) "/"
+  ["query"]=>
+  NULL
+  ["fragment"]=>
+  NULL
+}
+string(15) "http://1.2.0.3/"
+Ipv4EmptyPart: : bool(false)

--- a/ext/uri/tests/whatwg/parsing/host_success_ipv4_non_decimal_part_warning.phpt
+++ b/ext/uri/tests/whatwg/parsing/host_success_ipv4_non_decimal_part_warning.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Test Uri\WhatWg\Url parsing - host - IPv4 non-decimal part warning
+--FILE--
+<?php
+
+$errors = [];
+$url = Uri\WhatWg\Url::parse('http://0x1.2.3.4/', errors: $errors);
+
+var_dump($url);
+var_dump($url->toAsciiString());
+foreach ($errors as $error) {
+    echo $error->type->name, ': ', $error->context, ': ';
+    var_dump($error->failure);
+}
+
+?>
+--EXPECTF--
+object(Uri\WhatWg\Url)#%d (%d) {
+  ["scheme"]=>
+  string(4) "http"
+  ["username"]=>
+  NULL
+  ["password"]=>
+  NULL
+  ["host"]=>
+  string(7) "1.2.3.4"
+  ["port"]=>
+  NULL
+  ["path"]=>
+  string(1) "/"
+  ["query"]=>
+  NULL
+  ["fragment"]=>
+  NULL
+}
+string(15) "http://1.2.3.4/"
+Ipv4NonDecimalPart: /: bool(false)

--- a/ext/uri/tests/whatwg/parsing/path_success_invalid_reverse_solidus_warning.phpt
+++ b/ext/uri/tests/whatwg/parsing/path_success_invalid_reverse_solidus_warning.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Test Uri\WhatWg\Url parsing - path - invalid reverse solidus warning
+--FILE--
+<?php
+
+$errors = [];
+$url = Uri\WhatWg\Url::parse('http://example.com\\foo', errors: $errors);
+
+var_dump($url);
+var_dump($url->toAsciiString());
+foreach ($errors as $error) {
+    echo $error->type->name, ': ', $error->context, ': ';
+    var_dump($error->failure);
+}
+
+?>
+--EXPECTF--
+object(Uri\WhatWg\Url)#%d (%d) {
+  ["scheme"]=>
+  string(4) "http"
+  ["username"]=>
+  NULL
+  ["password"]=>
+  NULL
+  ["host"]=>
+  string(11) "example.com"
+  ["port"]=>
+  NULL
+  ["path"]=>
+  string(4) "/foo"
+  ["query"]=>
+  NULL
+  ["fragment"]=>
+  NULL
+}
+string(22) "http://example.com/foo"
+InvalidReverseSoldius: \foo: bool(false)

--- a/ext/uri/tests/whatwg/reference_resolution/parse_success_file_invalid_windows_drive_letter_warnings.phpt
+++ b/ext/uri/tests/whatwg/reference_resolution/parse_success_file_invalid_windows_drive_letter_warnings.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Test Uri\WhatWg\Url::parse() - success - file URL with invalid Windows drive letter warnings
+--FILE--
+<?php
+
+$errors = [];
+$baseUrl = new Uri\WhatWg\Url('file:///tmp/base');
+$url = Uri\WhatWg\Url::parse('c|/foo', $baseUrl, $errors);
+
+var_dump($url);
+var_dump($url->toAsciiString());
+foreach ($errors as $error) {
+    echo $error->type->name, ': ', $error->context, ': ';
+    var_dump($error->failure);
+}
+
+?>
+--EXPECTF--
+object(Uri\WhatWg\Url)#%d (%d) {
+  ["scheme"]=>
+  string(4) "file"
+  ["username"]=>
+  NULL
+  ["password"]=>
+  NULL
+  ["host"]=>
+  string(0) ""
+  ["port"]=>
+  NULL
+  ["path"]=>
+  string(7) "/c:/foo"
+  ["query"]=>
+  NULL
+  ["fragment"]=>
+  NULL
+}
+string(14) "file:///c:/foo"
+InvalidUrlUnit: |/foo: bool(false)
+FileInvalidWindowsDriveLetter: c|/foo: bool(false)

--- a/ext/uri/tests/zend/internal_api_error_parse_url_invalid_uri.phpt
+++ b/ext/uri/tests/zend/internal_api_error_parse_url_invalid_uri.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test zend_test_uri_parser() - error - invalid parse_url-based URI
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+try {
+    var_dump(zend_test_uri_parser('http://', 'parse_url'));
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Uri\InvalidUriException: The specified URI is malformed

--- a/ext/uri/tests/zend/internal_api_success_parse_url_absolute_uri_without_path.phpt
+++ b/ext/uri/tests/zend/internal_api_success_parse_url_absolute_uri_without_path.phpt
@@ -1,0 +1,70 @@
+--TEST--
+Test zend_test_uri_parser() - success - parse_url-based absolute URI without path
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+var_dump(zend_test_uri_parser('https://example.com', 'parse_url'));
+
+?>
+--EXPECT--
+array(3) {
+  ["normalized"]=>
+  array(8) {
+    ["scheme"]=>
+    string(5) "https"
+    ["username"]=>
+    NULL
+    ["password"]=>
+    NULL
+    ["host"]=>
+    string(11) "example.com"
+    ["port"]=>
+    NULL
+    ["path"]=>
+    NULL
+    ["query"]=>
+    NULL
+    ["fragment"]=>
+    NULL
+  }
+  ["raw"]=>
+  array(8) {
+    ["scheme"]=>
+    string(5) "https"
+    ["username"]=>
+    NULL
+    ["password"]=>
+    NULL
+    ["host"]=>
+    string(11) "example.com"
+    ["port"]=>
+    NULL
+    ["path"]=>
+    NULL
+    ["query"]=>
+    NULL
+    ["fragment"]=>
+    NULL
+  }
+  ["struct"]=>
+  array(8) {
+    ["scheme"]=>
+    string(5) "https"
+    ["username"]=>
+    NULL
+    ["password"]=>
+    NULL
+    ["host"]=>
+    string(11) "example.com"
+    ["port"]=>
+    int(0)
+    ["path"]=>
+    NULL
+    ["query"]=>
+    NULL
+    ["fragment"]=>
+    NULL
+  }
+}

--- a/ext/uri/tests/zend/internal_api_success_parse_url_relative_reference.phpt
+++ b/ext/uri/tests/zend/internal_api_success_parse_url_relative_reference.phpt
@@ -1,0 +1,70 @@
+--TEST--
+Test zend_test_uri_parser() - success - parse_url-based relative reference
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+var_dump(zend_test_uri_parser('/foo?bar#baz', 'parse_url'));
+
+?>
+--EXPECT--
+array(3) {
+  ["normalized"]=>
+  array(8) {
+    ["scheme"]=>
+    NULL
+    ["username"]=>
+    NULL
+    ["password"]=>
+    NULL
+    ["host"]=>
+    NULL
+    ["port"]=>
+    NULL
+    ["path"]=>
+    string(4) "/foo"
+    ["query"]=>
+    string(3) "bar"
+    ["fragment"]=>
+    string(3) "baz"
+  }
+  ["raw"]=>
+  array(8) {
+    ["scheme"]=>
+    NULL
+    ["username"]=>
+    NULL
+    ["password"]=>
+    NULL
+    ["host"]=>
+    NULL
+    ["port"]=>
+    NULL
+    ["path"]=>
+    string(4) "/foo"
+    ["query"]=>
+    string(3) "bar"
+    ["fragment"]=>
+    string(3) "baz"
+  }
+  ["struct"]=>
+  array(8) {
+    ["scheme"]=>
+    NULL
+    ["username"]=>
+    NULL
+    ["password"]=>
+    NULL
+    ["host"]=>
+    NULL
+    ["port"]=>
+    int(0)
+    ["path"]=>
+    string(4) "/foo"
+    ["query"]=>
+    string(3) "bar"
+    ["fragment"]=>
+    string(3) "baz"
+  }
+}


### PR DESCRIPTION
~This is fully Codex made. I threw a coverage report at it to close uncovered lines/branch gaps. It came up with a tonne of edge cases; this PR is the result of me massaging it a bit, and after filtering out nonsense that did not actually increase coverage as well as things that seemed too esoteric. So everything here increases coverage even though things might seem already tested -- that's because of using slightly different api paths.~

After #23286 and #23551 this is no longer fully Codex made, and was rather a starting point.

```
Coverage: ext/uri/tests

Base: 48d2b45e0748a0a83eddc841cb493a0ae817159a upstream/master
Tree: 8e4b223da30cf74a109274054999784586525836 working tree

+--------+----------+---------+--------------------+-------------------+--------+---------+
|        |    Tests | Sources |              Lines |          Branches |   Time |  Memory |
+--------+----------+---------+--------------------+-------------------+--------+---------+
| Base   |      519 |       7 | 2035/2281 (89.22%) | 733/1234 (59.40%) |  8.50s | 28.0 MB |
| Tree   |      563 |       7 | 2110/2281 (92.50%) | 792/1234 (64.18%) | 10.31s | 28.0 MB |
| Change | +44 / -0 |       0 |  +75 / -0 (+3.29%) | +59 / -0 (+4.78%) | +1.81s | +0.0 MB |
+--------+----------+---------+--------------------+-------------------+--------+---------+
```
