### PR TITLE
Document error_include_args in NEWS and UPGRADING

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -620,6 +620,8 @@ PHP                                                                        NEWS
   . Deprecate returning values from __construct() and __destruct(). (timwolla)
   . base_convert, bindex, hexdec and octdec now raise a notice when they cannot
     precisely convert the given number. (Sjoerd Langkemper)
+  . Added error_include_args INI option to make the display of function
+    arguments consistent in error output. (Calvin Buckley)
 
 - BCMath:
   . Added NUL-byte validation to BCMath functions. (jorgsowa)

--- a/UPGRADING
+++ b/UPGRADING
@@ -871,6 +871,15 @@ PHP 8.6 UPGRADE NOTES
 11. Changes to INI File Handling
 ========================================
 
+- Core:
+  . The error_include_args INI option has been added to make the display of
+    function arguments consistent in errors; it is off by default. Previously,
+    some functions shown a parameter in the error that was up to each call to
+    the internal error function. Now, all parameters as were actually passed to
+    the function will be displayed. This uses the same infrastructure as stack
+    traces, so i.e. sensitive parameters will not be displayed, and strings
+    will be truncated according to zend.exception_string_param_max_len.
+
 - Mbstring:
   . The mbstring.detect_order INI directive now updates the internal detection
     order when changed at runtime via ini_set(). Previously, runtime changes


### PR DESCRIPTION
Not sure how backdated NEWS will be useful, but this does add the note in UPGRADING which does matter.

Per https://github.com/php/php-src/pull/12276#issuecomment-5388504104