### PR TITLE
ext/dom: DOMDocument::adoptNode() stale document references in the ad…

### DIFF
--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -1086,21 +1086,26 @@ static zend_always_inline void php_dom_transfer_document_ref_single_node(xmlNode
 	}
 }
 
-static void php_dom_transfer_document_ref(xmlNodePtr node, php_libxml_ref_obj *new_document)
+static zend_always_inline void php_dom_transfer_document_ref_single_aux(xmlNodePtr node, php_libxml_ref_obj *new_document)
 {
-	if (node->children) {
-		php_dom_transfer_document_ref(node->children, new_document);
-	}
-
-	while (node) {
-		if (node->type == XML_ELEMENT_NODE) {
-			for (xmlAttrPtr attr = node->properties; attr != NULL; attr = attr->next) {
-				php_dom_transfer_document_ref_single_node((xmlNodePtr) attr, new_document);
+	php_dom_transfer_document_ref_single_node(node, new_document);
+	if (node->type == XML_ELEMENT_NODE) {
+		for (xmlAttrPtr attr = node->properties; attr; attr = attr->next) {
+			php_dom_transfer_document_ref_single_node((xmlNodePtr) attr, new_document);
+			for (xmlNodePtr child = attr->children; child; child = child->next) {
+				php_dom_transfer_document_ref_single_node((xmlNodePtr) child, new_document);
 			}
 		}
+	}
+}
 
-		php_dom_transfer_document_ref_single_node(node, new_document);
-		node = node->next;
+static void php_dom_transfer_document_ref(xmlNodePtr node, php_libxml_ref_obj *new_document)
+{
+	php_dom_transfer_document_ref_single_aux(node, new_document);
+	xmlNodePtr tmp = node->children;
+	while (tmp) {
+		php_dom_transfer_document_ref_single_aux(tmp, new_document);
+		tmp = php_dom_next_in_tree_order(tmp, node);
 	}
 }
 

--- a/ext/dom/tests/DOMDocument_adoptNode_sibling_subtree.phpt
+++ b/ext/dom/tests/DOMDocument_adoptNode_sibling_subtree.phpt
@@ -1,0 +1,22 @@
+--TEST--
+DOMDocument::adoptNode() with a node retained under a later sibling
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+$source = new DOMDocument();
+$root = $source->appendChild($source->createElement('root'));
+$root->appendChild($source->createElement('first'));
+$second = $root->appendChild($source->createElement('second'));
+$victim = $second->appendChild($source->createElement('grandchild'));
+
+$destination = new DOMDocument();
+$destination->appendChild($destination->adoptNode($root));
+unset($destination, $source, $root, $second);
+
+echo $victim->nodeName, PHP_EOL;
+
+?>
+--EXPECT--
+grandchild

--- a/ext/dom/tests/gh23352.phpt
+++ b/ext/dom/tests/gh23352.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-23352 (UAF reading an attribute value node retained across DOMDocument::adoptNode())
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+$source = new DOMDocument();
+$element = $source->appendChild($source->createElement('element'));
+$element->setAttribute('attribute', 'victim');
+$victim = $element->getAttributeNode('attribute')->firstChild;
+
+$destination = new DOMDocument();
+$destination->appendChild($destination->adoptNode($element));
+unset($destination, $source, $element);
+
+echo $victim->data, PHP_EOL;
+
+?>
+--EXPECT--
+victim

--- a/ext/dom/tests/modern/spec/gh23352.phpt
+++ b/ext/dom/tests/modern/spec/gh23352.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-23352 (UAF reading an attribute value node retained across Dom\Document::adoptNode())
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+$source = Dom\XMLDocument::createFromString('<root/>');
+$element = $source->documentElement;
+$element->setAttribute('attribute', 'victim');
+$victim = $element->getAttributeNode('attribute')->firstChild;
+
+$destination = Dom\XMLDocument::createEmpty();
+$destination->appendChild($destination->adoptNode($element));
+unset($destination, $source, $element);
+
+echo $victim->data, PHP_EOL;
+
+?>
+--EXPECT--
+victim


### PR DESCRIPTION
…opted subtree.

Fix #23352

php_dom_transfer_document_ref() only retargeted the leftmost descendant chain, and never an attribute's value nodes, leaving retained nodes pointing at the freed source document. Replaced with an iterative walk over the whole subtree.