### PR TITLE
Bound getSingletonPos before reading the next separator

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,8 @@ PHP                                                                        NEWS
     the ICU constructor adopts the TimeZone. (iliaal)
   . Fixed bug GH-23094 (NumberFormatter parsing offsets use UTF-16 positions
     for UTF-8 strings). (ColumbusLabs)
+  . Fixed Locale::parseLocale() reading past a trailing '-' or '_'.
+    (iliaal, Xuyang Zhang)
 
 - Opcache:
   . Fixed opcache.protect_memory race under ZTS. (realFlowControl)

--- a/ext/intl/locale/locale_methods.c
+++ b/ext/intl/locale/locale_methods.c
@@ -279,7 +279,7 @@ static zend_off_t getSingletonPos(const char* str)
 					break;
 				} else {
 					/* delimiter found; check for singleton */
-					if( isIDSeparator(*(str+i+2)) ){
+					if( (size_t)i + 2 < len && isIDSeparator(*(str+i+2)) ){
 						/* a singleton; so send the position of separator before singleton */
 						result = i+1;
 						break;

--- a/ext/intl/tests/locale_parse_trailing_separator.phpt
+++ b/ext/intl/tests/locale_parse_trailing_separator.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Locale::parseLocale() does not read past a trailing '-' or '_'
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+/* Enough lengths that the byte past the end clears the allocation. */
+foreach (['-', '_'] as $sep) {
+    for ($len = 1; $len <= 64; $len++) {
+        Locale::parseLocale(str_repeat('a', $len) . $sep);
+    }
+}
+
+$locales = [
+    'en-',
+    'foo-',
+    'en_US-',
+    'en_',
+    'de-CH-x-',
+];
+
+foreach ($locales as $locale) {
+    echo $locale, ': ';
+    var_export(Locale::parseLocale($locale));
+    echo "\n";
+}
+?>
+--EXPECT--
+en-: array (
+  'language' => 'en',
+)
+foo-: array (
+  'language' => 'foo',
+)
+en_US-: array (
+  'language' => 'en',
+  'region' => 'US',
+)
+en_: array (
+  'language' => 'en',
+)
+de-CH-x-: array (
+  'language' => 'de',
+  'region' => 'CH',
+)


### PR DESCRIPTION
getSingletonPos() read str[i+2] after the last '-' or '_' in a locale, one byte past the NUL for strings such as en-. Require i+2 to be inside the string. Output matches the unfixed parser unless that heap byte happens to be another separator; php/php-src#22498 closed for that reason.
