### PR TITLE
Fixed GH-22727: Attribute return opcodes to return statement

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,8 @@ PHP                                                                        NEWS
 - Core:
   . Fixed bug GH-15375 (Nested "yield from" skips items after a valid() or
     next() call on the inner generator). (iliaal)
+  . Fixed bug GH-22727 (RETURN opcodes for multiline expressions use the wrong
+    line). (Joost Waaijer)
   . Fixed bug GH-23301 (Nested "yield from" yields a value twice when the
     middle generator delegates again). (Lazizbek Ergashev)
 

--- a/Zend/tests/gh22727.phpt
+++ b/Zend/tests/gh22727.phpt
@@ -12,10 +12,10 @@ function test(): int
 
 try {
     test();
-} catch (TypeError $exception) {
-    echo $exception->getLine(), "\n";
+} catch (Throwable $e) {
+    echo $e::class, ': on line ', $e->getLine(), "\n";
 }
 
 ?>
 --EXPECT--
-5
+TypeError: on line 5

--- a/Zend/tests/gh22727.phpt
+++ b/Zend/tests/gh22727.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-22727: Return opcodes use the return statement line for multiline expressions
+--FILE--
+<?php
+
+function test(): int
+{
+    return match (true) {
+        true => 'not an int',
+    };
+}
+
+try {
+    test();
+} catch (TypeError $exception) {
+    echo $exception->getLine(), "\n";
+}
+
+?>
+--EXPECT--
+5

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5687,6 +5687,7 @@ static bool zend_has_finally(void) /* {{{ */
 static void zend_compile_return(zend_ast *ast) /* {{{ */
 {
 	zend_ast *expr_ast = ast->child[0];
+	uint32_t return_lineno = CG(zend_lineno);
 	bool is_generator = (CG(active_op_array)->fn_flags & ZEND_ACC_GENERATOR) != 0;
 	bool by_ref = (CG(active_op_array)->fn_flags & ZEND_ACC_RETURN_REFERENCE) != 0;
 
@@ -5707,6 +5708,8 @@ static void zend_compile_return(zend_ast *ast) /* {{{ */
 	} else {
 		zend_compile_expr(&expr_node, expr_ast);
 	}
+
+	CG(zend_lineno) = return_lineno;
 
 	if ((CG(active_op_array)->fn_flags & ZEND_ACC_HAS_FINALLY_BLOCK)
 	 && (expr_node.op_type == IS_CV || (by_ref && expr_node.op_type == IS_VAR))


### PR DESCRIPTION
> [!NOTE]
> This pull request description was prepared with assistance from OpenAI Codex and reviewed by the contributor.
>
> `zend_compile_return()` currently leaves `CG(zend_lineno)` at the last line compiled inside a multiline return expression. As a result, `VERIFY_RETURN_TYPE` and `RETURN` are attributed to a match arm or ternary branch instead of the `return` statement. Coverage drivers then omit the actual return line and may report a different branch line as executed. This is the specific return-expression case described in GH-22727 and is part of the broader GH-18985 issue.
>
> This patch captures the statement line before compiling the expression and restores it before emitting return-related opcodes. It deliberately avoids the broader expression compiler changes from GH-22833 that were reverted.
>
> A PHPT regression test verifies the user-visible TypeError line. The test fails on PHP 8.4.24 with line 6 instead of line 5, and passes on the patched PHP 8.4.26-dev build.
>
> Validation: debug NTS build with all `Zend/tests` (4,837 passed, 134 skipped, 1 expected failure, 0 failures); debug ZTS build with the focused regression test; and PCOV 1.0.12 verification showing the direct `return match` line changes from absent to hit count 1.