### PR TITLE
Fix GH-23453: bad free with a context engine ID longer than 32 bytes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -45,6 +45,10 @@ PHP                                                                        NEWS
   . Fixed a leak when a persistent connection failed a liveness check
     with no other live PDO handle. (iliaal)
 
+- SNMP:
+  . Fixed bug GH-23453 (SNMP::setSecurity() frees a non-malloced address with a
+    context engine ID longer than 32 bytes). (Lazizbek Ergashev)
+
 - Standard:
   . Fixed a memory leak in array_merge_recursive() when the recursive merge of
     an object converted to an array fails. (David Carlier)

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -1086,7 +1086,8 @@ static bool netsnmp_session_set_contextEngineID(struct snmp_session *s, zend_str
 	size_t	ebuf_len = 32, eout_len = 0;
 	uint8_t	*ebuf = (uint8_t *) emalloc(ebuf_len);
 
-	if (!snmp_hex_to_binary(&ebuf, &ebuf_len, &eout_len, 1, ZSTR_VAL(contextEngineID))) {
+	/* Disallow reallocation: ebuf comes from emalloc() and net-snmp would realloc() it. */
+	if (!snmp_hex_to_binary(&ebuf, &ebuf_len, &eout_len, 0, ZSTR_VAL(contextEngineID))) {
 		// TODO Promote to Error?
 		php_error_docref(NULL, E_WARNING, "Bad engine ID value '%s'", ZSTR_VAL(contextEngineID));
 		efree(ebuf);

--- a/ext/snmp/tests/gh23453.phpt
+++ b/ext/snmp/tests/gh23453.phpt
@@ -1,5 +1,5 @@
 --TEST--
-GH-23453 (ext/snmp: Attempted free on non-malloced address)
+GH-23453 (SNMP::setSecurity() frees a non-malloced address with a context engine ID longer than 32 bytes)
 --EXTENSIONS--
 snmp
 --FILE--

--- a/ext/snmp/tests/gh23453.phpt
+++ b/ext/snmp/tests/gh23453.phpt
@@ -1,0 +1,17 @@
+--TEST--
+GH-23453 (ext/snmp: Attempted free on non-malloced address)
+--EXTENSIONS--
+snmp
+--FILE--
+<?php
+$session = new SNMP(SNMP::VERSION_3, 'localhost', 'user');
+
+// 32 bytes is the maximum length of a context engine ID
+var_dump($session->setSecurity('authPriv', 'SHA', 'authpassword12345', 'AES', 'privpassword12345', 'myContext', str_repeat('aa', 32)));
+var_dump($session->setSecurity('authPriv', 'SHA', 'authpassword12345', 'AES', 'privpassword12345', 'myContext', str_repeat('aa', 33)));
+?>
+--EXPECTF--
+bool(true)
+
+Warning: SNMP::setSecurity(): Bad engine ID value 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' in %s on line %d
+bool(false)


### PR DESCRIPTION
`netsnmp_session_set_contextEngineID()` passes an emalloc()'d buffer to `snmp_hex_to_binary()` with `allow_realloc` set. A context engine ID longer than the 32-byte buffer makes net-snmp call `snmp_realloc()` on that pointer, which aborts the process.

RFC 3411 caps the engine ID at 32 bytes anyway, so this drops `allow_realloc`: an oversized value now hits the existing "Bad engine ID value" warning and returns false.

Fixes GH-23453
