### PR TITLE
ext/standard: enforce max_filter_count

### DIFF
--- a/ext/standard/php_fopen_wrapper.c
+++ b/ext/standard/php_fopen_wrapper.c
@@ -152,12 +152,10 @@ static zend_result php_stream_apply_filter_list(php_stream *stream, char *filter
 	php_stream_filter *temp_filter;
 
 	zend_long max_filter_count = max_filter_count_default;
-	bool max_filter_count_configured = false;
 	if (context != NULL) {
 		zval *option_val = php_stream_context_get_option(context, "filter", "max_filter_count");
 		if (option_val) {
 			max_filter_count = zval_get_long(option_val);
-			max_filter_count_configured = true;
 		}
 	}
 
@@ -167,13 +165,7 @@ static zend_result php_stream_apply_filter_list(php_stream *stream, char *filter
 		zend_long write_count = write_chain ? stream->writefilters.num_filters : 0;
 
 		if (read_count == max_filter_count || write_count == max_filter_count) {
-			if (max_filter_count_configured) {
-				return FAILURE;
-			} else {
-				// No max_filter_count configured; raise deprecation error if over default
-				zend_error(E_DEPRECATED, "Using more than " ZEND_LONG_FMT " filters in a php://filter URL is deprecated, "
-					"set this limit using the stream context option max_filter_count, or use stream_filter_append", max_filter_count_default);
-			}
+			return FAILURE;
 		}
 
 		php_url_decode(p, strlen(p));

--- a/ext/standard/tests/filters/max_filter_chain.phpt
+++ b/ext/standard/tests/filters/max_filter_chain.phpt
@@ -90,24 +90,30 @@ int(1)
 int(1)
 # file_get_contents on 17 filters
 
-Deprecated: Using more than 16 filters in a php://filter URL is deprecated, set this limit using the stream context option max_filter_count, or use stream_filter_append in %smax_filter_chain.php on line %d
-string(9) "SEVENTEEN"
+Warning: file_get_contents(): Failed to open stream: too many filters in %s on line %d
+bool(false)
 
-Deprecated: Using more than 16 filters in a php://filter URL is deprecated, set this limit using the stream context option max_filter_count, or use stream_filter_append in %smax_filter_chain.php on line %d
-string(9) "SEVENTEEN"
+Warning: file_get_contents(): Failed to open stream: too many filters in %s on line %d
+bool(false)
 
-Deprecated: Using more than 16 filters in a php://filter URL is deprecated, set this limit using the stream context option max_filter_count, or use stream_filter_append in %smax_filter_chain.php on line %d
-string(9) "SEVENTEEN"
+Warning: file_get_contents(): Failed to open stream: too many filters in %s on line %d
+bool(false)
 # include on 17 filters
 
-Deprecated: Using more than 16 filters in a php://filter URL is deprecated, set this limit using the stream context option max_filter_count, or use stream_filter_append in %smax_filter_chain.php on line %d
-int(1)
+Warning: include(): Failed to open stream: too many filters in %s on line %d
 
-Deprecated: Using more than 16 filters in a php://filter URL is deprecated, set this limit using the stream context option max_filter_count, or use stream_filter_append in %smax_filter_chain.php on line %d
-int(1)
+Warning: include(): Failed opening %s
+bool(false)
 
-Deprecated: Using more than 16 filters in a php://filter URL is deprecated, set this limit using the stream context option max_filter_count, or use stream_filter_append in %smax_filter_chain.php on line %d
-int(1)
+Warning: include(): Failed to open stream: too many filters in %s on line %d
+
+Warning: include(): Failed opening %s
+bool(false)
+
+Warning: include(): Failed to open stream: too many filters in %s on line %d
+
+Warning: include(): Failed opening %s
+bool(false)
 # file_get_contents on 3 filters, max_filter_count=2
 
 Warning: file_get_contents(): Failed to open stream: too many filters in %s on line %d
@@ -124,18 +130,18 @@ string(8) "NINETEEN"
 string(8) "NINETEEN"
 # warning is only given once, even when we add two filters over the limit
 
-Deprecated: Using more than 16 filters in a php://filter URL is deprecated, set this limit using the stream context option max_filter_count, or use stream_filter_append in %smax_filter_chain.php on line %d
-string(8) "EIGHTEEN"
+Warning: file_get_contents(): Failed to open stream: too many filters in %s on line %d
+bool(false)
 
-Deprecated: Using more than 16 filters in a php://filter URL is deprecated, set this limit using the stream context option max_filter_count, or use stream_filter_append in %smax_filter_chain.php on line %d
-string(8) "EIGHTEEN"
+Warning: file_get_contents(): Failed to open stream: too many filters in %s on line %d
+bool(false)
 
-Deprecated: Using more than 16 filters in a php://filter URL is deprecated, set this limit using the stream context option max_filter_count, or use stream_filter_append in %smax_filter_chain.php on line %d
-string(8) "EIGHTEEN"
+Warning: file_get_contents(): Failed to open stream: operation failed in %s on line %d
+bool(false)
 # warn on too many write filters, even when number of read filters is OK
 
-Deprecated: Using more than 16 filters in a php://filter URL is deprecated, set this limit using the stream context option max_filter_count, or use stream_filter_append in %smax_filter_chain.php on line %d
-bool(true)
+Warning: fopen(): Failed to open stream: too many filters in %s on line %d
+bool(false)
 # setting max_filter_count to -1 disables warning
 string(6) "TWENTY"
 string(6) "TWENTY"


### PR DESCRIPTION
Using more than 16 filters in a php://filter URL was deprecated in 8.6, and will fail in PHP 8.7. So this targets 8.7 to enforce this limit.