### PR TITLE
Fix GH-23332: ArrayObject iterator saturation leads to UAF

### DIFF
--- a/Zend/tests/gh23332.phpt
+++ b/Zend/tests/gh23332.phpt
@@ -1,0 +1,37 @@
+--TEST--
+GH-23332: Saturation of ArrayObject iterator leads to UAF
+--FILE--
+<?php
+$owner = new ArrayObject(['entry' => 1337]);
+
+$iterators = [];
+for ($i = 0; $i < 255; $i++) {
+  $it = $owner->getIterator();
+  $it->rewind();
+  $iterators[] = $it;
+}
+unset($it);
+
+$array = (array) $owner;
+
+$pass = 0;
+$retained = null;
+foreach ($array as &$value) {
+  if (++$pass === 1) {
+    $retained = $array;
+    $array = ['replacement' => 4242];
+    continue;
+  }
+  for ($i = 0; $i < 254; $i++) {
+    unset($iterators[$i]);
+  }
+  $retained = null;
+  unset($iterators[254]);
+}
+
+echo "done\n";
+var_dump($pass);
+?>
+--EXPECT--
+done
+int(2)

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -632,7 +632,7 @@ ZEND_API HashPosition ZEND_FASTCALL zend_hash_iterator_pos_ex(uint32_t idx, zval
 	ZEND_ASSERT(idx != (uint32_t)-1);
 	if (UNEXPECTED(iter->ht != ht) && !zend_hash_iterator_find_copy_pos(idx, ht)) {
 		if (EXPECTED(iter->ht) && EXPECTED(iter->ht != HT_POISONED_PTR)
-				&& EXPECTED(!HT_ITERATORS_OVERFLOW(ht))) {
+				&& EXPECTED(!HT_ITERATORS_OVERFLOW(iter->ht))) {
 			HT_DEC_ITERATORS_COUNT(iter->ht);
 		}
 


### PR DESCRIPTION
This fixes https://github.com/php/php-src/issues/23332

Before decrementing the iterator count, `zend_hash_iterator_pos_ex()` checked the overflow state of the wrong hash table. The check used the new hash table (`ht`), while the count was decremented on the iterator's current hash table (`iter->ht`).

When the current hash table's iterator count was saturated, this could make the count inconsistent and eventually lead to a use-after-free.