### PR TITLE
Fix UAF when setAttributeNS() frees a wrapped attribute child

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,8 @@ PHP                                                                        NEWS
 - DOM:
   . Fixed a use-after-free when cloning a DOMNameSpaceNode after
     DOMDocument::xinclude(). (iliaal)
+  . Fixed a use-after-free when Dom\Element::setAttributeNS() replaces the
+    value of an attribute whose child still has a live wrapper. (iliaal)
 
 - Intl:
   . Fixed a double-free when IntlGregorianCalendar construction fails after

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -1030,6 +1030,10 @@ static void dom_set_attribute_ns_modern(dom_object *intern, xmlNodePtr elemp, ze
 	if (errorcode == 0) {
 		php_dom_libxml_ns_mapper *ns_mapper = php_dom_get_ns_mapper(intern);
 		xmlNsPtr ns = php_dom_libxml_ns_mapper_get_ns_raw_prefix_string(ns_mapper, prefix, xmlStrlen(prefix), uri);
+		xmlNodePtr existing = (xmlNodePtr) xmlHasNsProp(elemp, localname, ns == NULL ? NULL : ns->href);
+		if (existing != NULL && existing->type != XML_ATTRIBUTE_DECL) {
+			node_list_unlink(existing->children);
+		}
 		xmlAttrPtr attr = xmlSetNsProp(elemp, ns, localname, BAD_CAST value);
 		if (UNEXPECTED(attr == NULL)) {
 			php_dom_throw_error(INVALID_STATE_ERR, /* strict */ true);

--- a/ext/dom/tests/modern/common/Element_setAttributeNS_live_child.phpt
+++ b/ext/dom/tests/modern/common/Element_setAttributeNS_live_child.phpt
@@ -1,0 +1,37 @@
+--TEST--
+setAttributeNS() keeps an attribute child that still has a live wrapper
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+$doc = Dom\XMLDocument::createFromString('<root xmlns:p="urn:x" p:attr="old"/>');
+$el = $doc->documentElement;
+$text = $el->getAttributeNodeNS('urn:x', 'attr')->firstChild;
+$el->setAttributeNS('urn:x', 'p:attr', 'new');
+echo "prefixed, detached: ";
+var_dump($text->parentNode === null);
+echo "prefixed, text: ";
+var_dump($text->textContent);
+echo "prefixed, new value: ";
+var_dump($el->getAttributeNS('urn:x', 'attr'));
+
+$doc = Dom\XMLDocument::createFromString('<root attr="old"/>');
+$el = $doc->documentElement;
+$text = $el->getAttributeNode('attr')->firstChild;
+$el->setAttributeNS(null, 'attr', 'new');
+echo "no namespace, detached: ";
+var_dump($text->parentNode === null);
+echo "no namespace, text: ";
+var_dump($text->textContent);
+echo "no namespace, new value: ";
+var_dump($el->getAttribute('attr'));
+
+?>
+--EXPECT--
+prefixed, detached: bool(true)
+prefixed, text: string(3) "old"
+prefixed, new value: string(3) "new"
+no namespace, detached: bool(true)
+no namespace, text: string(3) "old"
+no namespace, new value: string(3) "new"


### PR DESCRIPTION
Dom\Element::setAttributeNS() replaces an existing attribute's value by calling xmlSetNsProp() directly, and libxml2 frees the attribute's child list there. Nothing unlinks the children that still carry a PHP wrapper first, so a live Dom\Text goes on pointing at freed memory: it reports the new attribute text and claims to still be attached. dom_set_attribute_ns_legacy() has always unlinked them, and the modern setAttribute() replaces the value through dom_remove_all_children(), so only the modern namespace-aware setter is missing the step.

No DTD and no entity reference are needed. A single-text-child attribute is enough, which is why the test builds one rather than reusing the GH-23331 shape.

Independent of php/php-src#23337, which repairs node_list_unlink() itself. Neither fix needs the other, but an attribute holding TEXT/ENTITY_REF/TEXT needs both: with the two applied that case is valgrind-clean, and with either one alone valgrind still reports an invalid read through the surviving wrapper.

