### PR TITLE
Fix php_embed_ub_write() infinite loop on failed write

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,9 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 8.2.34
 
+- Embed:
+  . Fixed bug GH-23423 (php_embed_ub_write() infinite loop when a write
+    fails and the connection is not aborted). (Lazizbek Ergashev)
 
 30 Jul 2026, PHP 8.2.33
 

--- a/sapi/embed/php_embed.c
+++ b/sapi/embed/php_embed.c
@@ -82,6 +82,7 @@ static size_t php_embed_ub_write(const char *str, size_t str_length)
 		ret = php_embed_single_write(ptr, remaining);
 		if (!ret) {
 			php_handle_aborted_connection();
+			return str_length - remaining;
 		}
 		ptr += ret;
 		remaining -= ret;


### PR DESCRIPTION
php_embed_ub_write() never decrements remaining when php_embed_single_write() returns 0, so if php_handle_aborted_connection() doesn't actually abort (e.g. ignore_user_abort=1), the write loop spins forever. sapi_cgi_ub_write() already returns str_length - remaining in this same situation, so this makes php_embed_ub_write() do the same.

Fixes #23423