### PR TITLE
Avoid execute_data assertion while checking generator fiber state

### DIFF
--- a/Zend/tests/fibers/destructors_003.phpt
+++ b/Zend/tests/fibers/destructors_003.phpt
@@ -33,6 +33,28 @@ new Cycle();
 new Cycle();
 gc_collect_cycles();
 
+class ResumeGeneratorInFiberDestructor {
+    public function __destruct() {
+        $object = new self;
+        static $gen = (function () {
+            $from = (function () {
+                $object = new ResumeGeneratorInFiberDestructor;
+                yield;
+            })();
+            try {
+                yield from $from;
+            } finally {
+            }
+        })();
+        $fiber = new Fiber(function () use ($gen) {
+            $gen->next();
+        });
+        $fiber->start();
+    }
+}
+
+new ResumeGeneratorInFiberDestructor;
+
 ?>
 --EXPECT--
 0: Start destruct

--- a/Zend/zend_generators.c
+++ b/Zend/zend_generators.c
@@ -213,8 +213,6 @@ static zend_always_inline void clear_link_to_root(zend_generator *generator) {
 
 /* Check if the node 'generator' is running in a fiber */
 static inline bool check_node_running_in_fiber(zend_generator *generator) {
-	ZEND_ASSERT(generator->execute_data);
-
 	if (EXPECTED(generator->flags & ZEND_GENERATOR_IN_FIBER)) {
 		return true;
 	}


### PR DESCRIPTION
Fixes #20615.

Generator delegation trees can contain closed intermediate nodes while a descendant is running in a Fiber. The fiber-state walk only needs node flags and child links, so do not require execute_data to be present. Extend the existing Fiber destructor test with the reported regression scenario.