### PR TITLE
Fix GH-10134: report internal call arguments to GC

### DIFF
--- a/Zend/tests/fibers/gh10134-internal-call-args.phpt
+++ b/Zend/tests/fibers/gh10134-internal-call-args.phpt
@@ -1,0 +1,30 @@
+--TEST--
+GH-10134 (GC sees the arguments of an internal call a fiber is suspended inside)
+--FILE--
+<?php
+
+// No generator involved: the fiber is only kept alive by the array argument of
+// the internal array_map() frame it is suspended inside.
+class Canary {
+    public function __destruct() {
+        var_dump('Canary dtor');
+    }
+}
+
+$canary = new Canary();
+$fiber = new Fiber(function() use (&$fiber, $canary) {
+    array_map(function($x) { Fiber::suspend(); return $x; }, [$fiber]);
+});
+$fiber->start();
+
+$fiber = null;
+$canary = null;
+var_dump(gc_collect_cycles() > 0);
+
+var_dump('Shutdown');
+
+?>
+--EXPECT--
+string(11) "Canary dtor"
+bool(true)
+string(8) "Shutdown"

--- a/Zend/tests/fibers/gh10134.phpt
+++ b/Zend/tests/fibers/gh10134.phpt
@@ -1,0 +1,39 @@
+--TEST--
+GH-10134 (Non-suspended generators in suspended Fiber do not participate in GC)
+--FILE--
+<?php
+
+class Canary {
+    public function __construct(
+        public readonly string $x,
+    ) {
+    }
+
+    public function __destruct() {
+        var_dump($this->x);
+    }
+}
+
+$gen = (function() {
+    $canary = new Canary('Generator dtor');
+    $fiber = yield;
+    Fiber::suspend();
+})();
+
+$fiber = new Fiber(function() use ($gen, &$fiber) {
+    $canary = new Canary('Fiber dtor');
+    $gen->send($fiber);
+});
+$fiber->start();
+
+$gen = null;
+$fiber = null;
+gc_collect_cycles();
+
+var_dump('Shutdown');
+
+?>
+--EXPECT--
+string(14) "Generator dtor"
+string(10) "Fiber dtor"
+string(8) "Shutdown"

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -5012,6 +5012,17 @@ ZEND_API HashTable *zend_unfinished_execution_gc_ex(zend_execute_data *execute_d
 
 	if (!ZEND_USER_CODE(EX(func)->common.type)) {
 		ZEND_ASSERT(!(EX_CALL_INFO() & (ZEND_CALL_HAS_SYMBOL_TABLE|ZEND_CALL_FREE_EXTRA_ARGS|ZEND_CALL_HAS_EXTRA_NAMED_PARAMS)));
+		/* An internal function frame owns the arguments that were pushed for it and releases
+		 * them when it returns. Execution can be suspended inside such a call: a fiber that
+		 * suspends below an internal function leaves that frame on its stack, e.g.
+		 * Fiber::suspend() reached through Generator::send($arg). The arguments are then still
+		 * live, so they have to be reported or a cycle running through one of them is never
+		 * collected. Entered calls are removed from the caller's EX(call) chain, so these are
+		 * not also reported by zend_unfinished_calls_gc(). */
+		uint32_t num_args = ZEND_CALL_NUM_ARGS(execute_data);
+		for (uint32_t i = 0; i < num_args; i++) {
+			zend_get_gc_buffer_add_zval(gc_buffer, ZEND_CALL_VAR_NUM(execute_data, i));
+		}
 		return NULL;
 	}
 


### PR DESCRIPTION
Fixes GH-10134.

## The bug

A fiber can be suspended *below* an internal function. That leaves the internal frame parked on the fiber's stack with the arguments that were pushed for it still live — the frame owns them and only releases them when it returns.

`zend_unfinished_execution_gc_ex()` returns early for internal frames without reporting those arguments:

```c
if (!ZEND_USER_CODE(EX(func)->common.type)) {
    ZEND_ASSERT(...);
    return NULL;          /* arguments never reported */
}
```

So the cycle collector never sees them, and any cycle running through such an argument is uncollectable — it is only broken at request shutdown.

## Not specific to generators

GH-10134 reports this as a generator problem, because the reporter hit it through `Fiber::suspend()` inside a generator resumed by `Generator::send($fiber)` — `$fiber` lands in the argument slot of the internal `Generator::send` frame. But nothing about it is generator-specific. With no generator anywhere, a fiber suspended inside `array_map()` whose array argument holds the fiber behaves identically (second test added here).

## How it was diagnosed

`zend_fiber_object_gc()` is not at fault — it correctly walks the suspended fiber's frames, finds the generator frame, and calls `zend_generator_frame_gc()` on it. Instrumenting the collector's root processing showed the actual failure:

```
[root-before]     Fiber rc=2  PURPLE
  reported obj    Fiber rc=2            <- reported once
[root-after-mark] Fiber rc=1  GREY
[root-after-mark] Generator rc=3        <- restored from 0
```

The Fiber's refcount is 2 but the mark phase discovers only one of those references, so it lands at 1 instead of 0, `gc_scan` concludes it is externally referenced, and `gc_scan_black` restores every refcount it had decremented. Dumping the frames shows where the second reference lives:

```
frame ... INTERNAL func=send nargs=1
   ARG[0] type=8 Fiber 0x...      <- never reported
```

## On double counting

This was the main risk. It does not happen: on `ZEND_DO_ICALL` / `ZEND_DO_FCALL` the VM does `EX(call) = call->prev_execute_data`, so an *entered* frame is no longer in its caller's `EX(call)` chain and is therefore not also scanned by `zend_unfinished_calls_gc()`, which only walks calls that are still being built. Those pending frames are siblings rather than ancestors, so they never show up in the `prev_execute_data` walk either.

`zend_unfinished_execution_gc_ex()` has two callers. `zend_generator_frame_gc()` always passes `generator->execute_data`, which is user code, so only the fiber path is affected in practice.

## Testing

- Both new tests **fail on unmodified master and pass with this change** — I ran them against a pristine build to confirm they are real regression guards.
- The issue's verbatim script now prints the expected order (`Generator dtor`, `Fiber dtor`, `Shutdown`) instead of `Shutdown` first, and `gc_collect_cycles()` returns 1 instead of 0.
- **No premature frees**, which is the thing to worry about when handing GC additional edges: an object passed as an internal-frame argument that is *also* still referenced from live scope survives `gc_collect_cycles()` and remains usable. Checked explicitly.
- Full test suite on this build (`--disable-all --enable-debug`): **13386 passed, 0 failed, 0 warned** (7 expected-fail, the rest skipped for disabled extensions).
- `Zend/tests/fibers` and `Zend/tests/gc` under valgrind memcheck: clean.

Built and tested on Linux x86_64, `--disable-all --enable-debug`, so the extension-heavy parts of the suite were skipped; a normal CI run would cover those.
