### PR TITLE
Io\Poll\Context::wait() prevent integer overflow

### DIFF
--- a/ext/standard/io_poll.c
+++ b/ext/standard/io_poll.c
@@ -804,12 +804,15 @@ PHP_METHOD(Io_Poll_Context, wait)
 		if (max_events <= 0) {
 			max_events = 64;
 		}
-	} else if (max_events <= 0) {
+	} else if (UNEXPECTED(max_events <= 0)) {
 		zend_argument_value_error(2, "must be greater than 0");
+		RETURN_THROWS();
+	} else if (ZEND_LONG_INT_OVFL(max_events)) {
+		zend_argument_value_error(2, "must be less than or equal to %d", INT_MAX);
 		RETURN_THROWS();
 	}
 
-	php_poll_event *events = safe_emalloc(max_events, sizeof(*events), 0);
+	php_poll_event *events = safe_emalloc((size_t) max_events, sizeof(*events), 0);
 	int num_events = php_poll_wait(intern->ctx, events, (int) max_events, timeout ? &timeout_ts : NULL);
 
 	if (num_events < 0) {

--- a/ext/standard/tests/poll/poll_ctx_wait_error.phpt
+++ b/ext/standard/tests/poll/poll_ctx_wait_error.phpt
@@ -13,7 +13,19 @@ try {
 }
 
 try {
+    $poll_ctx->wait(maxEvents: PHP_INT_MIN);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
     $poll_ctx->wait(maxEvents: -1);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    $poll_ctx->wait(maxEvents: 0);
 } catch (Throwable $e) {
     echo $e::class, ': ', $e->getMessage(), PHP_EOL;
 }
@@ -21,4 +33,6 @@ try {
 ?>
 --EXPECT--
 ValueError: Io\Poll\Context::wait(): Argument #1 ($timeout) must not be negative
+ValueError: Io\Poll\Context::wait(): Argument #2 ($maxEvents) must be greater than 0
+ValueError: Io\Poll\Context::wait(): Argument #2 ($maxEvents) must be greater than 0
 ValueError: Io\Poll\Context::wait(): Argument #2 ($maxEvents) must be greater than 0

--- a/ext/standard/tests/poll/poll_ctx_wait_error_int64.phpt
+++ b/ext/standard/tests/poll/poll_ctx_wait_error_int64.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Io\Poll\Context::wait(): Parameter validation upper limit
+--SKIPIF--
+<?php
+if (PHP_INT_SIZE <= 4) {
+    die("skip this test is for > 32bit platforms only");
+}
+?>
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+
+$poll_ctx = new Io\Poll\Context();
+
+try {
+    $poll_ctx->wait(maxEvents: PHP_INT_MAX);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+ValueError: Io\Poll\Context::wait(): Argument #2 ($maxEvents) must be less than or equal to 2147483647


### PR DESCRIPTION
This prevents integer overflow in case of `SIZEOF_INT < SIZEOF_ZEND_LONG`