### PR TITLE
Fix bug #80056: SPL directory iterators lose entries on 9p filesystems

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,12 @@ PHP                                                                        NEWS
   . Fixed bug GH-23242 (PHP development server does not support Expect
     100-continue flow control). (Sjoerd Langkemper)
 
+- SPL:
+  . Fixed bug #80056 (DirectoryIterator, FilesystemIterator and
+    RecursiveDirectoryIterator lose directory entries on filesystems that
+    cannot rewind a directory handle after a partial read, e.g. 9p mounts
+    under WSL2 and Docker Desktop). (denkfabrik-li)
+
 
 27 Aug 2026, PHP 8.6.0beta2
 

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -256,6 +256,8 @@ static zend_result spl_filesystem_object_get_file_name(spl_filesystem_object *in
 
 static void spl_filesystem_dir_read(spl_filesystem_object *intern) /* {{{ */
 {
+	intern->u.dir.at_initial_entry = false;
+
 	if (intern->file_name) {
 		/* invalidate */
 		zend_string_release(intern->file_name);
@@ -309,7 +311,36 @@ static void spl_filesystem_dir_open(spl_filesystem_object* intern, zend_string *
 		do {
 			spl_filesystem_dir_read(intern);
 		} while (skip_dots && spl_filesystem_is_dot(intern->u.dir.entry.d_name));
+		intern->u.dir.at_initial_entry = true;
 	}
+}
+/* }}} */
+
+/* {{{ spl_filesystem_dir_rewind */
+/* rewind a directory resource to its first entry */
+static void spl_filesystem_dir_rewind(spl_filesystem_object *intern)
+{
+	bool skip_dots = SPL_HAS_FLAG(intern->flags, SPL_FILE_DIR_SKIPDOTS);
+
+	intern->u.dir.index = 0;
+
+	if (intern->u.dir.at_initial_entry) {
+		/* No entry has been consumed since the directory was opened or last
+		 * rewound, so the stream is still positioned at its first entry and
+		 * there is nothing to rewind. Skipping the redundant seek matters on
+		 * filesystems that cannot rewind a directory handle after a partial
+		 * read (e.g. 9p): rewinddir() would silently discard the entries
+		 * already buffered by the C library. */
+		return;
+	}
+
+	if (intern->u.dir.dirp) {
+		php_stream_rewinddir(intern->u.dir.dirp);
+	}
+	do {
+		spl_filesystem_dir_read(intern);
+	} while (skip_dots && spl_filesystem_is_dot(intern->u.dir.entry.d_name));
+	intern->u.dir.at_initial_entry = true;
 }
 /* }}} */
 
@@ -735,9 +766,7 @@ PHP_METHOD(DirectoryIterator, rewind)
 	ZEND_PARSE_PARAMETERS_NONE();
 
 	CHECK_DIRECTORY_ITERATOR_IS_INITIALIZED(intern);
-	intern->u.dir.index = 0;
-	php_stream_rewinddir(intern->u.dir.dirp);
-	spl_filesystem_dir_read(intern);
+	spl_filesystem_dir_rewind(intern);
 }
 /* }}} */
 
@@ -1361,17 +1390,10 @@ PHP_METHOD(FilesystemIterator, __construct)
 PHP_METHOD(FilesystemIterator, rewind)
 {
 	spl_filesystem_object *intern = spl_filesystem_from_obj(Z_OBJ_P(ZEND_THIS));
-	bool skip_dots = SPL_HAS_FLAG(intern->flags, SPL_FILE_DIR_SKIPDOTS);
 
 	ZEND_PARSE_PARAMETERS_NONE();
 
-	intern->u.dir.index = 0;
-	if (intern->u.dir.dirp) {
-		php_stream_rewinddir(intern->u.dir.dirp);
-	}
-	do {
-		spl_filesystem_dir_read(intern);
-	} while (skip_dots && spl_filesystem_is_dot(intern->u.dir.entry.d_name));
+	spl_filesystem_dir_rewind(intern);
 }
 /* }}} */
 
@@ -1638,11 +1660,7 @@ static void spl_filesystem_dir_it_rewind(zend_object_iterator *iter)
 {
 	spl_filesystem_object *object = spl_filesystem_iterator_to_object((spl_filesystem_iterator *)iter);
 
-	object->u.dir.index = 0;
-	if (object->u.dir.dirp) {
-		php_stream_rewinddir(object->u.dir.dirp);
-	}
-	spl_filesystem_dir_read(object);
+	spl_filesystem_dir_rewind(object);
 }
 /* }}} */
 
@@ -1726,15 +1744,8 @@ static void spl_filesystem_tree_it_rewind(zend_object_iterator *iter)
 {
 	spl_filesystem_iterator *iterator = (spl_filesystem_iterator *)iter;
 	spl_filesystem_object   *object   = spl_filesystem_iterator_to_object(iterator);
-	bool skip_dots = SPL_HAS_FLAG(object->flags, SPL_FILE_DIR_SKIPDOTS);
 
-	object->u.dir.index = 0;
-	if (object->u.dir.dirp) {
-		php_stream_rewinddir(object->u.dir.dirp);
-	}
-	do {
-		spl_filesystem_dir_read(object);
-	} while (skip_dots && spl_filesystem_is_dot(object->u.dir.entry.d_name));
+	spl_filesystem_dir_rewind(object);
 	if (!Z_ISUNDEF(iterator->current)) {
 		zval_ptr_dtor(&iterator->current);
 		ZVAL_UNDEF(&iterator->current);

--- a/ext/spl/spl_directory.h
+++ b/ext/spl/spl_directory.h
@@ -61,6 +61,11 @@ struct _spl_filesystem_object {
 			php_stream         *dirp;
 			zend_string        *sub_path;
 			zend_long          index;
+			/* Whether the stream is still positioned at its first (non-skipped)
+			 * entry, in which case rewinding is a no-op and is skipped: some
+			 * filesystems (e.g. 9p) cannot seek a directory handle after a
+			 * partial read and would silently lose buffered entries. */
+			bool               at_initial_entry;
 			zend_function      *func_rewind;
 			zend_function      *func_next;
 			zend_function      *func_valid;

--- a/ext/spl/tests/bug80056.phpt
+++ b/ext/spl/tests/bug80056.phpt
@@ -1,0 +1,126 @@
+--TEST--
+Bug #80056 (SPL directory iterators lose entries on filesystems that cannot rewind a directory)
+--FILE--
+<?php
+/* Simulates a filesystem (e.g. 9p as used by WSL2 and Docker Desktop) where
+ * seeking a directory handle after a partial read is silently ignored:
+ * rewinddir() reports success but the read position is not reset. */
+class BrokenSeekDir {
+    public $context;
+    private $entries = ['a.txt', 'b.txt', 'c.txt', 'd.txt', 'e.txt'];
+    private $idx = 0;
+
+    public function dir_opendir($path, $options): bool {
+        $this->idx = 0;
+        return true;
+    }
+
+    public function dir_readdir(): string|false {
+        return $this->idx < count($this->entries) ? $this->entries[$this->idx++] : false;
+    }
+
+    public function dir_rewinddir(): bool {
+        /* Broken on purpose: pretends to succeed without resetting the position. */
+        return true;
+    }
+
+    public function dir_closedir(): bool {
+        return true;
+    }
+
+    public function url_stat($path, $flags): array|false {
+        return ['dev' => 0, 'ino' => 0, 'mode' => 0100644, 'nlink' => 1,
+            'uid' => 0, 'gid' => 0, 'rdev' => -1, 'size' => 0,
+            'atime' => 0, 'mtime' => 0, 'ctime' => 0, 'blksize' => -1, 'blocks' => -1];
+    }
+}
+stream_wrapper_register('brokenseek', BrokenSeekDir::class);
+
+echo "DirectoryIterator:\n";
+$names = [];
+foreach (new DirectoryIterator('brokenseek://dir') as $info) {
+    $names[] = $info->getFilename();
+}
+var_dump($names);
+
+echo "FilesystemIterator:\n";
+$names = [];
+$it = new FilesystemIterator('brokenseek://dir',
+    FilesystemIterator::KEY_AS_FILENAME | FilesystemIterator::CURRENT_AS_PATHNAME);
+foreach ($it as $name => $path) {
+    $names[] = $name;
+}
+var_dump($names);
+
+echo "RecursiveDirectoryIterator:\n";
+$names = [];
+$it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator('brokenseek://dir',
+    FilesystemIterator::KEY_AS_FILENAME | FilesystemIterator::CURRENT_AS_PATHNAME));
+foreach ($it as $name => $path) {
+    $names[] = $name;
+}
+var_dump($names);
+
+echo "Entry accessed before iteration:\n";
+$it = new DirectoryIterator('brokenseek://dir');
+var_dump($it->current()->getFilename());
+$names = [];
+foreach ($it as $info) {
+    $names[] = $info->getFilename();
+}
+var_dump($names);
+?>
+--EXPECT--
+DirectoryIterator:
+array(5) {
+  [0]=>
+  string(5) "a.txt"
+  [1]=>
+  string(5) "b.txt"
+  [2]=>
+  string(5) "c.txt"
+  [3]=>
+  string(5) "d.txt"
+  [4]=>
+  string(5) "e.txt"
+}
+FilesystemIterator:
+array(5) {
+  [0]=>
+  string(5) "a.txt"
+  [1]=>
+  string(5) "b.txt"
+  [2]=>
+  string(5) "c.txt"
+  [3]=>
+  string(5) "d.txt"
+  [4]=>
+  string(5) "e.txt"
+}
+RecursiveDirectoryIterator:
+array(5) {
+  [0]=>
+  string(5) "a.txt"
+  [1]=>
+  string(5) "b.txt"
+  [2]=>
+  string(5) "c.txt"
+  [3]=>
+  string(5) "d.txt"
+  [4]=>
+  string(5) "e.txt"
+}
+Entry accessed before iteration:
+string(5) "a.txt"
+array(5) {
+  [0]=>
+  string(5) "a.txt"
+  [1]=>
+  string(5) "b.txt"
+  [2]=>
+  string(5) "c.txt"
+  [3]=>
+  string(5) "d.txt"
+  [4]=>
+  string(5) "e.txt"
+}

--- a/ext/spl/tests/spl_dir_iterator_rewind_noop.phpt
+++ b/ext/spl/tests/spl_dir_iterator_rewind_noop.phpt
@@ -1,0 +1,111 @@
+--TEST--
+SPL directory iterators only seek the directory stream when entries have been consumed
+--FILE--
+<?php
+class LoggingDir {
+    public static $rewinds = 0;
+    public $context;
+    private $entries = ['a.txt', 'b.txt', 'c.txt'];
+    private $idx = 0;
+
+    public function dir_opendir($path, $options): bool {
+        $this->idx = 0;
+        return true;
+    }
+
+    public function dir_readdir(): string|false {
+        return $this->idx < count($this->entries) ? $this->entries[$this->idx++] : false;
+    }
+
+    public function dir_rewinddir(): bool {
+        self::$rewinds++;
+        $this->idx = 0;
+        return true;
+    }
+
+    public function dir_closedir(): bool {
+        return true;
+    }
+}
+stream_wrapper_register('logdir', LoggingDir::class);
+
+echo "First iteration needs no seek:\n";
+$it = new FilesystemIterator('logdir://dir',
+    FilesystemIterator::KEY_AS_FILENAME | FilesystemIterator::CURRENT_AS_PATHNAME);
+$names = [];
+foreach ($it as $name => $path) {
+    $names[] = $name;
+}
+var_dump($names, LoggingDir::$rewinds);
+
+echo "Iterating again performs a real rewind:\n";
+$names = [];
+foreach ($it as $name => $path) {
+    $names[] = $name;
+}
+var_dump($names, LoggingDir::$rewinds);
+
+echo "Explicit rewind after next() performs a real rewind:\n";
+LoggingDir::$rewinds = 0;
+$it = new DirectoryIterator('logdir://dir');
+$it->next();
+$it->rewind();
+$names = [];
+while ($it->valid()) {
+    $names[] = $it->getFilename();
+    $it->next();
+}
+var_dump($names, LoggingDir::$rewinds);
+
+echo "Repeated rewind without reads stays a no-op:\n";
+LoggingDir::$rewinds = 0;
+$it = new DirectoryIterator('logdir://dir');
+$it->rewind();
+$it->rewind();
+$names = [];
+foreach ($it as $info) {
+    $names[] = $info->getFilename();
+}
+var_dump($names, LoggingDir::$rewinds);
+?>
+--EXPECT--
+First iteration needs no seek:
+array(3) {
+  [0]=>
+  string(5) "a.txt"
+  [1]=>
+  string(5) "b.txt"
+  [2]=>
+  string(5) "c.txt"
+}
+int(0)
+Iterating again performs a real rewind:
+array(3) {
+  [0]=>
+  string(5) "a.txt"
+  [1]=>
+  string(5) "b.txt"
+  [2]=>
+  string(5) "c.txt"
+}
+int(1)
+Explicit rewind after next() performs a real rewind:
+array(3) {
+  [0]=>
+  string(5) "a.txt"
+  [1]=>
+  string(5) "b.txt"
+  [2]=>
+  string(5) "c.txt"
+}
+int(1)
+Repeated rewind without reads stays a no-op:
+array(3) {
+  [0]=>
+  string(5) "a.txt"
+  [1]=>
+  string(5) "b.txt"
+  [2]=>
+  string(5) "c.txt"
+}
+int(0)


### PR DESCRIPTION
### Summary

`FilesystemIterator`, `RecursiveDirectoryIterator` and `DirectoryIterator` silently
lose directory entries on filesystems that cannot rewind a directory handle after a
partial read — most notably 9p mounts, which is what WSL2 and Docker Desktop on
Windows use to expose the Windows drive to Linux. An entire libc `getdents` buffer
vanishes from the iteration: ~21 entries with musl (2 KiB buffer), ~343 with glibc
(32 KiB buffer). `scandir()`, `glob()` and a plain `readdir()` loop over the same
directory return the complete listing.

The cause is PHP-specific behaviour, not just the kernel bug: the iterator
constructors eagerly read the first directory entry, and the implicit `rewind()` at
the start of the first `foreach` then calls `rewinddir()` on a stream whose position
is already past that first entry. On a healthy filesystem this seek is redundant (it
re-reads the entry the constructor already had); on 9p the seek is silently ignored
server-side while the C library discards its read buffer — everything that was in
that buffer is skipped.

This PR makes the rewind a no-op while the stream is still positioned at its first
entry, so the standard construct-then-`foreach` pattern never seeks at all.

### History

- https://bugs.php.net/bug.php?id=80056 (Sep 2020, RecursiveDirectoryIterator misses
  files under Docker/WSL2) — closed "Not a bug": *"this is unlikely to be a PHP issue"*.
- https://bugs.php.net/bug.php?id=80227 (Oct 2020, same on Alpine/Docker/WSL2) —
  closed "Not a bug": *"it's a WSL bug"*, pointing to microsoft/WSL#5074.
- https://github.com/microsoft/WSL/issues/5074 — closed by the bot without a fix;
  still reproducible today (measurements below, Windows 11, current WSL2/Docker
  Desktop).

Both reports were closed on the grounds that the underlying seek failure lives below
PHP — which is true. But no code change was ever proposed back then, and the seek
itself is avoidable: it is issued by PHP at a moment where it has nothing to do.
Every other PHP directory API (`scandir()`, `glob()`, `opendir()`/`readdir()`)
works on these mounts precisely because none of them seeks a partially-read handle.

The failure mode is nasty in practice because it is silent, size-dependent (only
directories with more entries than one libc buffer are affected) and
environment-dependent (works on ext4, breaks on the very same code under Docker
Desktop on Windows). Real-world sightings include Composer autoload scans, Laravel
migration discovery and PHPStan/Larastan file collection:
laravel/framework#61336, larastan/larastan#2538, projectsend/projectsend#1680.

### The mechanism

```text
new FilesystemIterator($dir)          # constructor opens the dir
  -> readdir()                        #   ...and eagerly reads entry #1
                                      #   libc fills its getdents buffer
foreach ($it as $f)                   # foreach starts with rewind()
  -> rewinddir()                      #   seek to offset 0
                                      #   9p: seek silently ignored,
                                      #   libc buffer discarded anyway
  -> readdir(), readdir(), ...        #   continues AFTER the discarded buffer
```

With musl's 2 KiB buffer the first ~21 entries disappear; with glibc's 32 KiB
buffer the first ~343. Directories at or below one buffer appear complete, which is
why small test cases pass and production directories fail.

### The fix

Track in `spl_filesystem_object.u.dir` whether the stream is still positioned at its
first (non-skipped) entry (`at_initial_entry`). All four rewind paths
(`DirectoryIterator::rewind()`, `FilesystemIterator::rewind()`, and the two internal
`zend_object_iterator` rewind handlers) are consolidated into one helper,
`spl_filesystem_dir_rewind()`, which skips the `rewinddir()` + re-read when nothing
has been consumed yet. Any actual read (`next()`, internal `move_forward`, the
clone catch-up loop, `seek()`) clears the flag, so a rewind after real consumption
still performs a real `rewinddir()` exactly as before.

### Behaviour / BC analysis

Unchanged:
- The constructor still opens the directory eagerly — an invalid path still throws
  `UnexpectedValueException` from the constructor.
- The constructor still pre-reads the first entry: `$it->current()`,
  `getFilename()`, `key()`, `hasChildren()` etc. right after construction behave
  exactly as before (and now also work on 9p, since the pre-read is sequential).
- `rewind()` after any entry has been consumed performs a real `rewinddir()` +
  re-read, as before (re-iterating an iterator, `seek()` backwards, clone).
- Result sets, ordering, keys, flags handling (`SKIP_DOTS`, …) on healthy
  filesystems: byte-for-byte identical output; the full test suite passes.

Observable differences (deliberate):
- While the stream is still on its first entry, `rewind()` no longer issues
  `rewinddir()` + `readdir()`. For userland stream wrappers this means
  `dir_rewinddir()` is no longer invoked at the start of the first iteration (one
  callback less; a wrapper that relied on being rewound before the first read was
  already broken, since the constructor pre-read has always happened before any
  rewind). One redundant syscall pair per iteration start is saved everywhere.
- POSIX allows `rewinddir()` to pick up directory modifications made after
  `opendir()`. A file created between construction and the first `foreach` was
  previously *sometimes* visible (filesystem-dependent, POSIX explicitly leaves it
  unspecified); with the no-op rewind the iteration keeps the view the constructor
  started with. Code relying on that was already unreliable across filesystems.

Known limitation (unchanged, inherent to broken seeks): re-iterating the *same*
iterator object (second `foreach`, explicit `rewind()` after `next()`) still
requires a real `rewinddir()` and therefore still misbehaves on 9p — same as a
userland `rewinddir()` call. This patch fixes the overwhelmingly common
construct-then-iterate-once pattern, which is what Composer/Laravel/PHPStan & co.
use.

### Tests

- `ext/spl/tests/bug80056.phpt` — simulates the broken filesystem with a userland
  stream wrapper whose `dir_rewinddir()` pretends to succeed without resetting the
  position (exactly the observable 9p behaviour). Fails on current master (each
  iterator loses its first entry), passes with the fix. Covers DirectoryIterator,
  FilesystemIterator, RecursiveDirectoryIterator + RecursiveIteratorIterator, and
  the "entry accessed before iteration" pattern.
- `ext/spl/tests/spl_dir_iterator_rewind_noop.phpt` — pins the new seek semantics
  with a counting wrapper: no `dir_rewinddir()` on first iteration, exactly one on
  re-iteration, exactly one for `rewind()` after `next()`, none for repeated
  `rewind()` without reads.
- Existing SPL suite: green (see verification below).

### Verification

Two-stage, with unpatched and patched CLI binaries built from the *same* master
checkout (`ext/spl/spl_directory.*` diff applied incrementally in the same
container build):

**(a) Test suite (ext4 inside the build containers):**

Full `ext/spl` suite with the patched CLI — identical results on
Debian bookworm (glibc) and Alpine 3.22 (musl):

```text
Number of tests :   810               799
Tests skipped   :    11 (  1.4%)
Tests failed    :     0 (  0.0%)
Expected fail   :     1 (  0.1%)   (pre-existing XFAIL, unrelated)
Tests passed    :   798 ( 98.5%)
```

A second build with `--enable-phar --enable-zend-test` additionally runs the
SPL-over-phar and stack-limit tests (gh14687, gh17225, gh15911, gh15672 — all
pass; 802 SPL tests passed total) plus the full `ext/phar` suite: 382 runnable
tests, 0 failures. Relevant because `Phar` extends `RecursiveDirectoryIterator`
and embeds `spl_filesystem_object`; its in-memory directory stream keeps a
working seek, so behaviour is unchanged there.

Both new tests FAIL on unpatched master, each iterator losing its first entry
(`array(4)` instead of `array(5)`, `a.txt` missing) — i.e. the regression tests
demonstrably catch the bug.

**(b) Live 9p mount (Docker Desktop on Windows 11, WSL2 backend; a Windows
directory with 500 `.php` files — plus 1 in a subdirectory for the recursive
case — mounted into the container; `stat -f -c %T` reports `v9fs`):**

| API                          | musl unpatched | musl patched | glibc unpatched | glibc patched |
|------------------------------|---------------:|-------------:|----------------:|--------------:|
| `scandir()`                  | 500            | 500          | 500             | 500           |
| `glob()`                     | 500            | 500          | 500             | 500           |
| `readdir()` loop             | 500            | 500          | 500             | 500           |
| `FilesystemIterator`         | **479**        | 500          | **157**         | 500           |
| `RecursiveDirectoryIterator` | **480**        | 501          | **158**         | 501           |
| `DirectoryIterator`          | **479**        | 500          | **157**         | 500           |

The losses match the libc buffer sizes exactly: musl drops its first 2 KiB
`getdents` buffer (21 entries), glibc its first 32 KiB buffer (343 entries).

One-liner reproducer for anyone with Docker Desktop on Windows (stock image,
directory with a few hundred files):

```text
> docker run --rm -v C:\some\big\dir:/mnt/d php:8.4-cli php -r \
    "echo count(scandir('/mnt/d'))-2, ' vs ', iterator_count(new FilesystemIterator('/mnt/d'));"
501 vs 158        # PHP 8.4.24, verified 2026-08-25
```