### PR TITLE
Make chmod tests work on docker mounted php-src

### DIFF
--- a/ext/standard/tests/file/chmod_basic.phpt
+++ b/ext/standard/tests/file/chmod_basic.phpt
@@ -11,7 +11,7 @@ if (substr(PHP_OS, 0, 3) == 'WIN') {
 
 define("MODE_MASK", 07777);
 
-$filename = __FILE__ . ".tmp";
+$filename = sys_get_temp_dir() . DIRECTORY_SEPARATOR . basename(__FILE__) . ".tmp";
 
 $fd = fopen($filename, "w+");
 fclose($fd);

--- a/ext/standard/tests/file/chmod_variation1.phpt
+++ b/ext/standard/tests/file/chmod_variation1.phpt
@@ -11,7 +11,7 @@ if (substr(PHP_OS, 0, 3) == 'WIN') {
 
 define("PERMISSIONS_MASK", 0777);
 
-$dirname = __DIR__ . "/" . basename(__FILE__, ".php") . "testdir";
+$dirname = sys_get_temp_dir() . DIRECTORY_SEPARATOR . basename(__FILE__, ".php") . "testdir";
 mkdir($dirname);
 
 for ($perms_to_set = 0777; $perms_to_set >= 0; $perms_to_set--) {

--- a/ext/standard/tests/file/chmod_variation2.phpt
+++ b/ext/standard/tests/file/chmod_variation2.phpt
@@ -11,12 +11,12 @@ if (substr(PHP_OS, 0, 3) == 'WIN') {
 
 define("PERMISSIONS_MASK", 0777);
 
-$script_directory = __DIR__;
+$script_directory = sys_get_temp_dir();
 chdir($script_directory);
 $test_dirname = basename(__FILE__, ".php") . "testdir";
 mkdir($test_dirname);
 
-$filepath = __FILE__ . ".tmp";
+$filepath = $script_directory . DIRECTORY_SEPARATOR . basename(__FILE__) . ".tmp";
 $filename = basename($filepath);
 $fd = fopen($filepath, "w+");
 fclose($fd);


### PR DESCRIPTION
Using `sys_get_temp_dir()` instead of `__DIR__`