### PR TITLE
ext/gd: Fix incorrect argument numbers in GD affine function errors

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,10 @@ PHP                                                                        NEWS
   . Fixed a use-after-free when cloning a DOMNameSpaceNode after
     DOMDocument::xinclude(). (iliaal)
 
+- GD:
+  . Fixed imageaffinematrixget() and imageaffinematrixconcat() reporting the
+    wrong argument in error messages. (Weilin Du)
+
 - Intl:
   . Fixed a double-free when IntlGregorianCalendar construction fails after
     the ICU constructor adopts the TimeZone. (iliaal)

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -4210,7 +4210,7 @@ PHP_FUNCTION(imageaffinematrixget)
 		case GD_AFFINE_SCALE: {
 			double x, y;
 			if (Z_TYPE_P(options) != IS_ARRAY) {
-				zend_argument_type_error(1, "must be of type array when using translate or scale");
+				zend_argument_type_error(2, "must be of type array when using translate or scale");
 				RETURN_THROWS();
 			}
 
@@ -4291,7 +4291,7 @@ PHP_FUNCTION(imageaffinematrixconcat)
 	}
 
 	if (zend_hash_num_elements(Z_ARRVAL_P(z_m2)) != 6) {
-		zend_argument_value_error(1, "must have 6 elements");
+		zend_argument_value_error(2, "must have 6 elements");
 		RETURN_THROWS();
 	}
 

--- a/ext/gd/tests/bug67248.phpt
+++ b/ext/gd/tests/bug67248.phpt
@@ -17,8 +17,8 @@ for($i=0;$i<7;$i++) {
 }
 ?>
 --EXPECTF--
-!! [TypeError] imageaffinematrixget(): Argument #1 ($type) must be of type array when using translate or scale
-!! [TypeError] imageaffinematrixget(): Argument #1 ($type) must be of type array when using translate or scale
+!! [TypeError] imageaffinematrixget(): Argument #2 ($options) must be of type array when using translate or scale
+!! [TypeError] imageaffinematrixget(): Argument #2 ($options) must be of type array when using translate or scale
 
 Warning: Object of class stdClass could not be converted to float in %s on line %d
 array(6) {

--- a/ext/gd/tests/imageaffinematrixconcat_error.phpt
+++ b/ext/gd/tests/imageaffinematrixconcat_error.phpt
@@ -6,9 +6,9 @@ gd
 <?php
 try {
     imageaffinematrixconcat([1, 0, 0, 1, 0, 0], []);
-} catch (ValueError $e) {
-    echo $e->getMessage(), "\n";
+} catch (ValueError $exception) {
+    echo $exception::class, ': ', $exception->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-imageaffinematrixconcat(): Argument #2 ($matrix2) must have 6 elements
+ValueError: imageaffinematrixconcat(): Argument #2 ($matrix2) must have 6 elements

--- a/ext/gd/tests/imageaffinematrixconcat_error.phpt
+++ b/ext/gd/tests/imageaffinematrixconcat_error.phpt
@@ -1,0 +1,14 @@
+--TEST--
+imageaffinematrixconcat() reports the correct argument for an invalid matrix size
+--EXTENSIONS--
+gd
+--FILE--
+<?php
+try {
+    imageaffinematrixconcat([1, 0, 0, 1, 0, 0], []);
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+imageaffinematrixconcat(): Argument #2 ($matrix2) must have 6 elements

--- a/ext/gd/tests/imageaffinematrixconcat_error.phpt
+++ b/ext/gd/tests/imageaffinematrixconcat_error.phpt
@@ -6,8 +6,8 @@ gd
 <?php
 try {
     imageaffinematrixconcat([1, 0, 0, 1, 0, 0], []);
-} catch (ValueError $exception) {
-    echo $exception::class, ': ', $exception->getMessage(), "\n";
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--


### PR DESCRIPTION
This fixes wrong argument in error message in imageaffinematrixget and mageaffinematrixconcat