### PR TITLE
Fix read buffer compaction in stream filter flush

### DIFF
--- a/ext/standard/tests/filters/stream_filter_remove_compact_read_buffer.phpt
+++ b/ext/standard/tests/filters/stream_filter_remove_compact_read_buffer.phpt
@@ -1,0 +1,31 @@
+--TEST--
+stream_filter_remove() compacts unread data before appending flushed data
+--FILE--
+<?php
+class ClosingSuffixFilter extends php_user_filter
+{
+    public function filter($in, $out, &$consumed, $closing): int
+    {
+        while ($bucket = stream_bucket_make_writeable($in)) {
+            $consumed += $bucket->datalen;
+            stream_bucket_append($out, $bucket);
+        }
+        if ($closing) {
+            stream_bucket_append($out, stream_bucket_new($this->stream, 'END'));
+        }
+        return PSFS_PASS_ON;
+    }
+}
+stream_filter_register('closing-suffix', ClosingSuffixFilter::class);
+$stream = fopen('php://memory', 'w+');
+fwrite($stream, 'abcdef');
+rewind($stream);
+$filter = stream_filter_append($stream, 'closing-suffix', STREAM_FILTER_READ);
+var_dump(fread($stream, 2));
+var_dump(stream_filter_remove($filter));
+var_dump(stream_get_contents($stream));
+?>
+--EXPECT--
+string(2) "ab"
+bool(true)
+string(7) "cdefEND"

--- a/main/streams/filter.c
+++ b/main/streams/filter.c
@@ -459,9 +459,9 @@ PHPAPI int _php_stream_filter_flush(php_stream_filter *filter, int finish)
 		/* Dump any newly flushed data to the read buffer */
 		if (stream->readpos > 0) {
 			/* Back the buffer up */
-			memcpy(stream->readbuf, stream->readbuf + stream->readpos, stream->writepos - stream->readpos);
-			stream->readpos = 0;
+			memmove(stream->readbuf, stream->readbuf + stream->readpos, stream->writepos - stream->readpos);
 			stream->writepos -= stream->readpos;
+			stream->readpos = 0;
 		}
 		if (flushed_size > (stream->readbuflen - stream->writepos)) {
 			/* Grow the buffer */


### PR DESCRIPTION
`php_stream_filter_flush()` compacts unread data before appending buckets produced by a read filter.

The source and destination ranges may overlap, making the use of `memcpy()` undefined behavior. Additionally, `readpos` was reset before it was subtracted from `writepos`, so the buffer size was not adjusted and stale data could remain visible.

Use `memmove()` and adjust `writepos` before resetting `readpos`, matching the existing buffer compaction logic in `php_stream_fill_read_buffer()`.

The issue was detected by static analysis:  [BUFFER_OVERLAP filter.c:[458:4].log](https://github.com/user-attachments/files/31381411/BUFFER_OVERLAP.filter.c.458.4.log)
