### PR TITLE
sapi/fpm: Removes XFAIL for "but test passes" test

### DIFF
--- a/sapi/fpm/tests/log-bwd-multiple-msgs-stdout-stderr.phpt
+++ b/sapi/fpm/tests/log-bwd-multiple-msgs-stdout-stderr.phpt
@@ -2,8 +2,6 @@
 FPM: Buffered worker output decorated log with multiple continuous messages (stdout/stderr mixed)
 --SKIPIF--
 <?php include "skipif.inc"; ?>
---XFAIL--
-Fails intermittently
 --FILE--
 <?php
 


### PR DESCRIPTION
76ca6bf removed, ea3a317 fixed race, c4639a2 restored with "Still fails intermittently" (6y ago). Later 1029537 and 4580b8b landed which could be related. Analysed 16,457 CI invocations, ran it thousands of times locally -- at least in CI and locally (macOS) it never fails but warns "XFAIL section but test passes". Worth trying the removal again. If a OS/local specific report hits we can try fixing it properly rather than sledgehammering with XFAIL.