### PR TITLE
ext/standard: Change return type of header_register_callback() to true

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -598,6 +598,9 @@ PHP 8.6 UPGRADE NOTES
     constants).
 
 - Standard:
+  . header_register_callback() now declares true as its return type. It has not
+    been able to return false since PHP 8.0.0, where passing an invalid
+    callback started throwing a TypeError instead.
   . ini_get_all() now includes a "builtin_default_value" element for each
     directive when $details is true. It holds the built-in default value of the
     directive (or null if it has none), independent of values set in php.ini,

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -1505,7 +1505,7 @@ function set_time_limit(int $seconds): bool {}
 
 /* main/SAPI.c */
 
-function header_register_callback(callable $callback): bool {}
+function header_register_callback(callable $callback): true {}
 
 /* main/output.c */
 

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,12 +1,12 @@
 /* This is a generated file, edit basic_functions.stub.php instead.
- * Stub hash: cf2ea35cd867f7091ee1fcf83bbfb543b51e5786
+ * Stub hash: 13b6fd340958d1a7c782c8f5f3685517e62e5edc
  * Has decl header: yes */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_header_register_callback, 0, 1, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_header_register_callback, 0, 1, IS_TRUE, 0)
 	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/standard/basic_functions_decl.h
+++ b/ext/standard/basic_functions_decl.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit basic_functions.stub.php instead.
- * Stub hash: cf2ea35cd867f7091ee1fcf83bbfb543b51e5786 */
+ * Stub hash: 13b6fd340958d1a7c782c8f5f3685517e62e5edc */
 
-#ifndef ZEND_BASIC_FUNCTIONS_DECL_cf2ea35cd867f7091ee1fcf83bbfb543b51e5786_H
-#define ZEND_BASIC_FUNCTIONS_DECL_cf2ea35cd867f7091ee1fcf83bbfb543b51e5786_H
+#ifndef ZEND_BASIC_FUNCTIONS_DECL_13b6fd340958d1a7c782c8f5f3685517e62e5edc_H
+#define ZEND_BASIC_FUNCTIONS_DECL_13b6fd340958d1a7c782c8f5f3685517e62e5edc_H
 
 typedef enum zend_enum_SortDirection {
 	ZEND_ENUM_SortDirection_Ascending = 1,
@@ -20,4 +20,4 @@ typedef enum zend_enum_RoundingMode {
 	ZEND_ENUM_RoundingMode_PositiveInfinity = 8,
 } zend_enum_RoundingMode;
 
-#endif /* ZEND_BASIC_FUNCTIONS_DECL_cf2ea35cd867f7091ee1fcf83bbfb543b51e5786_H */
+#endif /* ZEND_BASIC_FUNCTIONS_DECL_13b6fd340958d1a7c782c8f5f3685517e62e5edc_H */


### PR DESCRIPTION
`header_register_callback()` is declared as returning `bool`, but `PHP_FUNCTION(header_register_callback)` in `main/SAPI.c` has a single non-throwing exit, `RETURN_TRUE`.

The `false` return is a leftover from PHP 7:

```c
/* php-7.0.0, main/SAPI.c */
if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &callback_func) == FAILURE) {
    return;
}
if (!zend_is_callable(callback_func, 0, NULL)) {
    RETURN_FALSE;
}
```

PHP 8.0.0 moved the check to the `f` parameter specifier, which throws a `TypeError`, and the `RETURN_FALSE` went away with it. The declared type was never adjusted.

Checked on 8.4.22 and 8.5.8: every accepted callable form (closure, function name, `Class::method`, `[$obj, 'method']`, `__invoke` object, first-class callable syntax) returns `true`, an invalid callback throws `TypeError`, and registering after `headers_sent()` is already `true` — the case where the callback is knowingly discarded — returns `true` as well.

`true` being a subtype of `bool`, the only observable change is what Reflection reports.

Whether the `headers_sent` branch ought to report failure instead is a behaviour question, deliberately left out of this change.
