### PR TITLE
ext/standard: declare true as the return type of register_tick_function()

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -618,6 +618,9 @@ PHP 8.6 UPGRADE NOTES
   . header_register_callback() now declares true as its return type. It has not
     been able to return false since PHP 8.0.0, where passing an invalid
     callback started throwing a TypeError instead.
+  . register_tick_function() now declares true as its return type. It has
+    always returned true on success; an invalid callback throws a TypeError
+    via ZPP before the function body is reached.
   . ini_get_all() now includes a "builtin_default_value" element for each
     directive when $details is true. It holds the built-in default value of the
     directive (or null if it has none), independent of values set in php.ini,

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -2063,7 +2063,7 @@ function getprotobyname(string $protocol): int|false {}
 function getprotobynumber(int $protocol): string|false {}
 #endif
 
-function register_tick_function(callable $callback, mixed ...$args): bool {}
+function register_tick_function(callable $callback, mixed ...$args): true {}
 
 function unregister_tick_function(callable $callback): void {}
 

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit basic_functions.stub.php instead.
- * Stub hash: 13b6fd340958d1a7c782c8f5f3685517e62e5edc
+ * Stub hash: c645e310c00d9f4cb3856c94ee60d06071e28de0
  * Has decl header: yes */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
@@ -574,7 +574,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_getprotobynumber, 0, 1, MAY_BE_S
 ZEND_END_ARG_INFO()
 #endif
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_register_tick_function, 0, 1, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_register_tick_function, 0, 1, IS_TRUE, 0)
 	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
 	ZEND_ARG_VARIADIC_TYPE_INFO(0, args, IS_MIXED, 0)
 ZEND_END_ARG_INFO()

--- a/ext/standard/basic_functions_decl.h
+++ b/ext/standard/basic_functions_decl.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit basic_functions.stub.php instead.
- * Stub hash: 13b6fd340958d1a7c782c8f5f3685517e62e5edc */
+ * Stub hash: c645e310c00d9f4cb3856c94ee60d06071e28de0 */
 
-#ifndef ZEND_BASIC_FUNCTIONS_DECL_13b6fd340958d1a7c782c8f5f3685517e62e5edc_H
-#define ZEND_BASIC_FUNCTIONS_DECL_13b6fd340958d1a7c782c8f5f3685517e62e5edc_H
+#ifndef ZEND_BASIC_FUNCTIONS_DECL_c645e310c00d9f4cb3856c94ee60d06071e28de0_H
+#define ZEND_BASIC_FUNCTIONS_DECL_c645e310c00d9f4cb3856c94ee60d06071e28de0_H
 
 typedef enum zend_enum_SortDirection {
 	ZEND_ENUM_SortDirection_Ascending = 1,
@@ -20,4 +20,4 @@ typedef enum zend_enum_RoundingMode {
 	ZEND_ENUM_RoundingMode_PositiveInfinity = 8,
 } zend_enum_RoundingMode;
 
-#endif /* ZEND_BASIC_FUNCTIONS_DECL_13b6fd340958d1a7c782c8f5f3685517e62e5edc_H */
+#endif /* ZEND_BASIC_FUNCTIONS_DECL_c645e310c00d9f4cb3856c94ee60d06071e28de0_H */


### PR DESCRIPTION
`register_tick_function()` is declared `bool` but has no failure path beyond the ZPP step, which throws. `php_add_tick_function()` and `zend_llist_add_element()` are both `void`, so no status is being dropped. `true` is the only value ever returned.

`unregister_tick_function()` is already `void`, and `ksort()`, `asort()`, and `natsort()` in the same stub already declare `true`, so this follows existing practice.

Changes: `basic_functions.stub.php` (`bool` → `true`), regenerated arginfo, added test.