### PR TITLE
ext/readline: declare true as the return type of readline_completion_function()

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -606,6 +606,12 @@ PHP 8.6 UPGRADE NOTES
 - Phar:
   . Phar::mungServer() now supports reference values.
 
+- Readline:
+  . readline_completion_function() now declares true as its return type. The
+    function assigns a static callback and then tests whether the assignment
+    landed, which is a tautology; an invalid callback throws a TypeError via
+    ZPP before the function body is reached.
+
 - Sockets:
   . socket_addrinfo_lookup() now has an additional optional argument $error
     when not null, and on failure, gives the error code (one of the EAI_*

--- a/ext/readline/readline.c
+++ b/ext/readline/readline.c
@@ -489,8 +489,8 @@ PHP_FUNCTION(readline_completion_function)
 
 	/* NOTE: The rl_attempted_completion_function variable (and others) are part of the readline library, not php */
 	rl_attempted_completion_function = php_readline_completion_cb;
-	
-	RETURN_BOOL(rl_attempted_completion_function != NULL);
+
+	RETURN_TRUE;
 }
 
 /* }}} */

--- a/ext/readline/readline.stub.php
+++ b/ext/readline/readline.stub.php
@@ -29,7 +29,7 @@ function readline_read_history(?string $filename = null): bool {}
 
 function readline_write_history(?string $filename = null): bool {}
 
-function readline_completion_function(callable $callback): bool {}
+function readline_completion_function(callable $callback): true {}
 
 
 #ifdef HAVE_RL_CALLBACK_READ_CHAR

--- a/ext/readline/readline_arginfo.h
+++ b/ext/readline/readline_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit readline.stub.php instead.
- * Stub hash: 7a314f75d9a89a9ea4d525515bb6bacdf7be6746 */
+ * Stub hash: 848e798481f62ee09cfd8cc3dfa6b0814cfdd979 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_readline, 0, 0, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, prompt, IS_STRING, 1, "null")
@@ -28,7 +28,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_readline_write_history arginfo_readline_read_history
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_readline_completion_function, 0, 1, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_readline_completion_function, 0, 1, IS_TRUE, 0)
 	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
 ZEND_END_ARG_INFO()
 


### PR DESCRIPTION
`readline_completion_function()` is declared `bool`, but the function assigns a static function pointer to `rl_attempted_completion_function` and then returns `RETURN_BOOL(rl_attempted_completion_function != NULL)` — a tautology. The only other exit is the `TypeError` from ZPP. `true` is always returned.

The commit declares `true` and returns it directly instead of the redundant pointer comparison.

`ksort()`, `asort()`, and `natsort()` already declare `true` in ext/standard, so this follows existing practice.

Changes: `readline.stub.php` (`bool` → `true`), `readline.c` (`RETURN_BOOL(...)` → `RETURN_TRUE`), regenerated arginfo, added test.