### PR TITLE
JIT: Fix zend_jit_trace_find_init_fcall_op()

### DIFF
--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -1167,6 +1167,9 @@ static const zend_op *zend_jit_trace_find_init_fcall_op(zend_jit_trace_rec *p, c
 		const zend_op *opline = NULL;
 		int call_level = 0;
 
+		/* Scan trace buffer forward to find the first recorded opline after
+		 * the sequence of ZEND_JIT_TRACE_INIT_CALL, and keep track of the
+		 * call level. */
 		p++;
 		while (1) {
 			if (p->op == ZEND_JIT_TRACE_VM) {
@@ -1178,8 +1181,9 @@ static const zend_op *zend_jit_trace_find_init_fcall_op(zend_jit_trace_rec *p, c
 			} else {
 				return NULL;
 			}
-			p--;
+			p++;
 		}
+		/* Scan oplines backward to find the init fcall op */
 		if (opline) {
 			while (opline > op_array->opcodes) {
 				opline--;


### PR DESCRIPTION
`zend_jit_trace_find_init_fcall_op()` tries to find the `INIT_FCALL` opline corresponding to a `ZEND_JIT_TRACE_INIT_CALL` record, but it fails to do so in the `ZEND_JIT_TRACE_FAKE_INIT_CALL` case, for nested calls.

The `ZEND_JIT_TRACE_FAKE_INIT_CALL` case implies that `p` points to a sequence of `ZEND_JIT_TRACE_INIT_CALL` trace records. The first loop in `zend_jit_trace_find_init_fcall_op()` is supposed to find the first `opline` after the sequence, but it mistakenly decrements `p` after initially incrementing it. As a result `p` eventually points to an invalid record.

It works for non-nested calls because the `p->op == ZEND_JIT_TRACE_VM` condition is true on the first iteration in that case.

This can not lead to a crash or miscompilations, but this results in lost optimization opportunities.