### PR TITLE
Fix path_info pointer underflow in CGI fix_pathinfo handling

### DIFF
--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -1285,9 +1285,9 @@ static void init_request_info(fcgi_request *request)
 						 */
 						size_t slen = len - strlen(pt);
 						size_t pilen = env_path_info ? strlen(env_path_info) : 0;
-						char *path_info = env_path_info ? env_path_info + pilen - slen : NULL;
+						char *path_info = (env_path_info && pilen > slen) ? env_path_info + pilen - slen : NULL;
 
-						if (orig_path_info != path_info) {
+						if (path_info != NULL && orig_path_info != path_info) {
 							if (orig_path_info) {
 								char old;
 

--- a/sapi/cgi/tests/fix_pathinfo_underflow.phpt
+++ b/sapi/cgi/tests/fix_pathinfo_underflow.phpt
@@ -1,0 +1,37 @@
+--TEST--
+cgi fix_pathinfo with PATH_INFO shorter than the stripped suffix
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--FILE--
+<?php
+
+include "include.inc";
+
+$php = get_cgi_path();
+reset_env_vars();
+
+$d = __DIR__ . '/fix_pathinfo_underflow';
+@mkdir($d);
+$f = $d . '/info.php';
+file_put_contents($f, '<?php echo "PI=[", $_SERVER["PATH_INFO"] ?? "unset", "]", "\n"; ');
+
+putenv("REDIRECT_STATUS=1");
+putenv("SCRIPT_FILENAME=" . $f . "/" . str_repeat("a", 300));
+putenv("PATH_INFO=/");
+putenv("SCRIPT_NAME=/info.php");
+putenv("REQUEST_METHOD=GET");
+putenv("QUERY_STRING=");
+
+echo `$php -n -d cgi.fix_pathinfo=1 $f`;
+
+echo "Done\n";
+
+@unlink($f);
+@rmdir($d);
+?>
+--EXPECTF--
+X-Powered-By: PHP/%s
+Content-type: text/html%r; charset=.*|%r
+
+PI=[/]
+Done


### PR DESCRIPTION
cgi.fix_pathinfo derived PATH_INFO as env_path_info + pilen - slen even when PATH_INFO was shorter than the suffix stripped from SCRIPT_FILENAME, which under-runs the pointer. FPM received this guard in ab061f95ca9; CGI did not.
