### PR TITLE
Fix user.ini handling when the script directory prefixes doc_root

### DIFF
--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -798,8 +798,6 @@ static void php_cgi_ini_activate_user_config(char *path, size_t path_len, const 
 	/* Check whether cache entry has expired and rescan if it is */
 	if (request_time > entry->expires) {
 		char *real_path = NULL;
-		char *s1, *s2;
-		size_t s_len;
 
 		/* Clear the expired config */
 		zend_hash_clean(entry->user_config);
@@ -815,26 +813,16 @@ static void php_cgi_ini_activate_user_config(char *path, size_t path_len, const 
 			path_len = real_path_len;
 		}
 
-		if (path_len > doc_root_len) {
-			s1 = (char *) doc_root;
-			s2 = path;
-			s_len = doc_root_len;
-		} else {
-			s1 = path;
-			s2 = (char *) doc_root;
-			s_len = path_len;
-		}
-
 		/* we have to test if path is part of DOCUMENT_ROOT.
 		  if it is inside the docroot, we scan the tree up to the docroot
 			to find more user.ini, if not we only scan the current path.
 		  */
 #ifdef PHP_WIN32
-		if (strnicmp(s1, s2, s_len) == 0) {
+		if (path_len > doc_root_len && strnicmp(path, doc_root, doc_root_len) == 0) {
 #else
-		if (strncmp(s1, s2, s_len) == 0) {
+		if (path_len > doc_root_len && strncmp(path, doc_root, doc_root_len) == 0) {
 #endif
-			char *ptr = s2 + doc_root_len;
+			char *ptr = path + doc_root_len;
 #ifdef PHP_WIN32
 			while ((ptr = strpbrk(ptr, "\\/")) != NULL) {
 #else

--- a/sapi/cgi/tests/user-ini-doc-root-prefix.phpt
+++ b/sapi/cgi/tests/user-ini-doc-root-prefix.phpt
@@ -1,0 +1,41 @@
+--TEST--
+CGI: user.ini is loaded when the script directory prefixes doc_root
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--FILE--
+<?php
+
+include "include.inc";
+
+$php = get_cgi_path();
+reset_env_vars();
+
+$workDir = __DIR__ . '/user-ini-prefix';
+@mkdir($workDir);
+file_put_contents($workDir . '/info.php', "<?php echo ini_get('memory_limit'), \"\\n\"; ");
+file_put_contents($workDir . '/.user.ini', "memory_limit=77M\n");
+
+$f = $workDir . '/info.php';
+putenv("REDIRECT_STATUS=1");
+putenv("SCRIPT_FILENAME=" . $f);
+putenv("PATH_TRANSLATED=" . $f);
+putenv("DOCUMENT_ROOT=" . $workDir . '/www');
+putenv("REQUEST_METHOD=GET");
+putenv("QUERY_STRING=");
+
+echo `$php -n -d user_ini.cache_ttl=0 $f`;
+
+echo "Done\n";
+?>
+--EXPECTF--
+X-Powered-By: PHP/%s
+Content-type: text/html%r; charset=.*|%r
+
+77M
+Done
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/user-ini-prefix/info.php');
+@unlink(__DIR__ . '/user-ini-prefix/.user.ini');
+@rmdir(__DIR__ . '/user-ini-prefix');
+?>

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -653,8 +653,6 @@ static void php_cgi_ini_activate_user_config(char *path, int path_len, const cha
 	if (request_time > entry->expires) {
 		char * real_path;
 		int real_path_len;
-		char *s1, *s2;
-		int s_len;
 
 		/* Clear the expired config */
 		zend_hash_clean(entry->user_config);
@@ -669,22 +667,8 @@ static void php_cgi_ini_activate_user_config(char *path, int path_len, const cha
 			path_len = real_path_len;
 		}
 
-		if (path_len > doc_root_len) {
-			s1 = (char *) doc_root;
-			s2 = path;
-			s_len = doc_root_len;
-		} else {
-			s1 = path;
-			s2 = (char *) doc_root;
-			s_len = path_len;
-		}
-
-		/* we have to test if path is part of DOCUMENT_ROOT.
-		  if it is inside the docroot, we scan the tree up to the docroot
-			to find more user.ini, if not we only scan the current path.
-		  */
-		if (strncmp(s1, s2, s_len) == 0) {
-			ptr = s2 + doc_root_len;
+		if (path_len > doc_root_len && strncmp(path, doc_root, doc_root_len) == 0) {
+			ptr = path + doc_root_len;
 			while ((ptr = strchr(ptr, DEFAULT_SLASH)) != NULL) {
 				*ptr = 0;
 				php_parse_user_ini_file(path, PG(user_ini_filename), entry->user_config);

--- a/sapi/fpm/tests/user-ini-doc-root-prefix.phpt
+++ b/sapi/fpm/tests/user-ini-doc-root-prefix.phpt
@@ -1,0 +1,47 @@
+--TEST--
+FPM: user.ini is loaded when the script directory prefixes doc_root
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$workDir = __DIR__ . '/user-ini-prefix';
+@mkdir($workDir);
+file_put_contents($workDir . '/info.php', '<?php echo ini_get("memory_limit"); ');
+file_put_contents($workDir . '/.user.ini', "memory_limit=77M\n");
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+[unconfined]
+listen = {{ADDR}}
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 1
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+EOT;
+
+$tester = new FPM\Tester($cfg, '');
+$tester->start();
+$tester->expectLogStartNotices();
+$tester
+    ->request(scriptFilename: $workDir . '/info.php', headers: ['DOCUMENT_ROOT' => $workDir . '/www'])
+    ->expectBody('77M');
+$tester->terminate();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+@unlink(__DIR__ . '/user-ini-prefix/info.php');
+@unlink(__DIR__ . '/user-ini-prefix/.user.ini');
+@rmdir(__DIR__ . '/user-ini-prefix');
+?>


### PR DESCRIPTION
php_cgi_ini_activate_user_config() swapped the scan base when the script directory was shorter than DOCUMENT_ROOT, so a prefixing script dir never loaded .user.ini. Scan the tree only when path descends from doc_root. Same change in sapi/cgi and sapi/fpm.
