### PR TITLE
Close a UConverter that fails callback install

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,8 @@ PHP                                                                        NEWS
     the ICU constructor adopts the TimeZone. (iliaal)
   . Fixed bug GH-23094 (NumberFormatter parsing offsets use UTF-16 positions
     for UTF-8 strings). (ColumbusLabs)
+  . Fixed a leak when UConverter callback installation fails after
+    ucnv_open(). (iliaal)
 
 - Opcache:
   . Fixed opcache.protect_memory race under ZTS. (realFlowControl)

--- a/ext/intl/converter/converter.c
+++ b/ext/intl/converter/converter.c
@@ -393,6 +393,7 @@ static bool php_converter_set_encoding(php_converter_object *objval,
 	}
 
 	if (objval && !php_converter_set_callbacks(objval, cnv)) {
+		ucnv_close(cnv);
 		return false;
 	}
 


### PR DESCRIPTION
ucnv_open() can succeed and php_converter_set_callbacks() can still fail on a UConverter subclass. The converter was neither stored nor closed. Close it on that return. The default class skips callback install; transcode passes a NULL object.
