### PR TITLE
Fix wrong argument number in fsockopen/pfsockopen timeout error

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -39,6 +39,8 @@ PHP                                                                        NEWS
     with no other live PDO handle. (iliaal)
 
 - Standard:
+  . Fixed GH-23338 (fsockopen()/pfsockopen() ValueError reported wrong
+    argument number for $timeout). (lacatoire)
   . Fixed a memory leak in array_merge_recursive() when the recursive merge of
     an object converted to an array fails. (David Carlier)
 

--- a/ext/standard/fsock.c
+++ b/ext/standard/fsock.c
@@ -107,7 +107,7 @@ static void php_fsockopen_stream(INTERNAL_FUNCTION_PARAMETERS, int persistent)
 			efree(hashkey);
 		}
 
-		zend_argument_value_error(6, "must be -1 or between 0 and " ZEND_ULONG_FMT, ((double) PHP_TIMEOUT_ULL_MAX / 1000000.0));
+		zend_argument_value_error(5, "must be -1 or between 0 and %" PRIu64, (uint64_t) ((double) PHP_TIMEOUT_ULL_MAX / 1000000.0));
 		RETURN_THROWS();
 	} else {
 #ifndef PHP_WIN32

--- a/ext/standard/tests/network/fsockopen_timeout_out_of_range.phpt
+++ b/ext/standard/tests/network/fsockopen_timeout_out_of_range.phpt
@@ -1,0 +1,19 @@
+--TEST--
+fsockopen() and pfsockopen(): ValueError for $timeout reports correct argument number and name
+--FILE--
+<?php
+try {
+    fsockopen('localhost', 80, $errno, $errstr, -2.0);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
+}
+
+try {
+    pfsockopen('localhost', 80, $errno, $errstr, -2.0);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
+}
+?>
+--EXPECTF--
+ValueError: fsockopen(): Argument #5 ($timeout) must be -1 or between 0 and %s
+ValueError: pfsockopen(): Argument #5 ($timeout) must be -1 or between 0 and %s

--- a/ext/standard/tests/streams/gh14780.phpt
+++ b/ext/standard/tests/streams/gh14780.phpt
@@ -31,8 +31,8 @@ try {
 }
 ?>
 --EXPECTF--
-pfsockopen(): Argument #6 must be -1 or between 0 and %s
-pfsockopen(): Argument #6 must be -1 or between 0 and %s
+pfsockopen(): Argument #5 ($timeout) must be -1 or between 0 and %s
+pfsockopen(): Argument #5 ($timeout) must be -1 or between 0 and %s
 resource(%d) of type (persistent stream)
-pfsockopen(): Argument #6 must be -1 or between 0 and %s
-pfsockopen(): Argument #6 must be -1 or between 0 and %s
+pfsockopen(): Argument #5 ($timeout) must be -1 or between 0 and %s
+pfsockopen(): Argument #5 ($timeout) must be -1 or between 0 and %s


### PR DESCRIPTION
`php_fsockopen_stream()` called `zend_argument_value_error(6, ...)` for the `$timeout` parameter, but `$timeout` is the **5th** argument. Because `get_function_arg_name(func, arg_num)` returns `NULL` when `arg_num` exceeds the actual argument count, the error message reported the wrong number and dropped the parameter name.

The format string also used `ZEND_ULONG_FMT` (which expects a `zend_ulong`) but received a `double` expression — undefined behavior in C. This is fixed by adding a `(zend_ulong)` cast.

Before:
```
ValueError: fsockopen(): Argument #6 must be -1 or between 0 and 4294967295
```
After:
```
ValueError: fsockopen(): Argument #5 ($timeout) must be -1 or between 0 and 18446744073709
```

The same fix applies to `pfsockopen()`, which delegates to the same internal helper.

A regression test is included; it does not require network connectivity since the `ValueError` is raised before any connection attempt.