### PR TITLE
[intl] Fix leak of time zone wrapper in Calendar debug info

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -30,6 +30,7 @@ PHP                                                                        NEWS
   . Fixed bug GH-19320 (FPM UID and GID overflow). (Pratik Bhujel)
 
 - Intl:
+  . Fixed a memory leak when dumping IntlCalendar instances. (iliaal)
   . Fixed a memory leak when iterating IntlBreakIterator::getPartsIterator()
     results. (iliaal)
   . Fixed a double-free when IntlGregorianCalendar construction fails after

--- a/ext/intl/calendar/calendar_class.cpp
+++ b/ext/intl/calendar/calendar_class.cpp
@@ -171,6 +171,8 @@ static HashTable *Calendar_get_debug_info(zend_object *object, int *is_temp)
 		FREE_HASHTABLE(debug_info_tz);
 
 		zend_hash_str_update(debug_info, "timeZone", sizeof("timeZone") - 1, &ztz_debug);
+
+		zval_ptr_dtor(&ztz);
 	}
 
 	{

--- a/ext/intl/tests/calendar_get_debug_info_tz_leak.phpt
+++ b/ext/intl/tests/calendar_get_debug_info_tz_leak.phpt
@@ -1,0 +1,26 @@
+--TEST--
+IntlCalendar get_debug_info() must not leak the time zone wrapper object
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+$cal = IntlCalendar::createInstance('UTC');
+ob_start();
+var_dump($cal);
+ob_end_clean();
+
+$o = new stdClass;
+$before = spl_object_id($o);
+unset($o);
+for ($i = 0; $i < 10; $i++) {
+    ob_start();
+    var_dump($cal);
+    ob_end_clean();
+}
+$o = new stdClass;
+$after = spl_object_id($o);
+
+var_dump($after - $before);
+?>
+--EXPECT--
+int(0)


### PR DESCRIPTION
Calendar_get_debug_info() created a temporary IntlTimeZone wrapper zval via
timezone_object_construct() and never released it, leaking one wrapper object
per var_dump()/debug dump of an IntlCalendar instance. The wrapper is now
released with zval_ptr_dtor() after its debug info has been copied into the
result. Other timezone_object_construct() call sites write into return_value
and are refcount-managed. No other intl get_debug_info handler constructs a
temporary wrapper.
