### PR TITLE
Fix GH-23447: segfault when the SoapServer class fails to initialize

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -45,6 +45,10 @@ PHP                                                                        NEWS
   . Fixed a leak when a persistent connection failed a liveness check
     with no other live PDO handle. (iliaal)
 
+- SOAP:
+  . Fixed bug GH-23447 (Segfault when a class passed to SoapServer::setClass()
+    fails to initialize). (Lazizbek Ergashev)
+
 - Standard:
   . Fixed a memory leak in array_merge_recursive() when the recursive merge of
     an object converted to an array fails. (David Carlier)

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -1478,7 +1478,11 @@ PHP_METHOD(SoapServer, handle)
 
 		/* If new session or something weird happned */
 		if (soap_obj == NULL) {
-			object_init_ex(&tmp_soap, service->soap_class.ce);
+			if (UNEXPECTED(object_init_ex(&tmp_soap, service->soap_class.ce) != SUCCESS)) {
+				php_output_discard();
+				_soap_server_exception(service, function, ZEND_THIS);
+				goto fail;
+			}
 
 			/* Call constructor */
 			if (service->soap_class.ce->constructor) {

--- a/ext/soap/tests/gh23447.phpt
+++ b/ext/soap/tests/gh23447.phpt
@@ -1,5 +1,5 @@
 --TEST--
-GH-23447 (segfault on soap server handler when it contains undefined constant)
+GH-23447 (Segfault when a class passed to SoapServer::setClass() fails to initialize)
 --EXTENSIONS--
 soap
 --FILE--

--- a/ext/soap/tests/gh23447.phpt
+++ b/ext/soap/tests/gh23447.phpt
@@ -1,0 +1,26 @@
+--TEST--
+GH-23447 (segfault on soap server handler when it contains undefined constant)
+--EXTENSIONS--
+soap
+--FILE--
+<?php
+class foo {
+    private $broken = undefinedConstant;
+}
+
+$server = new SoapServer(null, array('uri' => 'http://testuri.org'));
+$server->setClass('foo');
+
+$server->handle(<<<'XML'
+<?xml version="1.0"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+  <SOAP-ENV:Body><anything/></SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
+XML);
+
+echo "ok\n";
+?>
+--EXPECT--
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"><SOAP-ENV:Body><SOAP-ENV:Fault><faultcode>SOAP-ENV:Server</faultcode><faultstring>Undefined constant "undefinedConstant"</faultstring></SOAP-ENV:Fault></SOAP-ENV:Body></SOAP-ENV:Envelope>
+ok

--- a/ext/soap/tests/gh23447.phpt
+++ b/ext/soap/tests/gh23447.phpt
@@ -2,13 +2,15 @@
 GH-23447 (Segfault when a class passed to SoapServer::setClass() fails to initialize)
 --EXTENSIONS--
 soap
+--CREDITS--
+Lu Maltsis (@lmaltsis)
 --FILE--
 <?php
 class foo {
     private $broken = undefinedConstant;
 }
 
-$server = new SoapServer(null, array('uri' => 'http://testuri.org'));
+$server = new SoapServer(null, ['uri' => 'http://testuri.org']);
 $server->setClass('foo');
 
 $server->handle(<<<'XML'


### PR DESCRIPTION
`SoapServer::handle()` ignored the return value of `object_init_ex()`, so when the class given to `setClass()` could not be instantiated the code carried on with a NULL zval and crashed on `Z_OBJCE_P(soap_obj)`. That happens for instance when a property default references an undefined constant, since evaluating it throws an `Error` and object creation fails.

Now the failure is reported as a SOAP fault, the same way a throwing constructor already is.

Fixes #23447
