### PR TITLE
CI: Build apache module on Unix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,8 @@ jobs:
               ldap-utils \
               openssl \
               slapd \
+              apache2 \
+              apache2-dev \
               libgmp-dev \
               libicu-dev \
               libtidy-dev \
@@ -90,6 +92,7 @@ jobs:
               --prefix=/usr \
               --enable-phpdbg \
               --enable-fpm \
+              --with-apxs2 \
               --with-pdo-mysql=mysqlnd \
               --with-mysqli=mysqlnd \
               --with-pgsql \

--- a/.github/actions/apk/action.yml
+++ b/.github/actions/apk/action.yml
@@ -55,6 +55,8 @@ runs:
             openldap-dev \
             unixodbc-dev \
             postgresql-dev \
+            apache2 \
+            apache2-dev \
             tzdata \
             musl-locales \
             musl-locales-lang \

--- a/.github/actions/apt-x32/action.yml
+++ b/.github/actions/apt-x32/action.yml
@@ -13,6 +13,8 @@ runs:
         apt-get update -y | true
         # TODO: Reenable postgresql + postgresql-contrib packages once they work again.
         apt-get install -y \
+          apache2:i386 \
+          apache2-dev:i386 \
           autoconf \
           bison \
           curl \

--- a/.github/actions/apt-x64/action.yml
+++ b/.github/actions/apt-x64/action.yml
@@ -22,6 +22,8 @@ runs:
 
         sudo apt-get update -y | true
         sudo apt-get install -y \
+          apache2 \
+          apache2-dev \
           autoconf \
           gcc \
           make \

--- a/.github/actions/brew/action.yml
+++ b/.github/actions/brew/action.yml
@@ -36,3 +36,5 @@ runs:
           libxslt \
           openssl@4
         brew link --force --overwrite openssl@4
+        brew install -v \
+          httpd

--- a/.github/actions/configure-alpine/action.yml
+++ b/.github/actions/configure-alpine/action.yml
@@ -18,6 +18,7 @@ runs:
           --prefix=/usr \
           --enable-phpdbg \
           --enable-fpm \
+          --with-apxs2 \
           --with-pdo-mysql=mysqlnd \
           --with-mysqli=mysqlnd \
           ${{ inputs.skipSlow == 'false' && '--with-pgsql' || '' }} \

--- a/.github/actions/configure-gentoo/action.yml
+++ b/.github/actions/configure-gentoo/action.yml
@@ -19,6 +19,7 @@ runs:
           --with-libdir=lib64 \
           --enable-phpdbg \
           --enable-fpm \
+          --with-apxs2 \
           --with-pdo-mysql=mysqlnd \
           --with-mysqli=mysqlnd \
           ${{ inputs.skipSlow == 'false' && '--with-pgsql' || '' }} \

--- a/.github/actions/configure-macos/action.yml
+++ b/.github/actions/configure-macos/action.yml
@@ -24,6 +24,7 @@ runs:
           --enable-option-checking=fatal \
           --prefix=/usr/local \
           --enable-fpm \
+          --with-apxs2 \
           --with-pdo-mysql=mysqlnd \
           --with-mysqli=mysqlnd \
           --with-pgsql="$BREW_OPT"/libpq \

--- a/.github/actions/configure-x32/action.yml
+++ b/.github/actions/configure-x32/action.yml
@@ -21,6 +21,7 @@ runs:
             --prefix=/usr \
             --enable-phpdbg \
             --enable-fpm \
+            --with-apxs2 \
             --enable-intl \
             --with-pdo-mysql=mysqlnd \
             --with-mysqli=mysqlnd \

--- a/.github/actions/configure-x64/action.yml
+++ b/.github/actions/configure-x64/action.yml
@@ -21,6 +21,7 @@ runs:
           --prefix=/usr \
           --enable-phpdbg \
           --enable-fpm \
+          --with-apxs2 \
           --with-pdo-mysql=mysqlnd \
           --with-mysqli=mysqlnd \
           ${{ inputs.skipSlow == 'false' && '--with-pgsql' || '' }} \

--- a/.github/actions/freebsd/action.yml
+++ b/.github/actions/freebsd/action.yml
@@ -48,6 +48,7 @@ runs:
             libavif \
             sqlite3 \
             curl \
+            apache24 \
             $OPCACHE_TLS_TESTS_DEPS
 
           ./buildconf -f
@@ -57,6 +58,7 @@ runs:
             --enable-debug \
             --enable-option-checking=fatal \
             --enable-fpm \
+            --with-apxs2 \
             --with-pdo-sqlite \
             --without-pear \
             --with-bz2 \

--- a/.github/actions/solaris/action.yml
+++ b/.github/actions/solaris/action.yml
@@ -18,7 +18,7 @@ runs:
         disable-cache: true
         prepare: |
           cd $GITHUB_WORKSPACE
-          pkg install bison developer/icu libzip oniguruma re2c
+          pkg install bison developer/icu libzip oniguruma re2c apache-24
 
           ./buildconf -f
           CC=gcc CXX=g++ \
@@ -31,6 +31,7 @@ runs:
             --enable-werror \
             --enable-option-checking=fatal \
             --enable-fpm \
+            --with-apxs2 \
             --without-pear \
             --with-bz2 \
             --with-jpeg \

--- a/sapi/apache2handler/apache_config.c
+++ b/sapi/apache2handler/apache_config.c
@@ -207,7 +207,7 @@ const command_rec php_dir_cmds[] =
 	AP_INIT_TAKE2("php_admin_value", php_apache_admin_value_handler, NULL, ACCESS_CONF|RSRC_CONF, "PHP Value Modifier (Admin)"),
 	AP_INIT_TAKE2("php_admin_flag", php_apache_admin_flag_handler, NULL, ACCESS_CONF|RSRC_CONF, "PHP Flag Modifier (Admin)"),
 	AP_INIT_TAKE1("PHPINIDir", php_apache_phpini_set, NULL, RSRC_CONF, "Directory containing the php.ini file"),
-	{NULL}
+	{}
 };
 
 static apr_status_t destroy_php_config(void *data)


### PR DESCRIPTION
There are no unit tests, but a smoke test is an improvement.

Note that the configure script needs httpd-the-executable to run, so not just apache2-dev is sufficient on Debian and Alpine.

Windows according to Shivam builds it with `--enable-snapshot-build`.

Tested locally on Alpine.

Partially addresses GH-23404