### PR TITLE
Fix live ranges for ZEND_JMP_SET and ZEND_COALESCE

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,8 @@ PHP                                                                        NEWS
     next() call on the inner generator). (iliaal)
   . Fixed bug GH-23301 (Nested "yield from" yields a value twice when the
     middle generator delegates again). (Lazizbek Ergashev)
+  . Fixed the live range of ZEND_JMP_SET and ZEND_COALESCE covering the
+    fall-through path. (Mrmaxmeier)
 
 - CLI:
   . Fixed bug GH-23425 (sapi_cli_server_send_headers() does not check the

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -777,6 +777,22 @@ static void emit_live_range(
 			kind = ZEND_LIVE_LOOP;
 			start++;
 			break;
+		case ZEND_JMP_SET:
+		case ZEND_COALESCE:
+			/* These opcodes only write their result on the branch they take.
+			 * The live range must therefore start at the jump target, not
+			 * behind the definition, or it would also cover the fall-through
+			 * path on which the result was never written. */
+			if (needs_live_range && !needs_live_range(op_array, orig_def_opline)) {
+				return;
+			}
+			kind = ZEND_LIVE_TMPVAR;
+			start = OP_JMP_ADDR(def_opline, def_opline->op2) - op_array->opcodes;
+			if (start >= end) {
+				/* The result is freed right at the jump target. */
+				return;
+			}
+			break;
 		/* Objects created via ZEND_NEW are only fully initialized
 		 * after the DO_FCALL (constructor call).
 		 * We are creating two live-ranges: ZEND_LINE_NEW for uninitialized

--- a/ext/opcache/tests/fuzzer_function_jit_live_range_coalesce.phpt
+++ b/ext/opcache/tests/fuzzer_function_jit_live_range_coalesce.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Live range of ZEND_COALESCE must not cover the fall-through path
+--EXTENSIONS--
+opcache
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit=disable
+--ENV--
+USE_ZEND_ALLOC=0
+USE_TRACKED_ALLOC=1
+--FILE--
+<?php
+$s = "b";
+try {
+    if ("a" . $s) {
+        $item ??= match (true) { 1 => 1 };
+    }
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
+}
+
+function coalesce($a, $b) {
+    return $a ?? $b;
+}
+var_dump(coalesce("x", "y"), coalesce(null, "y"));
+echo "OK\n";
+?>
+--EXPECT--
+UnhandledMatchError: Unhandled match case true
+string(1) "x"
+string(1) "y"
+OK

--- a/ext/opcache/tests/fuzzer_function_jit_live_range_jmp_set.phpt
+++ b/ext/opcache/tests/fuzzer_function_jit_live_range_jmp_set.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Live range of ZEND_JMP_SET must not cover the fall-through path
+--EXTENSIONS--
+opcache
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit=disable
+--ENV--
+USE_ZEND_ALLOC=0
+USE_TRACKED_ALLOC=1
+--FILE--
+<?php
+try {
+    $a ?: match (true) { 1 => 1 };
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
+}
+
+function elvis($a, $b) {
+    return $a ?: $b;
+}
+var_dump(elvis("x", "y"), elvis("", "y"), elvis(null, "z"));
+echo "OK\n";
+?>
+--EXPECTF--
+Warning: Undefined variable $a in %s on line %d
+UnhandledMatchError: Unhandled match case true
+string(1) "x"
+string(1) "y"
+string(1) "z"
+OK


### PR DESCRIPTION
Hi,

we ran into a use of an uninitialized value bug in the `fuzzer-function-jit` fuzzing target:

```php
<?php
try {
    $a ?: match (true) { 1 => 1 };
} catch (UnhandledMatchError $e) {
}
```

and the `??` variant:

```php
<?php
try {
    $a ?? match (true) { 1 => 1 };
} catch (UnhandledMatchError $e) {
}
```

Note: MSAN would be the right tool to detect this bug, but oss-fuzz flags this harness as ASAN-only because the JIT doesn't work with MSAN.

<details>

<summary>ASAN backtrace for reproducer (<code>?:</code> / ZEND_JMP_SET)</summary>

```
/out/php-fuzz-function-jit: Running 1 inputs 100 time(s) each.
Running: /testcase
AddressSanitizer:DEADLYSIGNAL
=================================================================
==14==ERROR: AddressSanitizer: SEGV on unknown address (pc 0x55e832e30ebf bp 0x7ffeab63ebd0 sp 0x7ffeab63eb30 T0)
==14==The signal is caused by a READ memory access.
==14==Hint: this fault was caused by a dereference of a high value address (see register values below).  Disassemble the provided pc to learn which register was used.
SCARINESS: 20 (wild-addr-read)
    #0 0x55e832e30ebf in zend_gc_delref /src/php-src/Zend/zend_types.h:835:2
    #1 0x55e832e30ebf in zval_delref_p /src/php-src/Zend/zend_types.h:1406:9
    #2 0x55e832e30ebf in zval_ptr_dtor_nogc /src/php-src/Zend/zend_variables.h:34:35
    #3 0x55e832e30ebf in cleanup_live_vars /src/php-src/Zend/zend_execute.c:4948:6
    #4 0x55e833170b00 in zend_dispatch_try_catch_finally_helper_SPEC /src/php-src/Zend/zend_vm_execute.h:3334:4
    #5 0x55e8333140bb in fuzzer_execute_ex /src/php-src/sapi/fuzzer/fuzzer-execute-common.h:65:12
    #6 0x55e832e3813d in zend_execute /src/php-src/Zend/zend_vm_execute.h:115989:2
    #7 0x55e8333153bf in fuzzer_do_request_from_buffer /src/php-src/sapi/fuzzer/fuzzer-sapi.c:293:5
    #8 0x55e833313954 in LLVMFuzzerTestOneInput /src/php-src/sapi/fuzzer/fuzzer-function-jit.c:32:2
    [..]

DEDUP_TOKEN: zend_gc_delref--zval_delref_p--zval_ptr_dtor_nogc
SUMMARY: AddressSanitizer: SEGV /src/php-src/Zend/zend_types.h:835:2 in zend_gc_delref
==14==ABORTING
```

</details>

<details>

<summary>ASAN backtrace for the <code>??</code> / ZEND_COALESCE variant</summary>

```
/out/php-fuzz-function-jit: Running 1 inputs 100 time(s) each.
Running: /testcase
AddressSanitizer:DEADLYSIGNAL
=================================================================
==14==ERROR: AddressSanitizer: SEGV on unknown address (pc 0x55eb3a830ebf bp 0x7ffd7f0cf250 sp 0x7ffd7f0cf1b0 T0)
==14==The signal is caused by a READ memory access.
==14==Hint: this fault was caused by a dereference of a high value address (see register values below).  Disassemble the provided pc to learn which register was used.
SCARINESS: 20 (wild-addr-read)
    #0 0x55eb3a830ebf in zend_gc_delref /src/php-src/Zend/zend_types.h:835:2
    #1 0x55eb3a830ebf in zval_delref_p /src/php-src/Zend/zend_types.h:1406:9
    #2 0x55eb3a830ebf in zval_ptr_dtor_nogc /src/php-src/Zend/zend_variables.h:34:35
    #3 0x55eb3a830ebf in cleanup_live_vars /src/php-src/Zend/zend_execute.c:4948:6
    #4 0x55eb3ab70b00 in zend_dispatch_try_catch_finally_helper_SPEC /src/php-src/Zend/zend_vm_execute.h:3334:4
    #5 0x55eb3ad140bb in fuzzer_execute_ex /src/php-src/sapi/fuzzer/fuzzer-execute-common.h:65:12
    #6 0x55eb3a83813d in zend_execute /src/php-src/Zend/zend_vm_execute.h:115989:2
    #7 0x55eb3ad153bf in fuzzer_do_request_from_buffer /src/php-src/sapi/fuzzer/fuzzer-sapi.c:293:5
    #8 0x55eb3ad13954 in LLVMFuzzerTestOneInput /src/php-src/sapi/fuzzer/fuzzer-function-jit.c:32:2
    [..]

DEDUP_TOKEN: zend_gc_delref--zval_delref_p--zval_ptr_dtor_nogc
SUMMARY: AddressSanitizer: SEGV /src/php-src/Zend/zend_types.h:835:2 in zend_gc_delref
==14==ABORTING
```

</details>


`ZEND_JMP_SET` (`?:`) and `ZEND_COALESCE` (`??`) both write their result *only* on the branch they take. `zend_calc_live_ranges()` started their live range right behind the definition, so the range also covered the fall-through path, on which the temporary was never written at all.

Normally this is harmless because another opcode redefines the result on the fall-through path, and the backward walk stops at that later definition, hiding the bogus range. Once the optimizer removes that redefinition the range shows up. In the reproducer the `QM_ASSIGN` of the else branch is gone because the `match` always throws, so unwinding the `UnhandledMatchError` makes `cleanup_live_vars()` destroy uninitialized stack memory.

The fix starts the live range at the jump target instead of behind the definition. On the branch that is taken control transfers there directly, so that is exactly the region in which the result is defined. If the result is freed right at the jump target the range is empty and no range is emitted at all.

Thanks!

---

_Found by the CISPA Fandango team while triaging findings in oss-fuzz harnesses._