### PR TITLE
Fix SNMP build with modern Net-SNMP API

### DIFF
--- a/ext/snmp/config.m4
+++ b/ext/snmp/config.m4
@@ -51,6 +51,13 @@ if test "$PHP_SNMP" != "no"; then
     [AC_MSG_FAILURE([SNMP sanity check failed.])],
     [$SNMP_SHARED_LIBADD])
 
+  dnl Check whether netsnmp_init_mib() exists.
+  PHP_CHECK_LIBRARY([$SNMP_LIBNAME], [netsnmp_init_mib],
+    [AC_DEFINE([HAVE_NETSNMP_INIT_MIB], [1],
+      [Define to 1 if the Net-SNMP library has the 'netsnmp_init_mib' function.])],
+    [],
+    [$SNMP_SHARED_LIBADD])
+
   dnl Check whether shutdown_snmp_logging() exists.
   PHP_CHECK_LIBRARY([$SNMP_LIBNAME], [shutdown_snmp_logging],
     [AC_DEFINE([HAVE_SHUTDOWN_SNMP_LOGGING], [1],

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -1687,7 +1687,11 @@ PHP_FUNCTION(snmp_init_mib)
 
 	shutdown_mib();
 	netsnmp_ds_set_string(NETSNMP_DS_LIBRARY_ID, NETSNMP_DS_LIB_MIBDIRS, ZSTR_VAL(mibdirs));
+#ifdef HAVE_NETSNMP_INIT_MIB
+	netsnmp_init_mib();
+#else
 	init_mib();
+#endif
 }
 /* }}} */
 
@@ -2228,7 +2232,11 @@ static PHP_RSHUTDOWN_FUNCTION(snmp)
 	if (mib_needs_reset) {
 		shutdown_mib();
 		netsnmp_ds_set_string(NETSNMP_DS_LIBRARY_ID, NETSNMP_DS_LIB_MIBDIRS, NULL);
+#ifdef HAVE_NETSNMP_INIT_MIB
+		netsnmp_init_mib();
+#else
 		init_mib();
+#endif
 	}
 
 	return SUCCESS;


### PR DESCRIPTION
Follow-up to #21452.

This fixes the SNMP build with newer Net-SNMP configurations that define `NETSNMP_NO_LEGACY_DEFINITIONS` like macOS, while retaining compatibility with older versions.

Ref: https://github.com/net-snmp/net-snmp/commit/73e5d1378a594a353b0df3be2200976863d7c556