### PR TITLE
Stop grapheme_str_split from using UBRK_DONE as a byte index

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,7 @@ PHP                                                                        NEWS
     the ICU constructor adopts the TimeZone. (iliaal)
   . Fixed bug GH-23094 (NumberFormatter parsing offsets use UTF-16 positions
     for UTF-8 strings). (ColumbusLabs)
+  . Fixed grapheme_str_split() treating UBRK_DONE as a byte index. (iliaal)
 
 - Opcache:
   . Fixed opcache.protect_memory race under ZTS. (realFlowControl)

--- a/ext/intl/grapheme/grapheme_string.c
+++ b/ext/intl/grapheme/grapheme_string.c
@@ -896,9 +896,9 @@ PHP_FUNCTION(grapheme_str_split)
 				add_next_index_stringl(return_value, pstr, pos - current);
 				end = pstr + pos - current;
 				i = 0;
+				pstr += pos - current;
+				current = pos;
 			}
-			pstr += pos - current;
-			current = pos;
 		} else {
 			i += 1;
 		}


### PR DESCRIPTION
When the last grapheme_str_split() group is short, ubrk_next() returns UBRK_DONE and the loop still advanced pstr by -1 - current. Skip that update when the iterator is done, matching the grapheme_strrev() fix.
