### PR TITLE
ext/ftp: validate $port range before narrowing to short in ftp_connect/ftp_ssl_connect

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -48,6 +48,11 @@ PHP 8.6 UPGRADE NOTES
     the integer index is greater than INT_MAX instead of overflowing to a
     smaller index.
 
+- FTP:
+  . ftp_connect() and ftp_ssl_connect() now throw a ValueError when $port is
+    outside the 0-65535 range, instead of silently truncating it to its low
+    16 bits (e.g. 65536 previously connected to port 21).
+
 - GD:
   . imagesetstyle(), imagefilter() and imagecrop() filter the types / values of
     their array arguments and raise a TypeError / ValueError accordingly.

--- a/ext/ftp/php_ftp.c
+++ b/ext/ftp/php_ftp.c
@@ -145,6 +145,11 @@ PHP_FUNCTION(ftp_connect)
 		RETURN_THROWS();
 	}
 
+	if (port < 0 || port > 65535) {
+		zend_argument_value_error(2, "must be between 0 and 65535");
+		RETURN_THROWS();
+	}
+
 	if (timeout_sec <= 0) {
 		zend_argument_value_error(3, "must be greater than 0");
 		RETURN_THROWS();
@@ -184,6 +189,11 @@ PHP_FUNCTION(ftp_ssl_connect)
 	zend_long		timeout_sec = FTP_DEFAULT_TIMEOUT;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|ll", &host, &host_len, &port, &timeout_sec) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	if (port < 0 || port > 65535) {
+		zend_argument_value_error(2, "must be between 0 and 65535");
 		RETURN_THROWS();
 	}
 

--- a/ext/ftp/tests/ftp_connect_port_range.phpt
+++ b/ext/ftp/tests/ftp_connect_port_range.phpt
@@ -1,0 +1,31 @@
+--TEST--
+ftp_connect(): $port values outside 0-65535 must throw ValueError, not alias onto a valid port
+--EXTENSIONS--
+ftp
+--FILE--
+<?php
+foreach ([-1, 65536, 65536 + 2121, PHP_INT_MIN, PHP_INT_MAX] as $port) {
+    try {
+        ftp_connect('127.0.0.1', $port);
+    } catch (ValueError $e) {
+        echo $e->getMessage(), "\n";
+    }
+}
+
+// Port 0 must be accepted (maps to default FTP port 21 in ftp_open)
+// We expect false (connection refused), not ValueError.
+$result = @ftp_connect('127.0.0.1', 0);
+var_dump($result === false || is_object($result)); // true either way
+
+// Port 65535 must be accepted (last valid port).
+$result = @ftp_connect('127.0.0.1', 65535);
+var_dump($result === false || is_object($result)); // true either way
+?>
+--EXPECT--
+ftp_connect(): Argument #2 ($port) must be between 0 and 65535
+ftp_connect(): Argument #2 ($port) must be between 0 and 65535
+ftp_connect(): Argument #2 ($port) must be between 0 and 65535
+ftp_connect(): Argument #2 ($port) must be between 0 and 65535
+ftp_connect(): Argument #2 ($port) must be between 0 and 65535
+bool(true)
+bool(true)

--- a/ext/ftp/tests/ftp_connect_port_range.phpt
+++ b/ext/ftp/tests/ftp_connect_port_range.phpt
@@ -7,8 +7,8 @@ ftp
 foreach ([-1, 65536, 65536 + 2121, PHP_INT_MIN, PHP_INT_MAX] as $port) {
     try {
         ftp_connect('127.0.0.1', $port);
-    } catch (ValueError $e) {
-        echo $e->getMessage(), "\n";
+    } catch (Throwable $e) {
+        echo $e::class, ': ', $e->getMessage(), "\n";
     }
 }
 
@@ -22,10 +22,10 @@ $result = @ftp_connect('127.0.0.1', 65535);
 var_dump($result === false || is_object($result)); // true either way
 ?>
 --EXPECT--
-ftp_connect(): Argument #2 ($port) must be between 0 and 65535
-ftp_connect(): Argument #2 ($port) must be between 0 and 65535
-ftp_connect(): Argument #2 ($port) must be between 0 and 65535
-ftp_connect(): Argument #2 ($port) must be between 0 and 65535
-ftp_connect(): Argument #2 ($port) must be between 0 and 65535
+ValueError: ftp_connect(): Argument #2 ($port) must be between 0 and 65535
+ValueError: ftp_connect(): Argument #2 ($port) must be between 0 and 65535
+ValueError: ftp_connect(): Argument #2 ($port) must be between 0 and 65535
+ValueError: ftp_connect(): Argument #2 ($port) must be between 0 and 65535
+ValueError: ftp_connect(): Argument #2 ($port) must be between 0 and 65535
 bool(true)
 bool(true)


### PR DESCRIPTION
`ftp_connect()` and `ftp_ssl_connect()` accept `$port` as `zend_long` but cast it to C `short` at the `ftp_open()` call site without range-checking first. Values outside 0–65535 silently wrap: `65536` narrows to `0`, which `ftp_open()` rewrites to `21`, connecting to the FTP control port regardless of what the caller requested.

The fix validates `$port` before the cast and throws a `ValueError` for out-of-range values, consistent with how other extensions handle integer narrowing.

A test covering the boundary and the silent-wrap case is added.