### PR TITLE
[SimpleXML] Fix creating new attributes via attributes() dimension write

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -71,6 +71,10 @@ PHP                                                                        NEWS
     an object converted to an array fails. (David Carlier)
   . Fixed read buffer compaction in php_stream_filter_flush(). (crystarm)
 
+- SimpleXML:
+  . Fixed writing to a dimension of the object returned by attributes() not
+    creating the attribute. (iliaal)
+
 - Zip:
   . Fixed bug GH-23276 (ZipArchive subclass storing its own stream cannot be
     garbage collected). (Weilin Du, ndossche)

--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -443,8 +443,7 @@ long_dim:
 	if (sxe->iter.type == SXE_ITER_ATTRLIST) {
 		attribs = 1;
 		elements = 0;
-		node = php_sxe_get_first_node_non_destructive(sxe, node);
-		attr = (xmlAttrPtr)node;
+		attr = (xmlAttrPtr)php_sxe_get_first_node_non_destructive(sxe, node);
 		test = sxe->iter.name != NULL;
 	} else if (sxe->iter.type != SXE_ITER_CHILD) {
 		mynode = node;

--- a/ext/simplexml/tests/attributes_dimension_write.phpt
+++ b/ext/simplexml/tests/attributes_dimension_write.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Creating new attributes via dimension and property writes on attributes()
+--FILE--
+<?php
+$x = simplexml_load_string('<r a="1"/>');
+$x->attributes()['new'] = 'v';
+echo $x->asXML();
+
+$a = simplexml_load_string('<r/>');
+$a->attributes()['created'] = 'yes';
+echo $a->asXML();
+
+$b = simplexml_load_string('<r a="1"/>');
+$attrs = $b->attributes();
+$attrs->other = 2;
+echo $b->asXML();
+
+$c = simplexml_load_string('<r a="1"/>');
+$c->attributes()['a'] = '2';
+echo $c->asXML();
+?>
+--EXPECT--
+<?xml version="1.0"?>
+<r a="1" new="v"/>
+<?xml version="1.0"?>
+<r created="yes"/>
+<?xml version="1.0"?>
+<r a="1" other="2"/>
+<?xml version="1.0"?>
+<r a="2"/>


### PR DESCRIPTION
Dimension writes like $x->attributes()["new"] = "v" did nothing for a not-yet-existing attribute, because sxe_prop_dim_write() replaced the element node with the first attribute node while resolving an SXE_ITER_ATTRLIST iterator, so xmlNewProp() hit a non-element node or never ran when the element had no attributes. sxe_prop_dim_write() now keeps the element node and resolves only the start of the attribute list, making dimension writes on attributes() behave like $x["new"] = "v". Property writes share this path and are fixed too; read, exists, and unset create nothing and are unaffected.
