### PR TITLE
fix: move error finalization after stream fields in stream_get_meta_data to prevent UAF

### DIFF
--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -563,7 +563,6 @@ PHP_FUNCTION(stream_get_meta_data)
 		add_assoc_bool(return_value, "blocked", 1);
 		add_assoc_bool(return_value, "eof", php_stream_eof(stream));
 	}
-	php_stream_error_operation_end_for_stream(stream);
 
 	if (!Z_ISUNDEF(stream->wrapperdata)) {
 		Z_ADDREF_P(&stream->wrapperdata);
@@ -598,6 +597,7 @@ PHP_FUNCTION(stream_get_meta_data)
 		add_assoc_string(return_value, "uri", stream->orig_path);
 	}
 
+	php_stream_error_operation_end_for_stream(stream);
 }
 /* }}} */
 


### PR DESCRIPTION
Fixes heap-use-after-free in stream_get_meta_data.

php_stream_error_operation_end_for_stream invokes the error handler which may fclose the stream. In the previous order this ran before wrapperdata, wrapper type, stream type, mode and uri were copied into the return value, so those reads touched freed memory. Deferring finalization until after all stream fields are copied closes the UAF window.

The change is a one-line reorder within PHP_FUNCTION(stream_get_meta_data). It keeps begin, populate and eof handling unchanged and only moves the end call after the last stream field access. This matches the pattern needed for the sibling reports 23259 and 23264 which share the same root cause.
