### PR TITLE
ext/sodium: Fix parameter name in the length-mismatch errors

### DIFF
--- a/ext/sodium/libsodium.c
+++ b/ext/sodium/libsodium.c
@@ -257,7 +257,7 @@ PHP_FUNCTION(sodium_add)
 	val = (unsigned char *) Z_STRVAL(*val_zv);
 	val_len = Z_STRLEN(*val_zv);
 	if (val_len != addv_len) {
-		zend_argument_error(sodium_exception_ce, 1, "and argument #2 ($string_2) must have the same length");
+		zend_argument_error(sodium_exception_ce, 1, "and argument #2 ($string2) must have the same length");
 		RETURN_THROWS();
 	}
 	sodium_add(val, addv, val_len);
@@ -277,7 +277,7 @@ PHP_FUNCTION(sodium_memcmp)
 		RETURN_THROWS();
 	}
 	if (len1 != len2) {
-		zend_argument_error(sodium_exception_ce, 1, "and argument #2 ($string_2) must have the same length");
+		zend_argument_error(sodium_exception_ce, 1, "and argument #2 ($string2) must have the same length");
 		RETURN_THROWS();
 	}
 	RETURN_LONG(sodium_memcmp(buf1, buf2, len1));
@@ -3038,7 +3038,7 @@ PHP_FUNCTION(sodium_compare)
 		RETURN_THROWS();
 	}
 	if (len1 != len2) {
-		zend_argument_error(sodium_exception_ce, 1, "and argument #2 ($string_2) must have the same length");
+		zend_argument_error(sodium_exception_ce, 1, "and argument #2 ($string2) must have the same length");
 		RETURN_THROWS();
 	} else {
 		RETURN_LONG(sodium_compare((const unsigned char *) buf1,

--- a/ext/sodium/tests/sodium_length_mismatch_error.phpt
+++ b/ext/sodium/tests/sodium_length_mismatch_error.phpt
@@ -1,0 +1,31 @@
+--TEST--
+The length-mismatch errors name the real second parameter
+--EXTENSIONS--
+sodium
+--FILE--
+<?php
+
+$short = str_repeat("\x01", 4);
+$long = str_repeat("\x01", 8);
+
+foreach (['sodium_add', 'sodium_memcmp', 'sodium_compare'] as $function) {
+    try {
+        $first = $short;
+        $function($first, $long);
+    } catch (SodiumException $e) {
+        echo $e->getMessage(), "\n";
+    }
+}
+
+/* the messages name argument #2, so that name has to be the real one */
+foreach ((new ReflectionFunction('sodium_add'))->getParameters() as $parameter) {
+    echo '$', $parameter->getName(), "\n";
+}
+
+?>
+--EXPECT--
+sodium_add(): Argument #1 ($string1) and argument #2 ($string2) must have the same length
+sodium_memcmp(): Argument #1 ($string1) and argument #2 ($string2) must have the same length
+sodium_compare(): Argument #1 ($string1) and argument #2 ($string2) must have the same length
+$string1
+$string2

--- a/ext/sodium/tests/sodium_length_mismatch_error.phpt
+++ b/ext/sodium/tests/sodium_length_mismatch_error.phpt
@@ -12,8 +12,8 @@ foreach (['sodium_add', 'sodium_memcmp', 'sodium_compare'] as $function) {
     try {
         $first = $short;
         $function($first, $long);
-    } catch (SodiumException $e) {
-        echo $e->getMessage(), "\n";
+    } catch (Throwable $e) {
+        echo $e::class, ': ', $e->getMessage(), "\n";
     }
 }
 
@@ -24,8 +24,8 @@ foreach ((new ReflectionFunction('sodium_add'))->getParameters() as $parameter) 
 
 ?>
 --EXPECT--
-sodium_add(): Argument #1 ($string1) and argument #2 ($string2) must have the same length
-sodium_memcmp(): Argument #1 ($string1) and argument #2 ($string2) must have the same length
-sodium_compare(): Argument #1 ($string1) and argument #2 ($string2) must have the same length
+SodiumException: sodium_add(): Argument #1 ($string1) and argument #2 ($string2) must have the same length
+SodiumException: sodium_memcmp(): Argument #1 ($string1) and argument #2 ($string2) must have the same length
+SodiumException: sodium_compare(): Argument #1 ($string1) and argument #2 ($string2) must have the same length
 $string1
 $string2


### PR DESCRIPTION
The length-mismatch errors of `sodium_add()`, `sodium_memcmp()` and `sodium_compare()` refer to `$string_2`, which does not exist. All three functions declare `$string2`.

The `Argument #1 ($string1)` part is generated from the arginfo and was already correct; only the hardcoded cross-reference to the second argument was stale.

The added test triggers the mismatch on all three functions and lists `sodium_add()`'s parameter names through Reflection, so a later rename that forgets these messages fails the test.
