### PR TITLE
Fix alternate form flag for %x testing stale signed value

### DIFF
--- a/main/snprintf.c
+++ b/main/snprintf.c
@@ -830,7 +830,7 @@ static size_t format_converter(buffy * odp, const char *fmt, va_list ap) /* {{{ 
 					}
 					s = ap_php_conv_p2(ui_num, 4, *fmt, &num_buf[NUM_BUF_SIZE], &s_len);
 					FIX_PRECISION(adjust_precision, precision, s, s_len);
-					if (alternate_form && i_num != 0) {
+					if (alternate_form && ui_num != 0) {
 						*--s = *fmt;	/* 'x' or 'X' */
 						*--s = '0';
 						s_len += 2;


### PR DESCRIPTION
Fix the alternate-form flag for %x/%X gating the 0x prefix on i_num, which is only ever assigned by the decimal conversions; a standalone %#x printed no prefix and %d %#x consumed the earlier conversion's value.
