### PR TITLE
fix: tambah fpm_trace_continue() pada backend trace mach

### DIFF
--- a/sapi/fpm/fpm/fpm_trace_mach.c
+++ b/sapi/fpm/fpm/fpm_trace_mach.c
@@ -51,6 +51,15 @@ int fpm_trace_signal(pid_t pid) /* {{{ */
 }
 /* }}} */
 
+int fpm_trace_continue(pid_t pid) /* {{{ */
+{
+	if (0 > fpm_pctl_kill(pid, FPM_PCTL_CONT)) {
+		zlog(ZLOG_SYSERROR, "failed to send SIGCONT to %d", pid);
+		return -1;
+	}
+	return 0;
+}
+
 int fpm_trace_ready(pid_t pid) /* {{{ */
 {
 	kern_return_t kr;


### PR DESCRIPTION
## Description

This PR adds support for resuming a process (`SIGCONT`) that was previously stopped via `ptrace` in the macOS backend.

The macOS backend already provides functionality for stopping a traced process. This change complements that behavior by adding the corresponding resume functionality, allowing a stopped process to continue execution when required.

This makes the process-control behavior more complete and provides a proper counterpart to the existing stop operation on macOS.

## Changes

* Added functionality to resume a previously stopped process using `SIGCONT`.
* Integrated the resume operation into the macOS `ptrace` backend.
* Complements the existing process-stop functionality.
