### PR TITLE
tests/GHSA-x692-q9x7-8c3f.phpt:  Add extensions required

### DIFF
--- a/ext/bcmath/tests/GHSA-x692-q9x7-8c3f.phpt
+++ b/ext/bcmath/tests/GHSA-x692-q9x7-8c3f.phpt
@@ -1,5 +1,7 @@
 --TEST--
 GHSA-x692-q9x7-8c3f: bccomp() out-of-bounds write
+--EXTENSIONS--
+bcmath
 --CREDITS--
 Recep Asan (recepasan)
 --FILE--


### PR DESCRIPTION
bccomp() is in bcmath extension. Add the requires to avoid test failure if bcmath extension not configured.