### PR TITLE
sapi/lsapi: fix sapi_lsapi_ub_write() return value on short write

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -49,6 +49,8 @@ PHP                                                                        NEWS
 - SAPI:
   . Fixed fuzzer targets failing to build in isolation. (Mrmaxmeier)
   . Fixed returns uninitialized value on LiteSpeed lsapi SAPI (Go Kudo)
+  . Fixed bug GH-23424 (sapi_lsapi_ub_write() returns str_length - ret
+    instead of ret when LSAPI_Write() short-writes). (Lazizbek Ergashev)
 
 27 Aug 2026, PHP 8.4.25
 

--- a/sapi/litespeed/lsapi_main.c
+++ b/sapi/litespeed/lsapi_main.c
@@ -139,7 +139,7 @@ static size_t sapi_lsapi_ub_write(const char *str, size_t str_length)
         ret  = LSAPI_Write( str, str_length );
         if ( ret < str_length ) {
             php_handle_aborted_connection();
-            return str_length - ret;
+            return ret;
         }
     } else {
         remain = str_length;


### PR DESCRIPTION
`sapi_lsapi_ub_write()` returns `str_length - ret` when `LSAPI_Write()` writes fewer bytes than requested. `LSAPI_Write()` already returns the number of bytes it wrote (`LSAPI_Write_r()` in lsapilib.c returns `p - pBuf`, or -1 on error), the same contract every other `ub_write` in this codebase follows, e.g. `sapi_cli_ub_write()` returns `ptr - str`. Subtracting that count from `str_length` gives the wrong value. Return `ret` instead.

Fixes #23424