### PR TITLE
Zend: Add missing ZPP specifier tests

### DIFF
--- a/Zend/tests/zpp/array_ht_or_long_zpp_specifier_strict_mode.phpt
+++ b/Zend/tests/zpp/array_ht_or_long_zpp_specifier_strict_mode.phpt
@@ -1,0 +1,73 @@
+--TEST--
+Test array_ht_or_long ZPP specifier (strict_mode)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$types = require 'types.inc';
+$functions = [
+    'zend_array_ht_or_long',
+    'zend_array_ht_or_long_or_null',
+];
+
+foreach ($functions as $i => $function) {
+    echo "Using $function:\n\n";
+
+    foreach ($types as $name => $type) {
+        printf("  %-16s ", "$name:");
+
+        try {
+            $result = $function($type);
+
+            $result === []
+                ? printf("array(0) {}\n")
+                : var_dump($result);
+
+        } catch (Throwable $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+    }
+
+    if ($i !== array_key_last($functions)) {
+        echo "\n";
+    }
+}
+
+?>
+--EXPECT--
+Using zend_array_ht_or_long:
+
+  null:            TypeError: zend_array_ht_or_long(): Argument #1 ($param) must be of type array|int, null given
+  false:           TypeError: zend_array_ht_or_long(): Argument #1 ($param) must be of type array|int, false given
+  true:            TypeError: zend_array_ht_or_long(): Argument #1 ($param) must be of type array|int, true given
+  42:              int(42)
+  73.5:            TypeError: zend_array_ht_or_long(): Argument #1 ($param) must be of type array|int, float given
+  'string':        TypeError: zend_array_ht_or_long(): Argument #1 ($param) must be of type array|int, string given
+  '15':            TypeError: zend_array_ht_or_long(): Argument #1 ($param) must be of type array|int, string given
+  '56.7':          TypeError: zend_array_ht_or_long(): Argument #1 ($param) must be of type array|int, string given
+  'stdClass':      TypeError: zend_array_ht_or_long(): Argument #1 ($param) must be of type array|int, string given
+  anon class name: TypeError: zend_array_ht_or_long(): Argument #1 ($param) must be of type array|int, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_ht_or_long(): Argument #1 ($param) must be of type array|int, stdClass given
+  new S():         TypeError: zend_array_ht_or_long(): Argument #1 ($param) must be of type array|int, S given
+  STDOUT:          TypeError: zend_array_ht_or_long(): Argument #1 ($param) must be of type array|int, resource given
+
+Using zend_array_ht_or_long_or_null:
+
+  null:            NULL
+  false:           TypeError: zend_array_ht_or_long_or_null(): Argument #1 ($param) must be of type array|int|null, false given
+  true:            TypeError: zend_array_ht_or_long_or_null(): Argument #1 ($param) must be of type array|int|null, true given
+  42:              int(42)
+  73.5:            TypeError: zend_array_ht_or_long_or_null(): Argument #1 ($param) must be of type array|int|null, float given
+  'string':        TypeError: zend_array_ht_or_long_or_null(): Argument #1 ($param) must be of type array|int|null, string given
+  '15':            TypeError: zend_array_ht_or_long_or_null(): Argument #1 ($param) must be of type array|int|null, string given
+  '56.7':          TypeError: zend_array_ht_or_long_or_null(): Argument #1 ($param) must be of type array|int|null, string given
+  'stdClass':      TypeError: zend_array_ht_or_long_or_null(): Argument #1 ($param) must be of type array|int|null, string given
+  anon class name: TypeError: zend_array_ht_or_long_or_null(): Argument #1 ($param) must be of type array|int|null, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_ht_or_long_or_null(): Argument #1 ($param) must be of type array|int|null, stdClass given
+  new S():         TypeError: zend_array_ht_or_long_or_null(): Argument #1 ($param) must be of type array|int|null, S given
+  STDOUT:          TypeError: zend_array_ht_or_long_or_null(): Argument #1 ($param) must be of type array|int|null, resource given

--- a/Zend/tests/zpp/array_ht_or_long_zpp_specifier_weak_mode.phpt
+++ b/Zend/tests/zpp/array_ht_or_long_zpp_specifier_weak_mode.phpt
@@ -1,0 +1,81 @@
+--TEST--
+Test array_ht_or_long ZPP specifier (weak_mode)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+$types = require 'types.inc';
+$functions = [
+    'zend_array_ht_or_long',
+    'zend_array_ht_or_long_or_null',
+];
+
+foreach ($functions as $i => $function) {
+    echo "Using $function:\n\n";
+
+    foreach ($types as $name => $type) {
+        printf("  %-16s ", "$name:");
+
+        try {
+            $result = $function($type);
+
+            $result === []
+                ? printf("array(0) {}\n")
+                : var_dump($result);
+
+        } catch (Throwable $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+    }
+
+    if ($i !== array_key_last($functions)) {
+        echo "\n";
+    }
+}
+
+?>
+--EXPECTF--
+Using zend_array_ht_or_long:
+
+  null:            
+Deprecated: zend_array_ht_or_long(): Passing null to parameter #1 ($param) of type array|int is deprecated in %s on line %d
+int(0)
+  false:           int(0)
+  true:            int(1)
+  42:              int(42)
+  73.5:            
+Deprecated: Implicit conversion from float 73.5 to int loses precision in %s on line %d
+int(73)
+  'string':        TypeError: zend_array_ht_or_long(): Argument #1 ($param) must be of type array|int, string given
+  '15':            int(15)
+  '56.7':          
+Deprecated: Implicit conversion from float-string "56.7" to int loses precision in %s on line %d
+int(56)
+  'stdClass':      TypeError: zend_array_ht_or_long(): Argument #1 ($param) must be of type array|int, string given
+  anon class name: TypeError: zend_array_ht_or_long(): Argument #1 ($param) must be of type array|int, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_ht_or_long(): Argument #1 ($param) must be of type array|int, stdClass given
+  new S():         TypeError: zend_array_ht_or_long(): Argument #1 ($param) must be of type array|int, S given
+  STDOUT:          TypeError: zend_array_ht_or_long(): Argument #1 ($param) must be of type array|int, resource given
+
+Using zend_array_ht_or_long_or_null:
+
+  null:            NULL
+  false:           int(0)
+  true:            int(1)
+  42:              int(42)
+  73.5:            
+Deprecated: Implicit conversion from float 73.5 to int loses precision in %s on line %d
+int(73)
+  'string':        TypeError: zend_array_ht_or_long_or_null(): Argument #1 ($param) must be of type array|int|null, string given
+  '15':            int(15)
+  '56.7':          
+Deprecated: Implicit conversion from float-string "56.7" to int loses precision in %s on line %d
+int(56)
+  'stdClass':      TypeError: zend_array_ht_or_long_or_null(): Argument #1 ($param) must be of type array|int|null, string given
+  anon class name: TypeError: zend_array_ht_or_long_or_null(): Argument #1 ($param) must be of type array|int|null, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_ht_or_long_or_null(): Argument #1 ($param) must be of type array|int|null, stdClass given
+  new S():         TypeError: zend_array_ht_or_long_or_null(): Argument #1 ($param) must be of type array|int|null, S given
+  STDOUT:          TypeError: zend_array_ht_or_long_or_null(): Argument #1 ($param) must be of type array|int|null, resource given

--- a/Zend/tests/zpp/array_ht_or_str_zpp_specifier_strict_mode.phpt
+++ b/Zend/tests/zpp/array_ht_or_str_zpp_specifier_strict_mode.phpt
@@ -1,0 +1,73 @@
+--TEST--
+Test array_ht_or_str ZPP specifier (strict_mode)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$types = require 'types.inc';
+$functions = [
+    'zend_array_ht_or_str',
+    'zend_array_ht_or_str_or_null',
+];
+
+foreach ($functions as $i => $function) {
+    echo "Using $function:\n\n";
+
+    foreach ($types as $name => $type) {
+        printf("  %-16s ", "$name:");
+
+        try {
+            $result = $function($type);
+
+            $result === []
+                ? printf("array(0) {}\n")
+                : var_dump($result);
+
+        } catch (Throwable $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+    }
+
+    if ($i !== array_key_last($functions)) {
+        echo "\n";
+    }
+}
+
+?>
+--EXPECTF--
+Using zend_array_ht_or_str:
+
+  null:            TypeError: zend_array_ht_or_str(): Argument #1 ($param) must be of type array|string, null given
+  false:           TypeError: zend_array_ht_or_str(): Argument #1 ($param) must be of type array|string, false given
+  true:            TypeError: zend_array_ht_or_str(): Argument #1 ($param) must be of type array|string, true given
+  42:              TypeError: zend_array_ht_or_str(): Argument #1 ($param) must be of type array|string, int given
+  73.5:            TypeError: zend_array_ht_or_str(): Argument #1 ($param) must be of type array|string, float given
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_ht_or_str(): Argument #1 ($param) must be of type array|string, stdClass given
+  new S():         TypeError: zend_array_ht_or_str(): Argument #1 ($param) must be of type array|string, S given
+  STDOUT:          TypeError: zend_array_ht_or_str(): Argument #1 ($param) must be of type array|string, resource given
+
+Using zend_array_ht_or_str_or_null:
+
+  null:            NULL
+  false:           TypeError: zend_array_ht_or_str_or_null(): Argument #1 ($param) must be of type array|string|null, false given
+  true:            TypeError: zend_array_ht_or_str_or_null(): Argument #1 ($param) must be of type array|string|null, true given
+  42:              TypeError: zend_array_ht_or_str_or_null(): Argument #1 ($param) must be of type array|string|null, int given
+  73.5:            TypeError: zend_array_ht_or_str_or_null(): Argument #1 ($param) must be of type array|string|null, float given
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_ht_or_str_or_null(): Argument #1 ($param) must be of type array|string|null, stdClass given
+  new S():         TypeError: zend_array_ht_or_str_or_null(): Argument #1 ($param) must be of type array|string|null, S given
+  STDOUT:          TypeError: zend_array_ht_or_str_or_null(): Argument #1 ($param) must be of type array|string|null, resource given

--- a/Zend/tests/zpp/array_ht_or_str_zpp_specifier_weak_mode.phpt
+++ b/Zend/tests/zpp/array_ht_or_str_zpp_specifier_weak_mode.phpt
@@ -1,0 +1,73 @@
+--TEST--
+Test array_ht_or_str ZPP specifier (weak_mode)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+$types = require 'types.inc';
+$functions = [
+    'zend_array_ht_or_str',
+    'zend_array_ht_or_str_or_null',
+];
+
+foreach ($functions as $i => $function) {
+    echo "Using $function:\n\n";
+
+    foreach ($types as $name => $type) {
+        printf("  %-16s ", "$name:");
+
+        try {
+            $result = $function($type);
+
+            $result === []
+                ? printf("array(0) {}\n")
+                : var_dump($result);
+
+        } catch (Throwable $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+    }
+
+    if ($i !== array_key_last($functions)) {
+        echo "\n";
+    }
+}
+
+?>
+--EXPECTF--
+Using zend_array_ht_or_str:
+
+  null:            
+Deprecated: zend_array_ht_or_str(): Passing null to parameter #1 ($param) of type array|string is deprecated in %s on line %d
+string(0) ""
+  false:           string(0) ""
+  true:            string(1) "1"
+  42:              string(2) "42"
+  73.5:            string(4) "73.5"
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_ht_or_str(): Argument #1 ($param) must be of type array|string, stdClass given
+  new S():         string(7) "S class"
+  STDOUT:          TypeError: zend_array_ht_or_str(): Argument #1 ($param) must be of type array|string, resource given
+
+Using zend_array_ht_or_str_or_null:
+
+  null:            NULL
+  false:           string(0) ""
+  true:            string(1) "1"
+  42:              string(2) "42"
+  73.5:            string(4) "73.5"
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_ht_or_str_or_null(): Argument #1 ($param) must be of type array|string|null, stdClass given
+  new S():         string(7) "S class"
+  STDOUT:          TypeError: zend_array_ht_or_str_or_null(): Argument #1 ($param) must be of type array|string|null, resource given

--- a/Zend/tests/zpp/array_ht_zpp_specifier_strict_mode.phpt
+++ b/Zend/tests/zpp/array_ht_zpp_specifier_strict_mode.phpt
@@ -1,0 +1,145 @@
+--TEST--
+Test array_ht ZPP specifier (strict_mode)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$types = require 'types.inc';
+$functions = [
+    'zend_array_ht',
+    'zend_array_ht_or_null',
+    'zend_array_ht_separate',
+    'zend_array_ht_slow_zpp',
+    'zend_array_ht_or_null_slow_zpp',
+    'zend_array_ht_deref_separate',
+];
+
+foreach ($functions as $i => $function) {
+    echo "Using $function:\n\n";
+
+    foreach ($types as $name => $type) {
+        printf("  %-16s ", "$name:");
+
+        try {
+            $result = $function($type);
+
+            $result === []
+                ? printf("array(0) {}\n")
+                : var_dump($result);
+
+        } catch (Throwable $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+    }
+
+    if ($i !== array_key_last($functions)) {
+        echo "\n";
+    }
+}
+
+?>
+--EXPECT--
+Using zend_array_ht:
+
+  null:            TypeError: zend_array_ht(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_ht(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_ht(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_ht(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_ht(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_ht(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_ht(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_ht(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_ht(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_ht(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_ht(): Argument #1 ($param) must be of type array, stdClass given
+  new S():         TypeError: zend_array_ht(): Argument #1 ($param) must be of type array, S given
+  STDOUT:          TypeError: zend_array_ht(): Argument #1 ($param) must be of type array, resource given
+
+Using zend_array_ht_or_null:
+
+  null:            NULL
+  false:           TypeError: zend_array_ht_or_null(): Argument #1 ($param) must be of type ?array, false given
+  true:            TypeError: zend_array_ht_or_null(): Argument #1 ($param) must be of type ?array, true given
+  42:              TypeError: zend_array_ht_or_null(): Argument #1 ($param) must be of type ?array, int given
+  73.5:            TypeError: zend_array_ht_or_null(): Argument #1 ($param) must be of type ?array, float given
+  'string':        TypeError: zend_array_ht_or_null(): Argument #1 ($param) must be of type ?array, string given
+  '15':            TypeError: zend_array_ht_or_null(): Argument #1 ($param) must be of type ?array, string given
+  '56.7':          TypeError: zend_array_ht_or_null(): Argument #1 ($param) must be of type ?array, string given
+  'stdClass':      TypeError: zend_array_ht_or_null(): Argument #1 ($param) must be of type ?array, string given
+  anon class name: TypeError: zend_array_ht_or_null(): Argument #1 ($param) must be of type ?array, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_ht_or_null(): Argument #1 ($param) must be of type ?array, stdClass given
+  new S():         TypeError: zend_array_ht_or_null(): Argument #1 ($param) must be of type ?array, S given
+  STDOUT:          TypeError: zend_array_ht_or_null(): Argument #1 ($param) must be of type ?array, resource given
+
+Using zend_array_ht_separate:
+
+  null:            TypeError: zend_array_ht_separate(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_ht_separate(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_ht_separate(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_ht_separate(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_ht_separate(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_ht_separate(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_ht_separate(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_ht_separate(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_ht_separate(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_ht_separate(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_ht_separate(): Argument #1 ($param) must be of type array, stdClass given
+  new S():         TypeError: zend_array_ht_separate(): Argument #1 ($param) must be of type array, S given
+  STDOUT:          TypeError: zend_array_ht_separate(): Argument #1 ($param) must be of type array, resource given
+
+Using zend_array_ht_slow_zpp:
+
+  null:            TypeError: zend_array_ht_slow_zpp(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_ht_slow_zpp(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_ht_slow_zpp(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_ht_slow_zpp(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_ht_slow_zpp(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_ht_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_ht_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_ht_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_ht_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_ht_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_ht_slow_zpp(): Argument #1 ($param) must be of type array, stdClass given
+  new S():         TypeError: zend_array_ht_slow_zpp(): Argument #1 ($param) must be of type array, S given
+  STDOUT:          TypeError: zend_array_ht_slow_zpp(): Argument #1 ($param) must be of type array, resource given
+
+Using zend_array_ht_or_null_slow_zpp:
+
+  null:            NULL
+  false:           TypeError: zend_array_ht_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, false given
+  true:            TypeError: zend_array_ht_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, true given
+  42:              TypeError: zend_array_ht_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, int given
+  73.5:            TypeError: zend_array_ht_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, float given
+  'string':        TypeError: zend_array_ht_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, string given
+  '15':            TypeError: zend_array_ht_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, string given
+  '56.7':          TypeError: zend_array_ht_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, string given
+  'stdClass':      TypeError: zend_array_ht_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, string given
+  anon class name: TypeError: zend_array_ht_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_ht_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, stdClass given
+  new S():         TypeError: zend_array_ht_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, S given
+  STDOUT:          TypeError: zend_array_ht_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, resource given
+
+Using zend_array_ht_deref_separate:
+
+  null:            TypeError: zend_array_ht_deref_separate(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_ht_deref_separate(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_ht_deref_separate(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_ht_deref_separate(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_ht_deref_separate(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_ht_deref_separate(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_ht_deref_separate(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_ht_deref_separate(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_ht_deref_separate(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_ht_deref_separate(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_ht_deref_separate(): Argument #1 ($param) must be of type array, stdClass given
+  new S():         TypeError: zend_array_ht_deref_separate(): Argument #1 ($param) must be of type array, S given
+  STDOUT:          TypeError: zend_array_ht_deref_separate(): Argument #1 ($param) must be of type array, resource given

--- a/Zend/tests/zpp/array_ht_zpp_specifier_weak_mode.phpt
+++ b/Zend/tests/zpp/array_ht_zpp_specifier_weak_mode.phpt
@@ -1,0 +1,143 @@
+--TEST--
+Test array_ht ZPP specifier (weak_mode)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+$types = require 'types.inc';
+$functions = [
+    'zend_array_ht',
+    'zend_array_ht_or_null',
+    'zend_array_ht_separate',
+    'zend_array_ht_slow_zpp',
+    'zend_array_ht_or_null_slow_zpp',
+    'zend_array_ht_deref_separate',
+];
+
+foreach ($functions as $i => $function) {
+    echo "Using $function:\n\n";
+
+    foreach ($types as $name => $type) {
+        printf("  %-16s ", "$name:");
+
+        try {
+            $result = $function($type);
+
+            $result === []
+                ? printf("array(0) {}\n")
+                : var_dump($result);
+
+        } catch (Throwable $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+    }
+
+    if ($i !== array_key_last($functions)) {
+        echo "\n";
+    }
+}
+
+?>
+--EXPECT--
+Using zend_array_ht:
+
+  null:            TypeError: zend_array_ht(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_ht(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_ht(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_ht(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_ht(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_ht(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_ht(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_ht(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_ht(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_ht(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_ht(): Argument #1 ($param) must be of type array, stdClass given
+  new S():         TypeError: zend_array_ht(): Argument #1 ($param) must be of type array, S given
+  STDOUT:          TypeError: zend_array_ht(): Argument #1 ($param) must be of type array, resource given
+
+Using zend_array_ht_or_null:
+
+  null:            NULL
+  false:           TypeError: zend_array_ht_or_null(): Argument #1 ($param) must be of type ?array, false given
+  true:            TypeError: zend_array_ht_or_null(): Argument #1 ($param) must be of type ?array, true given
+  42:              TypeError: zend_array_ht_or_null(): Argument #1 ($param) must be of type ?array, int given
+  73.5:            TypeError: zend_array_ht_or_null(): Argument #1 ($param) must be of type ?array, float given
+  'string':        TypeError: zend_array_ht_or_null(): Argument #1 ($param) must be of type ?array, string given
+  '15':            TypeError: zend_array_ht_or_null(): Argument #1 ($param) must be of type ?array, string given
+  '56.7':          TypeError: zend_array_ht_or_null(): Argument #1 ($param) must be of type ?array, string given
+  'stdClass':      TypeError: zend_array_ht_or_null(): Argument #1 ($param) must be of type ?array, string given
+  anon class name: TypeError: zend_array_ht_or_null(): Argument #1 ($param) must be of type ?array, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_ht_or_null(): Argument #1 ($param) must be of type ?array, stdClass given
+  new S():         TypeError: zend_array_ht_or_null(): Argument #1 ($param) must be of type ?array, S given
+  STDOUT:          TypeError: zend_array_ht_or_null(): Argument #1 ($param) must be of type ?array, resource given
+
+Using zend_array_ht_separate:
+
+  null:            TypeError: zend_array_ht_separate(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_ht_separate(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_ht_separate(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_ht_separate(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_ht_separate(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_ht_separate(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_ht_separate(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_ht_separate(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_ht_separate(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_ht_separate(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_ht_separate(): Argument #1 ($param) must be of type array, stdClass given
+  new S():         TypeError: zend_array_ht_separate(): Argument #1 ($param) must be of type array, S given
+  STDOUT:          TypeError: zend_array_ht_separate(): Argument #1 ($param) must be of type array, resource given
+
+Using zend_array_ht_slow_zpp:
+
+  null:            TypeError: zend_array_ht_slow_zpp(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_ht_slow_zpp(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_ht_slow_zpp(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_ht_slow_zpp(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_ht_slow_zpp(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_ht_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_ht_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_ht_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_ht_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_ht_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_ht_slow_zpp(): Argument #1 ($param) must be of type array, stdClass given
+  new S():         TypeError: zend_array_ht_slow_zpp(): Argument #1 ($param) must be of type array, S given
+  STDOUT:          TypeError: zend_array_ht_slow_zpp(): Argument #1 ($param) must be of type array, resource given
+
+Using zend_array_ht_or_null_slow_zpp:
+
+  null:            NULL
+  false:           TypeError: zend_array_ht_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, false given
+  true:            TypeError: zend_array_ht_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, true given
+  42:              TypeError: zend_array_ht_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, int given
+  73.5:            TypeError: zend_array_ht_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, float given
+  'string':        TypeError: zend_array_ht_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, string given
+  '15':            TypeError: zend_array_ht_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, string given
+  '56.7':          TypeError: zend_array_ht_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, string given
+  'stdClass':      TypeError: zend_array_ht_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, string given
+  anon class name: TypeError: zend_array_ht_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_ht_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, stdClass given
+  new S():         TypeError: zend_array_ht_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, S given
+  STDOUT:          TypeError: zend_array_ht_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, resource given
+
+Using zend_array_ht_deref_separate:
+
+  null:            TypeError: zend_array_ht_deref_separate(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_ht_deref_separate(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_ht_deref_separate(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_ht_deref_separate(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_ht_deref_separate(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_ht_deref_separate(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_ht_deref_separate(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_ht_deref_separate(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_ht_deref_separate(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_ht_deref_separate(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_ht_deref_separate(): Argument #1 ($param) must be of type array, stdClass given
+  new S():         TypeError: zend_array_ht_deref_separate(): Argument #1 ($param) must be of type array, S given
+  STDOUT:          TypeError: zend_array_ht_deref_separate(): Argument #1 ($param) must be of type array, resource given

--- a/Zend/tests/zpp/array_or_object_ht_zpp_specifier_strict_mode.phpt
+++ b/Zend/tests/zpp/array_or_object_ht_zpp_specifier_strict_mode.phpt
@@ -1,0 +1,109 @@
+--TEST--
+Test array_or_object_ht ZPP specifier (strict_mode)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$types = require 'types.inc';
+$functions = [
+    'zend_array_or_object_ht',
+    'zend_array_or_object_ht_separate',
+    'zend_array_or_object_ht_slow_zpp',
+    'zend_array_or_object_ht_deref_separate',
+];
+
+foreach ($functions as $i => $function) {
+    echo "Using $function:\n\n";
+
+    foreach ($types as $name => $type) {
+        printf("  %-16s ", "$name:");
+
+        try {
+            $result = $function($type);
+
+            $result === []
+                ? printf("array(0) {}\n")
+                : var_dump($result);
+
+        } catch (Throwable $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+    }
+
+    if ($i !== array_key_last($functions)) {
+        echo "\n";
+    }
+}
+
+?>
+--EXPECT--
+Using zend_array_or_object_ht:
+
+  null:            TypeError: zend_array_or_object_ht(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_or_object_ht(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_or_object_ht(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_or_object_ht(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_or_object_ht(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_or_object_ht(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_or_object_ht(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_or_object_ht(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_or_object_ht(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_or_object_ht(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  array(0) {}
+  new S():         array(0) {}
+  STDOUT:          TypeError: zend_array_or_object_ht(): Argument #1 ($param) must be of type array, resource given
+
+Using zend_array_or_object_ht_separate:
+
+  null:            TypeError: zend_array_or_object_ht_separate(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_or_object_ht_separate(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_or_object_ht_separate(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_or_object_ht_separate(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_or_object_ht_separate(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_or_object_ht_separate(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_or_object_ht_separate(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_or_object_ht_separate(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_or_object_ht_separate(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_or_object_ht_separate(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  array(0) {}
+  new S():         array(0) {}
+  STDOUT:          TypeError: zend_array_or_object_ht_separate(): Argument #1 ($param) must be of type array, resource given
+
+Using zend_array_or_object_ht_slow_zpp:
+
+  null:            TypeError: zend_array_or_object_ht_slow_zpp(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_or_object_ht_slow_zpp(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_or_object_ht_slow_zpp(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_or_object_ht_slow_zpp(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_or_object_ht_slow_zpp(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_or_object_ht_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_or_object_ht_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_or_object_ht_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_or_object_ht_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_or_object_ht_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  array(0) {}
+  new S():         array(0) {}
+  STDOUT:          TypeError: zend_array_or_object_ht_slow_zpp(): Argument #1 ($param) must be of type array, resource given
+
+Using zend_array_or_object_ht_deref_separate:
+
+  null:            TypeError: zend_array_or_object_ht_deref_separate(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_or_object_ht_deref_separate(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_or_object_ht_deref_separate(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_or_object_ht_deref_separate(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_or_object_ht_deref_separate(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_or_object_ht_deref_separate(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_or_object_ht_deref_separate(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_or_object_ht_deref_separate(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_or_object_ht_deref_separate(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_or_object_ht_deref_separate(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  array(0) {}
+  new S():         array(0) {}
+  STDOUT:          TypeError: zend_array_or_object_ht_deref_separate(): Argument #1 ($param) must be of type array, resource given

--- a/Zend/tests/zpp/array_or_object_ht_zpp_specifier_weak_mode.phpt
+++ b/Zend/tests/zpp/array_or_object_ht_zpp_specifier_weak_mode.phpt
@@ -1,0 +1,107 @@
+--TEST--
+Test array_or_object_ht ZPP specifier (weak_mode)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+$types = require 'types.inc';
+$functions = [
+    'zend_array_or_object_ht',
+    'zend_array_or_object_ht_separate',
+    'zend_array_or_object_ht_slow_zpp',
+    'zend_array_or_object_ht_deref_separate',
+];
+
+foreach ($functions as $i => $function) {
+    echo "Using $function:\n\n";
+
+    foreach ($types as $name => $type) {
+        printf("  %-16s ", "$name:");
+
+        try {
+            $result = $function($type);
+
+            $result === []
+                ? printf("array(0) {}\n")
+                : var_dump($result);
+
+        } catch (Throwable $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+    }
+
+    if ($i !== array_key_last($functions)) {
+        echo "\n";
+    }
+}
+
+?>
+--EXPECT--
+Using zend_array_or_object_ht:
+
+  null:            TypeError: zend_array_or_object_ht(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_or_object_ht(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_or_object_ht(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_or_object_ht(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_or_object_ht(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_or_object_ht(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_or_object_ht(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_or_object_ht(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_or_object_ht(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_or_object_ht(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  array(0) {}
+  new S():         array(0) {}
+  STDOUT:          TypeError: zend_array_or_object_ht(): Argument #1 ($param) must be of type array, resource given
+
+Using zend_array_or_object_ht_separate:
+
+  null:            TypeError: zend_array_or_object_ht_separate(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_or_object_ht_separate(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_or_object_ht_separate(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_or_object_ht_separate(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_or_object_ht_separate(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_or_object_ht_separate(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_or_object_ht_separate(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_or_object_ht_separate(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_or_object_ht_separate(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_or_object_ht_separate(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  array(0) {}
+  new S():         array(0) {}
+  STDOUT:          TypeError: zend_array_or_object_ht_separate(): Argument #1 ($param) must be of type array, resource given
+
+Using zend_array_or_object_ht_slow_zpp:
+
+  null:            TypeError: zend_array_or_object_ht_slow_zpp(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_or_object_ht_slow_zpp(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_or_object_ht_slow_zpp(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_or_object_ht_slow_zpp(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_or_object_ht_slow_zpp(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_or_object_ht_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_or_object_ht_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_or_object_ht_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_or_object_ht_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_or_object_ht_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  array(0) {}
+  new S():         array(0) {}
+  STDOUT:          TypeError: zend_array_or_object_ht_slow_zpp(): Argument #1 ($param) must be of type array, resource given
+
+Using zend_array_or_object_ht_deref_separate:
+
+  null:            TypeError: zend_array_or_object_ht_deref_separate(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_or_object_ht_deref_separate(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_or_object_ht_deref_separate(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_or_object_ht_deref_separate(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_or_object_ht_deref_separate(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_or_object_ht_deref_separate(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_or_object_ht_deref_separate(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_or_object_ht_deref_separate(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_or_object_ht_deref_separate(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_or_object_ht_deref_separate(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  array(0) {}
+  new S():         array(0) {}
+  STDOUT:          TypeError: zend_array_or_object_ht_deref_separate(): Argument #1 ($param) must be of type array, resource given

--- a/Zend/tests/zpp/array_or_object_zpp_specifier_strict_mode.phpt
+++ b/Zend/tests/zpp/array_or_object_zpp_specifier_strict_mode.phpt
@@ -1,0 +1,117 @@
+--TEST--
+Test array_or_object ZPP specifier (strict_mode)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$types = require 'types.inc';
+$functions = [
+    'zend_array_or_object',
+    'zend_array_or_object_separate',
+    'zend_array_or_object_slow_zpp',
+    'zend_array_or_object_deref_separate',
+];
+
+foreach ($functions as $i => $function) {
+    echo "Using $function:\n\n";
+
+    foreach ($types as $name => $type) {
+        printf("  %-16s ", "$name:");
+
+        try {
+            $result = $function($type);
+
+            $result === []
+                ? printf("array(0) {}\n")
+                : var_dump($result);
+
+        } catch (Throwable $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+    }
+
+    if ($i !== array_key_last($functions)) {
+        echo "\n";
+    }
+}
+
+?>
+--EXPECTF--
+Using zend_array_or_object:
+
+  null:            TypeError: zend_array_or_object(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_or_object(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_or_object(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_or_object(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_or_object(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_or_object(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_or_object(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_or_object(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_or_object(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_or_object(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  object(stdClass)#%d (%d) {
+}
+  new S():         object(S)#%d (%d) {
+}
+  STDOUT:          TypeError: zend_array_or_object(): Argument #1 ($param) must be of type array, resource given
+
+Using zend_array_or_object_separate:
+
+  null:            TypeError: zend_array_or_object_separate(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_or_object_separate(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_or_object_separate(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_or_object_separate(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_or_object_separate(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_or_object_separate(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_or_object_separate(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_or_object_separate(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_or_object_separate(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_or_object_separate(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  object(stdClass)#%d (%d) {
+}
+  new S():         object(S)#%d (%d) {
+}
+  STDOUT:          TypeError: zend_array_or_object_separate(): Argument #1 ($param) must be of type array, resource given
+
+Using zend_array_or_object_slow_zpp:
+
+  null:            TypeError: zend_array_or_object_slow_zpp(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_or_object_slow_zpp(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_or_object_slow_zpp(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_or_object_slow_zpp(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_or_object_slow_zpp(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_or_object_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_or_object_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_or_object_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_or_object_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_or_object_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  object(stdClass)#%d (%d) {
+}
+  new S():         object(S)#%d (%d) {
+}
+  STDOUT:          TypeError: zend_array_or_object_slow_zpp(): Argument #1 ($param) must be of type array, resource given
+
+Using zend_array_or_object_deref_separate:
+
+  null:            TypeError: zend_array_or_object_deref_separate(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_or_object_deref_separate(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_or_object_deref_separate(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_or_object_deref_separate(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_or_object_deref_separate(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_or_object_deref_separate(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_or_object_deref_separate(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_or_object_deref_separate(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_or_object_deref_separate(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_or_object_deref_separate(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  object(stdClass)#%d (%d) {
+}
+  new S():         object(S)#%d (%d) {
+}
+  STDOUT:          TypeError: zend_array_or_object_deref_separate(): Argument #1 ($param) must be of type array, resource given

--- a/Zend/tests/zpp/array_or_object_zpp_specifier_weak_mode.phpt
+++ b/Zend/tests/zpp/array_or_object_zpp_specifier_weak_mode.phpt
@@ -1,0 +1,115 @@
+--TEST--
+Test array_or_object ZPP specifier (weak_mode)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+$types = require 'types.inc';
+$functions = [
+    'zend_array_or_object',
+    'zend_array_or_object_separate',
+    'zend_array_or_object_slow_zpp',
+    'zend_array_or_object_deref_separate',
+];
+
+foreach ($functions as $i => $function) {
+    echo "Using $function:\n\n";
+
+    foreach ($types as $name => $type) {
+        printf("  %-16s ", "$name:");
+
+        try {
+            $result = $function($type);
+
+            $result === []
+                ? printf("array(0) {}\n")
+                : var_dump($result);
+
+        } catch (Throwable $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+    }
+
+    if ($i !== array_key_last($functions)) {
+        echo "\n";
+    }
+}
+
+?>
+--EXPECTF--
+Using zend_array_or_object:
+
+  null:            TypeError: zend_array_or_object(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_or_object(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_or_object(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_or_object(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_or_object(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_or_object(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_or_object(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_or_object(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_or_object(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_or_object(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  object(stdClass)#%d (%d) {
+}
+  new S():         object(S)#%d (%d) {
+}
+  STDOUT:          TypeError: zend_array_or_object(): Argument #1 ($param) must be of type array, resource given
+
+Using zend_array_or_object_separate:
+
+  null:            TypeError: zend_array_or_object_separate(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_or_object_separate(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_or_object_separate(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_or_object_separate(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_or_object_separate(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_or_object_separate(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_or_object_separate(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_or_object_separate(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_or_object_separate(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_or_object_separate(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  object(stdClass)#%d (%d) {
+}
+  new S():         object(S)#%d (%d) {
+}
+  STDOUT:          TypeError: zend_array_or_object_separate(): Argument #1 ($param) must be of type array, resource given
+
+Using zend_array_or_object_slow_zpp:
+
+  null:            TypeError: zend_array_or_object_slow_zpp(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_or_object_slow_zpp(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_or_object_slow_zpp(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_or_object_slow_zpp(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_or_object_slow_zpp(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_or_object_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_or_object_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_or_object_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_or_object_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_or_object_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  object(stdClass)#%d (%d) {
+}
+  new S():         object(S)#%d (%d) {
+}
+  STDOUT:          TypeError: zend_array_or_object_slow_zpp(): Argument #1 ($param) must be of type array, resource given
+
+Using zend_array_or_object_deref_separate:
+
+  null:            TypeError: zend_array_or_object_deref_separate(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_or_object_deref_separate(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_or_object_deref_separate(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_or_object_deref_separate(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_or_object_deref_separate(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_or_object_deref_separate(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_or_object_deref_separate(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_or_object_deref_separate(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_or_object_deref_separate(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_or_object_deref_separate(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  object(stdClass)#%d (%d) {
+}
+  new S():         object(S)#%d (%d) {
+}
+  STDOUT:          TypeError: zend_array_or_object_deref_separate(): Argument #1 ($param) must be of type array, resource given

--- a/Zend/tests/zpp/array_zpp_specifier_strict_mode.phpt
+++ b/Zend/tests/zpp/array_zpp_specifier_strict_mode.phpt
@@ -1,0 +1,145 @@
+--TEST--
+Test array ZPP specifier (strict_mode)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$types = require 'types.inc';
+$functions = [
+    'zend_array',
+    'zend_array_or_null',
+    'zend_array_separate',
+    'zend_array_slow_zpp',
+    'zend_array_or_null_slow_zpp',
+    'zend_array_deref_separate',
+];
+
+foreach ($functions as $i => $function) {
+    echo "Using $function:\n\n";
+
+    foreach ($types as $name => $type) {
+        printf("  %-16s ", "$name:");
+
+        try {
+            $result = $function($type);
+
+            $result === []
+                ? printf("array(0) {}\n")
+                : var_dump($result);
+
+        } catch (Throwable $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+    }
+
+    if ($i !== array_key_last($functions)) {
+        echo "\n";
+    }
+}
+
+?>
+--EXPECT--
+Using zend_array:
+
+  null:            TypeError: zend_array(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array(): Argument #1 ($param) must be of type array, stdClass given
+  new S():         TypeError: zend_array(): Argument #1 ($param) must be of type array, S given
+  STDOUT:          TypeError: zend_array(): Argument #1 ($param) must be of type array, resource given
+
+Using zend_array_or_null:
+
+  null:            NULL
+  false:           TypeError: zend_array_or_null(): Argument #1 ($param) must be of type ?array, false given
+  true:            TypeError: zend_array_or_null(): Argument #1 ($param) must be of type ?array, true given
+  42:              TypeError: zend_array_or_null(): Argument #1 ($param) must be of type ?array, int given
+  73.5:            TypeError: zend_array_or_null(): Argument #1 ($param) must be of type ?array, float given
+  'string':        TypeError: zend_array_or_null(): Argument #1 ($param) must be of type ?array, string given
+  '15':            TypeError: zend_array_or_null(): Argument #1 ($param) must be of type ?array, string given
+  '56.7':          TypeError: zend_array_or_null(): Argument #1 ($param) must be of type ?array, string given
+  'stdClass':      TypeError: zend_array_or_null(): Argument #1 ($param) must be of type ?array, string given
+  anon class name: TypeError: zend_array_or_null(): Argument #1 ($param) must be of type ?array, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_or_null(): Argument #1 ($param) must be of type ?array, stdClass given
+  new S():         TypeError: zend_array_or_null(): Argument #1 ($param) must be of type ?array, S given
+  STDOUT:          TypeError: zend_array_or_null(): Argument #1 ($param) must be of type ?array, resource given
+
+Using zend_array_separate:
+
+  null:            TypeError: zend_array_separate(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_separate(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_separate(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_separate(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_separate(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_separate(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_separate(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_separate(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_separate(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_separate(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_separate(): Argument #1 ($param) must be of type array, stdClass given
+  new S():         TypeError: zend_array_separate(): Argument #1 ($param) must be of type array, S given
+  STDOUT:          TypeError: zend_array_separate(): Argument #1 ($param) must be of type array, resource given
+
+Using zend_array_slow_zpp:
+
+  null:            TypeError: zend_array_slow_zpp(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_slow_zpp(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_slow_zpp(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_slow_zpp(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_slow_zpp(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_slow_zpp(): Argument #1 ($param) must be of type array, stdClass given
+  new S():         TypeError: zend_array_slow_zpp(): Argument #1 ($param) must be of type array, S given
+  STDOUT:          TypeError: zend_array_slow_zpp(): Argument #1 ($param) must be of type array, resource given
+
+Using zend_array_or_null_slow_zpp:
+
+  null:            NULL
+  false:           TypeError: zend_array_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, false given
+  true:            TypeError: zend_array_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, true given
+  42:              TypeError: zend_array_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, int given
+  73.5:            TypeError: zend_array_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, float given
+  'string':        TypeError: zend_array_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, string given
+  '15':            TypeError: zend_array_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, string given
+  '56.7':          TypeError: zend_array_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, string given
+  'stdClass':      TypeError: zend_array_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, string given
+  anon class name: TypeError: zend_array_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, stdClass given
+  new S():         TypeError: zend_array_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, S given
+  STDOUT:          TypeError: zend_array_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, resource given
+
+Using zend_array_deref_separate:
+
+  null:            TypeError: zend_array_deref_separate(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_deref_separate(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_deref_separate(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_deref_separate(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_deref_separate(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_deref_separate(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_deref_separate(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_deref_separate(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_deref_separate(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_deref_separate(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_deref_separate(): Argument #1 ($param) must be of type array, stdClass given
+  new S():         TypeError: zend_array_deref_separate(): Argument #1 ($param) must be of type array, S given
+  STDOUT:          TypeError: zend_array_deref_separate(): Argument #1 ($param) must be of type array, resource given

--- a/Zend/tests/zpp/array_zpp_specifier_weak_mode.phpt
+++ b/Zend/tests/zpp/array_zpp_specifier_weak_mode.phpt
@@ -1,0 +1,143 @@
+--TEST--
+Test array ZPP specifier (weak_mode)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+$types = require 'types.inc';
+$functions = [
+    'zend_array',
+    'zend_array_or_null',
+    'zend_array_separate',
+    'zend_array_slow_zpp',
+    'zend_array_or_null_slow_zpp',
+    'zend_array_deref_separate',
+];
+
+foreach ($functions as $i => $function) {
+    echo "Using $function:\n\n";
+
+    foreach ($types as $name => $type) {
+        printf("  %-16s ", "$name:");
+
+        try {
+            $result = $function($type);
+
+            $result === []
+                ? printf("array(0) {}\n")
+                : var_dump($result);
+
+        } catch (Throwable $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+    }
+
+    if ($i !== array_key_last($functions)) {
+        echo "\n";
+    }
+}
+
+?>
+--EXPECT--
+Using zend_array:
+
+  null:            TypeError: zend_array(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array(): Argument #1 ($param) must be of type array, stdClass given
+  new S():         TypeError: zend_array(): Argument #1 ($param) must be of type array, S given
+  STDOUT:          TypeError: zend_array(): Argument #1 ($param) must be of type array, resource given
+
+Using zend_array_or_null:
+
+  null:            NULL
+  false:           TypeError: zend_array_or_null(): Argument #1 ($param) must be of type ?array, false given
+  true:            TypeError: zend_array_or_null(): Argument #1 ($param) must be of type ?array, true given
+  42:              TypeError: zend_array_or_null(): Argument #1 ($param) must be of type ?array, int given
+  73.5:            TypeError: zend_array_or_null(): Argument #1 ($param) must be of type ?array, float given
+  'string':        TypeError: zend_array_or_null(): Argument #1 ($param) must be of type ?array, string given
+  '15':            TypeError: zend_array_or_null(): Argument #1 ($param) must be of type ?array, string given
+  '56.7':          TypeError: zend_array_or_null(): Argument #1 ($param) must be of type ?array, string given
+  'stdClass':      TypeError: zend_array_or_null(): Argument #1 ($param) must be of type ?array, string given
+  anon class name: TypeError: zend_array_or_null(): Argument #1 ($param) must be of type ?array, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_or_null(): Argument #1 ($param) must be of type ?array, stdClass given
+  new S():         TypeError: zend_array_or_null(): Argument #1 ($param) must be of type ?array, S given
+  STDOUT:          TypeError: zend_array_or_null(): Argument #1 ($param) must be of type ?array, resource given
+
+Using zend_array_separate:
+
+  null:            TypeError: zend_array_separate(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_separate(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_separate(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_separate(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_separate(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_separate(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_separate(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_separate(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_separate(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_separate(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_separate(): Argument #1 ($param) must be of type array, stdClass given
+  new S():         TypeError: zend_array_separate(): Argument #1 ($param) must be of type array, S given
+  STDOUT:          TypeError: zend_array_separate(): Argument #1 ($param) must be of type array, resource given
+
+Using zend_array_slow_zpp:
+
+  null:            TypeError: zend_array_slow_zpp(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_slow_zpp(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_slow_zpp(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_slow_zpp(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_slow_zpp(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_slow_zpp(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_slow_zpp(): Argument #1 ($param) must be of type array, stdClass given
+  new S():         TypeError: zend_array_slow_zpp(): Argument #1 ($param) must be of type array, S given
+  STDOUT:          TypeError: zend_array_slow_zpp(): Argument #1 ($param) must be of type array, resource given
+
+Using zend_array_or_null_slow_zpp:
+
+  null:            NULL
+  false:           TypeError: zend_array_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, false given
+  true:            TypeError: zend_array_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, true given
+  42:              TypeError: zend_array_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, int given
+  73.5:            TypeError: zend_array_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, float given
+  'string':        TypeError: zend_array_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, string given
+  '15':            TypeError: zend_array_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, string given
+  '56.7':          TypeError: zend_array_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, string given
+  'stdClass':      TypeError: zend_array_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, string given
+  anon class name: TypeError: zend_array_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, stdClass given
+  new S():         TypeError: zend_array_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, S given
+  STDOUT:          TypeError: zend_array_or_null_slow_zpp(): Argument #1 ($param) must be of type ?array, resource given
+
+Using zend_array_deref_separate:
+
+  null:            TypeError: zend_array_deref_separate(): Argument #1 ($param) must be of type array, null given
+  false:           TypeError: zend_array_deref_separate(): Argument #1 ($param) must be of type array, false given
+  true:            TypeError: zend_array_deref_separate(): Argument #1 ($param) must be of type array, true given
+  42:              TypeError: zend_array_deref_separate(): Argument #1 ($param) must be of type array, int given
+  73.5:            TypeError: zend_array_deref_separate(): Argument #1 ($param) must be of type array, float given
+  'string':        TypeError: zend_array_deref_separate(): Argument #1 ($param) must be of type array, string given
+  '15':            TypeError: zend_array_deref_separate(): Argument #1 ($param) must be of type array, string given
+  '56.7':          TypeError: zend_array_deref_separate(): Argument #1 ($param) must be of type array, string given
+  'stdClass':      TypeError: zend_array_deref_separate(): Argument #1 ($param) must be of type array, string given
+  anon class name: TypeError: zend_array_deref_separate(): Argument #1 ($param) must be of type array, string given
+  []:              array(0) {}
+  new stdClass():  TypeError: zend_array_deref_separate(): Argument #1 ($param) must be of type array, stdClass given
+  new S():         TypeError: zend_array_deref_separate(): Argument #1 ($param) must be of type array, S given
+  STDOUT:          TypeError: zend_array_deref_separate(): Argument #1 ($param) must be of type array, resource given

--- a/Zend/tests/zpp/enum_zpp_specifier.phpt
+++ b/Zend/tests/zpp/enum_zpp_specifier.phpt
@@ -1,0 +1,56 @@
+--TEST--
+Test Z_PARAM_ENUM specifier
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+$types = require 'types.inc';
+$types['ZendTestUnitEnum::Foo'] = ZendTestUnitEnum::Foo;
+
+$functions = [
+    'zend_enum',
+];
+
+foreach ($functions as $i => $function) {
+    echo "Using $function:\n\n";
+
+    foreach ($types as $name => $type) {
+        printf("  %-16s ", "$name:");
+
+        try {
+            $result = $function($type);
+
+            $result === []
+                ? printf("array(0) {}\n")
+                : var_dump($result);
+
+        } catch (Throwable $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+    }
+
+    if ($i !== array_key_last($functions)) {
+        echo "\n";
+    }
+}
+
+?>
+--EXPECT--
+Using zend_enum:
+
+  null:            TypeError: zend_enum(): Argument #1 ($param) must be of type ZendTestUnitEnum, null given
+  false:           TypeError: zend_enum(): Argument #1 ($param) must be of type ZendTestUnitEnum, false given
+  true:            TypeError: zend_enum(): Argument #1 ($param) must be of type ZendTestUnitEnum, true given
+  42:              TypeError: zend_enum(): Argument #1 ($param) must be of type ZendTestUnitEnum, int given
+  73.5:            TypeError: zend_enum(): Argument #1 ($param) must be of type ZendTestUnitEnum, float given
+  'string':        TypeError: zend_enum(): Argument #1 ($param) must be of type ZendTestUnitEnum, string given
+  '15':            TypeError: zend_enum(): Argument #1 ($param) must be of type ZendTestUnitEnum, string given
+  '56.7':          TypeError: zend_enum(): Argument #1 ($param) must be of type ZendTestUnitEnum, string given
+  'stdClass':      TypeError: zend_enum(): Argument #1 ($param) must be of type ZendTestUnitEnum, string given
+  anon class name: TypeError: zend_enum(): Argument #1 ($param) must be of type ZendTestUnitEnum, string given
+  []:              TypeError: zend_enum(): Argument #1 ($param) must be of type ZendTestUnitEnum, array given
+  new stdClass():  TypeError: zend_enum(): Argument #1 ($param) must be of type ZendTestUnitEnum, stdClass given
+  new S():         TypeError: zend_enum(): Argument #1 ($param) must be of type ZendTestUnitEnum, S given
+  STDOUT:          TypeError: zend_enum(): Argument #1 ($param) must be of type ZendTestUnitEnum, resource given
+  ZendTestUnitEnum::Foo: int(1)

--- a/Zend/tests/zpp/func_zpp_specifier_strict_mode.phpt
+++ b/Zend/tests/zpp/func_zpp_specifier_strict_mode.phpt
@@ -1,0 +1,153 @@
+--TEST--
+Test func ZPP specifier (strict_mode)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$types = require 'types.inc';
+$types['strlen'] = 'strlen';
+
+$functions = [
+    'zend_func',
+    'zend_func_or_null',
+    'zend_func_no_trampoline_free',
+    'zend_func_no_trampoline_free_or_null',
+    'zend_func_slow_zpp',
+    'zend_func_or_null_slow_zpp',
+];
+
+foreach ($functions as $i => $function) {
+    echo "Using $function:\n\n";
+
+    foreach ($types as $name => $type) {
+        printf("  %-16s ", "$name:");
+
+        try {
+            $result = $function($type);
+
+            $result === []
+                ? printf("array(0) {}\n")
+                : var_dump($result);
+
+        } catch (Throwable $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+    }
+
+    if ($i !== array_key_last($functions)) {
+        echo "\n";
+    }
+}
+
+?>
+--EXPECT--
+Using zend_func:
+
+  null:            TypeError: zend_func(): Argument #1 ($param) must be a valid callback, no array or string given
+  false:           TypeError: zend_func(): Argument #1 ($param) must be a valid callback, no array or string given
+  true:            TypeError: zend_func(): Argument #1 ($param) must be a valid callback, no array or string given
+  42:              TypeError: zend_func(): Argument #1 ($param) must be a valid callback, no array or string given
+  73.5:            TypeError: zend_func(): Argument #1 ($param) must be a valid callback, no array or string given
+  'string':        TypeError: zend_func(): Argument #1 ($param) must be a valid callback, function "string" not found or invalid function name
+  '15':            TypeError: zend_func(): Argument #1 ($param) must be a valid callback, function "15" not found or invalid function name
+  '56.7':          TypeError: zend_func(): Argument #1 ($param) must be a valid callback, function "56.7" not found or invalid function name
+  'stdClass':      TypeError: zend_func(): Argument #1 ($param) must be a valid callback, function "stdClass" not found or invalid function name
+  anon class name: TypeError: zend_func(): Argument #1 ($param) must be a valid callback, function "class@anonymous" not found or invalid function name
+  []:              TypeError: zend_func(): Argument #1 ($param) must be a valid callback, array callback must have exactly two members
+  new stdClass():  TypeError: zend_func(): Argument #1 ($param) must be a valid callback, no array or string given
+  new S():         TypeError: zend_func(): Argument #1 ($param) must be a valid callback, no array or string given
+  STDOUT:          TypeError: zend_func(): Argument #1 ($param) must be a valid callback, no array or string given
+  strlen:          string(6) "strlen"
+
+Using zend_func_or_null:
+
+  null:            NULL
+  false:           TypeError: zend_func_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  true:            TypeError: zend_func_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  42:              TypeError: zend_func_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  73.5:            TypeError: zend_func_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  'string':        TypeError: zend_func_or_null(): Argument #1 ($param) must be a valid callback or null, function "string" not found or invalid function name
+  '15':            TypeError: zend_func_or_null(): Argument #1 ($param) must be a valid callback or null, function "15" not found or invalid function name
+  '56.7':          TypeError: zend_func_or_null(): Argument #1 ($param) must be a valid callback or null, function "56.7" not found or invalid function name
+  'stdClass':      TypeError: zend_func_or_null(): Argument #1 ($param) must be a valid callback or null, function "stdClass" not found or invalid function name
+  anon class name: TypeError: zend_func_or_null(): Argument #1 ($param) must be a valid callback or null, function "class@anonymous" not found or invalid function name
+  []:              TypeError: zend_func_or_null(): Argument #1 ($param) must be a valid callback or null, array callback must have exactly two members
+  new stdClass():  TypeError: zend_func_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  new S():         TypeError: zend_func_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  STDOUT:          TypeError: zend_func_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  strlen:          string(6) "strlen"
+
+Using zend_func_no_trampoline_free:
+
+  null:            TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, no array or string given
+  false:           TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, no array or string given
+  true:            TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, no array or string given
+  42:              TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, no array or string given
+  73.5:            TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, no array or string given
+  'string':        TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, function "string" not found or invalid function name
+  '15':            TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, function "15" not found or invalid function name
+  '56.7':          TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, function "56.7" not found or invalid function name
+  'stdClass':      TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, function "stdClass" not found or invalid function name
+  anon class name: TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, function "class@anonymous" not found or invalid function name
+  []:              TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, array callback must have exactly two members
+  new stdClass():  TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, no array or string given
+  new S():         TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, no array or string given
+  STDOUT:          TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, no array or string given
+  strlen:          string(6) "strlen"
+
+Using zend_func_no_trampoline_free_or_null:
+
+  null:            NULL
+  false:           TypeError: zend_func_no_trampoline_free_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  true:            TypeError: zend_func_no_trampoline_free_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  42:              TypeError: zend_func_no_trampoline_free_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  73.5:            TypeError: zend_func_no_trampoline_free_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  'string':        TypeError: zend_func_no_trampoline_free_or_null(): Argument #1 ($param) must be a valid callback or null, function "string" not found or invalid function name
+  '15':            TypeError: zend_func_no_trampoline_free_or_null(): Argument #1 ($param) must be a valid callback or null, function "15" not found or invalid function name
+  '56.7':          TypeError: zend_func_no_trampoline_free_or_null(): Argument #1 ($param) must be a valid callback or null, function "56.7" not found or invalid function name
+  'stdClass':      TypeError: zend_func_no_trampoline_free_or_null(): Argument #1 ($param) must be a valid callback or null, function "stdClass" not found or invalid function name
+  anon class name: TypeError: zend_func_no_trampoline_free_or_null(): Argument #1 ($param) must be a valid callback or null, function "class@anonymous" not found or invalid function name
+  []:              TypeError: zend_func_no_trampoline_free_or_null(): Argument #1 ($param) must be a valid callback or null, array callback must have exactly two members
+  new stdClass():  TypeError: zend_func_no_trampoline_free_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  new S():         TypeError: zend_func_no_trampoline_free_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  STDOUT:          TypeError: zend_func_no_trampoline_free_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  strlen:          string(6) "strlen"
+
+Using zend_func_slow_zpp:
+
+  null:            TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, no array or string given
+  false:           TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, no array or string given
+  true:            TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, no array or string given
+  42:              TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, no array or string given
+  73.5:            TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, no array or string given
+  'string':        TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, function "string" not found or invalid function name
+  '15':            TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, function "15" not found or invalid function name
+  '56.7':          TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, function "56.7" not found or invalid function name
+  'stdClass':      TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, function "stdClass" not found or invalid function name
+  anon class name: TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, function "class@anonymous" not found or invalid function name
+  []:              TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, array callback must have exactly two members
+  new stdClass():  TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, no array or string given
+  new S():         TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, no array or string given
+  STDOUT:          TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, no array or string given
+  strlen:          string(6) "strlen"
+
+Using zend_func_or_null_slow_zpp:
+
+  null:            NULL
+  false:           TypeError: zend_func_or_null_slow_zpp(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  true:            TypeError: zend_func_or_null_slow_zpp(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  42:              TypeError: zend_func_or_null_slow_zpp(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  73.5:            TypeError: zend_func_or_null_slow_zpp(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  'string':        TypeError: zend_func_or_null_slow_zpp(): Argument #1 ($param) must be a valid callback or null, function "string" not found or invalid function name
+  '15':            TypeError: zend_func_or_null_slow_zpp(): Argument #1 ($param) must be a valid callback or null, function "15" not found or invalid function name
+  '56.7':          TypeError: zend_func_or_null_slow_zpp(): Argument #1 ($param) must be a valid callback or null, function "56.7" not found or invalid function name
+  'stdClass':      TypeError: zend_func_or_null_slow_zpp(): Argument #1 ($param) must be a valid callback or null, function "stdClass" not found or invalid function name
+  anon class name: TypeError: zend_func_or_null_slow_zpp(): Argument #1 ($param) must be a valid callback or null, function "class@anonymous" not found or invalid function name
+  []:              TypeError: zend_func_or_null_slow_zpp(): Argument #1 ($param) must be a valid callback or null, array callback must have exactly two members
+  new stdClass():  TypeError: zend_func_or_null_slow_zpp(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  new S():         TypeError: zend_func_or_null_slow_zpp(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  STDOUT:          TypeError: zend_func_or_null_slow_zpp(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  strlen:          string(6) "strlen"

--- a/Zend/tests/zpp/func_zpp_specifier_weak_mode.phpt
+++ b/Zend/tests/zpp/func_zpp_specifier_weak_mode.phpt
@@ -1,0 +1,151 @@
+--TEST--
+Test func ZPP specifier (weak_mode)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+$types = require 'types.inc';
+$types['strlen'] = 'strlen';
+
+$functions = [
+    'zend_func',
+    'zend_func_or_null',
+    'zend_func_no_trampoline_free',
+    'zend_func_no_trampoline_free_or_null',
+    'zend_func_slow_zpp',
+    'zend_func_or_null_slow_zpp',
+];
+
+foreach ($functions as $i => $function) {
+    echo "Using $function:\n\n";
+
+    foreach ($types as $name => $type) {
+        printf("  %-16s ", "$name:");
+
+        try {
+            $result = $function($type);
+
+            $result === []
+                ? printf("array(0) {}\n")
+                : var_dump($result);
+
+        } catch (Throwable $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+    }
+
+    if ($i !== array_key_last($functions)) {
+        echo "\n";
+    }
+}
+
+?>
+--EXPECT--
+Using zend_func:
+
+  null:            TypeError: zend_func(): Argument #1 ($param) must be a valid callback, no array or string given
+  false:           TypeError: zend_func(): Argument #1 ($param) must be a valid callback, no array or string given
+  true:            TypeError: zend_func(): Argument #1 ($param) must be a valid callback, no array or string given
+  42:              TypeError: zend_func(): Argument #1 ($param) must be a valid callback, no array or string given
+  73.5:            TypeError: zend_func(): Argument #1 ($param) must be a valid callback, no array or string given
+  'string':        TypeError: zend_func(): Argument #1 ($param) must be a valid callback, function "string" not found or invalid function name
+  '15':            TypeError: zend_func(): Argument #1 ($param) must be a valid callback, function "15" not found or invalid function name
+  '56.7':          TypeError: zend_func(): Argument #1 ($param) must be a valid callback, function "56.7" not found or invalid function name
+  'stdClass':      TypeError: zend_func(): Argument #1 ($param) must be a valid callback, function "stdClass" not found or invalid function name
+  anon class name: TypeError: zend_func(): Argument #1 ($param) must be a valid callback, function "class@anonymous" not found or invalid function name
+  []:              TypeError: zend_func(): Argument #1 ($param) must be a valid callback, array callback must have exactly two members
+  new stdClass():  TypeError: zend_func(): Argument #1 ($param) must be a valid callback, no array or string given
+  new S():         TypeError: zend_func(): Argument #1 ($param) must be a valid callback, no array or string given
+  STDOUT:          TypeError: zend_func(): Argument #1 ($param) must be a valid callback, no array or string given
+  strlen:          string(6) "strlen"
+
+Using zend_func_or_null:
+
+  null:            NULL
+  false:           TypeError: zend_func_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  true:            TypeError: zend_func_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  42:              TypeError: zend_func_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  73.5:            TypeError: zend_func_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  'string':        TypeError: zend_func_or_null(): Argument #1 ($param) must be a valid callback or null, function "string" not found or invalid function name
+  '15':            TypeError: zend_func_or_null(): Argument #1 ($param) must be a valid callback or null, function "15" not found or invalid function name
+  '56.7':          TypeError: zend_func_or_null(): Argument #1 ($param) must be a valid callback or null, function "56.7" not found or invalid function name
+  'stdClass':      TypeError: zend_func_or_null(): Argument #1 ($param) must be a valid callback or null, function "stdClass" not found or invalid function name
+  anon class name: TypeError: zend_func_or_null(): Argument #1 ($param) must be a valid callback or null, function "class@anonymous" not found or invalid function name
+  []:              TypeError: zend_func_or_null(): Argument #1 ($param) must be a valid callback or null, array callback must have exactly two members
+  new stdClass():  TypeError: zend_func_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  new S():         TypeError: zend_func_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  STDOUT:          TypeError: zend_func_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  strlen:          string(6) "strlen"
+
+Using zend_func_no_trampoline_free:
+
+  null:            TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, no array or string given
+  false:           TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, no array or string given
+  true:            TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, no array or string given
+  42:              TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, no array or string given
+  73.5:            TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, no array or string given
+  'string':        TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, function "string" not found or invalid function name
+  '15':            TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, function "15" not found or invalid function name
+  '56.7':          TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, function "56.7" not found or invalid function name
+  'stdClass':      TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, function "stdClass" not found or invalid function name
+  anon class name: TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, function "class@anonymous" not found or invalid function name
+  []:              TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, array callback must have exactly two members
+  new stdClass():  TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, no array or string given
+  new S():         TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, no array or string given
+  STDOUT:          TypeError: zend_func_no_trampoline_free(): Argument #1 ($param) must be a valid callback, no array or string given
+  strlen:          string(6) "strlen"
+
+Using zend_func_no_trampoline_free_or_null:
+
+  null:            NULL
+  false:           TypeError: zend_func_no_trampoline_free_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  true:            TypeError: zend_func_no_trampoline_free_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  42:              TypeError: zend_func_no_trampoline_free_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  73.5:            TypeError: zend_func_no_trampoline_free_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  'string':        TypeError: zend_func_no_trampoline_free_or_null(): Argument #1 ($param) must be a valid callback or null, function "string" not found or invalid function name
+  '15':            TypeError: zend_func_no_trampoline_free_or_null(): Argument #1 ($param) must be a valid callback or null, function "15" not found or invalid function name
+  '56.7':          TypeError: zend_func_no_trampoline_free_or_null(): Argument #1 ($param) must be a valid callback or null, function "56.7" not found or invalid function name
+  'stdClass':      TypeError: zend_func_no_trampoline_free_or_null(): Argument #1 ($param) must be a valid callback or null, function "stdClass" not found or invalid function name
+  anon class name: TypeError: zend_func_no_trampoline_free_or_null(): Argument #1 ($param) must be a valid callback or null, function "class@anonymous" not found or invalid function name
+  []:              TypeError: zend_func_no_trampoline_free_or_null(): Argument #1 ($param) must be a valid callback or null, array callback must have exactly two members
+  new stdClass():  TypeError: zend_func_no_trampoline_free_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  new S():         TypeError: zend_func_no_trampoline_free_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  STDOUT:          TypeError: zend_func_no_trampoline_free_or_null(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  strlen:          string(6) "strlen"
+
+Using zend_func_slow_zpp:
+
+  null:            TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, no array or string given
+  false:           TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, no array or string given
+  true:            TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, no array or string given
+  42:              TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, no array or string given
+  73.5:            TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, no array or string given
+  'string':        TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, function "string" not found or invalid function name
+  '15':            TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, function "15" not found or invalid function name
+  '56.7':          TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, function "56.7" not found or invalid function name
+  'stdClass':      TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, function "stdClass" not found or invalid function name
+  anon class name: TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, function "class@anonymous" not found or invalid function name
+  []:              TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, array callback must have exactly two members
+  new stdClass():  TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, no array or string given
+  new S():         TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, no array or string given
+  STDOUT:          TypeError: zend_func_slow_zpp(): Argument #1 ($param) must be a valid callback, no array or string given
+  strlen:          string(6) "strlen"
+
+Using zend_func_or_null_slow_zpp:
+
+  null:            NULL
+  false:           TypeError: zend_func_or_null_slow_zpp(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  true:            TypeError: zend_func_or_null_slow_zpp(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  42:              TypeError: zend_func_or_null_slow_zpp(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  73.5:            TypeError: zend_func_or_null_slow_zpp(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  'string':        TypeError: zend_func_or_null_slow_zpp(): Argument #1 ($param) must be a valid callback or null, function "string" not found or invalid function name
+  '15':            TypeError: zend_func_or_null_slow_zpp(): Argument #1 ($param) must be a valid callback or null, function "15" not found or invalid function name
+  '56.7':          TypeError: zend_func_or_null_slow_zpp(): Argument #1 ($param) must be a valid callback or null, function "56.7" not found or invalid function name
+  'stdClass':      TypeError: zend_func_or_null_slow_zpp(): Argument #1 ($param) must be a valid callback or null, function "stdClass" not found or invalid function name
+  anon class name: TypeError: zend_func_or_null_slow_zpp(): Argument #1 ($param) must be a valid callback or null, function "class@anonymous" not found or invalid function name
+  []:              TypeError: zend_func_or_null_slow_zpp(): Argument #1 ($param) must be a valid callback or null, array callback must have exactly two members
+  new stdClass():  TypeError: zend_func_or_null_slow_zpp(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  new S():         TypeError: zend_func_or_null_slow_zpp(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  STDOUT:          TypeError: zend_func_or_null_slow_zpp(): Argument #1 ($param) must be a valid callback or null, no array or string given
+  strlen:          string(6) "strlen"

--- a/Zend/tests/zpp/path_str_zpp_specifier_strict_mode.phpt
+++ b/Zend/tests/zpp/path_str_zpp_specifier_strict_mode.phpt
@@ -1,0 +1,109 @@
+--TEST--
+Test path_str ZPP specifier (strict_mode)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$types = require 'types.inc';
+$functions = [
+    'zend_path_str',
+    'zend_path_str_or_null',
+    'zend_path_str_slow_zpp',
+    'zend_path_str_or_null_slow_zpp',
+];
+
+foreach ($functions as $i => $function) {
+    echo "Using $function:\n\n";
+
+    foreach ($types as $name => $type) {
+        printf("  %-16s ", "$name:");
+
+        try {
+            $result = $function($type);
+
+            $result === []
+                ? printf("array(0) {}\n")
+                : var_dump($result);
+
+        } catch (Throwable $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+    }
+
+    if ($i !== array_key_last($functions)) {
+        echo "\n";
+    }
+}
+
+?>
+--EXPECT--
+Using zend_path_str:
+
+  null:            TypeError: zend_path_str(): Argument #1 ($param) must be of type string, null given
+  false:           TypeError: zend_path_str(): Argument #1 ($param) must be of type string, false given
+  true:            TypeError: zend_path_str(): Argument #1 ($param) must be of type string, true given
+  42:              TypeError: zend_path_str(): Argument #1 ($param) must be of type string, int given
+  73.5:            TypeError: zend_path_str(): Argument #1 ($param) must be of type string, float given
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: ValueError: zend_path_str(): Argument #1 ($param) must not contain any null bytes
+  []:              TypeError: zend_path_str(): Argument #1 ($param) must be of type string, array given
+  new stdClass():  TypeError: zend_path_str(): Argument #1 ($param) must be of type string, stdClass given
+  new S():         TypeError: zend_path_str(): Argument #1 ($param) must be of type string, S given
+  STDOUT:          TypeError: zend_path_str(): Argument #1 ($param) must be of type string, resource given
+
+Using zend_path_str_or_null:
+
+  null:            NULL
+  false:           TypeError: zend_path_str_or_null(): Argument #1 ($param) must be of type ?string, false given
+  true:            TypeError: zend_path_str_or_null(): Argument #1 ($param) must be of type ?string, true given
+  42:              TypeError: zend_path_str_or_null(): Argument #1 ($param) must be of type ?string, int given
+  73.5:            TypeError: zend_path_str_or_null(): Argument #1 ($param) must be of type ?string, float given
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: ValueError: zend_path_str_or_null(): Argument #1 ($param) must not contain any null bytes
+  []:              TypeError: zend_path_str_or_null(): Argument #1 ($param) must be of type ?string, array given
+  new stdClass():  TypeError: zend_path_str_or_null(): Argument #1 ($param) must be of type ?string, stdClass given
+  new S():         TypeError: zend_path_str_or_null(): Argument #1 ($param) must be of type ?string, S given
+  STDOUT:          TypeError: zend_path_str_or_null(): Argument #1 ($param) must be of type ?string, resource given
+
+Using zend_path_str_slow_zpp:
+
+  null:            TypeError: zend_path_str_slow_zpp(): Argument #1 ($param) must be of type string, null given
+  false:           TypeError: zend_path_str_slow_zpp(): Argument #1 ($param) must be of type string, false given
+  true:            TypeError: zend_path_str_slow_zpp(): Argument #1 ($param) must be of type string, true given
+  42:              TypeError: zend_path_str_slow_zpp(): Argument #1 ($param) must be of type string, int given
+  73.5:            TypeError: zend_path_str_slow_zpp(): Argument #1 ($param) must be of type string, float given
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: ValueError: zend_path_str_slow_zpp(): Argument #1 ($param) must not contain any null bytes
+  []:              TypeError: zend_path_str_slow_zpp(): Argument #1 ($param) must be of type string, array given
+  new stdClass():  TypeError: zend_path_str_slow_zpp(): Argument #1 ($param) must be of type string, stdClass given
+  new S():         TypeError: zend_path_str_slow_zpp(): Argument #1 ($param) must be of type string, S given
+  STDOUT:          TypeError: zend_path_str_slow_zpp(): Argument #1 ($param) must be of type string, resource given
+
+Using zend_path_str_or_null_slow_zpp:
+
+  null:            NULL
+  false:           TypeError: zend_path_str_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, false given
+  true:            TypeError: zend_path_str_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, true given
+  42:              TypeError: zend_path_str_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, int given
+  73.5:            TypeError: zend_path_str_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, float given
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: ValueError: zend_path_str_or_null_slow_zpp(): Argument #1 ($param) must not contain any null bytes
+  []:              TypeError: zend_path_str_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, array given
+  new stdClass():  TypeError: zend_path_str_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, stdClass given
+  new S():         TypeError: zend_path_str_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, S given
+  STDOUT:          TypeError: zend_path_str_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, resource given

--- a/Zend/tests/zpp/path_str_zpp_specifier_weak_mode.phpt
+++ b/Zend/tests/zpp/path_str_zpp_specifier_weak_mode.phpt
@@ -1,0 +1,111 @@
+--TEST--
+Test path_str ZPP specifier (weak_mode)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+$types = require 'types.inc';
+$functions = [
+    'zend_path_str',
+    'zend_path_str_or_null',
+    'zend_path_str_slow_zpp',
+    'zend_path_str_or_null_slow_zpp',
+];
+
+foreach ($functions as $i => $function) {
+    echo "Using $function:\n\n";
+
+    foreach ($types as $name => $type) {
+        printf("  %-16s ", "$name:");
+
+        try {
+            $result = $function($type);
+
+            $result === []
+                ? printf("array(0) {}\n")
+                : var_dump($result);
+
+        } catch (Throwable $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+    }
+
+    if ($i !== array_key_last($functions)) {
+        echo "\n";
+    }
+}
+
+?>
+--EXPECTF--
+Using zend_path_str:
+
+  null:            
+Deprecated: zend_path_str(): Passing null to parameter #1 ($param) of type string is deprecated in %s on line %d
+string(0) ""
+  false:           string(0) ""
+  true:            string(1) "1"
+  42:              string(2) "42"
+  73.5:            string(4) "73.5"
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: ValueError: zend_path_str(): Argument #1 ($param) must not contain any null bytes
+  []:              TypeError: zend_path_str(): Argument #1 ($param) must be of type string, array given
+  new stdClass():  TypeError: zend_path_str(): Argument #1 ($param) must be of type string, stdClass given
+  new S():         string(7) "S class"
+  STDOUT:          TypeError: zend_path_str(): Argument #1 ($param) must be of type string, resource given
+
+Using zend_path_str_or_null:
+
+  null:            NULL
+  false:           string(0) ""
+  true:            string(1) "1"
+  42:              string(2) "42"
+  73.5:            string(4) "73.5"
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: ValueError: zend_path_str_or_null(): Argument #1 ($param) must not contain any null bytes
+  []:              TypeError: zend_path_str_or_null(): Argument #1 ($param) must be of type ?string, array given
+  new stdClass():  TypeError: zend_path_str_or_null(): Argument #1 ($param) must be of type ?string, stdClass given
+  new S():         string(7) "S class"
+  STDOUT:          TypeError: zend_path_str_or_null(): Argument #1 ($param) must be of type ?string, resource given
+
+Using zend_path_str_slow_zpp:
+
+  null:            
+Deprecated: zend_path_str_slow_zpp(): Passing null to parameter #1 ($param) of type string is deprecated in %s on line %d
+string(0) ""
+  false:           string(0) ""
+  true:            string(1) "1"
+  42:              string(2) "42"
+  73.5:            string(4) "73.5"
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: ValueError: zend_path_str_slow_zpp(): Argument #1 ($param) must not contain any null bytes
+  []:              TypeError: zend_path_str_slow_zpp(): Argument #1 ($param) must be of type string, array given
+  new stdClass():  TypeError: zend_path_str_slow_zpp(): Argument #1 ($param) must be of type string, stdClass given
+  new S():         string(7) "S class"
+  STDOUT:          TypeError: zend_path_str_slow_zpp(): Argument #1 ($param) must be of type string, resource given
+
+Using zend_path_str_or_null_slow_zpp:
+
+  null:            NULL
+  false:           string(0) ""
+  true:            string(1) "1"
+  42:              string(2) "42"
+  73.5:            string(4) "73.5"
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: ValueError: zend_path_str_or_null_slow_zpp(): Argument #1 ($param) must not contain any null bytes
+  []:              TypeError: zend_path_str_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, array given
+  new stdClass():  TypeError: zend_path_str_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, stdClass given
+  new S():         string(7) "S class"
+  STDOUT:          TypeError: zend_path_str_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, resource given

--- a/Zend/tests/zpp/path_zpp_specifier_strict_mode.phpt
+++ b/Zend/tests/zpp/path_zpp_specifier_strict_mode.phpt
@@ -1,0 +1,109 @@
+--TEST--
+Test path ZPP specifier (strict_mode)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$types = require 'types.inc';
+$functions = [
+    'zend_path',
+    'zend_path_or_null',
+    'zend_path_slow_zpp',
+    'zend_path_or_null_slow_zpp',
+];
+
+foreach ($functions as $i => $function) {
+    echo "Using $function:\n\n";
+
+    foreach ($types as $name => $type) {
+        printf("  %-16s ", "$name:");
+
+        try {
+            $result = $function($type);
+
+            $result === []
+                ? printf("array(0) {}\n")
+                : var_dump($result);
+
+        } catch (Throwable $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+    }
+
+    if ($i !== array_key_last($functions)) {
+        echo "\n";
+    }
+}
+
+?>
+--EXPECT--
+Using zend_path:
+
+  null:            TypeError: zend_path(): Argument #1 ($param) must be of type string, null given
+  false:           TypeError: zend_path(): Argument #1 ($param) must be of type string, false given
+  true:            TypeError: zend_path(): Argument #1 ($param) must be of type string, true given
+  42:              TypeError: zend_path(): Argument #1 ($param) must be of type string, int given
+  73.5:            TypeError: zend_path(): Argument #1 ($param) must be of type string, float given
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: ValueError: zend_path(): Argument #1 ($param) must not contain any null bytes
+  []:              TypeError: zend_path(): Argument #1 ($param) must be of type string, array given
+  new stdClass():  TypeError: zend_path(): Argument #1 ($param) must be of type string, stdClass given
+  new S():         TypeError: zend_path(): Argument #1 ($param) must be of type string, S given
+  STDOUT:          TypeError: zend_path(): Argument #1 ($param) must be of type string, resource given
+
+Using zend_path_or_null:
+
+  null:            NULL
+  false:           TypeError: zend_path_or_null(): Argument #1 ($param) must be of type ?string, false given
+  true:            TypeError: zend_path_or_null(): Argument #1 ($param) must be of type ?string, true given
+  42:              TypeError: zend_path_or_null(): Argument #1 ($param) must be of type ?string, int given
+  73.5:            TypeError: zend_path_or_null(): Argument #1 ($param) must be of type ?string, float given
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: ValueError: zend_path_or_null(): Argument #1 ($param) must not contain any null bytes
+  []:              TypeError: zend_path_or_null(): Argument #1 ($param) must be of type ?string, array given
+  new stdClass():  TypeError: zend_path_or_null(): Argument #1 ($param) must be of type ?string, stdClass given
+  new S():         TypeError: zend_path_or_null(): Argument #1 ($param) must be of type ?string, S given
+  STDOUT:          TypeError: zend_path_or_null(): Argument #1 ($param) must be of type ?string, resource given
+
+Using zend_path_slow_zpp:
+
+  null:            TypeError: zend_path_slow_zpp(): Argument #1 ($param) must be of type string, null given
+  false:           TypeError: zend_path_slow_zpp(): Argument #1 ($param) must be of type string, false given
+  true:            TypeError: zend_path_slow_zpp(): Argument #1 ($param) must be of type string, true given
+  42:              TypeError: zend_path_slow_zpp(): Argument #1 ($param) must be of type string, int given
+  73.5:            TypeError: zend_path_slow_zpp(): Argument #1 ($param) must be of type string, float given
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: ValueError: zend_path_slow_zpp(): Argument #1 ($param) must not contain any null bytes
+  []:              TypeError: zend_path_slow_zpp(): Argument #1 ($param) must be of type string, array given
+  new stdClass():  TypeError: zend_path_slow_zpp(): Argument #1 ($param) must be of type string, stdClass given
+  new S():         TypeError: zend_path_slow_zpp(): Argument #1 ($param) must be of type string, S given
+  STDOUT:          TypeError: zend_path_slow_zpp(): Argument #1 ($param) must be of type string, resource given
+
+Using zend_path_or_null_slow_zpp:
+
+  null:            NULL
+  false:           TypeError: zend_path_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, false given
+  true:            TypeError: zend_path_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, true given
+  42:              TypeError: zend_path_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, int given
+  73.5:            TypeError: zend_path_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, float given
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: ValueError: zend_path_or_null_slow_zpp(): Argument #1 ($param) must not contain any null bytes
+  []:              TypeError: zend_path_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, array given
+  new stdClass():  TypeError: zend_path_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, stdClass given
+  new S():         TypeError: zend_path_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, S given
+  STDOUT:          TypeError: zend_path_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, resource given

--- a/Zend/tests/zpp/path_zpp_specifier_weak_mode.phpt
+++ b/Zend/tests/zpp/path_zpp_specifier_weak_mode.phpt
@@ -1,0 +1,111 @@
+--TEST--
+Test path ZPP specifier (weak_mode)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+$types = require 'types.inc';
+$functions = [
+    'zend_path',
+    'zend_path_or_null',
+    'zend_path_slow_zpp',
+    'zend_path_or_null_slow_zpp',
+];
+
+foreach ($functions as $i => $function) {
+    echo "Using $function:\n\n";
+
+    foreach ($types as $name => $type) {
+        printf("  %-16s ", "$name:");
+
+        try {
+            $result = $function($type);
+
+            $result === []
+                ? printf("array(0) {}\n")
+                : var_dump($result);
+
+        } catch (Throwable $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+    }
+
+    if ($i !== array_key_last($functions)) {
+        echo "\n";
+    }
+}
+
+?>
+--EXPECTF--
+Using zend_path:
+
+  null:            
+Deprecated: zend_path(): Passing null to parameter #1 ($param) of type string is deprecated in %s on line %d
+string(0) ""
+  false:           string(0) ""
+  true:            string(1) "1"
+  42:              string(2) "42"
+  73.5:            string(4) "73.5"
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: ValueError: zend_path(): Argument #1 ($param) must not contain any null bytes
+  []:              TypeError: zend_path(): Argument #1 ($param) must be of type string, array given
+  new stdClass():  TypeError: zend_path(): Argument #1 ($param) must be of type string, stdClass given
+  new S():         string(7) "S class"
+  STDOUT:          TypeError: zend_path(): Argument #1 ($param) must be of type string, resource given
+
+Using zend_path_or_null:
+
+  null:            NULL
+  false:           string(0) ""
+  true:            string(1) "1"
+  42:              string(2) "42"
+  73.5:            string(4) "73.5"
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: ValueError: zend_path_or_null(): Argument #1 ($param) must not contain any null bytes
+  []:              TypeError: zend_path_or_null(): Argument #1 ($param) must be of type ?string, array given
+  new stdClass():  TypeError: zend_path_or_null(): Argument #1 ($param) must be of type ?string, stdClass given
+  new S():         string(7) "S class"
+  STDOUT:          TypeError: zend_path_or_null(): Argument #1 ($param) must be of type ?string, resource given
+
+Using zend_path_slow_zpp:
+
+  null:            
+Deprecated: zend_path_slow_zpp(): Passing null to parameter #1 ($param) of type string is deprecated in %s on line %d
+string(0) ""
+  false:           string(0) ""
+  true:            string(1) "1"
+  42:              string(2) "42"
+  73.5:            string(4) "73.5"
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: ValueError: zend_path_slow_zpp(): Argument #1 ($param) must not contain any null bytes
+  []:              TypeError: zend_path_slow_zpp(): Argument #1 ($param) must be of type string, array given
+  new stdClass():  TypeError: zend_path_slow_zpp(): Argument #1 ($param) must be of type string, stdClass given
+  new S():         string(7) "S class"
+  STDOUT:          TypeError: zend_path_slow_zpp(): Argument #1 ($param) must be of type string, resource given
+
+Using zend_path_or_null_slow_zpp:
+
+  null:            NULL
+  false:           string(0) ""
+  true:            string(1) "1"
+  42:              string(2) "42"
+  73.5:            string(4) "73.5"
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: ValueError: zend_path_or_null_slow_zpp(): Argument #1 ($param) must not contain any null bytes
+  []:              TypeError: zend_path_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, array given
+  new stdClass():  TypeError: zend_path_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, stdClass given
+  new S():         string(7) "S class"
+  STDOUT:          TypeError: zend_path_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, resource given

--- a/Zend/tests/zpp/str_or_long_zpp_specifier_strict_mode.phpt
+++ b/Zend/tests/zpp/str_or_long_zpp_specifier_strict_mode.phpt
@@ -1,0 +1,73 @@
+--TEST--
+Test str_or_long ZPP specifier (strict_mode)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$types = require 'types.inc';
+$functions = [
+    'zend_str_or_long',
+    'zend_str_or_long_or_null',
+];
+
+foreach ($functions as $i => $function) {
+    echo "Using $function:\n\n";
+
+    foreach ($types as $name => $type) {
+        printf("  %-16s ", "$name:");
+
+        try {
+            $result = $function($type);
+
+            $result === []
+                ? printf("array(0) {}\n")
+                : var_dump($result);
+
+        } catch (Throwable $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+    }
+
+    if ($i !== array_key_last($functions)) {
+        echo "\n";
+    }
+}
+
+?>
+--EXPECTF--
+Using zend_str_or_long:
+
+  null:            TypeError: zend_str_or_long(): Argument #1 ($param) must be of type string|int, null given
+  false:           TypeError: zend_str_or_long(): Argument #1 ($param) must be of type string|int, false given
+  true:            TypeError: zend_str_or_long(): Argument #1 ($param) must be of type string|int, true given
+  42:              int(42)
+  73.5:            TypeError: zend_str_or_long(): Argument #1 ($param) must be of type string|int, float given
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              TypeError: zend_str_or_long(): Argument #1 ($param) must be of type string|int, array given
+  new stdClass():  TypeError: zend_str_or_long(): Argument #1 ($param) must be of type string|int, stdClass given
+  new S():         TypeError: zend_str_or_long(): Argument #1 ($param) must be of type string|int, S given
+  STDOUT:          TypeError: zend_str_or_long(): Argument #1 ($param) must be of type string|int, resource given
+
+Using zend_str_or_long_or_null:
+
+  null:            NULL
+  false:           TypeError: zend_str_or_long_or_null(): Argument #1 ($param) must be of type string|int|null, false given
+  true:            TypeError: zend_str_or_long_or_null(): Argument #1 ($param) must be of type string|int|null, true given
+  42:              int(42)
+  73.5:            TypeError: zend_str_or_long_or_null(): Argument #1 ($param) must be of type string|int|null, float given
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              TypeError: zend_str_or_long_or_null(): Argument #1 ($param) must be of type string|int|null, array given
+  new stdClass():  TypeError: zend_str_or_long_or_null(): Argument #1 ($param) must be of type string|int|null, stdClass given
+  new S():         TypeError: zend_str_or_long_or_null(): Argument #1 ($param) must be of type string|int|null, S given
+  STDOUT:          TypeError: zend_str_or_long_or_null(): Argument #1 ($param) must be of type string|int|null, resource given

--- a/Zend/tests/zpp/str_or_long_zpp_specifier_weak_mode.phpt
+++ b/Zend/tests/zpp/str_or_long_zpp_specifier_weak_mode.phpt
@@ -1,0 +1,77 @@
+--TEST--
+Test str_or_long ZPP specifier (weak_mode)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+$types = require 'types.inc';
+$functions = [
+    'zend_str_or_long',
+    'zend_str_or_long_or_null',
+];
+
+foreach ($functions as $i => $function) {
+    echo "Using $function:\n\n";
+
+    foreach ($types as $name => $type) {
+        printf("  %-16s ", "$name:");
+
+        try {
+            $result = $function($type);
+
+            $result === []
+                ? printf("array(0) {}\n")
+                : var_dump($result);
+
+        } catch (Throwable $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+    }
+
+    if ($i !== array_key_last($functions)) {
+        echo "\n";
+    }
+}
+
+?>
+--EXPECTF--
+Using zend_str_or_long:
+
+  null:            
+Deprecated: zend_str_or_long(): Passing null to parameter #1 ($param) of type string|int is deprecated in %s on line %d
+int(0)
+  false:           int(0)
+  true:            int(1)
+  42:              int(42)
+  73.5:            
+Deprecated: Implicit conversion from float 73.5 to int loses precision in %s on line %d
+int(73)
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              TypeError: zend_str_or_long(): Argument #1 ($param) must be of type string|int, array given
+  new stdClass():  TypeError: zend_str_or_long(): Argument #1 ($param) must be of type string|int, stdClass given
+  new S():         string(7) "S class"
+  STDOUT:          TypeError: zend_str_or_long(): Argument #1 ($param) must be of type string|int, resource given
+
+Using zend_str_or_long_or_null:
+
+  null:            NULL
+  false:           int(0)
+  true:            int(1)
+  42:              int(42)
+  73.5:            
+Deprecated: Implicit conversion from float 73.5 to int loses precision in %s on line %d
+int(73)
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              TypeError: zend_str_or_long_or_null(): Argument #1 ($param) must be of type string|int|null, array given
+  new stdClass():  TypeError: zend_str_or_long_or_null(): Argument #1 ($param) must be of type string|int|null, stdClass given
+  new S():         string(7) "S class"
+  STDOUT:          TypeError: zend_str_or_long_or_null(): Argument #1 ($param) must be of type string|int|null, resource given

--- a/Zend/tests/zpp/str_zpp_specifier_strict_mode.phpt
+++ b/Zend/tests/zpp/str_zpp_specifier_strict_mode.phpt
@@ -1,0 +1,109 @@
+--TEST--
+Test str ZPP specifier (strict_mode)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$types = require 'types.inc';
+$functions = [
+    'zend_str',
+    'zend_str_or_null',
+    'zend_str_slow_zpp',
+    'zend_str_or_null_slow_zpp',
+];
+
+foreach ($functions as $i => $function) {
+    echo "Using $function:\n\n";
+
+    foreach ($types as $name => $type) {
+        printf("  %-16s ", "$name:");
+
+        try {
+            $result = $function($type);
+
+            $result === []
+                ? printf("array(0) {}\n")
+                : var_dump($result);
+
+        } catch (Throwable $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+    }
+
+    if ($i !== array_key_last($functions)) {
+        echo "\n";
+    }
+}
+
+?>
+--EXPECTF--
+Using zend_str:
+
+  null:            TypeError: zend_str(): Argument #1 ($param) must be of type string, null given
+  false:           TypeError: zend_str(): Argument #1 ($param) must be of type string, false given
+  true:            TypeError: zend_str(): Argument #1 ($param) must be of type string, true given
+  42:              TypeError: zend_str(): Argument #1 ($param) must be of type string, int given
+  73.5:            TypeError: zend_str(): Argument #1 ($param) must be of type string, float given
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              TypeError: zend_str(): Argument #1 ($param) must be of type string, array given
+  new stdClass():  TypeError: zend_str(): Argument #1 ($param) must be of type string, stdClass given
+  new S():         TypeError: zend_str(): Argument #1 ($param) must be of type string, S given
+  STDOUT:          TypeError: zend_str(): Argument #1 ($param) must be of type string, resource given
+
+Using zend_str_or_null:
+
+  null:            NULL
+  false:           TypeError: zend_str_or_null(): Argument #1 ($param) must be of type ?string, false given
+  true:            TypeError: zend_str_or_null(): Argument #1 ($param) must be of type ?string, true given
+  42:              TypeError: zend_str_or_null(): Argument #1 ($param) must be of type ?string, int given
+  73.5:            TypeError: zend_str_or_null(): Argument #1 ($param) must be of type ?string, float given
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              TypeError: zend_str_or_null(): Argument #1 ($param) must be of type ?string, array given
+  new stdClass():  TypeError: zend_str_or_null(): Argument #1 ($param) must be of type ?string, stdClass given
+  new S():         TypeError: zend_str_or_null(): Argument #1 ($param) must be of type ?string, S given
+  STDOUT:          TypeError: zend_str_or_null(): Argument #1 ($param) must be of type ?string, resource given
+
+Using zend_str_slow_zpp:
+
+  null:            TypeError: zend_str_slow_zpp(): Argument #1 ($param) must be of type string, null given
+  false:           TypeError: zend_str_slow_zpp(): Argument #1 ($param) must be of type string, false given
+  true:            TypeError: zend_str_slow_zpp(): Argument #1 ($param) must be of type string, true given
+  42:              TypeError: zend_str_slow_zpp(): Argument #1 ($param) must be of type string, int given
+  73.5:            TypeError: zend_str_slow_zpp(): Argument #1 ($param) must be of type string, float given
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              TypeError: zend_str_slow_zpp(): Argument #1 ($param) must be of type string, array given
+  new stdClass():  TypeError: zend_str_slow_zpp(): Argument #1 ($param) must be of type string, stdClass given
+  new S():         TypeError: zend_str_slow_zpp(): Argument #1 ($param) must be of type string, S given
+  STDOUT:          TypeError: zend_str_slow_zpp(): Argument #1 ($param) must be of type string, resource given
+
+Using zend_str_or_null_slow_zpp:
+
+  null:            NULL
+  false:           TypeError: zend_str_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, false given
+  true:            TypeError: zend_str_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, true given
+  42:              TypeError: zend_str_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, int given
+  73.5:            TypeError: zend_str_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, float given
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              TypeError: zend_str_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, array given
+  new stdClass():  TypeError: zend_str_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, stdClass given
+  new S():         TypeError: zend_str_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, S given
+  STDOUT:          TypeError: zend_str_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, resource given

--- a/Zend/tests/zpp/str_zpp_specifier_weak_mode.phpt
+++ b/Zend/tests/zpp/str_zpp_specifier_weak_mode.phpt
@@ -1,0 +1,111 @@
+--TEST--
+Test str ZPP specifier (weak_mode)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+$types = require 'types.inc';
+$functions = [
+    'zend_str',
+    'zend_str_or_null',
+    'zend_str_slow_zpp',
+    'zend_str_or_null_slow_zpp',
+];
+
+foreach ($functions as $i => $function) {
+    echo "Using $function:\n\n";
+
+    foreach ($types as $name => $type) {
+        printf("  %-16s ", "$name:");
+
+        try {
+            $result = $function($type);
+
+            $result === []
+                ? printf("array(0) {}\n")
+                : var_dump($result);
+
+        } catch (Throwable $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+    }
+
+    if ($i !== array_key_last($functions)) {
+        echo "\n";
+    }
+}
+
+?>
+--EXPECTF--
+Using zend_str:
+
+  null:            
+Deprecated: zend_str(): Passing null to parameter #1 ($param) of type string is deprecated in %s on line %d
+string(0) ""
+  false:           string(0) ""
+  true:            string(1) "1"
+  42:              string(2) "42"
+  73.5:            string(4) "73.5"
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              TypeError: zend_str(): Argument #1 ($param) must be of type string, array given
+  new stdClass():  TypeError: zend_str(): Argument #1 ($param) must be of type string, stdClass given
+  new S():         string(7) "S class"
+  STDOUT:          TypeError: zend_str(): Argument #1 ($param) must be of type string, resource given
+
+Using zend_str_or_null:
+
+  null:            NULL
+  false:           string(0) ""
+  true:            string(1) "1"
+  42:              string(2) "42"
+  73.5:            string(4) "73.5"
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              TypeError: zend_str_or_null(): Argument #1 ($param) must be of type ?string, array given
+  new stdClass():  TypeError: zend_str_or_null(): Argument #1 ($param) must be of type ?string, stdClass given
+  new S():         string(7) "S class"
+  STDOUT:          TypeError: zend_str_or_null(): Argument #1 ($param) must be of type ?string, resource given
+
+Using zend_str_slow_zpp:
+
+  null:            
+Deprecated: zend_str_slow_zpp(): Passing null to parameter #1 ($param) of type string is deprecated in %s on line %d
+string(0) ""
+  false:           string(0) ""
+  true:            string(1) "1"
+  42:              string(2) "42"
+  73.5:            string(4) "73.5"
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              TypeError: zend_str_slow_zpp(): Argument #1 ($param) must be of type string, array given
+  new stdClass():  TypeError: zend_str_slow_zpp(): Argument #1 ($param) must be of type string, stdClass given
+  new S():         string(7) "S class"
+  STDOUT:          TypeError: zend_str_slow_zpp(): Argument #1 ($param) must be of type string, resource given
+
+Using zend_str_or_null_slow_zpp:
+
+  null:            NULL
+  false:           string(0) ""
+  true:            string(1) "1"
+  42:              string(2) "42"
+  73.5:            string(4) "73.5"
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              TypeError: zend_str_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, array given
+  new stdClass():  TypeError: zend_str_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, stdClass given
+  new S():         string(7) "S class"
+  STDOUT:          TypeError: zend_str_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, resource given

--- a/Zend/tests/zpp/string_param_zpp_specifier_strict_mode.phpt
+++ b/Zend/tests/zpp/string_param_zpp_specifier_strict_mode.phpt
@@ -1,0 +1,109 @@
+--TEST--
+Test string_param ZPP specifier (strict_mode)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$types = require 'types.inc';
+$functions = [
+    'zend_string_param',
+    'zend_string_param_or_null',
+    'zend_string_param_slow_zpp',
+    'zend_string_param_or_null_slow_zpp',
+];
+
+foreach ($functions as $i => $function) {
+    echo "Using $function:\n\n";
+
+    foreach ($types as $name => $type) {
+        printf("  %-16s ", "$name:");
+
+        try {
+            $result = $function($type);
+
+            $result === []
+                ? printf("array(0) {}\n")
+                : var_dump($result);
+
+        } catch (Throwable $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+    }
+
+    if ($i !== array_key_last($functions)) {
+        echo "\n";
+    }
+}
+
+?>
+--EXPECTF--
+Using zend_string_param:
+
+  null:            TypeError: zend_string_param(): Argument #1 ($param) must be of type string, null given
+  false:           TypeError: zend_string_param(): Argument #1 ($param) must be of type string, false given
+  true:            TypeError: zend_string_param(): Argument #1 ($param) must be of type string, true given
+  42:              TypeError: zend_string_param(): Argument #1 ($param) must be of type string, int given
+  73.5:            TypeError: zend_string_param(): Argument #1 ($param) must be of type string, float given
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              TypeError: zend_string_param(): Argument #1 ($param) must be of type string, array given
+  new stdClass():  TypeError: zend_string_param(): Argument #1 ($param) must be of type string, stdClass given
+  new S():         TypeError: zend_string_param(): Argument #1 ($param) must be of type string, S given
+  STDOUT:          TypeError: zend_string_param(): Argument #1 ($param) must be of type string, resource given
+
+Using zend_string_param_or_null:
+
+  null:            NULL
+  false:           TypeError: zend_string_param_or_null(): Argument #1 ($param) must be of type ?string, false given
+  true:            TypeError: zend_string_param_or_null(): Argument #1 ($param) must be of type ?string, true given
+  42:              TypeError: zend_string_param_or_null(): Argument #1 ($param) must be of type ?string, int given
+  73.5:            TypeError: zend_string_param_or_null(): Argument #1 ($param) must be of type ?string, float given
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              TypeError: zend_string_param_or_null(): Argument #1 ($param) must be of type ?string, array given
+  new stdClass():  TypeError: zend_string_param_or_null(): Argument #1 ($param) must be of type ?string, stdClass given
+  new S():         TypeError: zend_string_param_or_null(): Argument #1 ($param) must be of type ?string, S given
+  STDOUT:          TypeError: zend_string_param_or_null(): Argument #1 ($param) must be of type ?string, resource given
+
+Using zend_string_param_slow_zpp:
+
+  null:            TypeError: zend_string_param_slow_zpp(): Argument #1 ($param) must be of type string, null given
+  false:           TypeError: zend_string_param_slow_zpp(): Argument #1 ($param) must be of type string, false given
+  true:            TypeError: zend_string_param_slow_zpp(): Argument #1 ($param) must be of type string, true given
+  42:              TypeError: zend_string_param_slow_zpp(): Argument #1 ($param) must be of type string, int given
+  73.5:            TypeError: zend_string_param_slow_zpp(): Argument #1 ($param) must be of type string, float given
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              TypeError: zend_string_param_slow_zpp(): Argument #1 ($param) must be of type string, array given
+  new stdClass():  TypeError: zend_string_param_slow_zpp(): Argument #1 ($param) must be of type string, stdClass given
+  new S():         TypeError: zend_string_param_slow_zpp(): Argument #1 ($param) must be of type string, S given
+  STDOUT:          TypeError: zend_string_param_slow_zpp(): Argument #1 ($param) must be of type string, resource given
+
+Using zend_string_param_or_null_slow_zpp:
+
+  null:            NULL
+  false:           TypeError: zend_string_param_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, false given
+  true:            TypeError: zend_string_param_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, true given
+  42:              TypeError: zend_string_param_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, int given
+  73.5:            TypeError: zend_string_param_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, float given
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              TypeError: zend_string_param_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, array given
+  new stdClass():  TypeError: zend_string_param_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, stdClass given
+  new S():         TypeError: zend_string_param_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, S given
+  STDOUT:          TypeError: zend_string_param_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, resource given

--- a/Zend/tests/zpp/string_param_zpp_specifier_weak_mode.phpt
+++ b/Zend/tests/zpp/string_param_zpp_specifier_weak_mode.phpt
@@ -1,0 +1,111 @@
+--TEST--
+Test string_param ZPP specifier (weak_mode)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+$types = require 'types.inc';
+$functions = [
+    'zend_string_param',
+    'zend_string_param_or_null',
+    'zend_string_param_slow_zpp',
+    'zend_string_param_or_null_slow_zpp',
+];
+
+foreach ($functions as $i => $function) {
+    echo "Using $function:\n\n";
+
+    foreach ($types as $name => $type) {
+        printf("  %-16s ", "$name:");
+
+        try {
+            $result = $function($type);
+
+            $result === []
+                ? printf("array(0) {}\n")
+                : var_dump($result);
+
+        } catch (Throwable $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+    }
+
+    if ($i !== array_key_last($functions)) {
+        echo "\n";
+    }
+}
+
+?>
+--EXPECTF--
+Using zend_string_param:
+
+  null:            
+Deprecated: zend_string_param(): Passing null to parameter #1 ($param) of type string is deprecated in %s on line %d
+string(0) ""
+  false:           string(0) ""
+  true:            string(1) "1"
+  42:              string(2) "42"
+  73.5:            string(4) "73.5"
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              TypeError: zend_string_param(): Argument #1 ($param) must be of type string, array given
+  new stdClass():  TypeError: zend_string_param(): Argument #1 ($param) must be of type string, stdClass given
+  new S():         string(7) "S class"
+  STDOUT:          TypeError: zend_string_param(): Argument #1 ($param) must be of type string, resource given
+
+Using zend_string_param_or_null:
+
+  null:            NULL
+  false:           string(0) ""
+  true:            string(1) "1"
+  42:              string(2) "42"
+  73.5:            string(4) "73.5"
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              TypeError: zend_string_param_or_null(): Argument #1 ($param) must be of type ?string, array given
+  new stdClass():  TypeError: zend_string_param_or_null(): Argument #1 ($param) must be of type ?string, stdClass given
+  new S():         string(7) "S class"
+  STDOUT:          TypeError: zend_string_param_or_null(): Argument #1 ($param) must be of type ?string, resource given
+
+Using zend_string_param_slow_zpp:
+
+  null:            
+Deprecated: zend_string_param_slow_zpp(): Passing null to parameter #1 ($param) of type string is deprecated in %s on line %d
+string(0) ""
+  false:           string(0) ""
+  true:            string(1) "1"
+  42:              string(2) "42"
+  73.5:            string(4) "73.5"
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              TypeError: zend_string_param_slow_zpp(): Argument #1 ($param) must be of type string, array given
+  new stdClass():  TypeError: zend_string_param_slow_zpp(): Argument #1 ($param) must be of type string, stdClass given
+  new S():         string(7) "S class"
+  STDOUT:          TypeError: zend_string_param_slow_zpp(): Argument #1 ($param) must be of type string, resource given
+
+Using zend_string_param_or_null_slow_zpp:
+
+  null:            NULL
+  false:           string(0) ""
+  true:            string(1) "1"
+  42:              string(2) "42"
+  73.5:            string(4) "73.5"
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              TypeError: zend_string_param_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, array given
+  new stdClass():  TypeError: zend_string_param_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, stdClass given
+  new S():         string(7) "S class"
+  STDOUT:          TypeError: zend_string_param_or_null_slow_zpp(): Argument #1 ($param) must be of type ?string, resource given

--- a/Zend/tests/zpp/variadic_zpp_specifier.phpt
+++ b/Zend/tests/zpp/variadic_zpp_specifier.phpt
@@ -1,0 +1,60 @@
+--TEST--
+Test variadic ZPP specifiers
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+var_dump(zend_variadic());
+var_dump(zend_variadic(1, "foo", [1, 2]));
+var_dump(zend_variadic_slow_zpp());
+var_dump(zend_variadic_slow_zpp(1, "foo", [1, 2]));
+var_dump(zend_variadic_with_named(1, "foo", b: "bar"));
+
+try {
+    zend_variadic(1, b: "bar");
+} catch (Error $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+array(0) {
+}
+array(3) {
+  [0]=>
+  int(1)
+  [1]=>
+  string(3) "foo"
+  [2]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    int(2)
+  }
+}
+array(0) {
+}
+array(3) {
+  [0]=>
+  int(1)
+  [1]=>
+  string(3) "foo"
+  [2]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    int(2)
+  }
+}
+array(3) {
+  [0]=>
+  int(1)
+  [1]=>
+  string(3) "foo"
+  ["b"]=>
+  string(3) "bar"
+}
+ArgumentCountError: Internal function zend_variadic() does not accept named variadic arguments

--- a/Zend/tests/zpp/zval_zpp_specifier_strict_mode.phpt
+++ b/Zend/tests/zpp/zval_zpp_specifier_strict_mode.phpt
@@ -1,0 +1,157 @@
+--TEST--
+Test zval ZPP specifier (strict_mode)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$types = require 'types.inc';
+$functions = [
+    'zend_zval',
+    'zend_zval_or_null',
+    'zend_zval_separate',
+    'zend_zval_slow_zpp',
+    'zend_zval_or_null_slow_zpp',
+    'zend_zval_deref_separate',
+];
+
+foreach ($functions as $i => $function) {
+    echo "Using $function:\n\n";
+
+    foreach ($types as $name => $type) {
+        printf("  %-16s ", "$name:");
+
+        try {
+            $result = $function($type);
+
+            $result === []
+                ? printf("array(0) {}\n")
+                : var_dump($result);
+
+        } catch (Throwable $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+    }
+
+    if ($i !== array_key_last($functions)) {
+        echo "\n";
+    }
+}
+
+?>
+--EXPECTF--
+Using zend_zval:
+
+  null:            NULL
+  false:           bool(false)
+  true:            bool(true)
+  42:              int(42)
+  73.5:            float(73.5)
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              array(0) {}
+  new stdClass():  object(stdClass)#%d (%d) {
+}
+  new S():         object(S)#%d (%d) {
+}
+  STDOUT:          resource(%d) of type (stream)
+
+Using zend_zval_or_null:
+
+  null:            NULL
+  false:           bool(false)
+  true:            bool(true)
+  42:              int(42)
+  73.5:            float(73.5)
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              array(0) {}
+  new stdClass():  object(stdClass)#%d (%d) {
+}
+  new S():         object(S)#%d (%d) {
+}
+  STDOUT:          resource(%d) of type (stream)
+
+Using zend_zval_separate:
+
+  null:            NULL
+  false:           bool(false)
+  true:            bool(true)
+  42:              int(42)
+  73.5:            float(73.5)
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              array(0) {}
+  new stdClass():  object(stdClass)#%d (%d) {
+}
+  new S():         object(S)#%d (%d) {
+}
+  STDOUT:          resource(%d) of type (stream)
+
+Using zend_zval_slow_zpp:
+
+  null:            NULL
+  false:           bool(false)
+  true:            bool(true)
+  42:              int(42)
+  73.5:            float(73.5)
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              array(0) {}
+  new stdClass():  object(stdClass)#%d (%d) {
+}
+  new S():         object(S)#%d (%d) {
+}
+  STDOUT:          resource(%d) of type (stream)
+
+Using zend_zval_or_null_slow_zpp:
+
+  null:            NULL
+  false:           bool(false)
+  true:            bool(true)
+  42:              int(42)
+  73.5:            float(73.5)
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              array(0) {}
+  new stdClass():  object(stdClass)#%d (%d) {
+}
+  new S():         object(S)#%d (%d) {
+}
+  STDOUT:          resource(%d) of type (stream)
+
+Using zend_zval_deref_separate:
+
+  null:            NULL
+  false:           bool(false)
+  true:            bool(true)
+  42:              int(42)
+  73.5:            float(73.5)
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              array(0) {}
+  new stdClass():  object(stdClass)#%d (%d) {
+}
+  new S():         object(S)#%d (%d) {
+}
+  STDOUT:          resource(%d) of type (stream)

--- a/Zend/tests/zpp/zval_zpp_specifier_weak_mode.phpt
+++ b/Zend/tests/zpp/zval_zpp_specifier_weak_mode.phpt
@@ -1,0 +1,155 @@
+--TEST--
+Test zval ZPP specifier (weak_mode)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+$types = require 'types.inc';
+$functions = [
+    'zend_zval',
+    'zend_zval_or_null',
+    'zend_zval_separate',
+    'zend_zval_slow_zpp',
+    'zend_zval_or_null_slow_zpp',
+    'zend_zval_deref_separate',
+];
+
+foreach ($functions as $i => $function) {
+    echo "Using $function:\n\n";
+
+    foreach ($types as $name => $type) {
+        printf("  %-16s ", "$name:");
+
+        try {
+            $result = $function($type);
+
+            $result === []
+                ? printf("array(0) {}\n")
+                : var_dump($result);
+
+        } catch (Throwable $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+    }
+
+    if ($i !== array_key_last($functions)) {
+        echo "\n";
+    }
+}
+
+?>
+--EXPECTF--
+Using zend_zval:
+
+  null:            NULL
+  false:           bool(false)
+  true:            bool(true)
+  42:              int(42)
+  73.5:            float(73.5)
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              array(0) {}
+  new stdClass():  object(stdClass)#%d (%d) {
+}
+  new S():         object(S)#%d (%d) {
+}
+  STDOUT:          resource(%d) of type (stream)
+
+Using zend_zval_or_null:
+
+  null:            NULL
+  false:           bool(false)
+  true:            bool(true)
+  42:              int(42)
+  73.5:            float(73.5)
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              array(0) {}
+  new stdClass():  object(stdClass)#%d (%d) {
+}
+  new S():         object(S)#%d (%d) {
+}
+  STDOUT:          resource(%d) of type (stream)
+
+Using zend_zval_separate:
+
+  null:            NULL
+  false:           bool(false)
+  true:            bool(true)
+  42:              int(42)
+  73.5:            float(73.5)
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              array(0) {}
+  new stdClass():  object(stdClass)#%d (%d) {
+}
+  new S():         object(S)#%d (%d) {
+}
+  STDOUT:          resource(%d) of type (stream)
+
+Using zend_zval_slow_zpp:
+
+  null:            NULL
+  false:           bool(false)
+  true:            bool(true)
+  42:              int(42)
+  73.5:            float(73.5)
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              array(0) {}
+  new stdClass():  object(stdClass)#%d (%d) {
+}
+  new S():         object(S)#%d (%d) {
+}
+  STDOUT:          resource(%d) of type (stream)
+
+Using zend_zval_or_null_slow_zpp:
+
+  null:            NULL
+  false:           bool(false)
+  true:            bool(true)
+  42:              int(42)
+  73.5:            float(73.5)
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              array(0) {}
+  new stdClass():  object(stdClass)#%d (%d) {
+}
+  new S():         object(S)#%d (%d) {
+}
+  STDOUT:          resource(%d) of type (stream)
+
+Using zend_zval_deref_separate:
+
+  null:            NULL
+  false:           bool(false)
+  true:            bool(true)
+  42:              int(42)
+  73.5:            float(73.5)
+  'string':        string(6) "string"
+  '15':            string(2) "15"
+  '56.7':          string(4) "56.7"
+  'stdClass':      string(8) "stdClass"
+  anon class name: string(%d) "class@anonymous%s"
+  []:              array(0) {}
+  new stdClass():  object(stdClass)#%d (%d) {
+}
+  new S():         object(S)#%d (%d) {
+}
+  STDOUT:          resource(%d) of type (stream)

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -890,6 +890,861 @@ static const zend_function_entry ext_function_legacy[] = {
 	ZEND_FE(zend_iterable_legacy, arginfo_zend_iterable_legacy)
 	ZEND_FE_END
 };
+/* Tests Z_PARAM_ENUM */
+static ZEND_FUNCTION(zend_enum)
+{
+	zend_long case_id;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ENUM(case_id, zend_test_unit_enum)
+	ZEND_PARSE_PARAMETERS_END();
+
+	RETURN_LONG(case_id);
+}
+
+/* Tests Z_PARAM_ARRAY specifiers */
+static ZEND_FUNCTION(zend_array)
+{
+	zval *zv;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY(zv)
+	ZEND_PARSE_PARAMETERS_END();
+
+	RETURN_COPY(zv);
+}
+
+static ZEND_FUNCTION(zend_array_or_null)
+{
+	zval *zv;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY_OR_NULL(zv)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (!zv) {
+		RETURN_NULL();
+	}
+	RETURN_COPY(zv);
+}
+
+static ZEND_FUNCTION(zend_array_separate)
+{
+	zval *zv;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY_EX(zv, 0, 1)
+	ZEND_PARSE_PARAMETERS_END();
+
+	RETURN_COPY(zv);
+}
+
+static ZEND_FUNCTION(zend_array_deref_separate)
+{
+	zval *zv;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY_EX2(zv, 0, 1, 1)
+	ZEND_PARSE_PARAMETERS_END();
+
+	RETURN_COPY(zv);
+}
+
+static ZEND_FUNCTION(zend_array_slow_zpp)
+{
+	zval *zv;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "a", &zv) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	RETURN_COPY(zv);
+}
+
+static ZEND_FUNCTION(zend_array_or_null_slow_zpp)
+{
+	zval *zv;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "a!", &zv) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	if (!zv) {
+		RETURN_NULL();
+	}
+	RETURN_COPY(zv);
+}
+
+/* Tests Z_PARAM_ARRAY_OR_OBJECT specifiers */
+static ZEND_FUNCTION(zend_array_or_object)
+{
+	zval *zv;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY_OR_OBJECT(zv)
+	ZEND_PARSE_PARAMETERS_END();
+
+	RETURN_COPY(zv);
+}
+
+static ZEND_FUNCTION(zend_array_or_object_separate)
+{
+	zval *zv;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY_OR_OBJECT_EX(zv, 0, 1)
+	ZEND_PARSE_PARAMETERS_END();
+
+	RETURN_COPY(zv);
+}
+
+static ZEND_FUNCTION(zend_array_or_object_deref_separate)
+{
+	zval *zv;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY_OR_OBJECT_EX2(zv, 0, 1, 1)
+	ZEND_PARSE_PARAMETERS_END();
+
+	RETURN_COPY(zv);
+}
+
+static ZEND_FUNCTION(zend_array_or_object_slow_zpp)
+{
+	zval *zv;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "A", &zv) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	RETURN_COPY(zv);
+}
+
+/* Tests Z_PARAM_ARRAY_HT specifiers */
+static ZEND_FUNCTION(zend_array_ht)
+{
+	HashTable *ht;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY_HT(ht)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (GC_FLAGS(ht) & IS_ARRAY_IMMUTABLE) {
+		RETURN_EMPTY_ARRAY();
+	}
+	GC_ADDREF(ht);
+	RETURN_ARR(ht);
+}
+
+static ZEND_FUNCTION(zend_array_ht_or_null)
+{
+	HashTable *ht;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY_HT_OR_NULL(ht)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (!ht) {
+		RETURN_NULL();
+	}
+	if (GC_FLAGS(ht) & IS_ARRAY_IMMUTABLE) {
+		RETURN_EMPTY_ARRAY();
+	}
+	GC_ADDREF(ht);
+	RETURN_ARR(ht);
+}
+
+static ZEND_FUNCTION(zend_array_ht_separate)
+{
+	HashTable *ht;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY_HT_EX(ht, 0, 1)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (GC_FLAGS(ht) & IS_ARRAY_IMMUTABLE) {
+		RETURN_EMPTY_ARRAY();
+	}
+	GC_ADDREF(ht);
+	RETURN_ARR(ht);
+}
+
+static ZEND_FUNCTION(zend_array_ht_deref_separate)
+{
+	HashTable *ht;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY_HT_EX2(ht, 0, 1, 1)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (GC_FLAGS(ht) & IS_ARRAY_IMMUTABLE) {
+		RETURN_EMPTY_ARRAY();
+	}
+	GC_ADDREF(ht);
+	RETURN_ARR(ht);
+}
+
+static ZEND_FUNCTION(zend_array_ht_slow_zpp)
+{
+	HashTable *ht;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "h", &ht) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	if (GC_FLAGS(ht) & IS_ARRAY_IMMUTABLE) {
+		RETURN_EMPTY_ARRAY();
+	}
+	GC_ADDREF(ht);
+	RETURN_ARR(ht);
+}
+
+static ZEND_FUNCTION(zend_array_ht_or_null_slow_zpp)
+{
+	HashTable *ht;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "h!", &ht) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	if (!ht) {
+		RETURN_NULL();
+	}
+	if (GC_FLAGS(ht) & IS_ARRAY_IMMUTABLE) {
+		RETURN_EMPTY_ARRAY();
+	}
+	GC_ADDREF(ht);
+	RETURN_ARR(ht);
+}
+
+/* Tests Z_PARAM_ARRAY_HT_OR_LONG specifiers */
+static ZEND_FUNCTION(zend_array_ht_or_long)
+{
+	HashTable *ht = NULL;
+	zend_long l = 0;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY_HT_OR_LONG(ht, l)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (ht) {
+		if (GC_FLAGS(ht) & IS_ARRAY_IMMUTABLE) {
+			RETURN_EMPTY_ARRAY();
+		}
+		GC_ADDREF(ht);
+		RETURN_ARR(ht);
+	}
+	RETURN_LONG(l);
+}
+
+static ZEND_FUNCTION(zend_array_ht_or_long_or_null)
+{
+	HashTable *ht = NULL;
+	zend_long l = 0;
+	bool is_null = 0;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY_HT_OR_LONG_OR_NULL(ht, l, is_null)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (is_null) {
+		RETURN_NULL();
+	}
+	if (ht) {
+		if (GC_FLAGS(ht) & IS_ARRAY_IMMUTABLE) {
+			RETURN_EMPTY_ARRAY();
+		}
+		GC_ADDREF(ht);
+		RETURN_ARR(ht);
+	}
+	RETURN_LONG(l);
+}
+
+/* Tests Z_PARAM_ARRAY_HT_OR_STR specifiers */
+static ZEND_FUNCTION(zend_array_ht_or_str)
+{
+	HashTable *ht = NULL;
+	zend_string *str = NULL;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY_HT_OR_STR(ht, str)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (ht) {
+		if (GC_FLAGS(ht) & IS_ARRAY_IMMUTABLE) {
+			RETURN_EMPTY_ARRAY();
+		}
+		GC_ADDREF(ht);
+		RETURN_ARR(ht);
+	}
+	RETURN_STR_COPY(str);
+}
+
+static ZEND_FUNCTION(zend_array_ht_or_str_or_null)
+{
+	HashTable *ht = NULL;
+	zend_string *str = NULL;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY_HT_OR_STR_OR_NULL(ht, str)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (ht) {
+		if (GC_FLAGS(ht) & IS_ARRAY_IMMUTABLE) {
+			RETURN_EMPTY_ARRAY();
+		}
+		GC_ADDREF(ht);
+		RETURN_ARR(ht);
+	} else if (str) {
+		RETURN_STR_COPY(str);
+	}
+	RETURN_NULL();
+}
+
+/* Tests Z_PARAM_ARRAY_OR_OBJECT_HT specifiers */
+static ZEND_FUNCTION(zend_array_or_object_ht)
+{
+	HashTable *ht;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY_OR_OBJECT_HT(ht)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (GC_FLAGS(ht) & IS_ARRAY_IMMUTABLE) {
+		RETURN_EMPTY_ARRAY();
+	}
+	GC_ADDREF(ht);
+	RETURN_ARR(ht);
+}
+
+static ZEND_FUNCTION(zend_array_or_object_ht_separate)
+{
+	HashTable *ht;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY_OR_OBJECT_HT_EX(ht, 0, 1)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (GC_FLAGS(ht) & IS_ARRAY_IMMUTABLE) {
+		RETURN_EMPTY_ARRAY();
+	}
+	GC_ADDREF(ht);
+	RETURN_ARR(ht);
+}
+
+static ZEND_FUNCTION(zend_array_or_object_ht_deref_separate)
+{
+	HashTable *ht;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY_OR_OBJECT_HT_EX2(ht, 0, 1, 1)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (GC_FLAGS(ht) & IS_ARRAY_IMMUTABLE) {
+		RETURN_EMPTY_ARRAY();
+	}
+	GC_ADDREF(ht);
+	RETURN_ARR(ht);
+}
+
+static ZEND_FUNCTION(zend_array_or_object_ht_slow_zpp)
+{
+	HashTable *ht;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "H", &ht) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	if (GC_FLAGS(ht) & IS_ARRAY_IMMUTABLE) {
+		RETURN_EMPTY_ARRAY();
+	}
+	GC_ADDREF(ht);
+	RETURN_ARR(ht);
+}
+
+/* Tests Z_PARAM_FUNC specifiers */
+static ZEND_FUNCTION(zend_func)
+{
+	zend_fcall_info fci;
+	zend_fcall_info_cache fcc;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_FUNC(fci, fcc)
+	ZEND_PARSE_PARAMETERS_END();
+
+	RETURN_STR_COPY(fcc.function_handler->common.function_name);
+}
+
+static ZEND_FUNCTION(zend_func_or_null)
+{
+	zend_fcall_info fci;
+	zend_fcall_info_cache fcc;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_FUNC_OR_NULL(fci, fcc)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (!ZEND_FCC_INITIALIZED(fcc)) {
+		RETURN_NULL();
+	}
+
+	RETURN_STR_COPY(fcc.function_handler->common.function_name);
+}
+
+static ZEND_FUNCTION(zend_func_no_trampoline_free)
+{
+	zend_fcall_info fci;
+	zend_fcall_info_cache fcc;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_FUNC_NO_TRAMPOLINE_FREE(fci, fcc)
+	ZEND_PARSE_PARAMETERS_END();
+
+	RETURN_STR_COPY(fcc.function_handler->common.function_name);
+}
+
+static ZEND_FUNCTION(zend_func_no_trampoline_free_or_null)
+{
+	zend_fcall_info fci;
+	zend_fcall_info_cache fcc;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_FUNC_NO_TRAMPOLINE_FREE_OR_NULL(fci, fcc)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (!ZEND_FCC_INITIALIZED(fcc)) {
+		RETURN_NULL();
+	}
+
+	RETURN_STR_COPY(fcc.function_handler->common.function_name);
+}
+
+static ZEND_FUNCTION(zend_func_slow_zpp)
+{
+	zend_fcall_info fci;
+	zend_fcall_info_cache fcc;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "f", &fci, &fcc) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	RETURN_STR_COPY(fcc.function_handler->common.function_name);
+}
+
+static ZEND_FUNCTION(zend_func_or_null_slow_zpp)
+{
+	zend_fcall_info fci;
+	zend_fcall_info_cache fcc;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "f!", &fci, &fcc) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	if (!ZEND_FCC_INITIALIZED(fcc)) {
+		RETURN_NULL();
+	}
+
+	RETURN_STR_COPY(fcc.function_handler->common.function_name);
+}
+
+/* Tests Z_PARAM_PATH specifiers */
+static ZEND_FUNCTION(zend_path)
+{
+	char *path;
+	size_t path_len;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_PATH(path, path_len)
+	ZEND_PARSE_PARAMETERS_END();
+
+	RETURN_STRINGL(path, path_len);
+}
+
+static ZEND_FUNCTION(zend_path_or_null)
+{
+	char *path;
+	size_t path_len;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_PATH_OR_NULL(path, path_len)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (!path) {
+		RETURN_NULL();
+	}
+
+	RETURN_STRINGL(path, path_len);
+}
+
+static ZEND_FUNCTION(zend_path_slow_zpp)
+{
+	char *path;
+	size_t path_len;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "p", &path, &path_len) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	RETURN_STRINGL(path, path_len);
+}
+
+static ZEND_FUNCTION(zend_path_or_null_slow_zpp)
+{
+	char *path;
+	size_t path_len;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "p!", &path, &path_len) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	if (!path) {
+		RETURN_NULL();
+	}
+
+	RETURN_STRINGL(path, path_len);
+}
+
+/* Tests Z_PARAM_PATH_STR specifiers */
+static ZEND_FUNCTION(zend_path_str)
+{
+	zend_string *path;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_PATH_STR(path)
+	ZEND_PARSE_PARAMETERS_END();
+
+	RETURN_STR_COPY(path);
+}
+
+static ZEND_FUNCTION(zend_path_str_or_null)
+{
+	zend_string *path;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_PATH_STR_OR_NULL(path)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (!path) {
+		RETURN_NULL();
+	}
+
+	RETURN_STR_COPY(path);
+}
+
+static ZEND_FUNCTION(zend_path_str_slow_zpp)
+{
+	zend_string *path;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "P", &path) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	RETURN_STR_COPY(path);
+}
+
+static ZEND_FUNCTION(zend_path_str_or_null_slow_zpp)
+{
+	zend_string *path;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "P!", &path) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	if (!path) {
+		RETURN_NULL();
+	}
+
+	RETURN_STR_COPY(path);
+}
+
+/* Tests Z_PARAM_STRING specifiers */
+static ZEND_FUNCTION(zend_string_param)
+{
+	char *str;
+	size_t str_len;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STRING(str, str_len)
+	ZEND_PARSE_PARAMETERS_END();
+
+	RETURN_STRINGL(str, str_len);
+}
+
+static ZEND_FUNCTION(zend_string_param_or_null)
+{
+	char *str;
+	size_t str_len;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STRING_OR_NULL(str, str_len)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (!str) {
+		RETURN_NULL();
+	}
+
+	RETURN_STRINGL(str, str_len);
+}
+
+static ZEND_FUNCTION(zend_string_param_slow_zpp)
+{
+	char *str;
+	size_t str_len;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &str, &str_len) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	RETURN_STRINGL(str, str_len);
+}
+
+static ZEND_FUNCTION(zend_string_param_or_null_slow_zpp)
+{
+	char *str;
+	size_t str_len;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s!", &str, &str_len) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	if (!str) {
+		RETURN_NULL();
+	}
+
+	RETURN_STRINGL(str, str_len);
+}
+
+/* Tests Z_PARAM_STR specifiers */
+static ZEND_FUNCTION(zend_str)
+{
+	zend_string *str;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(str)
+	ZEND_PARSE_PARAMETERS_END();
+
+	RETURN_STR_COPY(str);
+}
+
+static ZEND_FUNCTION(zend_str_or_null)
+{
+	zend_string *str;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR_OR_NULL(str)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (!str) {
+		RETURN_NULL();
+	}
+
+	RETURN_STR_COPY(str);
+}
+
+static ZEND_FUNCTION(zend_str_slow_zpp)
+{
+	zend_string *str;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S", &str) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	RETURN_STR_COPY(str);
+}
+
+static ZEND_FUNCTION(zend_str_or_null_slow_zpp)
+{
+	zend_string *str;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S!", &str) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	if (!str) {
+		RETURN_NULL();
+	}
+
+	RETURN_STR_COPY(str);
+}
+
+/* Tests Z_PARAM_STR_OR_LONG specifiers */
+static ZEND_FUNCTION(zend_str_or_long)
+{
+	zend_string *str = NULL;
+	zend_long l = 0;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR_OR_LONG(str, l)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (str) {
+		RETURN_STR_COPY(str);
+	}
+	RETURN_LONG(l);
+}
+
+static ZEND_FUNCTION(zend_str_or_long_or_null)
+{
+	zend_string *str = NULL;
+	zend_long l = 0;
+	bool is_null = 0;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR_OR_LONG_OR_NULL(str, l, is_null)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (is_null) {
+		RETURN_NULL();
+	}
+	if (str) {
+		RETURN_STR_COPY(str);
+	}
+	RETURN_LONG(l);
+}
+
+/* Tests Z_PARAM_ZVAL specifiers */
+static ZEND_FUNCTION(zend_zval)
+{
+	zval *zv;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ZVAL(zv)
+	ZEND_PARSE_PARAMETERS_END();
+
+	RETURN_COPY(zv);
+}
+
+static ZEND_FUNCTION(zend_zval_or_null)
+{
+	zval *zv;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ZVAL_OR_NULL(zv)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (!zv) {
+		RETURN_NULL();
+	}
+
+	RETURN_COPY(zv);
+}
+
+static ZEND_FUNCTION(zend_zval_separate)
+{
+	zval *zv;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ZVAL_EX(zv, 0, 1)
+	ZEND_PARSE_PARAMETERS_END();
+
+	RETURN_COPY(zv);
+}
+
+static ZEND_FUNCTION(zend_zval_deref_separate)
+{
+	zval *zv;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ZVAL_EX2(zv, 0, 1, 1)
+	ZEND_PARSE_PARAMETERS_END();
+
+	RETURN_COPY(zv);
+}
+
+static ZEND_FUNCTION(zend_zval_slow_zpp)
+{
+	zval *zv;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &zv) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	RETURN_COPY(zv);
+}
+
+static ZEND_FUNCTION(zend_zval_or_null_slow_zpp)
+{
+	zval *zv;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z!", &zv) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	if (!zv) {
+		RETURN_NULL();
+	}
+
+	RETURN_COPY(zv);
+}
+
+/* Tests Z_PARAM_VARIADIC specifiers */
+static ZEND_FUNCTION(zend_variadic)
+{
+	zval *args;
+	uint32_t num_args;
+
+	ZEND_PARSE_PARAMETERS_START(0, -1)
+		Z_PARAM_VARIADIC('*', args, num_args)
+	ZEND_PARSE_PARAMETERS_END();
+
+	array_init(return_value);
+	for (uint32_t i = 0; i < num_args; i++) {
+		add_next_index_zval(return_value, &args[i]);
+		if (Z_REFCOUNTED(args[i])) {
+			GC_TRY_ADDREF(Z_COUNTED(args[i]));
+		}
+	}
+}
+
+static ZEND_FUNCTION(zend_variadic_with_named)
+{
+	zval *args;
+	uint32_t num_args;
+	HashTable *named;
+
+	ZEND_PARSE_PARAMETERS_START(0, -1)
+		Z_PARAM_VARIADIC_WITH_NAMED(args, num_args, named)
+	ZEND_PARSE_PARAMETERS_END();
+
+	array_init(return_value);
+	for (uint32_t i = 0; i < num_args; i++) {
+		add_next_index_zval(return_value, &args[i]);
+		if (Z_REFCOUNTED(args[i])) {
+			GC_TRY_ADDREF(Z_COUNTED(args[i]));
+		}
+	}
+	if (named) {
+		zend_string *name;
+		zval *val;
+		ZEND_HASH_FOREACH_STR_KEY_VAL(named, name, val) {
+			if (name) {
+				add_assoc_zval_ex(return_value, ZSTR_VAL(name), ZSTR_LEN(name), val);
+				if (Z_REFCOUNTED_P(val)) {
+					GC_TRY_ADDREF(Z_COUNTED_P(val));
+				}
+			}
+		} ZEND_HASH_FOREACH_END();
+	}
+}
+
+static ZEND_FUNCTION(zend_variadic_slow_zpp)
+{
+	zval *args = NULL;
+	uint32_t num_args = 0;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "*", &args, &num_args) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	array_init(return_value);
+	for (uint32_t i = 0; i < num_args; i++) {
+		add_next_index_zval(return_value, &args[i]);
+		if (Z_REFCOUNTED(args[i])) {
+			GC_TRY_ADDREF(Z_COUNTED(args[i]));
+		}
+	}
+}
+
 /* END ZPP test functions */
 
 static ZEND_FUNCTION(zend_test_compile_string)

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -378,6 +378,80 @@ namespace {
 
     function zend_number_or_string_or_null(string|int|float|null $param): string|int|float|null {}
 
+	function zend_enum(ZendTestUnitEnum $param): int {}
+
+	function zend_array(array $param): array {}
+	function zend_array_or_null(?array $param): ?array {}
+	function zend_array_separate(array $param): array {}
+	function zend_array_deref_separate(array &$param): array {}
+	function zend_array_slow_zpp(array $param): array {}
+	function zend_array_or_null_slow_zpp(?array $param): ?array {}
+
+	function zend_array_or_object(array|object $param): array|object {}
+	function zend_array_or_object_separate(array|object $param): array|object {}
+	function zend_array_or_object_deref_separate(array|object &$param): array|object {}
+	function zend_array_or_object_slow_zpp(array|object $param): array|object {}
+
+	function zend_array_ht(array $param): array {}
+	function zend_array_ht_or_null(?array $param): ?array {}
+	function zend_array_ht_separate(array $param): array {}
+	function zend_array_ht_deref_separate(array &$param): array {}
+	function zend_array_ht_slow_zpp(array $param): array {}
+	function zend_array_ht_or_null_slow_zpp(?array $param): ?array {}
+
+	function zend_array_ht_or_long(array|int $param): array|int {}
+	function zend_array_ht_or_long_or_null(array|int|null $param): array|int|null {}
+
+	function zend_array_ht_or_str(array|string $param): array|string {}
+	function zend_array_ht_or_str_or_null(array|string|null $param): array|string|null {}
+
+	function zend_array_or_object_ht(array|object $param): array {}
+	function zend_array_or_object_ht_separate(array|object $param): array {}
+	function zend_array_or_object_ht_deref_separate(array|object &$param): array {}
+	function zend_array_or_object_ht_slow_zpp(array|object $param): array {}
+
+	function zend_func(callable $param): string {}
+	function zend_func_or_null(?callable $param): ?string {}
+	function zend_func_no_trampoline_free(callable $param): string {}
+	function zend_func_no_trampoline_free_or_null(?callable $param): ?string {}
+	function zend_func_slow_zpp(callable $param): string {}
+	function zend_func_or_null_slow_zpp(?callable $param): ?string {}
+
+	function zend_path(string $param): string {}
+	function zend_path_or_null(?string $param): ?string {}
+	function zend_path_slow_zpp(string $param): string {}
+	function zend_path_or_null_slow_zpp(?string $param): ?string {}
+
+	function zend_path_str(string $param): string {}
+	function zend_path_str_or_null(?string $param): ?string {}
+	function zend_path_str_slow_zpp(string $param): string {}
+	function zend_path_str_or_null_slow_zpp(?string $param): ?string {}
+
+	function zend_string_param(string $param): string {}
+	function zend_string_param_or_null(?string $param): ?string {}
+	function zend_string_param_slow_zpp(string $param): string {}
+	function zend_string_param_or_null_slow_zpp(?string $param): ?string {}
+
+	function zend_str(string $param): string {}
+	function zend_str_or_null(?string $param): ?string {}
+	function zend_str_slow_zpp(string $param): string {}
+	function zend_str_or_null_slow_zpp(?string $param): ?string {}
+
+	function zend_str_or_long(string|int $param): string|int {}
+	function zend_str_or_long_or_null(string|int|null $param): string|int|null {}
+
+	function zend_zval(mixed $param): mixed {}
+	function zend_zval_or_null(mixed $param): mixed {}
+	function zend_zval_separate(mixed $param): mixed {}
+	function zend_zval_deref_separate(mixed &$param): mixed {}
+	function zend_zval_slow_zpp(mixed $param): mixed {}
+	function zend_zval_or_null_slow_zpp(mixed $param): mixed {}
+
+	function zend_variadic(mixed ...$args): array {}
+	function zend_variadic_with_named(mixed ...$args): array {}
+	function zend_variadic_slow_zpp(mixed ...$args): array {}
+
+
     function zend_iterable(iterable $arg1, ?iterable $arg2 = null): void {}
 
     function zend_weakmap_attach(object $object, mixed $value): bool {}

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit test.stub.php instead.
- * Stub hash: 4d728e740122add9d4c91f5c1abb5f5017690636
+ * Stub hash: 8e10a86b1ea68cbbce5dbe775078c766275a69a8
  * Has decl header: yes */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_trigger_bailout, 0, 0, IS_NEVER, 0)
@@ -194,6 +194,160 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_zend_number_or_string_or_null, 0, 1, MAY_BE_STRING|MAY_BE_LONG|MAY_BE_DOUBLE|MAY_BE_NULL)
 	ZEND_ARG_TYPE_MASK(0, param, MAY_BE_STRING|MAY_BE_LONG|MAY_BE_DOUBLE|MAY_BE_NULL, NULL)
 ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_enum, 0, 1, IS_LONG, 0)
+	ZEND_ARG_OBJ_INFO(0, param, ZendTestUnitEnum, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_array, 0, 1, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, param, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_array_or_null, 0, 1, IS_ARRAY, 1)
+	ZEND_ARG_TYPE_INFO(0, param, IS_ARRAY, 1)
+ZEND_END_ARG_INFO()
+
+#define arginfo_zend_array_separate arginfo_zend_array
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_array_deref_separate, 0, 1, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(1, param, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_zend_array_slow_zpp arginfo_zend_array
+
+#define arginfo_zend_array_or_null_slow_zpp arginfo_zend_array_or_null
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_zend_array_or_object, 0, 1, MAY_BE_ARRAY|MAY_BE_OBJECT)
+	ZEND_ARG_TYPE_MASK(0, param, MAY_BE_ARRAY|MAY_BE_OBJECT, NULL)
+ZEND_END_ARG_INFO()
+
+#define arginfo_zend_array_or_object_separate arginfo_zend_array_or_object
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_zend_array_or_object_deref_separate, 0, 1, MAY_BE_ARRAY|MAY_BE_OBJECT)
+	ZEND_ARG_TYPE_MASK(1, param, MAY_BE_ARRAY|MAY_BE_OBJECT, NULL)
+ZEND_END_ARG_INFO()
+
+#define arginfo_zend_array_or_object_slow_zpp arginfo_zend_array_or_object
+
+#define arginfo_zend_array_ht arginfo_zend_array
+
+#define arginfo_zend_array_ht_or_null arginfo_zend_array_or_null
+
+#define arginfo_zend_array_ht_separate arginfo_zend_array
+
+#define arginfo_zend_array_ht_deref_separate arginfo_zend_array_deref_separate
+
+#define arginfo_zend_array_ht_slow_zpp arginfo_zend_array
+
+#define arginfo_zend_array_ht_or_null_slow_zpp arginfo_zend_array_or_null
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_zend_array_ht_or_long, 0, 1, MAY_BE_ARRAY|MAY_BE_LONG)
+	ZEND_ARG_TYPE_MASK(0, param, MAY_BE_ARRAY|MAY_BE_LONG, NULL)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_zend_array_ht_or_long_or_null, 0, 1, MAY_BE_ARRAY|MAY_BE_LONG|MAY_BE_NULL)
+	ZEND_ARG_TYPE_MASK(0, param, MAY_BE_ARRAY|MAY_BE_LONG|MAY_BE_NULL, NULL)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_zend_array_ht_or_str, 0, 1, MAY_BE_ARRAY|MAY_BE_STRING)
+	ZEND_ARG_TYPE_MASK(0, param, MAY_BE_ARRAY|MAY_BE_STRING, NULL)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_zend_array_ht_or_str_or_null, 0, 1, MAY_BE_ARRAY|MAY_BE_STRING|MAY_BE_NULL)
+	ZEND_ARG_TYPE_MASK(0, param, MAY_BE_ARRAY|MAY_BE_STRING|MAY_BE_NULL, NULL)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_array_or_object_ht, 0, 1, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_MASK(0, param, MAY_BE_ARRAY|MAY_BE_OBJECT, NULL)
+ZEND_END_ARG_INFO()
+
+#define arginfo_zend_array_or_object_ht_separate arginfo_zend_array_or_object_ht
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_array_or_object_ht_deref_separate, 0, 1, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_MASK(1, param, MAY_BE_ARRAY|MAY_BE_OBJECT, NULL)
+ZEND_END_ARG_INFO()
+
+#define arginfo_zend_array_or_object_ht_slow_zpp arginfo_zend_array_or_object_ht
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_func, 0, 1, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, param, IS_CALLABLE, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_func_or_null, 0, 1, IS_STRING, 1)
+	ZEND_ARG_TYPE_INFO(0, param, IS_CALLABLE, 1)
+ZEND_END_ARG_INFO()
+
+#define arginfo_zend_func_no_trampoline_free arginfo_zend_func
+
+#define arginfo_zend_func_no_trampoline_free_or_null arginfo_zend_func_or_null
+
+#define arginfo_zend_func_slow_zpp arginfo_zend_func
+
+#define arginfo_zend_func_or_null_slow_zpp arginfo_zend_func_or_null
+
+#define arginfo_zend_path arginfo_zend_class_name
+
+#define arginfo_zend_path_or_null arginfo_zend_class_name_or_null
+
+#define arginfo_zend_path_slow_zpp arginfo_zend_class_name
+
+#define arginfo_zend_path_or_null_slow_zpp arginfo_zend_class_name_or_null
+
+#define arginfo_zend_path_str arginfo_zend_class_name
+
+#define arginfo_zend_path_str_or_null arginfo_zend_class_name_or_null
+
+#define arginfo_zend_path_str_slow_zpp arginfo_zend_class_name
+
+#define arginfo_zend_path_str_or_null_slow_zpp arginfo_zend_class_name_or_null
+
+#define arginfo_zend_string_param arginfo_zend_class_name
+
+#define arginfo_zend_string_param_or_null arginfo_zend_class_name_or_null
+
+#define arginfo_zend_string_param_slow_zpp arginfo_zend_class_name
+
+#define arginfo_zend_string_param_or_null_slow_zpp arginfo_zend_class_name_or_null
+
+#define arginfo_zend_str arginfo_zend_class_name
+
+#define arginfo_zend_str_or_null arginfo_zend_class_name_or_null
+
+#define arginfo_zend_str_slow_zpp arginfo_zend_class_name
+
+#define arginfo_zend_str_or_null_slow_zpp arginfo_zend_class_name_or_null
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_zend_str_or_long, 0, 1, MAY_BE_STRING|MAY_BE_LONG)
+	ZEND_ARG_TYPE_MASK(0, param, MAY_BE_STRING|MAY_BE_LONG, NULL)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_zend_str_or_long_or_null, 0, 1, MAY_BE_STRING|MAY_BE_LONG|MAY_BE_NULL)
+	ZEND_ARG_TYPE_MASK(0, param, MAY_BE_STRING|MAY_BE_LONG|MAY_BE_NULL, NULL)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_zval, 0, 1, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, param, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_zend_zval_or_null arginfo_zend_zval
+
+#define arginfo_zend_zval_separate arginfo_zend_zval
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_zval_deref_separate, 0, 1, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(1, param, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_zend_zval_slow_zpp arginfo_zend_zval
+
+#define arginfo_zend_zval_or_null_slow_zpp arginfo_zend_zval
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_variadic, 0, 0, IS_ARRAY, 0)
+	ZEND_ARG_VARIADIC_TYPE_INFO(0, args, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_zend_variadic_with_named arginfo_zend_variadic
+
+#define arginfo_zend_variadic_slow_zpp arginfo_zend_variadic
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_iterable, 0, 1, IS_VOID, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, arg1, Traversable, MAY_BE_ARRAY, NULL)
@@ -477,6 +631,64 @@ static ZEND_FUNCTION(zend_obj_stdclass_or_int);
 static ZEND_FUNCTION(zend_obj_stdclass_or_int_or_null);
 static ZEND_FUNCTION(zend_number_or_string);
 static ZEND_FUNCTION(zend_number_or_string_or_null);
+static ZEND_FUNCTION(zend_enum);
+static ZEND_FUNCTION(zend_array);
+static ZEND_FUNCTION(zend_array_or_null);
+static ZEND_FUNCTION(zend_array_separate);
+static ZEND_FUNCTION(zend_array_deref_separate);
+static ZEND_FUNCTION(zend_array_slow_zpp);
+static ZEND_FUNCTION(zend_array_or_null_slow_zpp);
+static ZEND_FUNCTION(zend_array_or_object);
+static ZEND_FUNCTION(zend_array_or_object_separate);
+static ZEND_FUNCTION(zend_array_or_object_deref_separate);
+static ZEND_FUNCTION(zend_array_or_object_slow_zpp);
+static ZEND_FUNCTION(zend_array_ht);
+static ZEND_FUNCTION(zend_array_ht_or_null);
+static ZEND_FUNCTION(zend_array_ht_separate);
+static ZEND_FUNCTION(zend_array_ht_deref_separate);
+static ZEND_FUNCTION(zend_array_ht_slow_zpp);
+static ZEND_FUNCTION(zend_array_ht_or_null_slow_zpp);
+static ZEND_FUNCTION(zend_array_ht_or_long);
+static ZEND_FUNCTION(zend_array_ht_or_long_or_null);
+static ZEND_FUNCTION(zend_array_ht_or_str);
+static ZEND_FUNCTION(zend_array_ht_or_str_or_null);
+static ZEND_FUNCTION(zend_array_or_object_ht);
+static ZEND_FUNCTION(zend_array_or_object_ht_separate);
+static ZEND_FUNCTION(zend_array_or_object_ht_deref_separate);
+static ZEND_FUNCTION(zend_array_or_object_ht_slow_zpp);
+static ZEND_FUNCTION(zend_func);
+static ZEND_FUNCTION(zend_func_or_null);
+static ZEND_FUNCTION(zend_func_no_trampoline_free);
+static ZEND_FUNCTION(zend_func_no_trampoline_free_or_null);
+static ZEND_FUNCTION(zend_func_slow_zpp);
+static ZEND_FUNCTION(zend_func_or_null_slow_zpp);
+static ZEND_FUNCTION(zend_path);
+static ZEND_FUNCTION(zend_path_or_null);
+static ZEND_FUNCTION(zend_path_slow_zpp);
+static ZEND_FUNCTION(zend_path_or_null_slow_zpp);
+static ZEND_FUNCTION(zend_path_str);
+static ZEND_FUNCTION(zend_path_str_or_null);
+static ZEND_FUNCTION(zend_path_str_slow_zpp);
+static ZEND_FUNCTION(zend_path_str_or_null_slow_zpp);
+static ZEND_FUNCTION(zend_string_param);
+static ZEND_FUNCTION(zend_string_param_or_null);
+static ZEND_FUNCTION(zend_string_param_slow_zpp);
+static ZEND_FUNCTION(zend_string_param_or_null_slow_zpp);
+static ZEND_FUNCTION(zend_str);
+static ZEND_FUNCTION(zend_str_or_null);
+static ZEND_FUNCTION(zend_str_slow_zpp);
+static ZEND_FUNCTION(zend_str_or_null_slow_zpp);
+static ZEND_FUNCTION(zend_str_or_long);
+static ZEND_FUNCTION(zend_str_or_long_or_null);
+static ZEND_FUNCTION(zend_zval);
+static ZEND_FUNCTION(zend_zval_or_null);
+static ZEND_FUNCTION(zend_zval_separate);
+static ZEND_FUNCTION(zend_zval_deref_separate);
+static ZEND_FUNCTION(zend_zval_slow_zpp);
+static ZEND_FUNCTION(zend_zval_or_null_slow_zpp);
+static ZEND_FUNCTION(zend_variadic);
+static ZEND_FUNCTION(zend_variadic_with_named);
+static ZEND_FUNCTION(zend_variadic_slow_zpp);
 static ZEND_FUNCTION(zend_iterable);
 static ZEND_FUNCTION(zend_weakmap_attach);
 static ZEND_FUNCTION(zend_weakmap_remove);
@@ -653,6 +865,64 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(zend_obj_stdclass_or_int_or_null, arginfo_zend_obj_stdclass_or_int_or_null)
 	ZEND_FE(zend_number_or_string, arginfo_zend_number_or_string)
 	ZEND_FE(zend_number_or_string_or_null, arginfo_zend_number_or_string_or_null)
+	ZEND_FE(zend_enum, arginfo_zend_enum)
+	ZEND_FE(zend_array, arginfo_zend_array)
+	ZEND_FE(zend_array_or_null, arginfo_zend_array_or_null)
+	ZEND_FE(zend_array_separate, arginfo_zend_array_separate)
+	ZEND_FE(zend_array_deref_separate, arginfo_zend_array_deref_separate)
+	ZEND_FE(zend_array_slow_zpp, arginfo_zend_array_slow_zpp)
+	ZEND_FE(zend_array_or_null_slow_zpp, arginfo_zend_array_or_null_slow_zpp)
+	ZEND_FE(zend_array_or_object, arginfo_zend_array_or_object)
+	ZEND_FE(zend_array_or_object_separate, arginfo_zend_array_or_object_separate)
+	ZEND_FE(zend_array_or_object_deref_separate, arginfo_zend_array_or_object_deref_separate)
+	ZEND_FE(zend_array_or_object_slow_zpp, arginfo_zend_array_or_object_slow_zpp)
+	ZEND_FE(zend_array_ht, arginfo_zend_array_ht)
+	ZEND_FE(zend_array_ht_or_null, arginfo_zend_array_ht_or_null)
+	ZEND_FE(zend_array_ht_separate, arginfo_zend_array_ht_separate)
+	ZEND_FE(zend_array_ht_deref_separate, arginfo_zend_array_ht_deref_separate)
+	ZEND_FE(zend_array_ht_slow_zpp, arginfo_zend_array_ht_slow_zpp)
+	ZEND_FE(zend_array_ht_or_null_slow_zpp, arginfo_zend_array_ht_or_null_slow_zpp)
+	ZEND_FE(zend_array_ht_or_long, arginfo_zend_array_ht_or_long)
+	ZEND_FE(zend_array_ht_or_long_or_null, arginfo_zend_array_ht_or_long_or_null)
+	ZEND_FE(zend_array_ht_or_str, arginfo_zend_array_ht_or_str)
+	ZEND_FE(zend_array_ht_or_str_or_null, arginfo_zend_array_ht_or_str_or_null)
+	ZEND_FE(zend_array_or_object_ht, arginfo_zend_array_or_object_ht)
+	ZEND_FE(zend_array_or_object_ht_separate, arginfo_zend_array_or_object_ht_separate)
+	ZEND_FE(zend_array_or_object_ht_deref_separate, arginfo_zend_array_or_object_ht_deref_separate)
+	ZEND_FE(zend_array_or_object_ht_slow_zpp, arginfo_zend_array_or_object_ht_slow_zpp)
+	ZEND_FE(zend_func, arginfo_zend_func)
+	ZEND_FE(zend_func_or_null, arginfo_zend_func_or_null)
+	ZEND_FE(zend_func_no_trampoline_free, arginfo_zend_func_no_trampoline_free)
+	ZEND_FE(zend_func_no_trampoline_free_or_null, arginfo_zend_func_no_trampoline_free_or_null)
+	ZEND_FE(zend_func_slow_zpp, arginfo_zend_func_slow_zpp)
+	ZEND_FE(zend_func_or_null_slow_zpp, arginfo_zend_func_or_null_slow_zpp)
+	ZEND_FE(zend_path, arginfo_zend_path)
+	ZEND_FE(zend_path_or_null, arginfo_zend_path_or_null)
+	ZEND_FE(zend_path_slow_zpp, arginfo_zend_path_slow_zpp)
+	ZEND_FE(zend_path_or_null_slow_zpp, arginfo_zend_path_or_null_slow_zpp)
+	ZEND_FE(zend_path_str, arginfo_zend_path_str)
+	ZEND_FE(zend_path_str_or_null, arginfo_zend_path_str_or_null)
+	ZEND_FE(zend_path_str_slow_zpp, arginfo_zend_path_str_slow_zpp)
+	ZEND_FE(zend_path_str_or_null_slow_zpp, arginfo_zend_path_str_or_null_slow_zpp)
+	ZEND_FE(zend_string_param, arginfo_zend_string_param)
+	ZEND_FE(zend_string_param_or_null, arginfo_zend_string_param_or_null)
+	ZEND_FE(zend_string_param_slow_zpp, arginfo_zend_string_param_slow_zpp)
+	ZEND_FE(zend_string_param_or_null_slow_zpp, arginfo_zend_string_param_or_null_slow_zpp)
+	ZEND_FE(zend_str, arginfo_zend_str)
+	ZEND_FE(zend_str_or_null, arginfo_zend_str_or_null)
+	ZEND_FE(zend_str_slow_zpp, arginfo_zend_str_slow_zpp)
+	ZEND_FE(zend_str_or_null_slow_zpp, arginfo_zend_str_or_null_slow_zpp)
+	ZEND_FE(zend_str_or_long, arginfo_zend_str_or_long)
+	ZEND_FE(zend_str_or_long_or_null, arginfo_zend_str_or_long_or_null)
+	ZEND_FE(zend_zval, arginfo_zend_zval)
+	ZEND_FE(zend_zval_or_null, arginfo_zend_zval_or_null)
+	ZEND_FE(zend_zval_separate, arginfo_zend_zval_separate)
+	ZEND_FE(zend_zval_deref_separate, arginfo_zend_zval_deref_separate)
+	ZEND_FE(zend_zval_slow_zpp, arginfo_zend_zval_slow_zpp)
+	ZEND_FE(zend_zval_or_null_slow_zpp, arginfo_zend_zval_or_null_slow_zpp)
+	ZEND_FE(zend_variadic, arginfo_zend_variadic)
+	ZEND_FE(zend_variadic_with_named, arginfo_zend_variadic_with_named)
+	ZEND_FE(zend_variadic_slow_zpp, arginfo_zend_variadic_slow_zpp)
 	ZEND_FE(zend_iterable, arginfo_zend_iterable)
 	ZEND_FE(zend_weakmap_attach, arginfo_zend_weakmap_attach)
 	ZEND_FE(zend_weakmap_remove, arginfo_zend_weakmap_remove)

--- a/ext/zend_test/test_decl.h
+++ b/ext/zend_test/test_decl.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit test.stub.php instead.
- * Stub hash: 4d728e740122add9d4c91f5c1abb5f5017690636 */
+ * Stub hash: 8e10a86b1ea68cbbce5dbe775078c766275a69a8 */
 
-#ifndef ZEND_TEST_DECL_4d728e740122add9d4c91f5c1abb5f5017690636_H
-#define ZEND_TEST_DECL_4d728e740122add9d4c91f5c1abb5f5017690636_H
+#ifndef ZEND_TEST_DECL_8e10a86b1ea68cbbce5dbe775078c766275a69a8_H
+#define ZEND_TEST_DECL_8e10a86b1ea68cbbce5dbe775078c766275a69a8_H
 
 typedef enum zend_enum_ZendTestUnitEnum {
 	ZEND_ENUM_ZendTestUnitEnum_Foo = 1,
@@ -27,4 +27,4 @@ typedef enum zend_enum_ZendTestEnumWithInterface {
 	ZEND_ENUM_ZendTestEnumWithInterface_Bar = 2,
 } zend_enum_ZendTestEnumWithInterface;
 
-#endif /* ZEND_TEST_DECL_4d728e740122add9d4c91f5c1abb5f5017690636_H */
+#endif /* ZEND_TEST_DECL_8e10a86b1ea68cbbce5dbe775078c766275a69a8_H */

--- a/ext/zend_test/test_legacy_arginfo.h
+++ b/ext/zend_test/test_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit test.stub.php instead.
- * Stub hash: 4d728e740122add9d4c91f5c1abb5f5017690636
+ * Stub hash: 8e10a86b1ea68cbbce5dbe775078c766275a69a8
  * Has decl header: yes */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_zend_trigger_bailout, 0, 0, 0)
@@ -142,6 +142,126 @@ ZEND_END_ARG_INFO()
 #define arginfo_zend_number_or_string arginfo_zend_bool
 
 #define arginfo_zend_number_or_string_or_null arginfo_zend_bool
+
+#define arginfo_zend_enum arginfo_zend_bool
+
+#define arginfo_zend_array arginfo_zend_bool
+
+#define arginfo_zend_array_or_null arginfo_zend_bool
+
+#define arginfo_zend_array_separate arginfo_zend_bool
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zend_array_deref_separate, 0, 0, 1)
+	ZEND_ARG_INFO(1, param)
+ZEND_END_ARG_INFO()
+
+#define arginfo_zend_array_slow_zpp arginfo_zend_bool
+
+#define arginfo_zend_array_or_null_slow_zpp arginfo_zend_bool
+
+#define arginfo_zend_array_or_object arginfo_zend_bool
+
+#define arginfo_zend_array_or_object_separate arginfo_zend_bool
+
+#define arginfo_zend_array_or_object_deref_separate arginfo_zend_array_deref_separate
+
+#define arginfo_zend_array_or_object_slow_zpp arginfo_zend_bool
+
+#define arginfo_zend_array_ht arginfo_zend_bool
+
+#define arginfo_zend_array_ht_or_null arginfo_zend_bool
+
+#define arginfo_zend_array_ht_separate arginfo_zend_bool
+
+#define arginfo_zend_array_ht_deref_separate arginfo_zend_array_deref_separate
+
+#define arginfo_zend_array_ht_slow_zpp arginfo_zend_bool
+
+#define arginfo_zend_array_ht_or_null_slow_zpp arginfo_zend_bool
+
+#define arginfo_zend_array_ht_or_long arginfo_zend_bool
+
+#define arginfo_zend_array_ht_or_long_or_null arginfo_zend_bool
+
+#define arginfo_zend_array_ht_or_str arginfo_zend_bool
+
+#define arginfo_zend_array_ht_or_str_or_null arginfo_zend_bool
+
+#define arginfo_zend_array_or_object_ht arginfo_zend_bool
+
+#define arginfo_zend_array_or_object_ht_separate arginfo_zend_bool
+
+#define arginfo_zend_array_or_object_ht_deref_separate arginfo_zend_array_deref_separate
+
+#define arginfo_zend_array_or_object_ht_slow_zpp arginfo_zend_bool
+
+#define arginfo_zend_func arginfo_zend_bool
+
+#define arginfo_zend_func_or_null arginfo_zend_bool
+
+#define arginfo_zend_func_no_trampoline_free arginfo_zend_bool
+
+#define arginfo_zend_func_no_trampoline_free_or_null arginfo_zend_bool
+
+#define arginfo_zend_func_slow_zpp arginfo_zend_bool
+
+#define arginfo_zend_func_or_null_slow_zpp arginfo_zend_bool
+
+#define arginfo_zend_path arginfo_zend_bool
+
+#define arginfo_zend_path_or_null arginfo_zend_bool
+
+#define arginfo_zend_path_slow_zpp arginfo_zend_bool
+
+#define arginfo_zend_path_or_null_slow_zpp arginfo_zend_bool
+
+#define arginfo_zend_path_str arginfo_zend_bool
+
+#define arginfo_zend_path_str_or_null arginfo_zend_bool
+
+#define arginfo_zend_path_str_slow_zpp arginfo_zend_bool
+
+#define arginfo_zend_path_str_or_null_slow_zpp arginfo_zend_bool
+
+#define arginfo_zend_string_param arginfo_zend_bool
+
+#define arginfo_zend_string_param_or_null arginfo_zend_bool
+
+#define arginfo_zend_string_param_slow_zpp arginfo_zend_bool
+
+#define arginfo_zend_string_param_or_null_slow_zpp arginfo_zend_bool
+
+#define arginfo_zend_str arginfo_zend_bool
+
+#define arginfo_zend_str_or_null arginfo_zend_bool
+
+#define arginfo_zend_str_slow_zpp arginfo_zend_bool
+
+#define arginfo_zend_str_or_null_slow_zpp arginfo_zend_bool
+
+#define arginfo_zend_str_or_long arginfo_zend_bool
+
+#define arginfo_zend_str_or_long_or_null arginfo_zend_bool
+
+#define arginfo_zend_zval arginfo_zend_bool
+
+#define arginfo_zend_zval_or_null arginfo_zend_bool
+
+#define arginfo_zend_zval_separate arginfo_zend_bool
+
+#define arginfo_zend_zval_deref_separate arginfo_zend_array_deref_separate
+
+#define arginfo_zend_zval_slow_zpp arginfo_zend_bool
+
+#define arginfo_zend_zval_or_null_slow_zpp arginfo_zend_bool
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zend_variadic, 0, 0, 0)
+	ZEND_ARG_VARIADIC_INFO(0, args)
+ZEND_END_ARG_INFO()
+
+#define arginfo_zend_variadic_with_named arginfo_zend_variadic
+
+#define arginfo_zend_variadic_slow_zpp arginfo_zend_variadic
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_zend_iterable, 0, 0, 1)
 	ZEND_ARG_INFO(0, arg1)
@@ -402,6 +522,64 @@ static ZEND_FUNCTION(zend_obj_stdclass_or_int);
 static ZEND_FUNCTION(zend_obj_stdclass_or_int_or_null);
 static ZEND_FUNCTION(zend_number_or_string);
 static ZEND_FUNCTION(zend_number_or_string_or_null);
+static ZEND_FUNCTION(zend_enum);
+static ZEND_FUNCTION(zend_array);
+static ZEND_FUNCTION(zend_array_or_null);
+static ZEND_FUNCTION(zend_array_separate);
+static ZEND_FUNCTION(zend_array_deref_separate);
+static ZEND_FUNCTION(zend_array_slow_zpp);
+static ZEND_FUNCTION(zend_array_or_null_slow_zpp);
+static ZEND_FUNCTION(zend_array_or_object);
+static ZEND_FUNCTION(zend_array_or_object_separate);
+static ZEND_FUNCTION(zend_array_or_object_deref_separate);
+static ZEND_FUNCTION(zend_array_or_object_slow_zpp);
+static ZEND_FUNCTION(zend_array_ht);
+static ZEND_FUNCTION(zend_array_ht_or_null);
+static ZEND_FUNCTION(zend_array_ht_separate);
+static ZEND_FUNCTION(zend_array_ht_deref_separate);
+static ZEND_FUNCTION(zend_array_ht_slow_zpp);
+static ZEND_FUNCTION(zend_array_ht_or_null_slow_zpp);
+static ZEND_FUNCTION(zend_array_ht_or_long);
+static ZEND_FUNCTION(zend_array_ht_or_long_or_null);
+static ZEND_FUNCTION(zend_array_ht_or_str);
+static ZEND_FUNCTION(zend_array_ht_or_str_or_null);
+static ZEND_FUNCTION(zend_array_or_object_ht);
+static ZEND_FUNCTION(zend_array_or_object_ht_separate);
+static ZEND_FUNCTION(zend_array_or_object_ht_deref_separate);
+static ZEND_FUNCTION(zend_array_or_object_ht_slow_zpp);
+static ZEND_FUNCTION(zend_func);
+static ZEND_FUNCTION(zend_func_or_null);
+static ZEND_FUNCTION(zend_func_no_trampoline_free);
+static ZEND_FUNCTION(zend_func_no_trampoline_free_or_null);
+static ZEND_FUNCTION(zend_func_slow_zpp);
+static ZEND_FUNCTION(zend_func_or_null_slow_zpp);
+static ZEND_FUNCTION(zend_path);
+static ZEND_FUNCTION(zend_path_or_null);
+static ZEND_FUNCTION(zend_path_slow_zpp);
+static ZEND_FUNCTION(zend_path_or_null_slow_zpp);
+static ZEND_FUNCTION(zend_path_str);
+static ZEND_FUNCTION(zend_path_str_or_null);
+static ZEND_FUNCTION(zend_path_str_slow_zpp);
+static ZEND_FUNCTION(zend_path_str_or_null_slow_zpp);
+static ZEND_FUNCTION(zend_string_param);
+static ZEND_FUNCTION(zend_string_param_or_null);
+static ZEND_FUNCTION(zend_string_param_slow_zpp);
+static ZEND_FUNCTION(zend_string_param_or_null_slow_zpp);
+static ZEND_FUNCTION(zend_str);
+static ZEND_FUNCTION(zend_str_or_null);
+static ZEND_FUNCTION(zend_str_slow_zpp);
+static ZEND_FUNCTION(zend_str_or_null_slow_zpp);
+static ZEND_FUNCTION(zend_str_or_long);
+static ZEND_FUNCTION(zend_str_or_long_or_null);
+static ZEND_FUNCTION(zend_zval);
+static ZEND_FUNCTION(zend_zval_or_null);
+static ZEND_FUNCTION(zend_zval_separate);
+static ZEND_FUNCTION(zend_zval_deref_separate);
+static ZEND_FUNCTION(zend_zval_slow_zpp);
+static ZEND_FUNCTION(zend_zval_or_null_slow_zpp);
+static ZEND_FUNCTION(zend_variadic);
+static ZEND_FUNCTION(zend_variadic_with_named);
+static ZEND_FUNCTION(zend_variadic_slow_zpp);
 static ZEND_FUNCTION(zend_iterable);
 static ZEND_FUNCTION(zend_weakmap_attach);
 static ZEND_FUNCTION(zend_weakmap_remove);
@@ -550,6 +728,64 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(zend_obj_stdclass_or_int_or_null, arginfo_zend_obj_stdclass_or_int_or_null)
 	ZEND_FE(zend_number_or_string, arginfo_zend_number_or_string)
 	ZEND_FE(zend_number_or_string_or_null, arginfo_zend_number_or_string_or_null)
+	ZEND_FE(zend_enum, arginfo_zend_enum)
+	ZEND_FE(zend_array, arginfo_zend_array)
+	ZEND_FE(zend_array_or_null, arginfo_zend_array_or_null)
+	ZEND_FE(zend_array_separate, arginfo_zend_array_separate)
+	ZEND_FE(zend_array_deref_separate, arginfo_zend_array_deref_separate)
+	ZEND_FE(zend_array_slow_zpp, arginfo_zend_array_slow_zpp)
+	ZEND_FE(zend_array_or_null_slow_zpp, arginfo_zend_array_or_null_slow_zpp)
+	ZEND_FE(zend_array_or_object, arginfo_zend_array_or_object)
+	ZEND_FE(zend_array_or_object_separate, arginfo_zend_array_or_object_separate)
+	ZEND_FE(zend_array_or_object_deref_separate, arginfo_zend_array_or_object_deref_separate)
+	ZEND_FE(zend_array_or_object_slow_zpp, arginfo_zend_array_or_object_slow_zpp)
+	ZEND_FE(zend_array_ht, arginfo_zend_array_ht)
+	ZEND_FE(zend_array_ht_or_null, arginfo_zend_array_ht_or_null)
+	ZEND_FE(zend_array_ht_separate, arginfo_zend_array_ht_separate)
+	ZEND_FE(zend_array_ht_deref_separate, arginfo_zend_array_ht_deref_separate)
+	ZEND_FE(zend_array_ht_slow_zpp, arginfo_zend_array_ht_slow_zpp)
+	ZEND_FE(zend_array_ht_or_null_slow_zpp, arginfo_zend_array_ht_or_null_slow_zpp)
+	ZEND_FE(zend_array_ht_or_long, arginfo_zend_array_ht_or_long)
+	ZEND_FE(zend_array_ht_or_long_or_null, arginfo_zend_array_ht_or_long_or_null)
+	ZEND_FE(zend_array_ht_or_str, arginfo_zend_array_ht_or_str)
+	ZEND_FE(zend_array_ht_or_str_or_null, arginfo_zend_array_ht_or_str_or_null)
+	ZEND_FE(zend_array_or_object_ht, arginfo_zend_array_or_object_ht)
+	ZEND_FE(zend_array_or_object_ht_separate, arginfo_zend_array_or_object_ht_separate)
+	ZEND_FE(zend_array_or_object_ht_deref_separate, arginfo_zend_array_or_object_ht_deref_separate)
+	ZEND_FE(zend_array_or_object_ht_slow_zpp, arginfo_zend_array_or_object_ht_slow_zpp)
+	ZEND_FE(zend_func, arginfo_zend_func)
+	ZEND_FE(zend_func_or_null, arginfo_zend_func_or_null)
+	ZEND_FE(zend_func_no_trampoline_free, arginfo_zend_func_no_trampoline_free)
+	ZEND_FE(zend_func_no_trampoline_free_or_null, arginfo_zend_func_no_trampoline_free_or_null)
+	ZEND_FE(zend_func_slow_zpp, arginfo_zend_func_slow_zpp)
+	ZEND_FE(zend_func_or_null_slow_zpp, arginfo_zend_func_or_null_slow_zpp)
+	ZEND_FE(zend_path, arginfo_zend_path)
+	ZEND_FE(zend_path_or_null, arginfo_zend_path_or_null)
+	ZEND_FE(zend_path_slow_zpp, arginfo_zend_path_slow_zpp)
+	ZEND_FE(zend_path_or_null_slow_zpp, arginfo_zend_path_or_null_slow_zpp)
+	ZEND_FE(zend_path_str, arginfo_zend_path_str)
+	ZEND_FE(zend_path_str_or_null, arginfo_zend_path_str_or_null)
+	ZEND_FE(zend_path_str_slow_zpp, arginfo_zend_path_str_slow_zpp)
+	ZEND_FE(zend_path_str_or_null_slow_zpp, arginfo_zend_path_str_or_null_slow_zpp)
+	ZEND_FE(zend_string_param, arginfo_zend_string_param)
+	ZEND_FE(zend_string_param_or_null, arginfo_zend_string_param_or_null)
+	ZEND_FE(zend_string_param_slow_zpp, arginfo_zend_string_param_slow_zpp)
+	ZEND_FE(zend_string_param_or_null_slow_zpp, arginfo_zend_string_param_or_null_slow_zpp)
+	ZEND_FE(zend_str, arginfo_zend_str)
+	ZEND_FE(zend_str_or_null, arginfo_zend_str_or_null)
+	ZEND_FE(zend_str_slow_zpp, arginfo_zend_str_slow_zpp)
+	ZEND_FE(zend_str_or_null_slow_zpp, arginfo_zend_str_or_null_slow_zpp)
+	ZEND_FE(zend_str_or_long, arginfo_zend_str_or_long)
+	ZEND_FE(zend_str_or_long_or_null, arginfo_zend_str_or_long_or_null)
+	ZEND_FE(zend_zval, arginfo_zend_zval)
+	ZEND_FE(zend_zval_or_null, arginfo_zend_zval_or_null)
+	ZEND_FE(zend_zval_separate, arginfo_zend_zval_separate)
+	ZEND_FE(zend_zval_deref_separate, arginfo_zend_zval_deref_separate)
+	ZEND_FE(zend_zval_slow_zpp, arginfo_zend_zval_slow_zpp)
+	ZEND_FE(zend_zval_or_null_slow_zpp, arginfo_zend_zval_or_null_slow_zpp)
+	ZEND_FE(zend_variadic, arginfo_zend_variadic)
+	ZEND_FE(zend_variadic_with_named, arginfo_zend_variadic_with_named)
+	ZEND_FE(zend_variadic_slow_zpp, arginfo_zend_variadic_slow_zpp)
 	ZEND_FE(zend_iterable, arginfo_zend_iterable)
 	ZEND_FE(zend_weakmap_attach, arginfo_zend_weakmap_attach)
 	ZEND_FE(zend_weakmap_remove, arginfo_zend_weakmap_remove)


### PR DESCRIPTION
Adds missing test coverage for Zend Parameter Parsing (ZPP) specifiers as outlined in GH-23280.

### Summary of Changes
- Added helper functions to `ext/zend_test` (`test.stub.php` and `test.c`) to exercise missing ZPP specifiers (`Z_PARAM_ENUM`, `Z_PARAM_ARRAY*`, `Z_PARAM_ARRAY_HT*`, `Z_PARAM_ARRAY_OR_OBJECT*`, `Z_PARAM_FUNC*`, `Z_PARAM_PATH*`, `Z_PARAM_STRING*`, `Z_PARAM_STR*`, `Z_PARAM_ZVAL*`, `Z_PARAM_VARIADIC*`, and union specifiers).
- Added `.phpt` test cases in `Zend/tests/zpp/` covering both strict and weak type modes.

Closes GH-23280.