### PR TITLE
ext/pgsql: fix the class name casing of pg_close_stmt()'s connection

### DIFF
--- a/ext/pgsql/pgsql.stub.php
+++ b/ext/pgsql/pgsql.stub.php
@@ -956,7 +956,7 @@ namespace {
     function pg_set_chunked_rows_size(PgSql\Connection $connection, int $size): bool {}
 #endif
 #ifdef HAVE_PG_CLOSE_STMT
-    function pg_close_stmt(Pgsql\Connection $connection, string $statement_name): PgSql\Result|false {}
+    function pg_close_stmt(PgSql\Connection $connection, string $statement_name): PgSql\Result|false {}
 #endif
 }
 

--- a/ext/pgsql/pgsql_arginfo.h
+++ b/ext/pgsql/pgsql_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit pgsql.stub.php instead.
- * Stub hash: f25b5a574c96d4bc2f08b8cacab16f499a164a6b */
+ * Stub hash: fa7cd778f4e791b15ffc8f1786384332449bda5a */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_pg_connect, 0, 1, PgSql\\Connection, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, connection_string, IS_STRING, 0)
@@ -503,7 +503,7 @@ ZEND_END_ARG_INFO()
 
 #if defined(HAVE_PG_CLOSE_STMT)
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_pg_close_stmt, 0, 2, PgSql\\Result, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, connection, Pgsql\\Connection, 0)
+	ZEND_ARG_OBJ_INFO(0, connection, PgSql\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, statement_name, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif

--- a/ext/pgsql/tests/pg_close_stmt_parameter_type.phpt
+++ b/ext/pgsql/tests/pg_close_stmt_parameter_type.phpt
@@ -1,0 +1,22 @@
+--TEST--
+pg_close_stmt(): the connection parameter is typed like every other pgsql function
+--EXTENSIONS--
+pgsql
+--SKIPIF--
+<?php
+if (!function_exists('pg_close_stmt')) die('skip pg_close_stmt() requires libpq >= 17');
+?>
+--FILE--
+<?php
+
+foreach (['pg_close_stmt', 'pg_connect_poll'] as $function) {
+    $parameter = (new ReflectionFunction($function))->getParameters()[0];
+    printf("%-16s %s\n", $function, $parameter->getType());
+}
+
+var_dump((new ReflectionClass(PgSql\Connection::class))->getName());
+?>
+--EXPECT--
+pg_close_stmt    PgSql\Connection
+pg_connect_poll  PgSql\Connection
+string(16) "PgSql\Connection"


### PR DESCRIPTION
`pg_close_stmt()` declares its connection as `Pgsql\Connection`:

```php
function pg_close_stmt(Pgsql\Connection $connection, string $statement_name): PgSql\Result|false {}
```

The class is `PgSql\Connection`, declared that way a few lines below in the same stub and spelled that way by the other thirty-one references in the generated arginfo. This was the only `Pgsql` left in the extension.

Class name resolution is case-insensitive, so nothing breaks at runtime; what leaks is the declaration. On builds where the function exists (libpq >= 17), `ReflectionParameter::getType()` reports `Pgsql\Connection` for this one function and `PgSql\Connection` for every other. The return type on the same line already says `PgSql\Result`.

`pgsql_arginfo.h` is regenerated: one `ZEND_ARG_OBJ_INFO` line plus the stub hash, and no `Pgsql` remains in the file.

The added test needs no server: it reads the declared types through Reflection, prints `pg_close_stmt()` next to `pg_connect_poll()`, which takes the same non-nullable typed connection, and checks both against the class name. It skips where `pg_close_stmt()` is not compiled in.
