### PR TITLE
Close the keyword UEnumeration on Locale::getKeywords failure

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,8 @@ PHP                                                                        NEWS
     the ICU constructor adopts the TimeZone. (iliaal)
   . Fixed bug GH-23094 (NumberFormatter parsing offsets use UTF-16 positions
     for UTF-8 strings). (ColumbusLabs)
+  . Fixed a leak in Locale::getKeywords() when a keyword value cannot be
+    read. (iliaal)
 
 - Opcache:
   . Fixed opcache.protect_memory race under ZTS. (realFlowControl)

--- a/ext/intl/locale/locale_methods.c
+++ b/ext/intl/locale/locale_methods.c
@@ -776,6 +776,7 @@ PHP_FUNCTION( locale_get_keywords )
 					zend_string_efree( kw_value_str );
 				}
 				zend_array_destroy(Z_ARR_P(return_value));
+				uenum_close( e );
 				RETURN_FALSE;
 			}
 

--- a/ext/intl/tests/locale_get_keywords_failure.phpt
+++ b/ext/intl/tests/locale_get_keywords_failure.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Locale::getKeywords() closes the keyword enumeration on failure
+--EXTENSIONS--
+intl
+--SKIPIF--
+<?php
+if (version_compare(INTL_ICU_VERSION, '59.1', '<')) {
+    die('skip for ICU >= 59.1');
+}
+?>
+--FILE--
+<?php
+var_dump(Locale::getKeywords('en@foo=bar!'));
+var_dump(intl_get_error_code() === U_ILLEGAL_ARGUMENT_ERROR);
+?>
+--EXPECT--
+bool(false)
+bool(true)


### PR DESCRIPTION
Locale::getKeywords() destroyed the result array and returned when uloc_getKeywordValue() failed, without uenum_close(). Close the enumeration on that path. The success path already does.
