### PR TITLE
Return false from rewrite_name_to_position() on IM001 error path

### DIFF
--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -76,7 +76,7 @@ static inline bool rewrite_name_to_position(pdo_stmt_t *stmt, struct pdo_bound_p
 			if (param->paramno >= 0) {
 				/* TODO Error? */
 				pdo_raise_impl_error(stmt->dbh, stmt, "IM001", "PDO refuses to handle repeating the same :named parameter for multiple positions with this driver, as it might be unsafe to do so.  Consider using a separate name for each parameter instead");
-				return -1;
+				return false;
 			}
 			param->paramno = position;
 			return 1;


### PR DESCRIPTION
rewrite_name_to_position() is declared bool, so the -1 returned after raising the IM001 error for a repeated :named parameter was converted to true and the caller's failure check never saw the failure, leaving bindParam() and bindColumn() reporting success despite the error. Returning false makes the error propagate; no other -1 return remains in the function.
