### PR TITLE
Fix weakref unregister assertion after stack overflow

### DIFF
--- a/Zend/zend_weakrefs.c
+++ b/Zend/zend_weakrefs.c
@@ -123,7 +123,12 @@ static void zend_weakref_register(zend_object *object, void *payload) {
 static void zend_weakref_unregister(zend_object *object, void *payload, bool weakref_free) {
 	zend_ulong obj_key = zend_object_to_weakref_key(object);
 	void *tagged_ptr = zend_hash_index_find_ptr(&EG(weakrefs), obj_key);
-	ZEND_ASSERT(tagged_ptr && "Weakref not registered?");
+	if (UNEXPECTED(!tagged_ptr)) {
+		/* The referent may already have been unregistered while unwinding from
+		 * a stack overflow. There is nothing left to detach in that case. */
+		GC_DEL_FLAGS(object, IS_OBJ_WEAKLY_REFERENCED);
+		return;
+	}
 
 	void *ptr = ZEND_WEAKREF_GET_PTR(tagged_ptr);
 	uintptr_t tag = ZEND_WEAKREF_GET_TAG(tagged_ptr);


### PR DESCRIPTION
Fixes #22650.

Handle the narrow case where a WeakReference is being unregistered after its referent has already disappeared from EG(weakrefs) during stack-overflow unwinding. Clear the stale IS_OBJ_WEAKLY_REFERENCED flag and return instead of asserting on a registry entry that is no longer present. Normal registered weakref invariants remain unchanged.