### PR TITLE
Fix leak of driver_params argument of PDOStatement::bindParam() and bindColumn()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -46,6 +46,8 @@ PHP                                                                        NEWS
 - PDO:
   . Fixed a leak when a persistent connection failed a liveness check
     with no other live PDO handle. (iliaal)
+  . Fixed a leak of the driver_params argument in bindParam() and
+    bindColumn(). (iliaal)
 
 - Standard:
   . Fixed a memory leak in array_merge_recursive() when the recursive merge of

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -330,6 +330,7 @@ static bool really_register_bound_param(struct pdo_bound_param_data *param, pdo_
 			zend_string_release_ex(param->name, 0);
 			param->name = NULL;
 		}
+		zval_ptr_dtor(&param->driver_params);
 		return 0;
 	}
 
@@ -344,6 +345,7 @@ static bool really_register_bound_param(struct pdo_bound_param_data *param, pdo_
 				zend_string_release_ex(param->name, 0);
 				param->name = NULL;
 			}
+			zval_ptr_dtor(&param->driver_params);
 			return 0;
 		}
 	}
@@ -1461,9 +1463,11 @@ static void register_bound_param(INTERNAL_FUNCTION_PARAMETERS, int is_param) /* 
 		if (!Z_ISUNDEF(param.parameter)) {
 			zval_ptr_dtor(&(param.parameter));
 		}
+		zval_ptr_dtor(&param.driver_params);
 
 		RETURN_FALSE;
 	}
+	zval_ptr_dtor(&param.driver_params);
 
 	RETURN_TRUE;
 } /* }}} */

--- a/ext/pdo/tests/bug_driver_params_leak.phpt
+++ b/ext/pdo/tests/bug_driver_params_leak.phpt
@@ -1,0 +1,89 @@
+--TEST--
+PDO: bindParam() must not leak driver_params
+--EXTENSIONS--
+pdo
+pdo_sqlite
+--FILE--
+<?php
+class C {}
+$db = new PDO('sqlite::memory:');
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$stmt = $db->prepare('SELECT ?');
+
+$n = 20000;
+$dp = str_repeat('a', 1024);
+$obj = new C();
+try {
+    $stmt->bindParam(1, $obj, PDO::PARAM_STR, 0, $dp);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
+}
+for ($i = 0; $i < $n; $i++) {
+    $dp = str_repeat('a', 1024);
+    $obj = new C();
+    try {
+        $stmt->bindParam(1, $obj, PDO::PARAM_STR, 0, $dp);
+    } catch (Error $e) {
+    }
+}
+$before = memory_get_usage();
+for ($i = 0; $i < $n; $i++) {
+    $dp = str_repeat('b', 1024);
+    $obj = new C();
+    try {
+        $stmt->bindParam(1, $obj, PDO::PARAM_STR, 0, $dp);
+    } catch (Error $e) {
+    }
+}
+$diff = memory_get_usage() - $before;
+if ($diff > 1000) {
+    echo "LEAK\n";
+} else {
+    echo "OK\n";
+}
+
+$stmt2 = $db->prepare('SELECT :bar');
+$v = 'x';
+for ($i = 0; $i < $n; $i++) {
+    $dp = str_repeat('c', 1024);
+    try {
+        $stmt2->bindParam(':missing', $v, PDO::PARAM_STR, 0, $dp);
+    } catch (PDOException $e) {
+    }
+}
+$before = memory_get_usage();
+for ($i = 0; $i < $n; $i++) {
+    $dp = str_repeat('d', 1024);
+    try {
+        $stmt2->bindParam(':missing', $v, PDO::PARAM_STR, 0, $dp);
+    } catch (PDOException $e) {
+    }
+}
+$diff = memory_get_usage() - $before;
+if ($diff > 1000) {
+    echo "LEAK\n";
+} else {
+    echo "OK\n";
+}
+
+for ($i = 0; $i < $n; $i++) {
+    $dp = str_repeat('e', 1024);
+    $stmt->bindParam(1, $v, PDO::PARAM_STR, 0, $dp);
+}
+$before = memory_get_usage();
+for ($i = 0; $i < $n; $i++) {
+    $dp = str_repeat('f', 1024);
+    $stmt->bindParam(1, $v, PDO::PARAM_STR, 0, $dp);
+}
+$diff = memory_get_usage() - $before;
+if ($diff > 1000) {
+    echo "LEAK\n";
+} else {
+    echo "OK\n";
+}
+?>
+--EXPECT--
+Error: Object of class C could not be converted to string
+OK
+OK
+OK


### PR DESCRIPTION
PDOStatement::bindParam() and bindColumn() leak references on the driver_params argument: register_bound_param() never releases its transient copy, and really_register_bound_param() drops its hash-bound reference on neither of its two early failure returns, so 200k failing bindParam() calls grow memory by about 128MB and even successful calls leak one reference each. Both paths now release what they take; the EVT_ALLOC hook failure needed no change because deleting the hash entry frees it through param_dtor().
