### PR TITLE
ext/pdo_pgsql: Fix PDO::CURSOR_SCROLL statements failing under lazy fetching

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -52,6 +52,10 @@ PHP                                                                        NEWS
   . Fixed bug GH-23418 (Use-after-free when looking up mounted directories).
     (Weilin Du)
 
+- PDO_PGSQL:
+  . Fixed PDO::CURSOR_SCROLL statements failing under lazy fetching
+    (PDO::ATTR_PREFETCH => 0). (KentarouTakeda)
+
 - Readline:
   . Fixed the interactive shell not waiting for the pager process to exit.
     (Weilin Du)

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -287,7 +287,16 @@ static bool pgsql_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *
 	scrollable = pdo_attr_lval(driver_options, PDO_ATTR_CURSOR,
 		PDO_CURSOR_FWDONLY) == PDO_CURSOR_SCROLL;
 
+	S->is_unbuffered =
+		driver_options
+		&& (val = zend_hash_index_find(Z_ARRVAL_P(driver_options), PDO_ATTR_PREFETCH))
+		&& pdo_get_long_param(&lval, val)
+		? !lval
+		: H->default_fetching_laziness
+	;
+
 	if (scrollable) {
+		S->is_unbuffered = false;
 		if (S->cursor_name) {
 			efree(S->cursor_name);
 		}
@@ -311,14 +320,6 @@ static bool pgsql_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *
 		stmt->supports_placeholders = PDO_PLACEHOLDER_NAMED;
 		stmt->named_rewrite_template = "$%d";
 	}
-
-	S->is_unbuffered =
-		driver_options
-		&& (val = zend_hash_index_find(Z_ARRVAL_P(driver_options), PDO_ATTR_PREFETCH))
-		&& pdo_get_long_param(&lval, val)
-		? !lval
-		: H->default_fetching_laziness
-	;
 
 	ret = pdo_parse_params(stmt, sql, &nsql);
 

--- a/ext/pdo_pgsql/tests/cursor_scroll_lazy_fetch.phpt
+++ b/ext/pdo_pgsql/tests/cursor_scroll_lazy_fetch.phpt
@@ -1,0 +1,33 @@
+--TEST--
+PDO PgSQL a scrollable cursor is unaffected by lazy fetching
+--EXTENSIONS--
+pdo_pgsql
+--SKIPIF--
+<?php
+require __DIR__ . '/config.inc';
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+PDOTest::skip();
+?>
+--FILE--
+<?php
+
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$pdo = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$sql = "SELECT * FROM generate_series(1, 3)";
+$scrollable = [PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL];
+
+$stmt = $pdo->prepare($sql, $scrollable + [PDO::ATTR_PREFETCH => 0]);
+$stmt->execute();
+echo 'lazy on the statement: ', implode(',', $stmt->fetchAll(PDO::FETCH_COLUMN)), PHP_EOL;
+
+$pdo->setAttribute(PDO::ATTR_PREFETCH, 0);
+$stmt = $pdo->prepare($sql, $scrollable);
+$stmt->execute();
+echo 'lazy on the connection: ', implode(',', $stmt->fetchAll(PDO::FETCH_COLUMN)), PHP_EOL;
+
+?>
+--EXPECT--
+lazy on the statement: 1,2,3
+lazy on the connection: 1,2,3


### PR DESCRIPTION
A statement prepared with `PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL` and lazy fetching (`PDO::ATTR_PREFETCH => 0`) fails at `execute()` with `SQLSTATE[HY000]: General error: 7` and no message. Either option alone works.

A cursor does not stream its result, but `S->is_unbuffered` stays set, so `execute()` calls `PQgetResult()` with nothing in flight. The fix clears the flag when the statement has a cursor.

The test is David Carlier's, from #23210.