### PR TITLE
Fix bounds check in multibyte UTF detection

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,8 @@ PHP                                                                        NEWS
 ?? ??? ????, PHP 8.4.26
 
 - Core:
+  . Fixed out-of-bounds reads during automatic UTF-16/32 encoding detection.
+    (Yudai Takada)
   . Fixed bug GH-15375 (Nested "yield from" skips items after a valid() or
     next() call on the inner generator). (iliaal)
   . Fixed bug GH-23301 (Nested "yield from" yields a value twice when the

--- a/Zend/tests/multibyte/multibyte_encoding_008.phpt
+++ b/Zend/tests/multibyte/multibyte_encoding_008.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Zend Multibyte does not read past the script during UTF-16 detection
+--EXTENSIONS--
+mbstring
+--INI--
+zend.multibyte=1
+internal_encoding=UTF-8
+--FILE--
+<?php
+$filename = __DIR__ . '/multibyte_encoding_008.tmp.php';
+file_put_contents($filename, "<\0?\0p\0h\0p\0");
+include $filename;
+echo "Done\n";
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/multibyte_encoding_008.tmp.php');
+?>
+--EXPECT--
+Done

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -327,14 +327,13 @@ ZEND_API zend_result zend_lex_tstring(zval *zv, unsigned char *ident)
 static const zend_encoding *zend_multibyte_detect_utf_encoding(const unsigned char *script, size_t script_size)
 {
 	const unsigned char *p;
+	size_t offset = 0;
 	int wchar_size = 2;
 	int le = 0;
 
 	/* utf-16 or utf-32? */
-	p = script;
-	assert(p >= script);
-	while ((size_t)(p-script) < script_size) {
-		p = memchr(p, 0, script_size-(p-script)-2);
+	while (offset < script_size && script_size - offset > 2) {
+		p = memchr(script + offset, 0, script_size - offset - 2);
 		if (!p) {
 			break;
 		}
@@ -344,13 +343,13 @@ static const zend_encoding *zend_multibyte_detect_utf_encoding(const unsigned ch
 		}
 
 		/* searching for UTF-32 specific byte orders, so this will do */
-		p += 4;
+		offset = p - script + 4;
 	}
 
 	/* BE or LE? */
-	p = script;
-	assert(p >= script);
-	while ((size_t)(p-script) < script_size) {
+	offset = 0;
+	while (script_size - offset >= (size_t) wchar_size) {
+		p = script + offset;
 		if (*p == '\0' && *(p+wchar_size-1) != '\0') {
 			/* BE */
 			le = 0;
@@ -360,7 +359,7 @@ static const zend_encoding *zend_multibyte_detect_utf_encoding(const unsigned ch
 			le = 1;
 			break;
 		}
-		p += wchar_size;
+		offset += wchar_size;
 	}
 
 	if (wchar_size == 2) {


### PR DESCRIPTION
`zend_multibyte_detect_utf_encoding()` advances the search position by four bytes after each NUL while looking for UTF-32-specific byte orders. When fewer than three bytes remain, `script_size - (p - script) - 2` underflows and passes a huge `size_t` value to `memchr()`.

Scripts are normally backed by a buffer with `ZEND_MMAP_AHEAD` zero padding, so this generally does not crash. Instead, `memchr()` may find a NUL in the padding and misdetect a BOM-less UTF-16 script as UTF-32, corrupting the script during conversion when `zend.multibyte` is enabled.

Track the search position as an offset and call `memchr()` only while at least three bytes remain. This also avoids advancing a pointer beyond the script buffer.

For example, with `zend.multibyte=1` and `internal_encoding=UTF-8`:

```php
$filename = __DIR__ . '/utf16le.php';
file_put_contents($filename, "<\0?\0p\0h\0p\0");
include $filename;
echo "Done\n";
```

#### Expected

```text
Done
```

The 10-byte BOM-less UTF-16LE script is detected as UTF-16LE.

 #### Actual

```text
???Done
```

After the search reaches offset 9, the length calculation underflows. `memchr()` finds a NUL in the trailing padding, causing the script to be misdetected as UTF-32LE.