### PR TITLE
Fix GH-23385: Use-after-free in SplDoublyLinkedList::serialize()

### DIFF
--- a/ext/spl/spl_dllist.c
+++ b/ext/spl/spl_dllist.c
@@ -1019,10 +1019,15 @@ PHP_METHOD(SplDoublyLinkedList, serialize)
 		smart_str_appendc(&buf, ':');
 		next = current->next;
 
+		/* Serializing an element can run user code, which may remove this
+		 * element (and its neighbour) from the list, so hold a reference on
+		 * both for the duration of the call. */
+		SPL_LLIST_ADDREF(current);
 		SPL_LLIST_CHECK_ADDREF(next);
 
 		php_var_serialize(&buf, &current->data, &var_hash);
 
+		SPL_LLIST_DELREF(current);
 		SPL_LLIST_CHECK_DELREF_EX(next, break;);
 
 		current = next;

--- a/ext/spl/tests/gh23385.phpt
+++ b/ext/spl/tests/gh23385.phpt
@@ -1,0 +1,57 @@
+--TEST--
+GH-23385 (Use-after-free in SplDoublyLinkedList::serialize())
+--FILE--
+<?php
+class RemoveSelf {
+    public function __serialize(): array {
+        global $list;
+        unset($list[0]);
+        return [];
+    }
+}
+
+$list = new SplDoublyLinkedList();
+$list->push([new RemoveSelf(), [1, 2, 3]]);
+$list->push("tail");
+var_dump($list->serialize());
+var_dump($list->count());
+
+class RemoveNext {
+    public function __serialize(): array {
+        global $list2;
+        unset($list2[1]);
+        return [];
+    }
+}
+
+$list2 = new SplDoublyLinkedList();
+$list2->push(new RemoveNext());
+$list2->push("removed");
+$list2->push("after");
+var_dump($list2->serialize());
+var_dump($list2->count());
+
+class RemoveAll {
+    public function __serialize(): array {
+        global $list3;
+        while (!$list3->isEmpty()) {
+            $list3->pop();
+        }
+        return [];
+    }
+}
+
+$list3 = new SplDoublyLinkedList();
+$list3->push([new RemoveAll(), [1, 2]]);
+$list3->push("x");
+$list3->push("y");
+var_dump($list3->serialize());
+var_dump($list3->count());
+?>
+--EXPECTF--
+string(%d) "i:0;:a:2:{i:0;O:10:"RemoveSelf":0:{}i:1;a:3:{i:0;i:1;i:1;i:2;i:2;i:3;}}:s:4:"tail";"
+int(1)
+string(%d) "i:0;:O:10:"RemoveNext":0:{}"
+int(2)
+string(%d) "i:0;:a:2:{i:0;O:9:"RemoveAll":0:{}i:1;a:2:{i:0;i:1;i:1;i:2;}}"
+int(0)

--- a/ext/standard/tests/serialize/serialize_array_ref_reentrancy.phpt
+++ b/ext/standard/tests/serialize/serialize_array_ref_reentrancy.phpt
@@ -1,0 +1,21 @@
+--TEST--
+serialize(): a by-reference __serialize() that grows the array being walked must not free it
+--FILE--
+<?php
+class G {
+    public $ref;
+    public function __serialize(): array {
+        for ($i = 0; $i < 128; $i++) {
+            $this->ref[] = 'x' . $i;
+        }
+        return ['d' => 1];
+    }
+}
+$g = new G();
+$inner = [$g, 'tail'];
+$g->ref = &$inner;
+$top = [&$inner];
+var_dump(serialize($top));
+?>
+--EXPECT--
+string(59) "a:1:{i:0;a:2:{i:0;O:1:"G":1:{s:1:"d";i:1;}i:1;s:4:"tail";}}"

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -1319,13 +1319,17 @@ again:
 				zend_release_properties(myht);
 				return;
 			}
-		case IS_ARRAY:
+		case IS_ARRAY: {
 			smart_str_appendl(buf, "a:", 2);
 			myht = Z_ARRVAL_P(struc);
+			bool rcn = !is_root && (in_rcn_array || GC_REFCOUNT(myht) > 1);
+			GC_TRY_ADDREF(myht);
 			php_var_serialize_nested_data(
 				buf, struc, myht, zend_array_count(myht), /* incomplete_class */ 0, var_hash,
-					!is_root && (in_rcn_array || GC_REFCOUNT(myht) > 1));
+					rcn);
+			GC_TRY_DTOR_NO_REF(myht);
 			return;
+		}
 		case IS_REFERENCE:
 			struc = Z_REFVAL_P(struc);
 			goto again;


### PR DESCRIPTION
Fixes GH-23385.

### The SPL side

`SplDoublyLinkedList::serialize()` walks the list and passes each element's zval straight to `php_var_serialize()`:

```c
	while (current) {
		next = current->next;
		SPL_LLIST_CHECK_ADDREF(next);
		php_var_serialize(&buf, &current->data, &var_hash);
		SPL_LLIST_CHECK_DELREF_EX(next, break;);
		current = next;
	}
```

Serializing an element can re-enter userland (`__serialize`, `__sleep`, `Serializable::serialize`), and that code can remove the element that is being serialized. The loop already anticipates this for the *next* element but not for the current one, so `offsetUnset()` drops the last reference and frees it while `php_var_serialize()` still uses `&current->data` as its `struc` argument.

The element is already built to outlive its removal from the list, see the "Keep consistency if element is kept alive" branch in `offsetUnset()`, so taking a reference for the duration of the call is all that is needed.

### Why there are two commits

The reproducer in the issue frees two different things, and only one of them is the SPL bug.

`offsetUnset()` also destroys `element->data`, which drops the array's last reference while `php_var_serialize_nested_data()` is iterating it. That half was already fixed on master by cc8abaf9f (GH-22714), which holds a ref on the HashTable across the walk, but that commit never made it to PHP-8.4/8.5. So on this branch the issue's reproducer still crashes there even with the SPL fix applied.

The first commit is that backport, unchanged apart from the surrounding `incomplete_class` argument style on this branch, together with its test. Please drop it if you would rather merge cc8abaf9f up yourself; the second commit stands on its own and merges up cleanly.

### Verification

Built PHP-8.4 (`--disable-all --enable-debug`) with ASan and `USE_ZEND_ALLOC=0`.

Before, the issue's reproducer:

```
==1803822==ERROR: AddressSanitizer: heap-use-after-free
READ of size 4 ... php_var_serialize_nested_data var.c:1009
freed by ... zim_SplDoublyLinkedList_offsetUnset spl_dllist.c:758
```

After, both that reproducer and a variant that hits only the SPL half (a nested array after the object, so the walk dereferences `struc` again once the element is gone) run clean, with no leaks reported.

`ext/spl/` and `ext/standard/tests/serialize/`: 920 pass, same 4 pre-existing failures as an unpatched checkout of this branch in the same ASan build (RecursiveIteratorIterator_dtor_order, bug79710, bug67247, bug77751). Unpatched: 918 pass, so the delta is exactly the two added tests.

The new `gh23385.phpt` covers three shapes: an element removing itself, an element removing its successor, and an element clearing the whole list.

### Note on AI use

I used Claude Code while working on this. I reproduced the crash, wrote and reviewed the change, and ran the test suites myself.