### PR TITLE
Fix JUnit timing aggregation for long-running tests

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -3386,6 +3386,7 @@ class JUnit
 
         $time = $time ?? $this->getTimer($file_name);
         $this->record($suite, 'execution_time', $time);
+        $formatted_time = number_format($time, 4, '.', '');
 
         $escaped_details = htmlspecialchars($details, ENT_QUOTES, 'UTF-8');
         $escaped_details = preg_replace_callback('/[\0-\x08\x0B\x0C\x0E-\x1F]/', function ($c) {
@@ -3394,7 +3395,7 @@ class JUnit
         $escaped_message = htmlspecialchars($message, ENT_QUOTES, 'UTF-8');
 
         $escaped_test_name = htmlspecialchars($file_name . ' (' . $test_name . ')', ENT_QUOTES);
-        $this->rootSuite['files'][$file_name]['xml'] = "<testcase name='$escaped_test_name' time='$time'>\n";
+        $this->rootSuite['files'][$file_name]['xml'] = "<testcase name='$escaped_test_name' time='$formatted_time'>\n";
 
         if (is_array($type)) {
             $output_type = $type[0] . 'ED';
@@ -3439,7 +3440,7 @@ class JUnit
         }
 
         if (isset($this->rootSuite['files'][$file_name]['total'])) {
-            return number_format($this->rootSuite['files'][$file_name]['total'], 4);
+            return $this->rootSuite['files'][$file_name]['total'];
         }
 
         return 0;


### PR DESCRIPTION
This fixes a warning when doing math on a `number_format`ted string.

I'm opening this against PHP 8.4 because in parallel mode, when the test worker encounters a php_error of any kind, it will terminate all workers and abort the run. This is quite undesirable. But of course, if a maintainer/reviewer is against that, we can move it to master instead.