### PR TITLE
ext/standard: Adds and modifies XFAIL tests for filter bucket leaks

### DIFF
--- a/ext/standard/tests/filters/stream_filter_register_class_coerce_consumed_by_ref_param.phpt
+++ b/ext/standard/tests/filters/stream_filter_register_class_coerce_consumed_by_ref_param.phpt
@@ -1,7 +1,30 @@
 --TEST--
 stream_filter_register() with a class that coerces the $consumed parameter of filter method
---XFAIL--
-This leaks memory
+--SKIPIF--
+<?php
+
+// this leaks memory
+// remove SKIPIF section when GH-20058 is merged OR when debug
+// builds report "warn: XFAIL section but test passes"
+
+if (getenv('SKIP_MSAN')) {
+	die('skip requires a leak detector');
+}
+
+if (getenv('SKIP_ASAN') && PHP_OS_FAMILY !== 'Windows') {
+	die('xfail User filters leak unprocessed buckets');
+}
+
+if (PHP_DEBUG && getenv('USE_ZEND_ALLOC') !== '0') {
+	die('xfail User filters leak unprocessed buckets');
+}
+
+if (getenv('USE_ZEND_ALLOC') === '0' && getenv('ZEND_DONT_UNLOAD_MODULES') === '1') {
+	die('xleak User filters leak unprocessed buckets');
+}
+
+die('skip requires a leak detector');
+?>
 --FILE--
 <?php
 

--- a/ext/standard/tests/filters/stream_filter_register_mock_class_filter.phpt
+++ b/ext/standard/tests/filters/stream_filter_register_mock_class_filter.phpt
@@ -1,7 +1,30 @@
 --TEST--
 stream_filter_register() with a class name exist that mocks php_user_filter with a filter method
---XFAIL--
-This leaks memory
+--SKIPIF--
+<?php
+
+// this leaks memory
+// remove SKIPIF section when GH-20058 is merged OR when debug
+// builds report "warn: XFAIL section but test passes"
+
+if (getenv('SKIP_MSAN')) {
+	die('skip requires a leak detector');
+}
+
+if (getenv('SKIP_ASAN') && PHP_OS_FAMILY !== 'Windows') {
+	die('xfail User filters leak unprocessed buckets');
+}
+
+if (PHP_DEBUG && getenv('USE_ZEND_ALLOC') !== '0') {
+	die('xfail User filters leak unprocessed buckets');
+}
+
+if (getenv('USE_ZEND_ALLOC') === '0' && getenv('ZEND_DONT_UNLOAD_MODULES') === '1') {
+	die('xleak User filters leak unprocessed buckets');
+}
+
+die('skip requires a leak detector');
+?>
 --FILE--
 <?php
 

--- a/ext/standard/tests/filters/stream_filter_register_unprocessed_buckets.phpt
+++ b/ext/standard/tests/filters/stream_filter_register_unprocessed_buckets.phpt
@@ -1,0 +1,80 @@
+--TEST--
+stream_filter_register() with classes that leave unprocessed buckets for PSFS_FEED_ME and PSFS_ERR_FATAL
+--SKIPIF--
+<?php
+
+// this leaks memory
+// remove SKIPIF section when debug builds report "warn: XFAIL section but test passes"
+
+if (getenv('SKIP_MSAN')) {
+	die('skip requires a leak detector');
+}
+
+if (getenv('SKIP_ASAN') && PHP_OS_FAMILY !== 'Windows') {
+	die('xfail User filters leak unprocessed buckets');
+}
+
+if (PHP_DEBUG && getenv('USE_ZEND_ALLOC') !== '0') {
+	die('xfail User filters leak unprocessed buckets');
+}
+
+if (getenv('USE_ZEND_ALLOC') === '0' && getenv('ZEND_DONT_UNLOAD_MODULES') === '1') {
+	die('xleak User filters leak unprocessed buckets');
+}
+
+die('skip requires a leak detector');
+?>
+--FILE--
+<?php
+
+class FeedFilter extends php_user_filter
+{
+	public function filter($in, $out, &$consumed, bool $closing): int {
+		return PSFS_FEED_ME;
+	}
+}
+
+class FatalFilter extends php_user_filter
+{
+	private bool $emitted = false;
+
+	public function filter($in, $out, &$consumed, bool $closing): int
+	{
+		if ($closing && !$this->emitted) {
+			$this->emitted = true;
+			$bucket = stream_bucket_new($this->stream, "x");
+			stream_bucket_append($out, $bucket);
+		}
+
+		return PSFS_ERR_FATAL;
+	}
+}
+
+stream_filter_register("test.feed", FeedFilter::class);
+
+$stream = fopen("php://memory", "w+");
+fwrite($stream, "x\nabcdef");
+rewind($stream);
+
+var_dump(fgets($stream));
+var_dump(stream_filter_append($stream, "test.feed", STREAM_FILTER_READ));
+fclose($stream);
+
+stream_filter_register("test.fatal", FatalFilter::class);
+
+$stream = fopen("php://memory", "w+");
+$filter = stream_filter_append($stream, "test.fatal", STREAM_FILTER_WRITE);
+
+var_dump(stream_filter_remove($filter));
+fclose($stream);
+
+?>
+--EXPECTF--
+string(2) "x
+"
+
+Warning: stream_filter_append(): Unprocessed filter buckets remaining on input brigade in %s on line %d
+resource(%d) of type (stream filter)
+
+Warning: stream_filter_remove(): Unable to flush filter, not removing in %s on line %d
+bool(false)

--- a/ext/standard/tests/filters/stream_filter_register_unprocessed_buckets_reentrant.phpt
+++ b/ext/standard/tests/filters/stream_filter_register_unprocessed_buckets_reentrant.phpt
@@ -1,0 +1,68 @@
+--TEST--
+stream_filter_register() with a class whose input brigade is modified by a warning handler
+--SKIPIF--
+<?php
+
+// this leaks memory
+// remove SKIPIF section when debug builds report "warn: XFAIL section but test passes"
+
+if (getenv('SKIP_MSAN')) {
+	die('skip requires a leak detector');
+}
+
+if (getenv('SKIP_ASAN') && PHP_OS_FAMILY !== 'Windows') {
+	die('xfail User filters leak unprocessed buckets');
+}
+
+if (PHP_DEBUG && getenv('USE_ZEND_ALLOC') !== '0') {
+	die('xfail User filters leak unprocessed buckets');
+}
+
+if (getenv('USE_ZEND_ALLOC') === '0' && getenv('ZEND_DONT_UNLOAD_MODULES') === '1') {
+	die('xleak User filters leak unprocessed buckets');
+}
+
+die('skip requires a leak detector');
+?>
+--FILE--
+<?php
+
+class ReentrantFilter extends php_user_filter
+{
+	private bool $firstCall = true;
+
+	public function filter($in, $out, &$consumed, bool $closing): int
+	{
+		if ($this->firstCall) {
+			$this->firstCall = false;
+			$GLOBALS['brigade'] = $in;
+			$GLOBALS['bucket'] = stream_bucket_new($this->stream, 'refilled');
+		}
+
+		return PSFS_PASS_ON;
+	}
+}
+
+stream_filter_register('test.reentrant', ReentrantFilter::class);
+
+set_error_handler(static function (int $severity, string $message): bool
+{
+	if (str_contains($message, 'Unprocessed filter buckets')) {
+		stream_bucket_append($GLOBALS['brigade'], $GLOBALS['bucket']);
+		echo "Handled warning\n";
+		return true;
+	}
+
+	return false;
+});
+
+$stream = fopen('php://memory', 'w+');
+stream_filter_append($stream, 'test.reentrant', STREAM_FILTER_WRITE);
+
+var_dump(fwrite($stream, 'input'));
+fclose($stream);
+
+?>
+--EXPECT--
+Handled warning
+int(0)


### PR DESCRIPTION
I wanted to [fix](https://github.com/php/php-src/compare/master...NickSdot:php__php-src:tests/sfr-xfail-warn-fix) two `warn: XFAIL section but test passes` but found https://github.com/php/php-src/pull/20058 which already attempts fixing the leaks; don't want to open an overlapping one. However, the PR is already a bit older -- currently builds without leak detection warn because `XFAIL` is too broad. So here we change to use `SKIPIF` to "xfail", "xleak", or skip only where relevant so that we for the time being have no warnings where no leaks can be detected and tests pass. Additionally, two tests for related issues that surfaced were added  (also mentioned in https://github.com/php/php-src/pull/20058#issuecomment-5035247768) .

Should this target 8.4 (20058 still targets 8.3)?

cc @Girgias the two modified tests were added by you, are you okay with this change?
cc @iliaal would you want to look at the two added tests?