### PR TITLE
[intl] Fix empty-needle grapheme_strpos offsets

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -32,6 +32,8 @@ PHP                                                                        NEWS
   . Fixed bug GH-19320 (FPM UID and GID overflow). (Pratik Bhujel)
 
 - Intl:
+  . Fixed grapheme_strpos() and grapheme_strrpos() with an empty needle
+    returning UTF-16 offsets instead of grapheme offsets. (Ilia Alshanetsky)
   . Fixed a memory leak when dumping IntlCalendar instances. (Ilia Alshanetsky)
   . Fixed a memory leak when iterating IntlBreakIterator::getPartsIterator()
     results. (iliaal)

--- a/ext/intl/grapheme/grapheme_util.c
+++ b/ext/intl/grapheme/grapheme_util.c
@@ -131,7 +131,11 @@ int32_t grapheme_strpos_utf16(char *haystack, size_t haystack_len, char *needle,
 			ret_pos = -1;
 			goto finish;
 		}
-		ret_pos = last && offset >= 0 ? uhaystack_len : offset_pos;
+		if (last && offset >= 0) {
+			ret_pos = grapheme_count_graphemes(bi, uhaystack, uhaystack_len);
+		} else {
+			ret_pos = grapheme_count_graphemes(bi, uhaystack, offset_pos);
+		}
 		goto finish;
 	}
 

--- a/ext/intl/tests/grapheme_empty_offset_multibyte.phpt
+++ b/ext/intl/tests/grapheme_empty_offset_multibyte.phpt
@@ -1,0 +1,36 @@
+--TEST--
+grapheme_strpos() family with empty needle and offset on multi-code-unit graphemes
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+
+ini_set("intl.error_level", E_WARNING);
+
+var_dump(grapheme_strpos("😀x", ""));
+var_dump(grapheme_strpos("😀x", "", 0));
+var_dump(grapheme_strpos("😀x", "", 1));
+var_dump(grapheme_stripos("😀x", "", 1));
+var_dump(grapheme_strpos("😀x", "", -1));
+var_dump(grapheme_strrpos("😀x", ""));
+var_dump(grapheme_strrpos("😀x", "", 1));
+var_dump(grapheme_strripos("😀x", "", 1));
+var_dump(grapheme_strrpos("😀x", "", -1));
+try {
+    var_dump(grapheme_strpos("😀x", "", 5));
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+int(0)
+int(0)
+int(1)
+int(1)
+int(1)
+int(2)
+int(2)
+int(2)
+int(1)
+ValueError: grapheme_strpos(): Argument #3 ($offset) must be contained in argument #1 ($haystack)


### PR DESCRIPTION
grapheme_strpos() and grapheme_strrpos() with an empty needle return the raw UTF-16 code-unit position instead of a grapheme index, so on a haystack containing a non-BMP or combining grapheme the reported offset is too large: grapheme_strpos("😀x", "", 1) gives 3 where 1 is correct. The empty-needle early return in grapheme_strpos_utf16() skips the grapheme_count_graphemes() conversion that the non-empty search already does. grapheme_strstr() is unaffected: it consumes the separate raw UTF-16 out-parameter, not the return value.
