### PR TITLE
PHP array_shift(): Optimize tail move on hole-free packed arrays

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -54,6 +54,8 @@ PHP                                                                        NEWS
   . Fixed read buffer compaction in php_stream_filter_flush(). (crystarm)
   . Io\Poll\Context::wait() now rejects a $maxEvents value greater than
     INT_MAX instead of truncating it. (marc-mabe)
+  . Improved performance of array_shift() on packed arrays without holes.
+    (mehmetcansahin)
 
 - SimpleXML:
   . Fixed writing to a dimension of the object returned by attributes() not

--- a/UPGRADING
+++ b/UPGRADING
@@ -977,6 +977,7 @@ PHP 8.6 UPGRADE NOTES
   . Improved performance of array_fill_keys().
   . Improved performance of array_intersect().
   . Improved performance of array_map() with multiple arrays passed.
+  . Improved performance of array_shift() on packed arrays without holes.
   . Improved performance of array_sum() and array_product() for
     integer-only arrays.
   . Improved performance of array_unshift().

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -3576,6 +3576,8 @@ PHP_FUNCTION(array_shift)
 	/* re-index like it did before */
 	if (HT_IS_PACKED(Z_ARRVAL_P(stack))) {
 		uint32_t k = 0;
+		/* Must be read before the deletion below opens a hole. */
+		bool without_holes = HT_IS_WITHOUT_HOLES(Z_ARRVAL_P(stack));
 
 		/* Get the first value and copy it into the return value */
 		idx = 0;
@@ -3596,15 +3598,32 @@ PHP_FUNCTION(array_shift)
 		zend_hash_packed_del_val(Z_ARRVAL_P(stack), val);
 
 		if (EXPECTED(!HT_HAS_ITERATORS(Z_ARRVAL_P(stack)))) {
-			for (idx = 0; idx < Z_ARRVAL_P(stack)->nNumUsed; idx++) {
-				val = Z_ARRVAL_P(stack)->arPacked + idx;
-				if (Z_TYPE_P(val) == IS_UNDEF) continue;
-				if (idx != k) {
-					zval *q = Z_ARRVAL_P(stack)->arPacked + k;
-					ZVAL_COPY_VALUE(q, val);
-					ZVAL_UNDEF(val);
+			if (without_holes) {
+				/* The slot just vacated is the only hole, so the rest moves down by one
+				 * without having to test every slot. */
+				HashTable *ht = Z_ARRVAL_P(stack);
+
+				if (ht->nNumUsed > 0) {
+					k = ht->nNumUsed - 1;
+					if (k == 1) {
+						/* Avoid the memmove() call overhead for the common tiny-array case. */
+						ZVAL_COPY_VALUE(ht->arPacked, ht->arPacked + 1);
+					} else {
+						memmove(ht->arPacked, ht->arPacked + 1, sizeof(zval) * k);
+					}
+					ZVAL_UNDEF(ht->arPacked + k);
 				}
-				k++;
+			} else {
+				for (idx = 0; idx < Z_ARRVAL_P(stack)->nNumUsed; idx++) {
+					val = Z_ARRVAL_P(stack)->arPacked + idx;
+					if (Z_TYPE_P(val) == IS_UNDEF) continue;
+					if (idx != k) {
+						zval *q = Z_ARRVAL_P(stack)->arPacked + k;
+						ZVAL_COPY_VALUE(q, val);
+						ZVAL_UNDEF(val);
+					}
+					k++;
+				}
 			}
 		} else {
 			uint32_t iter_pos = zend_hash_iterators_lower_pos(Z_ARRVAL_P(stack), 0);

--- a/ext/standard/tests/array/array_shift_packed.phpt
+++ b/ext/standard/tests/array/array_shift_packed.phpt
@@ -1,0 +1,82 @@
+--TEST--
+array_shift() on packed arrays: hole-free fast path and holed fallback
+--FILE--
+<?php
+// Hole-free tail move (tail longer than one element).
+$a = [1, "two", 3, 4, 5];
+var_dump(array_shift($a), $a);
+$a[] = 6; // The next appended key must follow the compacted tail.
+var_dump($a);
+
+// Hole-free two-element array (single-element tail).
+$a = [10, 20];
+var_dump(array_shift($a), $a);
+
+// Hole-free single element: shifts to empty, the next appended key is 0.
+$a = [42];
+var_dump(array_shift($a), $a);
+$a[] = 7;
+var_dump($a);
+
+// Holes at the head and in the middle: the compaction loop must skip them.
+$a = [1, 2, 3, 4, 5];
+unset($a[0], $a[2]);
+var_dump(array_shift($a), $a);
+
+// Shift a holed array down to empty: the next appended key must be 0.
+$a = [10, 20];
+unset($a[0]);
+var_dump(array_shift($a), $a);
+$a[] = 30;
+var_dump($a);
+?>
+--EXPECT--
+int(1)
+array(4) {
+  [0]=>
+  string(3) "two"
+  [1]=>
+  int(3)
+  [2]=>
+  int(4)
+  [3]=>
+  int(5)
+}
+array(5) {
+  [0]=>
+  string(3) "two"
+  [1]=>
+  int(3)
+  [2]=>
+  int(4)
+  [3]=>
+  int(5)
+  [4]=>
+  int(6)
+}
+int(10)
+array(1) {
+  [0]=>
+  int(20)
+}
+int(42)
+array(0) {
+}
+array(1) {
+  [0]=>
+  int(7)
+}
+int(2)
+array(2) {
+  [0]=>
+  int(4)
+  [1]=>
+  int(5)
+}
+int(20)
+array(0) {
+}
+array(1) {
+  [0]=>
+  int(30)
+}


### PR DESCRIPTION
For a packed array without holes, removing the first element leaves a contiguous tail. When no iterator is active, `array_shift()` now moves that tail with a single `memmove()` instead of testing every slot for `IS_UNDEF`; a one element tail is moved directly to avoid the call overhead. Packed arrays with holes, arrays with active iterators, and hash arrays keep the existing paths.

### Benchmarks

Draining a packed int array (`$a = $base; while ($a) array_shift($a);`):

| n | repetitions | base | this PR | speedup |
|---:|------------:|-----:|--------:|--------:|
| 100 | 20,000 | 160.5 ms | 58.7 ms | 2.7× |
| 1,000 | 2,000 | 1,075.6 ms | 249.9 ms | 4.3× |
| 10,000 | 200 | 10,726.5 ms | 2,602.4 ms | 4.1× |

Two-element regression check (`$a = [0, 1]; array_shift($a);` x 100M, exercises the direct-copy specialization): 3.528s → 3.438 s, no tiny-array slowdown observed.

<details>
<summary>Benchmark scripts</summary>

Draining benchmark:

```php
<?php
foreach ([100, 1000, 10000] as $n) {
    $reps = intdiv(2000000, $n);
    $base = range(0, $n - 1);
    $best = PHP_FLOAT_MAX;
    for ($run = 0; $run < 3; $run++) {
        $t = hrtime(true);
        for ($r = 0; $r < $reps; $r++) {
            $a = $base;
            while ($a) array_shift($a);
        }
        $best = min($best, (hrtime(true) - $t) / 1e6);
    }
    printf("n=%-6d drain x%-5d best: %8.1f ms\n", $n, $reps, $best);
}
```

Two-element regression check:

```php
<?php
$best = PHP_FLOAT_MAX;
for ($run = 0; $run < 3; $run++) {
    $t = hrtime(true);
    for ($i = 0; $i < 100000000; $i++) {
        $a = [0, 1];
        array_shift($a);
    }
    $best = min($best, (hrtime(true) - $t) / 1e9);
}
printf("fresh [0,1] x100M best: %.3f s\n", $best);
```

</details>
