### PR TITLE
Fix unbounded write on negative star precision in format_converter

### DIFF
--- a/main/snprintf.c
+++ b/main/snprintf.c
@@ -580,8 +580,10 @@ static size_t format_converter(buffy * odp, const char *fmt, va_list ap) /* {{{ 
 					} else if (*fmt == '*') {
 						precision = va_arg(ap, int);
 						fmt++;
-						if (precision < -1)
-							precision = -1;
+						if (precision < 0) {
+							adjust_precision = false;
+							precision = 0;
+						}
 					} else
 						precision = 0;
 				} else


### PR DESCRIPTION
A negative star precision was only clamped to -1, so FIX_PRECISION() treated it as SIZE_MAX and wrote backwards through the buffer. Treat omitted precision that way in format_converter() only. xbuf_format_converter() keeps -1 as the %H shortest-float sentinel used by serialize_precision.
