### PR TITLE
Fix GH-23477: Memory leak on duplicate native Phar manifest entries

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -55,6 +55,8 @@ PHP                                                                        NEWS
 - Phar:
   . Fixed bug GH-23418 (Use-after-free when looking up mounted directories).
     (Weilin Du)
+  . Fixed bug GH-23477 (Memory leak on duplicate native Phar manifest entries).
+    (Weilin Du)
 
 - Standard:
   . Fixed a memory leak in array_merge_recursive() when the recursive merge of

--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -1234,7 +1234,10 @@ static zend_result phar_parse_pharfile(php_stream *fp, char *fname, size_t fname
 		} else {
 			str = zend_string_init(entry.filename, entry.filename_len, 0);
 		}
-		zend_hash_add_mem(&mydata->manifest, str, (void*)&entry, sizeof(phar_entry_info));
+		if (!zend_hash_add_mem(&mydata->manifest, str, (void*)&entry, sizeof(phar_entry_info))) {
+			phar_metadata_tracker_free(&entry.metadata_tracker, entry.is_persistent);
+			pefree(entry.filename, entry.is_persistent);
+		}
 		zend_string_release(str);
 	}
 

--- a/ext/phar/tests/gh23477.phpt
+++ b/ext/phar/tests/gh23477.phpt
@@ -1,0 +1,39 @@
+--TEST--
+GH-23477 (Memory leak on duplicate native Phar manifest entry)
+--EXTENSIONS--
+phar
+--INI--
+phar.require_hash=0
+--FILE--
+<?php
+$stub = "<?php __HALT_COMPILER(); ?>\r\n";
+
+function u32($value) {
+    return pack('V', $value);
+}
+
+function entry($name, $data, $metadata) {
+    $header = u32(strlen($name)) . $name
+        . u32(strlen($data)) . u32(0) . u32(strlen($data))
+        . u32(crc32($data)) . u32(0)
+        . u32(strlen($metadata)) . $metadata;
+    return [$header, $data];
+}
+
+$first = entry('a.txt', 'hello', 'i:1;');
+$second = entry('a.txt', 'world', 'i:2;');
+$manifest = u32(2) . "\x11\x00" . u32(0) . u32(0) . u32(0)
+    . $first[0] . $second[0];
+
+file_put_contents(__DIR__ . '/gh23477.phar',
+    $stub . u32(strlen($manifest)) . $manifest . $first[1] . $second[1]);
+
+$phar = new Phar(__DIR__ . '/gh23477.phar');
+echo iterator_count($phar), "\n";
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/gh23477.phar');
+?>
+--EXPECT--
+1


### PR DESCRIPTION
When a native Phar manifest contains duplicate filenames,`zend_hash_add_mem()` fails to insert the duplicate entry and does not take ownership of its allocated filename and metadata. And cause the memory leak since it can't be freed.

The fix is quite simple tho. Check the insertion result and release these allocations on failure.

ps.Plz leave this for me to merge. I want to double check this when I have time. I am busy recently.