### PR TITLE
ext/standard: Fix 1-char relative Location redirects after GH-23467

### DIFF
--- a/ext/standard/http_fopen_wrapper.c
+++ b/ext/standard/http_fopen_wrapper.c
@@ -1060,7 +1060,7 @@ finish:
 			{
 				char *loc_path = NULL;
 				if (*header_info.location != '/') {
-					if (header_info.location_len > 0 && resource->path) {
+					if (header_info.location_len > 1 && resource->path) {
 						char *s = strrchr(ZSTR_VAL(resource->path), '/');
 						if (!s) {
 							s = ZSTR_VAL(resource->path);

--- a/ext/standard/tests/http/http_single_char_location_redirect.phpt
+++ b/ext/standard/tests/http/http_single_char_location_redirect.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Single-char relative Location header keeps resolving against the host root (pre-GH-23467 behavior)
+--DESCRIPTION--
+Not RFC 3986 compliant ("x" against "/a/b" gives "/a/x"), but matches
+PHP's long-standing behavior of resolving against the host root. See GH-23521.
+--FILE--
+<?php
+$serverCode = <<<'CODE'
+$server = stream_socket_server("tcp://127.0.0.1:0", $errno, $errstr);
+phpt_notify_server_start($server);
+
+for ($n = 0; $n < 2; $n++) {
+    $conn = stream_socket_accept($server, 10);
+    if (!$conn) {
+        break;
+    }
+    $req = fgets($conn);
+    while (trim(fgets($conn)) !== '') {}
+    $uri = explode(' ', $req)[1];
+    if ($n < 1) {
+        fwrite($conn, "HTTP/1.1 302 Found\r\nLocation: x\r\nContent-Length: 0\r\n\r\n");
+    } else {
+        $body = "uri=$uri";
+        fwrite($conn, "HTTP/1.1 200 OK\r\nContent-Length: " . strlen($body) . "\r\n\r\n$body");
+    }
+    fclose($conn);
+}
+CODE;
+
+$clientCode = <<<'CODE'
+$ctx = stream_context_create(['http' => ['follow_location' => 1]]);
+echo @file_get_contents("http://{{ ADDR }}/a/b", false, $ctx), "\n";
+CODE;
+
+include sprintf("%s/../../../openssl/tests/ServerClientTestCase.inc", __DIR__);
+ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
+?>
+--EXPECT--
+uri=/x


### PR DESCRIPTION
Follow-up to 8196275133e (GH-23467), which introduced a small regression.

The new check (`location_len > 0`) also changed how single-character relative redirects are resolved. The old check only applied to locations of 2 characters or more.

Before regression: `Location: x` from `http://host/a/b` redirected to `http://host/x`
After:  it redirects to `http://host/a//x`