### PR TITLE
Fix GH-23332: HashTable iterator counter loses its saturation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,8 @@ PHP                                                                        NEWS
     next() call on the inner generator). (iliaal)
   . Fixed bug GH-23301 (Nested "yield from" yields a value twice when the
     middle generator delegates again). (Lazizbek Ergashev)
+  . Fixed bug GH-23332 (Saturation of the HashTable iterator counter leads to
+    UAF). (luizmenos, iliaal)
 
 - DOM:
   . Fixed a use-after-free when cloning a DOMNameSpaceNode after

--- a/Zend/tests/gh23332.phpt
+++ b/Zend/tests/gh23332.phpt
@@ -1,0 +1,45 @@
+--TEST--
+GH-23332 (Saturation of the HashTable iterator counter leads to UAF)
+--FILE--
+<?php
+function gen(array &$a) {
+    foreach ($a as &$v) {
+        yield;
+    }
+}
+
+$a = ['first' => 1, 'second' => 2, 'third' => 3];
+
+// Saturate $a's iterator counter (it caps at 255).
+$gens = [];
+for ($i = 0; $i < 255; $i++) {
+    $g = gen($a);
+    $g->current();
+    $gens[] = $g;
+}
+unset($g);
+
+$array = $a;
+
+$pass = 0;
+$retained = null;
+foreach ($array as $key => &$value) {
+    echo "pass ", ++$pass, ": $key => $value\n";
+    if ($pass === 1) {
+        $retained = $array;
+        $array = ['replacement' => 4242];
+        continue;
+    }
+    for ($i = 0; $i < 254; $i++) {
+        unset($gens[$i]);
+    }
+    $retained = null;
+    unset($gens[254]);
+}
+
+echo "done\n";
+?>
+--EXPECT--
+pass 1: first => 1
+pass 2: replacement => 4242
+done

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -632,7 +632,7 @@ ZEND_API HashPosition ZEND_FASTCALL zend_hash_iterator_pos_ex(uint32_t idx, zval
 	ZEND_ASSERT(idx != (uint32_t)-1);
 	if (UNEXPECTED(iter->ht != ht) && !zend_hash_iterator_find_copy_pos(idx, ht)) {
 		if (EXPECTED(iter->ht) && EXPECTED(iter->ht != HT_POISONED_PTR)
-				&& EXPECTED(!HT_ITERATORS_OVERFLOW(ht))) {
+				&& EXPECTED(!HT_ITERATORS_OVERFLOW(iter->ht))) {
 			HT_DEC_ITERATORS_COUNT(iter->ht);
 		}
 


### PR DESCRIPTION
zend_hash_iterator_pos_ex() decrements iter->ht's iterator counter while gating that decrement on ht's overflow state. A saturated counter can therefore drop below 0xff and later reach zero with iterators still live, so zend_array_destroy() frees the table without poisoning them. Wrong since ebf900a9ebd.

Generators reach the same code as ArrayObject, so the test uses them and lives in Zend/tests. It is red only on a debug build; on a release build valgrind reports the invalid read and write.

luizmenos found the same one-line change independently in #23399 and closed it in favor of this one; NEWS credits both of us.

Fixes GH-23332
