### PR TITLE
Fix block pass dropping ZEND_FAST_CALL OP2 definition

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -51,6 +51,8 @@ PHP                                                                        NEWS
   . Fixed a tracing JIT crash when compiling a side trace for a method of a
     class that could not be stored in the inheritance cache. (GH-21710)
     (Arnaud, iliaal)
+  . Fixed the block pass dropping the definition of the ZEND_FAST_CALL OP2
+    operand. (Mrmaxmeier)
 
 - PDO:
   . Fixed a leak when a persistent connection failed a liveness check

--- a/Zend/Optimizer/block_pass.c
+++ b/Zend/Optimizer/block_pass.c
@@ -398,6 +398,16 @@ static void zend_optimize_block(zend_basic_block *block, zend_op_array *op_array
 				}
 				break;
 
+			case ZEND_FAST_CALL:
+				if (opline->op2_type & (IS_TMP_VAR|IS_VAR)) {
+					/* OP2 holds the pending return value, which is consumed by the
+					 * following RETURN, or destroyed by
+					 * zend_dispatch_try_catch_finally_helper() if the finally block
+					 * throws. Its source must not be removed. */
+					Tsource[VAR_NUM(opline->op2.var)] = NULL;
+				}
+				break;
+
 			case ZEND_SWITCH_LONG:
 			case ZEND_SWITCH_STRING:
 			case ZEND_MATCH:

--- a/ext/opcache/tests/fuzzer_function_jit_live_range_fast_call.phpt
+++ b/ext/opcache/tests/fuzzer_function_jit_live_range_fast_call.phpt
@@ -1,0 +1,49 @@
+--TEST--
+Block pass must not remove the source of the ZEND_FAST_CALL OP2 return value
+--EXTENSIONS--
+opcache
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit=disable
+--ENV--
+USE_ZEND_ALLOC=0
+USE_TRACKED_ALLOC=1
+--FILE--
+<?php
+function test_scalar() {
+    $x = 1;
+    try {
+        try {
+            return true ? 1.5 : 2.5;
+        } finally {
+            undef_fn();
+        }
+    } catch (Throwable $e) {
+        echo $e::class, ': ', $e->getMessage(), "\n";
+    }
+    return "fallback";
+}
+
+function test_refcounted() {
+    $x = 1;
+    try {
+        try {
+            return true ? "returned" : "other";
+        } finally {
+            undef_fn();
+        }
+    } catch (Throwable $e) {
+        echo $e::class, ': ', $e->getMessage(), "\n";
+    }
+    return "fallback";
+}
+
+var_dump(test_scalar());
+var_dump(test_refcounted());
+?>
+--EXPECT--
+Error: Call to undefined function undef_fn()
+string(8) "fallback"
+Error: Call to undefined function undef_fn()
+string(8) "fallback"


### PR DESCRIPTION
Hi,

we ran into a use of an uninitialized value bug with the `fuzzer-function-jit` fuzzing target:

```php
<?php
function test() {
    $x = 1;
    try {
        try {
            return true ? "returned" : "other";
        } finally {
            undef_fn();
        }
    } catch (Error $e) {
        echo $e->getMessage(), "\n";
    }
    return "fallback";
}

var_dump(test());
```

Note: MSAN would be the right tool to detect this bug, but oss-fuzz flags this harness as ASAN-only because the JIT doesn't work with MSAN.

<details>

<summary>ASAN backtrace for reproducer</summary>

```
/out/php-fuzz-function-jit: Running 1 inputs 100 time(s) each.
Running: /testcase
AddressSanitizer:DEADLYSIGNAL
=================================================================
==14==ERROR: AddressSanitizer: SEGV on unknown address (pc 0x55b7732f8d13 bp 0x7ffd18a57e80 sp 0x7ffd18a57e60 T0)
==14==The signal is caused by a READ memory access.
==14==Hint: this fault was caused by a dereference of a high value address (see register values below).  Disassemble the provided pc to learn which register was used.
SCARINESS: 20 (wild-addr-read)
    #0 0x55b7732f8d13 in zend_gc_delref /src/php-src/Zend/zend_types.h:835:2
    #1 0x55b7732f8d13 in i_zval_ptr_dtor /src/php-src/Zend/zend_variables.h:43:8
    #2 0x55b7732f8d13 in zval_ptr_dtor /src/php-src/Zend/zend_variables.c:83:2
    #3 0x55b773170d59 in zend_dispatch_try_catch_finally_helper_SPEC /src/php-src/Zend/zend_vm_execute.h:3359:5
    #4 0x55b7733140bb in fuzzer_execute_ex /src/php-src/sapi/fuzzer/fuzzer-execute-common.h:65:12
    #5 0x55b772ecc006 in ZEND_DO_FCALL_SPEC_RETVAL_USED_HANDLER /src/php-src/Zend/zend_vm_execute.h:2131:4
    #6 0x55b7733140bb in fuzzer_execute_ex /src/php-src/sapi/fuzzer/fuzzer-execute-common.h:65:12
    #7 0x55b772e3813d in zend_execute /src/php-src/Zend/zend_vm_execute.h:115989:2
    #8 0x55b7733153bf in fuzzer_do_request_from_buffer /src/php-src/sapi/fuzzer/fuzzer-sapi.c:293:5
    #9 0x55b773313954 in LLVMFuzzerTestOneInput /src/php-src/sapi/fuzzer/fuzzer-function-jit.c:32:2
    [..]

DEDUP_TOKEN: zend_gc_delref--i_zval_ptr_dtor--zval_ptr_dtor
SUMMARY: AddressSanitizer: SEGV /src/php-src/Zend/zend_types.h:835:2 in zend_gc_delref
==14==ABORTING
```

</details>

When a `return` crosses a `finally` block, PHP first stores the return value in a temporary. Both the `ZEND_FAST_CALL` that enters the `finally` block and the later `ZEND_RETURN` refer to that temporary. The OP2 reference on `ZEND_FAST_CALL` is needed during exception unwinding: if the `finally` block throws, the VM uses it to find and destroy the pending return value.

The block pass did not account for this extra use. After propagating the value into `ZEND_RETURN`, it considered the `QM_ASSIGN` that initialized the temporary dead and removed it. This left the optimized op_array with

```
FAST_CALL finally T3
```

but no opcode that initialized `T3`. If the `finally` block then threw, exception unwinding attempted to destroy the uninitialized temporary.

The fix marks the OP2 temporary as ineligible for this source-removal optimization. This uses the same mechanism already used for operands that must remain available to `ZEND_FETCH_LIST_R` and similar opcodes.


Thanks!

---

_Found by the CISPA Fandango team while triaging findings in oss-fuzz harnesses._
