### PR TITLE
Fix fseek() accepting $whence values that do not fit in an int

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -95,6 +95,8 @@ PHP                                                                        NEWS
     wrong). (Lazizbek Ergashev)
   . Fixed fseek() accepting $whence values that do not fit in an int, which
     were silently truncated onto a valid seek constant. (lacatoire)
+  . Fixed a failed seek discarding the read buffer, which desynchronized the
+    stream from its reported position. (lacatoire)
 
 - SimpleXML:
   . Fixed writing to a dimension of the object returned by attributes() not

--- a/NEWS
+++ b/NEWS
@@ -93,6 +93,8 @@ PHP                                                                        NEWS
     argument number for $timeout). (lacatoire)
   . Fixed bug GH-23576 (Next index for array returned from array_keys() is
     wrong). (Lazizbek Ergashev)
+  . Fixed fseek() accepting $whence values that do not fit in an int, which
+    were silently truncated onto a valid seek constant. (lacatoire)
 
 - SimpleXML:
   . Fixed writing to a dimension of the object returned by attributes() not

--- a/NEWS
+++ b/NEWS
@@ -81,6 +81,10 @@ PHP                                                                        NEWS
   . Added support for the libsodium 1.0.22 KEM APIs (X-Wing and ML-KEM768).
     (Zachary DuBois)
 
+- SPL:
+  . Fixed SplFileObject::fseek() accepting $whence values that do not fit in an
+    int, which were silently truncated onto a valid seek constant. (lacatoire)
+
 - Standard:
   . Fixed a segfault when a stream filter callback unsets StreamBucket::$data
     before re-attaching the bucket. (iliaal)

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -2458,8 +2458,17 @@ PHP_METHOD(SplFileObject, fseek)
 
 	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED(intern);
 
-	spl_filesystem_file_free_line(intern);
-	RETURN_LONG(php_stream_seek(intern->u.file.stream, pos, (int)whence));
+	if (ZEND_LONG_EXCEEDS_INT(whence)) {
+		RETURN_LONG(-1);
+	}
+
+	int ret = php_stream_seek(intern->u.file.stream, pos, (int)whence);
+
+	if (ret == 0) {
+		spl_filesystem_file_free_line(intern);
+	}
+
+	RETURN_LONG(ret);
 } /* }}} */
 
 /* {{{ Get a character from the file */

--- a/ext/spl/tests/SplFileObject/SplFileObject_fseek_whence_invalid_inrange.phpt
+++ b/ext/spl/tests/SplFileObject/SplFileObject_fseek_whence_invalid_inrange.phpt
@@ -1,0 +1,48 @@
+--TEST--
+SplFileObject::fseek(): a failed seek must not discard the current line
+--FILE--
+<?php
+$tmp = __DIR__ . '/SplFileObject_fseek_whence_invalid_inrange.tmp';
+file_put_contents($tmp, "aaa\nbbb\nccc\n");
+
+foreach ([99, -2147483648, 2147483647] as $whence) {
+    echo 'whence=', $whence, PHP_EOL;
+
+    $file = new SplFileObject($tmp);
+    var_dump($file->current());
+    var_dump($file->fseek(3, $whence));
+    var_dump($file->ftell());
+    var_dump($file->current());
+    unset($file);
+
+    echo PHP_EOL;
+}
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/SplFileObject_fseek_whence_invalid_inrange.tmp');
+?>
+--EXPECT--
+whence=99
+string(4) "aaa
+"
+int(-1)
+int(4)
+string(4) "aaa
+"
+
+whence=-2147483648
+string(4) "aaa
+"
+int(-1)
+int(4)
+string(4) "aaa
+"
+
+whence=2147483647
+string(4) "aaa
+"
+int(-1)
+int(4)
+string(4) "aaa
+"

--- a/ext/spl/tests/SplFileObject/SplFileObject_fseek_whence_overflow.phpt
+++ b/ext/spl/tests/SplFileObject/SplFileObject_fseek_whence_overflow.phpt
@@ -1,0 +1,49 @@
+--TEST--
+SplFileObject::fseek(): $whence values that overflow int must return -1, not alias onto a valid constant
+--SKIPIF--
+<?php
+if (PHP_INT_SIZE < 8) die("skip 64-bit only");
+?>
+--FILE--
+<?php
+$tmp = __DIR__ . '/SplFileObject_fseek_whence_overflow.tmp';
+file_put_contents($tmp, "0123456789");
+$bias = 2 ** 32;
+
+$file = new SplFileObject($tmp);
+
+// SEEK_CUR + 2**32 must not alias onto SEEK_CUR (1)
+$file->fseek(4);
+var_dump($file->fseek(3, SEEK_CUR + $bias));  // -1
+var_dump($file->ftell());                     // 4 (unchanged)
+
+// SEEK_END + 2**32 must not alias onto SEEK_END (2)
+$file->fseek(4);
+var_dump($file->fseek(3, SEEK_END + $bias));  // -1
+var_dump($file->ftell());                     // 4 (unchanged)
+
+// PHP_INT_MIN must not alias onto SEEK_SET (0)
+$file->fseek(4);
+var_dump($file->fseek(3, PHP_INT_MIN));       // -1
+var_dump($file->ftell());                     // 4 (unchanged)
+
+// Sanity: normal SEEK_CUR still works
+$file->fseek(4);
+var_dump($file->fseek(3, SEEK_CUR));          // 0
+var_dump($file->ftell());                     // 7
+
+unset($file);
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/SplFileObject_fseek_whence_overflow.tmp');
+?>
+--EXPECT--
+int(-1)
+int(4)
+int(-1)
+int(4)
+int(-1)
+int(4)
+int(0)
+int(7)

--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -1103,6 +1103,10 @@ PHPAPI PHP_FUNCTION(fseek)
 		Z_PARAM_LONG(whence)
 	ZEND_PARSE_PARAMETERS_END();
 
+	if (whence < INT_MIN || whence > INT_MAX) {
+		RETURN_LONG(-1);
+	}
+
 	php_stream_error_operation_begin();
 	RETVAL_LONG(php_stream_seek(stream, offset, (int) whence));
 	php_stream_error_operation_end_for_stream(stream);

--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -1103,7 +1103,7 @@ PHPAPI PHP_FUNCTION(fseek)
 		Z_PARAM_LONG(whence)
 	ZEND_PARSE_PARAMETERS_END();
 
-	if (whence < INT_MIN || whence > INT_MAX) {
+	if (ZEND_LONG_EXCEEDS_INT(whence)) {
 		RETURN_LONG(-1);
 	}
 

--- a/ext/standard/tests/file/fseek_whence_invalid_inrange.phpt
+++ b/ext/standard/tests/file/fseek_whence_invalid_inrange.phpt
@@ -1,0 +1,40 @@
+--TEST--
+fseek(): an invalid $whence that fits in an int must not desynchronize the stream
+--FILE--
+<?php
+$tmp = __DIR__ . '/fseek_whence_invalid_inrange.tmp';
+file_put_contents($tmp, "0123456789");
+
+foreach ([99, -2147483648, 2147483647] as $whence) {
+    echo 'whence=', $whence, PHP_EOL;
+    $h = fopen($tmp, 'r');
+    var_dump(fread($h, 4));
+    var_dump(fseek($h, 3, $whence));
+    var_dump(ftell($h));
+    var_dump(fread($h, 6));
+    fclose($h);
+    echo PHP_EOL;
+}
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/fseek_whence_invalid_inrange.tmp');
+?>
+--EXPECT--
+whence=99
+string(4) "0123"
+int(-1)
+int(4)
+string(6) "456789"
+
+whence=-2147483648
+string(4) "0123"
+int(-1)
+int(4)
+string(6) "456789"
+
+whence=2147483647
+string(4) "0123"
+int(-1)
+int(4)
+string(6) "456789"

--- a/ext/standard/tests/file/fseek_whence_invalid_inrange.phpt
+++ b/ext/standard/tests/file/fseek_whence_invalid_inrange.phpt
@@ -7,12 +7,21 @@ file_put_contents($tmp, "0123456789");
 
 foreach ([99, -2147483648, 2147483647] as $whence) {
     echo 'whence=', $whence, PHP_EOL;
-    $h = fopen($tmp, 'r');
-    var_dump(fread($h, 4));
-    var_dump(fseek($h, 3, $whence));
-    var_dump(ftell($h));
-    var_dump(fread($h, 6));
-    fclose($h);
+
+    foreach (['file' => $tmp, 'memory' => 'php://memory'] as $label => $target) {
+        echo $label, PHP_EOL;
+        $h = fopen($target, $label === 'file' ? 'r' : 'w+');
+        if ($label === 'memory') {
+            fwrite($h, "0123456789");
+            rewind($h);
+        }
+        var_dump(fread($h, 4));
+        var_dump(fseek($h, 3, $whence));
+        var_dump(ftell($h));
+        var_dump(fread($h, 6));
+        fclose($h);
+    }
+
     echo PHP_EOL;
 }
 ?>
@@ -22,18 +31,36 @@ foreach ([99, -2147483648, 2147483647] as $whence) {
 ?>
 --EXPECT--
 whence=99
+file
+string(4) "0123"
+int(-1)
+int(4)
+string(6) "456789"
+memory
 string(4) "0123"
 int(-1)
 int(4)
 string(6) "456789"
 
 whence=-2147483648
+file
+string(4) "0123"
+int(-1)
+int(4)
+string(6) "456789"
+memory
 string(4) "0123"
 int(-1)
 int(4)
 string(6) "456789"
 
 whence=2147483647
+file
+string(4) "0123"
+int(-1)
+int(4)
+string(6) "456789"
+memory
 string(4) "0123"
 int(-1)
 int(4)

--- a/ext/standard/tests/file/fseek_whence_overflow.phpt
+++ b/ext/standard/tests/file/fseek_whence_overflow.phpt
@@ -1,0 +1,46 @@
+--TEST--
+fseek(): $whence values that overflow int must return -1, not alias onto a valid constant
+--SKIPIF--
+<?php
+if (PHP_INT_SIZE < 8) die("skip 64-bit only");
+?>
+--FILE--
+<?php
+$tmp = tempnam(sys_get_temp_dir(), 'fseek');
+file_put_contents($tmp, "0123456789");
+$bias = 2 ** 32;
+
+$h = fopen($tmp, 'r');
+
+// SEEK_CUR + 2**32 must not alias onto SEEK_CUR (1)
+fseek($h, 4);
+var_dump(fseek($h, 3, SEEK_CUR + $bias));  // -1
+var_dump(ftell($h));                        // 4 (unchanged)
+
+// SEEK_END + 2**32 must not alias onto SEEK_END (2)
+fseek($h, 4);
+var_dump(fseek($h, 3, SEEK_END + $bias));  // -1
+var_dump(ftell($h));                        // 4 (unchanged)
+
+// PHP_INT_MIN must not alias onto SEEK_SET (0)
+fseek($h, 4);
+var_dump(fseek($h, 3, PHP_INT_MIN));       // -1
+var_dump(ftell($h));                        // 4 (unchanged)
+
+// Sanity: normal SEEK_CUR still works
+fseek($h, 4);
+var_dump(fseek($h, 3, SEEK_CUR));          // 0
+var_dump(ftell($h));                        // 7
+
+fclose($h);
+unlink($tmp);
+?>
+--EXPECT--
+int(-1)
+int(4)
+int(-1)
+int(4)
+int(-1)
+int(4)
+int(0)
+int(7)

--- a/ext/standard/tests/file/fseek_whence_overflow.phpt
+++ b/ext/standard/tests/file/fseek_whence_overflow.phpt
@@ -6,7 +6,7 @@ if (PHP_INT_SIZE < 8) die("skip 64-bit only");
 ?>
 --FILE--
 <?php
-$tmp = tempnam(sys_get_temp_dir(), 'fseek');
+$tmp = __DIR__ . '/fseek_whence_overflow.tmp';
 file_put_contents($tmp, "0123456789");
 $bias = 2 ** 32;
 
@@ -33,7 +33,10 @@ var_dump(fseek($h, 3, SEEK_CUR));          // 0
 var_dump(ftell($h));                        // 7
 
 fclose($h);
-unlink($tmp);
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/fseek_whence_overflow.tmp');
 ?>
 --EXPECT--
 int(-1)

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -1367,6 +1367,7 @@ PHPAPI int php_stream_seek(php_stream *stream, zend_off_t offset, int whence)
 
 
 	if (stream->ops->seek && (stream->flags & PHP_STREAM_FLAG_NO_SEEK) == 0) {
+		zend_off_t old_position = stream->position;
 		int ret;
 		switch(whence) {
 			case SEEK_CUR:
@@ -1386,6 +1387,13 @@ PHPAPI int php_stream_seek(php_stream *stream, zend_off_t offset, int whence)
 		ret = stream->ops->seek(stream, offset, whence, &stream->position);
 
 		if (((stream->flags & PHP_STREAM_FLAG_NO_SEEK) == 0) || ret == 0) {
+			if (ret != 0 && stream->position == old_position) {
+				/* the seek failed without moving the stream, so the buffered
+				 * data and the filter state still describe the current
+				 * position and must be left alone */
+				return ret;
+			}
+
 			if (ret == 0) {
 				stream->eof = 0;
 				stream->fatal_error = 0;


### PR DESCRIPTION
`fseek()` parses `$whence` as a `zend_long`, but casts it to a C `int` when calling `php_stream_seek()`. Values whose low 32 bits alias onto a valid seek constant are accepted and acted upon.

On a 64-bit build, with a 10-byte file and the cursor at 4:

```
fseek($h, 3, SEEK_CUR + 2**32)  =>  0   position 7    (treated as SEEK_CUR)
fseek($h, 3, PHP_INT_MIN)       =>  0   position 3    (treated as SEEK_SET)
fseek($h, 3, SEEK_END + 2**32)  =>  0   position 13   (treated as SEEK_END)
```

A return value of `0` means success, so the call reports that a seek nobody asked for went through.

The fix rejects values outside the `int` range before the cast:

```c
if (whence < INT_MIN || whence > INT_MAX) {
	RETURN_LONG(-1);
}
```

`-1` is not a new convention: it is already what `fseek()` returns for an invalid `$whence` that happens to fit in an `int`, and the position is left untouched in both cases.

```
fseek($h, 3, 99)  =>  -1   position unchanged
```

Platform constants such as `SEEK_DATA` (3) and `SEEK_HOLE` (4) fit in an `int` and are unaffected.

`ext/standard/tests/file/fseek_whence_overflow.phpt` covers the three aliasing forms and a plain `SEEK_CUR` as a regression guard. It skips on 32-bit builds, where no `zend_long` can exceed an `int`.

Tested on a 64-bit Linux build: the new test passes, and `ext/standard/tests/file`, `ext/standard/tests/streams` and `ext/standard/tests/filters` show no regression.
