### PR TITLE
Cache freed VM stack pages instead of freeing them immediately

### DIFF
--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -210,6 +210,13 @@ ZEND_API void zend_vm_stack_destroy(void)
 {
 	zend_vm_stack stack = EG(vm_stack);
 
+	while (EG(vm_stack_page_cache) != NULL) {
+		zend_vm_stack cached = EG(vm_stack_page_cache);
+		EG(vm_stack_page_cache) = cached->prev;
+		efree(cached);
+	}
+	EG(vm_stack_page_cache_count) = 0;
+
 	while (stack != NULL) {
 		zend_vm_stack p = stack->prev;
 		efree(stack);

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -193,6 +193,8 @@ ZEND_API void zend_vm_stack_init(void)
 	EG(vm_stack_page_size) = ZEND_VM_STACK_PAGE_SIZE;
 	EG(vm_stack_page_cache) = NULL;
 	EG(vm_stack_page_cache_count) = 0;
+	EG(fiber_vm_stack_page_cache) = NULL;
+	EG(fiber_vm_stack_page_cache_count) = 0;
 	EG(vm_stack) = zend_vm_stack_new_page(ZEND_VM_STACK_PAGE_SIZE, NULL);
 	EG(vm_stack_top) = EG(vm_stack)->top;
 	EG(vm_stack_end) = EG(vm_stack)->end;
@@ -205,6 +207,8 @@ ZEND_API void zend_vm_stack_init_ex(size_t page_size)
 	EG(vm_stack_page_size) = page_size;
 	EG(vm_stack_page_cache) = NULL;
 	EG(vm_stack_page_cache_count) = 0;
+	EG(fiber_vm_stack_page_cache) = NULL;
+	EG(fiber_vm_stack_page_cache_count) = 0;
 	EG(vm_stack) = zend_vm_stack_new_page(page_size, NULL);
 	EG(vm_stack_top) = EG(vm_stack)->top;
 	EG(vm_stack_end) = EG(vm_stack)->end;
@@ -214,6 +218,15 @@ ZEND_API void zend_vm_stack_destroy(void)
 {
 	zend_vm_stack stack = EG(vm_stack);
 
+	while (stack != NULL) {
+		zend_vm_stack p = stack->prev;
+		efree(stack);
+		stack = p;
+	}
+}
+
+ZEND_API void zend_vm_stack_destroy_caches(void)
+{
 	while (EG(vm_stack_page_cache) != NULL) {
 		zend_vm_stack cached = EG(vm_stack_page_cache);
 		EG(vm_stack_page_cache) = cached->prev;
@@ -221,11 +234,12 @@ ZEND_API void zend_vm_stack_destroy(void)
 	}
 	EG(vm_stack_page_cache_count) = 0;
 
-	while (stack != NULL) {
-		zend_vm_stack p = stack->prev;
-		efree(stack);
-		stack = p;
+	while (EG(fiber_vm_stack_page_cache) != NULL) {
+		zend_vm_stack cached = EG(fiber_vm_stack_page_cache);
+		EG(fiber_vm_stack_page_cache) = cached->prev;
+		efree(cached);
 	}
+	EG(fiber_vm_stack_page_cache_count) = 0;
 }
 
 ZEND_API void* zend_vm_stack_extend(size_t size)

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -191,6 +191,8 @@ ZEND_API const zend_internal_function zend_pass_function = {
 ZEND_API void zend_vm_stack_init(void)
 {
 	EG(vm_stack_page_size) = ZEND_VM_STACK_PAGE_SIZE;
+	EG(vm_stack_page_cache) = NULL;
+	EG(vm_stack_page_cache_count) = 0;
 	EG(vm_stack) = zend_vm_stack_new_page(ZEND_VM_STACK_PAGE_SIZE, NULL);
 	EG(vm_stack_top) = EG(vm_stack)->top;
 	EG(vm_stack_end) = EG(vm_stack)->end;
@@ -201,6 +203,8 @@ ZEND_API void zend_vm_stack_init_ex(size_t page_size)
 	/* page_size must be a power of 2 */
 	ZEND_ASSERT(page_size > 0 && (page_size & (page_size - 1)) == 0);
 	EG(vm_stack_page_size) = page_size;
+	EG(vm_stack_page_cache) = NULL;
+	EG(vm_stack_page_cache_count) = 0;
 	EG(vm_stack) = zend_vm_stack_new_page(page_size, NULL);
 	EG(vm_stack_top) = EG(vm_stack)->top;
 	EG(vm_stack_end) = EG(vm_stack)->end;

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -325,7 +325,14 @@ ZEND_API void zend_vm_stack_destroy(void);
 ZEND_API void* zend_vm_stack_extend(size_t size);
 
 static zend_always_inline zend_vm_stack zend_vm_stack_new_page(size_t size, zend_vm_stack prev) {
-	zend_vm_stack page = (zend_vm_stack)emalloc(size);
+	zend_vm_stack page = EG(vm_stack_page_cache);
+
+	if (page != NULL && EXPECTED((size_t)((char*)page->end - (char*)page) == size)) {
+		EG(vm_stack_page_cache) = page->prev;
+		EG(vm_stack_page_cache_count)--;
+	} else {
+		page = (zend_vm_stack)emalloc(size);
+	}
 
 	page->top = ZEND_VM_STACK_ELEMENTS(page);
 	page->end = (zval*)((char*)page + size);
@@ -421,7 +428,14 @@ static zend_always_inline void zend_vm_stack_free_call_frame_ex(uint32_t call_in
 		EG(vm_stack_top) = prev->top;
 		EG(vm_stack_end) = prev->end;
 		EG(vm_stack) = prev;
-		efree(p);
+		if (EG(vm_stack_page_cache_count) < 32
+			&& (size_t)((char*)p->end - (char*)p) == EG(vm_stack_page_size)) {
+			p->prev = EG(vm_stack_page_cache);
+			EG(vm_stack_page_cache) = p;
+			EG(vm_stack_page_cache_count)++;
+		} else {
+			efree(p);
+		}
 	} else {
 		EG(vm_stack_top) = (zval*)call;
 	}

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -322,15 +322,39 @@ ZEND_STATIC_ASSERT(ZEND_MM_ALIGNED_SIZE(sizeof(zval)) == sizeof(zval),
 ZEND_API void zend_vm_stack_init(void);
 ZEND_API void zend_vm_stack_init_ex(size_t page_size);
 ZEND_API void zend_vm_stack_destroy(void);
+ZEND_API void zend_vm_stack_destroy_caches(void);
 ZEND_API void* zend_vm_stack_extend(size_t size);
 
-static zend_always_inline zend_vm_stack zend_vm_stack_new_page(size_t size, zend_vm_stack prev) {
-	zend_vm_stack page = EG(vm_stack_page_cache);
+#define ZEND_FIBER_VM_STACK_SIZE (1024 * sizeof(zval))
 
-	if (page != NULL && EXPECTED((size_t)((char*)page->end - (char*)page) == size)) {
-		EG(vm_stack_page_cache) = page->prev;
-		EG(vm_stack_page_cache_count)--;
+static zend_always_inline zend_vm_stack zend_vm_stack_cached_page(size_t size) {
+	zend_vm_stack page;
+
+	if (size == ZEND_FIBER_VM_STACK_SIZE) {
+		page = EG(fiber_vm_stack_page_cache);
+		if (page) {
+			ZEND_ASSERT((size_t)((char*)page->end - (char*)page) == size);
+			EG(fiber_vm_stack_page_cache) = page->prev;
+			EG(fiber_vm_stack_page_cache_count)--;
+			return page;
+		}
 	} else {
+		page = EG(vm_stack_page_cache);
+		ZEND_ASSERT(!page || ((size_t)((char*)page->end - (char*)page) == size) || size != EG(vm_stack_page_size));
+		if (page && EXPECTED((size_t)((char*)page->end - (char*)page) == size)) {
+			EG(vm_stack_page_cache) = page->prev;
+			EG(vm_stack_page_cache_count)--;
+			return page;
+		}
+	}
+
+	return NULL;
+}
+
+static zend_always_inline zend_vm_stack zend_vm_stack_new_page(size_t size, zend_vm_stack prev) {
+	zend_vm_stack page = zend_vm_stack_cached_page(size);
+
+	if (!page) {
 		page = (zend_vm_stack)emalloc(size);
 	}
 
@@ -428,13 +452,23 @@ static zend_always_inline void zend_vm_stack_free_call_frame_ex(uint32_t call_in
 		EG(vm_stack_top) = prev->top;
 		EG(vm_stack_end) = prev->end;
 		EG(vm_stack) = prev;
-		if (EG(vm_stack_page_cache_count) < 32
-			&& (size_t)((char*)p->end - (char*)p) == EG(vm_stack_page_size)) {
-			p->prev = EG(vm_stack_page_cache);
-			EG(vm_stack_page_cache) = p;
-			EG(vm_stack_page_cache_count)++;
+		if ((size_t)((char*)p->end - (char*)p) == ZEND_FIBER_VM_STACK_SIZE) {
+			if (EG(fiber_vm_stack_page_cache_count) < 32) {
+				p->prev = EG(fiber_vm_stack_page_cache);
+				EG(fiber_vm_stack_page_cache) = p;
+				EG(fiber_vm_stack_page_cache_count)++;
+			} else {
+				efree(p);
+			}
 		} else {
-			efree(p);
+			if (EG(vm_stack_page_cache_count) < 32
+					&& (size_t)((char*)p->end - (char*)p) == EG(vm_stack_page_size)) {
+				p->prev = EG(vm_stack_page_cache);
+				EG(vm_stack_page_cache) = p;
+				EG(vm_stack_page_cache_count)++;
+			} else {
+				efree(p);
+			}
 		}
 	} else {
 		EG(vm_stack_top) = (zval*)call;

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -482,6 +482,7 @@ void shutdown_executor(void) /* {{{ */
 		zend_hash_discard(EG(class_table), EG(persistent_classes_count));
 	} else {
 		zend_vm_stack_destroy();
+		zend_vm_stack_destroy_caches();
 
 		if (EG(full_tables_cleanup)) {
 			zend_hash_reverse_apply(EG(function_table), clean_non_persistent_function_full);

--- a/Zend/zend_fibers.h
+++ b/Zend/zend_fibers.h
@@ -25,7 +25,6 @@
 #define ZEND_FIBER_GUARD_PAGES 1
 
 #define ZEND_FIBER_DEFAULT_C_STACK_SIZE (4096 * (((sizeof(void *)) < 8) ? 256 : 512))
-#define ZEND_FIBER_VM_STACK_SIZE (1024 * sizeof(zval))
 
 BEGIN_EXTERN_C()
 

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -202,6 +202,8 @@ struct _zend_executor_globals {
 	zval          *vm_stack_end;
 	zend_vm_stack  vm_stack;
 	size_t         vm_stack_page_size;
+	zend_vm_stack  vm_stack_page_cache;
+	uint32_t       vm_stack_page_cache_count;
 
 	struct _zend_execute_data *current_execute_data;
 	const zend_class_entry *fake_scope; /* used to avoid checks accessing properties */

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -204,6 +204,9 @@ struct _zend_executor_globals {
 	size_t         vm_stack_page_size;
 	zend_vm_stack  vm_stack_page_cache;
 	uint32_t       vm_stack_page_cache_count;
+	/* Fibers use a different page size, so they need a separate cache */
+	zend_vm_stack  fiber_vm_stack_page_cache;
+	uint32_t       fiber_vm_stack_page_cache_count;
 
 	struct _zend_execute_data *current_execute_data;
 	const zend_class_entry *fake_scope; /* used to avoid checks accessing properties */


### PR DESCRIPTION
> **Disclaimer:** I found out this issue when measuring performance of a giant subsystem rewrite in PHPStan, which performed better on many projects but worse on a particular one. This issue and pull request was discovered and debugged with the help of an LLM, afterwards discussed privately with Arnaud Le Blanc who told me that it's an interesting finding and worth reviewing.

A call stack whose depth oscillates across a VM stack page boundary allocates and frees a 256KB page on every oscillation: `zend_vm_stack_extend()` on the way down, and the immediate `efree()` in `zend_vm_stack_free_call_frame_ex()` on the way back. Every such allocation goes through `zend_mm_alloc_large()`, whose search for contiguous free pages degrades on a large, fragmented heap — in the worst case scanning every chunk's free-page bitmap, failing, and paying an `mmap`/`munmap` round-trip per oscillation.

Long-running processes with multi-GB heaps hit this hard. I found it profiling PHPStan analysing a large codebase in a single process (`gc_disable()`, multi-GB heap): **73–90% of all CPU time** was in `zend_mm_alloc_pages` reached from the `ZEND_INIT_METHOD_CALL` handlers — pure VM stack page churn, no useful work.

### The change

Keep up to 32 freed standard-size VM stack pages in a per-executor free list (`EG(vm_stack_page_cache)`) and serve `zend_vm_stack_new_page()` from it; flush the list in `zend_vm_stack_destroy()`. Details relevant to review:

- Only pages of exactly `EG(vm_stack_page_size)` are cached (checked on both push and pop); oversized pages — frames larger than the page size — are still freed eagerly.
- The retention ceiling is 32 × 256KB = 8MB per executor, and the cache is flushed at `zend_vm_stack_destroy()`, so nothing outlives the request. In practice an oscillating workload holds one or two pages.
- The cache lives in executor globals, so ZTS builds get one per thread; no shared state.
- The fast path adds one predictable branch to `zend_vm_stack_new_page()`; the reclaim path replaces an `efree()` with a list push under the same size check.

### Benchmark

Isolated reproducer ([gist with benchmark + reproducer](https://gist.github.com/ondrejmirtes/1c1bc4894e63ddcb6c58d7bfe59cdb7a)): recursion to a fixed depth in a loop, with the heap optionally pre-fragmented by ~600k interleaved ~5.5KB allocations keeping every other one, so the free space is 2-page holes that can never satisfy a 64-page VM stack request. Each iteration is one full depth oscillation.

Apple M1 Pro, macOS, NTS, minimal `--disable-all` build of master (`c621cbe27ff`), 20,000 iterations per cell, µs per oscillation:

| depth | master, fresh heap | master, fragmented | patched, fresh | patched, fragmented |
|------:|------:|------:|------:|------:|
| 1,500 |  40.0 |  40.1 |  40.1 |  38.5 |
| 3,000 |  79.0 |  79.7 |  77.5 |  77.0 |
| 4,500 | 119.5 | **1,846.1 (15.4×)** | 114.7 | 116.4 |
| 6,000 | 158.2 | **3,543.9 (22.4×)** | 152.7 | 154.0 |
| 9,000 | 331.7 | **7,185.8 (21.7×)** | 229.6 | 230.4 |

The cliff between depth 3,000 and 4,500 is where the recursion outgrows the initial VM stack page and every iteration starts paying the alloc/free cycle. With the patch the fragmented column matches the fresh column at every depth — and the deep fresh-heap case improves too (depth 9,000: 331.7 → 229.6µs), since even a fast allocator round-trip is slower than popping a cached page.

Real-workload effect: PHPStan (before it shipped its own userland mitigation), analysing the same 40 files of a large codebase single-process with the heap pre-fragmented as above: **537s → 51s wall** with the patch — identical to its fresh-heap time.
