### PR TITLE
sapi: Remove unused SAPI methods which are in default SAPI properties

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -138,6 +138,7 @@ PHP 8.6 INTERNALS UPGRADE NOTES
     zend_parse_arg_TYPE() APIs instead.
   . The zend_is_countable() function was removed.
   . The sapi_force_http_10() function was removed.
+  . The sapi_get_fd() function was removed.
 
 - Changed:
   . Internal functions that return by reference are now expected to
@@ -350,6 +351,8 @@ PHP 8.6 INTERNALS UPGRADE NOTES
 ========================
 
 - The force_http_10 method has been removed.
+
+- The get_fd method has been removed.
 
 - SAPIs should explicitly release a thread's resources by calling
   ts_free_thread() before terminating it. tsrm_shutdown() can only release the

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -139,6 +139,7 @@ PHP 8.6 INTERNALS UPGRADE NOTES
   . The zend_is_countable() function was removed.
   . The sapi_force_http_10() function was removed.
   . The sapi_get_fd() function was removed.
+  . The sapi_get_target_uid() and sapi_get_target_gid() functions were removed.
 
 - Changed:
   . Internal functions that return by reference are now expected to
@@ -353,6 +354,8 @@ PHP 8.6 INTERNALS UPGRADE NOTES
 - The force_http_10 method has been removed.
 
 - The get_fd method has been removed.
+
+- The get_target_uid and get_target_gid methods have been removed.
 
 - SAPIs should explicitly release a thread's resources by calling
   ts_free_thread() before terminating it. tsrm_shutdown() can only release the

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -137,6 +137,7 @@ PHP 8.6 INTERNALS UPGRADE NOTES
   . The zend_parse_parameter() function has been removed, use one fo the
     zend_parse_arg_TYPE() APIs instead.
   . The zend_is_countable() function was removed.
+  . The sapi_force_http_10() function was removed.
 
 - Changed:
   . Internal functions that return by reference are now expected to
@@ -347,6 +348,8 @@ PHP 8.6 INTERNALS UPGRADE NOTES
 ========================
 5. SAPI changes
 ========================
+
+- The force_http_10 method has been removed.
 
 - SAPIs should explicitly release a thread's resources by calling
   ts_free_thread() before terminating it. tsrm_shutdown() can only release the

--- a/main/SAPI.c
+++ b/main/SAPI.c
@@ -1045,15 +1045,6 @@ SAPI_API int sapi_get_fd(int *fd)
 	}
 }
 
-SAPI_API int sapi_force_http_10(void)
-{
-	if (sapi_module.force_http_10) {
-		return sapi_module.force_http_10();
-	} else {
-		return FAILURE;
-	}
-}
-
 
 SAPI_API int sapi_get_target_uid(uid_t *obj)
 {

--- a/main/SAPI.c
+++ b/main/SAPI.c
@@ -1036,25 +1036,6 @@ SAPI_API char *sapi_getenv(const char *name, size_t name_len)
 	return value;
 }
 
-
-SAPI_API int sapi_get_target_uid(uid_t *obj)
-{
-	if (sapi_module.get_target_uid) {
-		return sapi_module.get_target_uid(obj);
-	} else {
-		return FAILURE;
-	}
-}
-
-SAPI_API int sapi_get_target_gid(gid_t *obj)
-{
-	if (sapi_module.get_target_gid) {
-		return sapi_module.get_target_gid(obj);
-	} else {
-		return FAILURE;
-	}
-}
-
 SAPI_API double sapi_get_request_time(void)
 {
 	if(SG(global_request_time)) return SG(global_request_time);

--- a/main/SAPI.c
+++ b/main/SAPI.c
@@ -1036,15 +1036,6 @@ SAPI_API char *sapi_getenv(const char *name, size_t name_len)
 	return value;
 }
 
-SAPI_API int sapi_get_fd(int *fd)
-{
-	if (sapi_module.get_fd) {
-		return sapi_module.get_fd(fd);
-	} else {
-		return FAILURE;
-	}
-}
-
 
 SAPI_API int sapi_get_target_uid(uid_t *obj)
 {

--- a/main/SAPI.h
+++ b/main/SAPI.h
@@ -224,8 +224,6 @@ SAPI_API void sapi_get_default_content_type_header(sapi_header_struct *default_h
 SAPI_API size_t sapi_apply_default_charset(char **mimetype, size_t len);
 SAPI_API void sapi_activate_headers_only(void);
 
-SAPI_API int sapi_get_target_uid(uid_t *);
-SAPI_API int sapi_get_target_gid(gid_t *);
 SAPI_API double sapi_get_request_time(void);
 SAPI_API void sapi_terminate_process(void);
 END_EXTERN_C()
@@ -267,9 +265,6 @@ struct _sapi_module_struct {
 
 	int php_ini_ignore;
 	int php_ini_ignore_cwd; /* don't look for php.ini in the current directory */
-
-	int (*get_target_uid)(uid_t *);
-	int (*get_target_gid)(gid_t *);
 
 	unsigned int (*input_filter)(int arg, const char *var, char **val, size_t val_len, size_t *new_val_len);
 
@@ -322,8 +317,6 @@ END_EXTERN_C()
 	NULL, /* executable_location     */ \
 	0,    /* php_ini_ignore          */ \
 	0,    /* php_ini_ignore_cwd      */ \
-	NULL, /* get_target_uid          */ \
-	NULL, /* get_target_gid          */ \
 	NULL, /* input_filter            */ \
 	NULL, /* ini_defaults            */ \
 	0,    /* phpinfo_as_text;        */ \

--- a/main/SAPI.h
+++ b/main/SAPI.h
@@ -224,8 +224,6 @@ SAPI_API void sapi_get_default_content_type_header(sapi_header_struct *default_h
 SAPI_API size_t sapi_apply_default_charset(char **mimetype, size_t len);
 SAPI_API void sapi_activate_headers_only(void);
 
-SAPI_API int sapi_get_fd(int *fd);
-
 SAPI_API int sapi_get_target_uid(uid_t *);
 SAPI_API int sapi_get_target_gid(gid_t *);
 SAPI_API double sapi_get_request_time(void);
@@ -269,8 +267,6 @@ struct _sapi_module_struct {
 
 	int php_ini_ignore;
 	int php_ini_ignore_cwd; /* don't look for php.ini in the current directory */
-
-	int (*get_fd)(int *fd);
 
 	int (*get_target_uid)(uid_t *);
 	int (*get_target_gid)(gid_t *);
@@ -326,7 +322,6 @@ END_EXTERN_C()
 	NULL, /* executable_location     */ \
 	0,    /* php_ini_ignore          */ \
 	0,    /* php_ini_ignore_cwd      */ \
-	NULL, /* get_fd                  */ \
 	NULL, /* get_target_uid          */ \
 	NULL, /* get_target_gid          */ \
 	NULL, /* input_filter            */ \

--- a/main/SAPI.h
+++ b/main/SAPI.h
@@ -225,7 +225,6 @@ SAPI_API size_t sapi_apply_default_charset(char **mimetype, size_t len);
 SAPI_API void sapi_activate_headers_only(void);
 
 SAPI_API int sapi_get_fd(int *fd);
-SAPI_API int sapi_force_http_10(void);
 
 SAPI_API int sapi_get_target_uid(uid_t *);
 SAPI_API int sapi_get_target_gid(gid_t *);
@@ -272,8 +271,6 @@ struct _sapi_module_struct {
 	int php_ini_ignore_cwd; /* don't look for php.ini in the current directory */
 
 	int (*get_fd)(int *fd);
-
-	int (*force_http_10)(void);
 
 	int (*get_target_uid)(uid_t *);
 	int (*get_target_gid)(gid_t *);
@@ -330,7 +327,6 @@ END_EXTERN_C()
 	0,    /* php_ini_ignore          */ \
 	0,    /* php_ini_ignore_cwd      */ \
 	NULL, /* get_fd                  */ \
-	NULL, /* force_http_10           */ \
 	NULL, /* get_target_uid          */ \
 	NULL, /* get_target_gid          */ \
 	NULL, /* input_filter            */ \


### PR DESCRIPTION
Removes `get_fd`, `force_http_10`, `get_target_uid`, and `get_target_gid`.