### PR TITLE
fix(fpm): Fix FPM test harness object leaks reported under ASan and Valgrind.

### DIFF
--- a/sapi/fpm/tests/response.inc
+++ b/sapi/fpm/tests/response.inc
@@ -5,10 +5,12 @@ namespace FPM;
 abstract class BaseResponse
 {
     /**
-     * Tester instance
-     * @var Tester
+     * Tester instance. Held weakly so that responses do not form a reference
+     * cycle with the tester, which would keep both alive until the executor
+     * object store shutdown and get reported as a leak by ASAN/Valgrind.
+     * @var \WeakReference<Tester>
      */
-    private Tester $tester;
+    private \WeakReference $tester;
 
     /**
      * @var bool
@@ -20,7 +22,7 @@ abstract class BaseResponse
      */
     public function __construct(Tester $tester)
     {
-        $this->tester = $tester;
+        $this->tester = \WeakReference::create($tester);
     }
 
     /**
@@ -50,7 +52,7 @@ abstract class BaseResponse
         }
         echo $errorMessage;
 
-        $this->tester->printLogs();
+        $this->tester->get()?->printLogs();
 
         return false;
     }

--- a/sapi/fpm/tests/tester.inc
+++ b/sapi/fpm/tests/tester.inc
@@ -548,7 +548,7 @@ class Tester
 
         $this->masterProcess = proc_open($cmd, $desc, $pipes, null, $envVars);
         register_shutdown_function(
-            function ($masterProcess) use ($configFile) {
+            static function ($masterProcess) use ($configFile) {
                 @unlink($configFile);
                 if (is_resource($masterProcess)) {
                     @proc_terminate($masterProcess);


### PR DESCRIPTION
This fix addresses an issue in clang-23 stable where running memory tests with ASan causes fpm to flag memory as unreleased.