### PR TITLE
sapi: Remove sapi_terminate_process

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -137,6 +137,7 @@ PHP 8.6 INTERNALS UPGRADE NOTES
   . The zend_parse_parameter() function has been removed, use one fo the
     zend_parse_arg_TYPE() APIs instead.
   . The zend_is_countable() function was removed.
+  . The sapi_terminate_process() function was removed.
 
 - Changed:
   . Internal functions that return by reference are now expected to
@@ -347,6 +348,8 @@ PHP 8.6 INTERNALS UPGRADE NOTES
 ========================
 5. SAPI changes
 ========================
+
+- The terminate_process method has been removed.
 
 - SAPIs should explicitly release a thread's resources by calling
   ts_free_thread() before terminating it. tsrm_shutdown() can only release the

--- a/main/SAPI.c
+++ b/main/SAPI.c
@@ -1089,12 +1089,6 @@ SAPI_API double sapi_get_request_time(void)
 	return SG(global_request_time);
 }
 
-SAPI_API void sapi_terminate_process(void) {
-	if (sapi_module.terminate_process) {
-		sapi_module.terminate_process();
-	}
-}
-
 SAPI_API void sapi_add_request_header(const char *var, unsigned int var_len, char *val, unsigned int val_len, void *arg) /* {{{ */
 {
 	zval *return_value = (zval*)arg;

--- a/main/SAPI.h
+++ b/main/SAPI.h
@@ -230,7 +230,6 @@ SAPI_API int sapi_force_http_10(void);
 SAPI_API int sapi_get_target_uid(uid_t *);
 SAPI_API int sapi_get_target_gid(gid_t *);
 SAPI_API double sapi_get_request_time(void);
-SAPI_API void sapi_terminate_process(void);
 END_EXTERN_C()
 
 struct _sapi_module_struct {
@@ -260,7 +259,6 @@ struct _sapi_module_struct {
 	void (*register_server_variables)(zval *track_vars_array);
 	void (*log_message)(const char *message, int syslog_type_int);
 	zend_result (*get_request_time)(double *request_time);
-	void (*terminate_process)(void);
 
 	char *php_ini_path_override;
 

--- a/sapi/apache2handler/sapi_apache2.c
+++ b/sapi/apache2handler/sapi_apache2.c
@@ -410,7 +410,6 @@ static sapi_module_struct apache2_sapi_module = {
 	php_apache_sapi_register_variables,
 	php_apache_sapi_log_message,			/* Log message */
 	php_apache_sapi_get_request_time,		/* Request Time */
-	NULL,						/* Child Terminate */
 
 	STANDARD_SAPI_MODULE_PROPERTIES
 };

--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -999,7 +999,6 @@ static sapi_module_struct cgi_sapi_module = {
 	sapi_cgi_register_variables,	/* register server variables */
 	sapi_cgi_log_message,			/* Log message */
 	NULL,							/* Get request time */
-	NULL,							/* Child terminate */
 
 	STANDARD_SAPI_MODULE_PROPERTIES
 };

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -422,7 +422,6 @@ static sapi_module_struct cli_sapi_module = {
 	sapi_cli_register_variables,	/* register server variables */
 	sapi_cli_log_message,			/* Log message */
 	NULL,							/* Get request time */
-	NULL,							/* Child terminate */
 
 	STANDARD_SAPI_MODULE_PROPERTIES
 };

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -820,7 +820,6 @@ sapi_module_struct cli_server_sapi_module = {
 	sapi_cli_server_register_variables,	/* register server variables */
 	sapi_cli_server_log_message,	/* Log message */
 	NULL,							/* Get request time */
-	NULL,							/* Child terminate */
 
 	STANDARD_SAPI_MODULE_PROPERTIES
 }; /* }}} */

--- a/sapi/embed/php_embed.c
+++ b/sapi/embed/php_embed.c
@@ -142,7 +142,6 @@ EMBED_SAPI_API sapi_module_struct php_embed_module = {
 	php_embed_register_variables,  /* register server variables */
 	php_embed_log_message,         /* Log message */
 	NULL,                          /* Get request time */
-	NULL,                          /* Child terminate */
 
 	STANDARD_SAPI_MODULE_PROPERTIES
 };

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -812,7 +812,6 @@ static sapi_module_struct cgi_sapi_module = {
 	sapi_cgi_register_variables,	/* register server variables */
 	sapi_cgi_log_message,			/* Log message */
 	NULL,							/* Get request time */
-	NULL,							/* Child terminate */
 
 	STANDARD_SAPI_MODULE_PROPERTIES
 };

--- a/sapi/fuzzer/fuzzer-sapi.c
+++ b/sapi/fuzzer/fuzzer-sapi.c
@@ -119,7 +119,6 @@ static sapi_module_struct fuzzer_module = {
 	register_variables,  /* register server variables */
 	log_message,         /* Log message */
 	NULL,                          /* Get request time */
-	NULL,                          /* Child terminate */
 
 	STANDARD_SAPI_MODULE_PROPERTIES
 };

--- a/sapi/litespeed/lsapi_main.c
+++ b/sapi/litespeed/lsapi_main.c
@@ -614,7 +614,6 @@ static sapi_module_struct lsapi_sapi_module =
     sapi_lsapi_register_variables,  /* register server variables */
     sapi_lsapi_log_message,         /* Log message */
     NULL,                           /* Get request time */
-    NULL,                           /* Child terminate */
 
     STANDARD_SAPI_MODULE_PROPERTIES
 

--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -953,7 +953,7 @@ static sapi_module_struct phpdbg_sapi_module = {
 	php_sapi_phpdbg_register_vars,  /* register server variables */
 	php_sapi_phpdbg_log_message,    /* Log message */
 	NULL,                           /* Get request time */
-	NULL,                           /* Child terminate */
+
 	STANDARD_SAPI_MODULE_PROPERTIES
 };
 /* }}} */


### PR DESCRIPTION
This is unused; this is a vestige of 6c158374ba57792b0e283053e0a22944a42ef25b and 45e327a672746e4fb5fe57fa10ff758d1143ad0a, which set up some timeout code which was removed in 650c1c0a7d94d3bb052a93407b6e280df9c265a4. Remove this useless function from SAPIs.