### PR TITLE
[DOM] Fix getNamedItemNS() with empty URI not matching null namespace

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,8 @@ PHP                                                                        NEWS
     return value of php_cli_server_client_send_through()). (Lazizbek Ergashev)
 
 - DOM:
+  . Fixed NamedNodeMap::getNamedItemNS() with an empty URI not matching
+    the null namespace in spec-following mode. (iliaal)
   . Fixed a use-after-free when cloning a DOMNameSpaceNode after
     DOMDocument::xinclude(). (iliaal)
   . Fixed bug GH-23331 (UAF when node_list_unlink() skips attribute children

--- a/ext/dom/namednodemap.c
+++ b/ext/dom/namednodemap.c
@@ -213,6 +213,9 @@ PHP_METHOD(DOMNamedNodeMap, getNamedItemNS)
 	objmap = (dom_nnodemap_object *)intern->ptr;
 
 	if (objmap != NULL) {
+		if (urilen == 0 && objmap->baseobj != NULL && objmap->nodetype != XML_NOTATION_NODE && objmap->nodetype != XML_ENTITY_NODE && php_dom_follow_spec_intern(objmap->baseobj)) {
+			uri = NULL;
+		}
 		if ((objmap->nodetype == XML_NOTATION_NODE) ||
 			objmap->nodetype == XML_ENTITY_NODE) {
 			if (objmap->ht) {
@@ -229,6 +232,9 @@ PHP_METHOD(DOMNamedNodeMap, getNamedItemNS)
 			nodep = dom_object_get_node(objmap->baseobj);
 			if (nodep) {
 				itemnode = (xmlNodePtr)xmlHasNsProp(nodep, BAD_CAST named, BAD_CAST uri);
+				if (itemnode != NULL && itemnode->type == XML_ATTRIBUTE_DECL) {
+					itemnode = NULL;
+				}
 			}
 		}
 	}

--- a/ext/dom/tests/modern/spec/NamedNodeMap_getNamedItemNS.phpt
+++ b/ext/dom/tests/modern/spec/NamedNodeMap_getNamedItemNS.phpt
@@ -1,0 +1,25 @@
+--TEST--
+getNamedItemNS() with an empty URI must look up the null namespace
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$d = new DOMDocument();
+$d->loadXML('<root xmlns:q="urn:q" bar="no-ns" q:bar="ns"/>');
+$a = $d->documentElement->attributes->getNamedItemNS('', 'bar');
+var_dump($a === null ? null : $a->nodeValue);
+$b = $d->documentElement->attributes->getNamedItemNS('urn:q', 'bar');
+var_dump($b === null ? null : $b->nodeValue);
+$d2 = Dom\XMLDocument::createFromString('<root xmlns:q="urn:q" bar="no-ns" q:bar="ns"/>');
+$a2 = $d2->documentElement->attributes->getNamedItemNS('', 'bar');
+var_dump($a2 === null ? null : $a2->nodeValue);
+var_dump($d2->documentElement->hasAttributeNS('', 'bar'));
+$c = $d2->documentElement->attributes->getNamedItemNS('urn:q', 'bar');
+var_dump($c === null ? null : $c->nodeValue);
+?>
+--EXPECT--
+NULL
+string(2) "ns"
+string(5) "no-ns"
+bool(true)
+string(2) "ns"

--- a/ext/dom/tests/modern/spec/NamedNodeMap_getNamedItemNS_dtd_default.phpt
+++ b/ext/dom/tests/modern/spec/NamedNodeMap_getNamedItemNS_dtd_default.phpt
@@ -1,0 +1,24 @@
+--TEST--
+getNamedItemNS() with empty URI must not throw on DTD default attributes
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$xml = <<<XML
+<?xml version="1.0"?>
+<!DOCTYPE root [
+<!ELEMENT root EMPTY>
+<!ATTLIST root defaulted CDATA "from-dtd">
+]>
+<root real="present"/>
+XML;
+
+$el = Dom\XMLDocument::createFromString($xml)->documentElement;
+$defaulted = $el->attributes->getNamedItemNS('', 'defaulted');
+var_dump($defaulted === null ? null : $defaulted->nodeValue);
+$real = $el->attributes->getNamedItemNS('', 'real');
+var_dump($real === null ? null : $real->nodeValue);
+?>
+--EXPECT--
+NULL
+string(7) "present"


### PR DESCRIPTION
Dom\NamedNodeMap::getNamedItemNS() passed an empty-string URI straight to xmlHasNsProp(), which matches NULL-namespace attributes only when the URI pointer is NULL, so getNamedItemNS("", "bar") returned NULL even though hasAttributeNS("", "bar") found the attribute in spec-following mode. An empty URI now normalizes to NULL at the namednodemap entry point when a base object is present, the same conversion dom_get_attribute_ns() applies in element.c. A sibling audit of xmlHasNsProp() and xmlGetNsProp() call sites found no other path passing a user-supplied URI.
