### PR TITLE
Tests: Migrate old extension checks from SKIPIF to EXTENSIONS

### DIFF
--- a/ext/intl/tests/listformatter/listformatter_clone.phpt
+++ b/ext/intl/tests/listformatter/listformatter_clone.phpt
@@ -1,11 +1,7 @@
 --TEST--
 Test IntlListFormatter cannot be cloned
---SKIPIF--
-<?php
-if (!extension_loaded('intl')) {
-    die('skip intl extension not available');
-}
-?>
+--EXTENSIONS--
+intl
 --FILE--
 <?php
 

--- a/ext/mysqli/tests/bug51647.phpt
+++ b/ext/mysqli/tests/bug51647.phpt
@@ -2,15 +2,13 @@
 Bug #51647 (Certificate file without private key (pk in another file) doesn't work)
 --EXTENSIONS--
 mysqli
+openssl
 --SKIPIF--
 <?php
 require_once 'connect.inc';
 
 if (!defined('MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT'))
     die("skip Requires MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT");
-
-if (!extension_loaded("openssl"))
-    die("skip PHP streams lack support for SSL. mysqli is compiled to use mysqlnd which uses PHP streams in turn.");
 
 if (!($link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)))
     die(sprintf("skip Connect failed, [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));

--- a/ext/mysqli/tests/bug55283.phpt
+++ b/ext/mysqli/tests/bug55283.phpt
@@ -2,15 +2,13 @@
 Bug #55283 (SSL options set by mysqli_ssl_set ignored for MySQLi persistent connections)
 --EXTENSIONS--
 mysqli
+openssl
 --SKIPIF--
 <?php
 require_once 'connect.inc';
 
 if (!defined('MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT'))
     die("skip Requires MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT");
-
-if (!extension_loaded("openssl"))
-    die("skip PHP streams lack support for SSL. mysqli is compiled to use mysqlnd which uses PHP streams in turn.");
 
 if (!($link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)))
     die(sprintf("skip Connect failed, [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));

--- a/ext/pdo_pgsql/tests/issue78621.phpt
+++ b/ext/pdo_pgsql/tests/issue78621.phpt
@@ -1,8 +1,10 @@
 --TEST--
 Pdo\Pgsql::setNoticeCallback catches Postgres "raise notice".
+--EXTENSIONS--
+pdo
+pdo_pgsql
 --SKIPIF--
 <?php
-if (!extension_loaded('pdo') || !extension_loaded('pdo_pgsql')) die('skip not loaded');
 require_once dirname(__FILE__) . '/../../../ext/pdo/tests/pdo_test.inc';
 require_once dirname(__FILE__) . '/config.inc';
 PDOTest::skip();

--- a/ext/pdo_pgsql/tests/issue78621_closure.phpt
+++ b/ext/pdo_pgsql/tests/issue78621_closure.phpt
@@ -1,8 +1,10 @@
 --TEST--
 Pdo\Pgsql::setNoticeCallback catches Postgres "raise notice".
+--EXTENSIONS--
+pdo
+pdo_pgsql
 --SKIPIF--
 <?php
-if (!extension_loaded('pdo') || !extension_loaded('pdo_pgsql')) die('skip not loaded');
 require_once dirname(__FILE__) . '/../../../ext/pdo/tests/pdo_test.inc';
 require_once dirname(__FILE__) . '/config.inc';
 PDOTest::skip();

--- a/ext/pdo_pgsql/tests/issue78621_method.phpt
+++ b/ext/pdo_pgsql/tests/issue78621_method.phpt
@@ -1,8 +1,10 @@
 --TEST--
 Pdo\Pgsql::setNoticeCallback catches Postgres "raise notice".
+--EXTENSIONS--
+pdo
+pdo_pgsql
 --SKIPIF--
 <?php
-if (!extension_loaded('pdo') || !extension_loaded('pdo_pgsql')) die('skip not loaded');
 require_once dirname(__FILE__) . '/../../../ext/pdo/tests/pdo_test.inc';
 require_once dirname(__FILE__) . '/config.inc';
 PDOTest::skip();


### PR DESCRIPTION
We have the `--EXTENSIONS--` section now so we can migrate these old extension checks in our tests