### PR TITLE
ext/pcntl: fix declared signature of pcntl_signal($restart_syscalls)

### DIFF
--- a/ext/pcntl/pcntl.stub.php
+++ b/ext/pcntl/pcntl.stub.php
@@ -1023,7 +1023,7 @@ const PCNTL_ECAPMODE = UNKNOWN;
     function pcntl_wait(&$status, int $flags = 0, &$resource_usage = []): int {}
 
     /** @param callable|int $handler */
-    function pcntl_signal(int $signal, $handler, bool $restart_syscalls = true): bool {}
+    function pcntl_signal(int $signal, $handler, ?bool $restart_syscalls = null): bool {}
 
     /** @return callable|int */
     function pcntl_signal_get_handler(int $signal) {}

--- a/ext/pcntl/pcntl_arginfo.h
+++ b/ext/pcntl/pcntl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit pcntl.stub.php instead.
- * Stub hash: 04e7b30c6fb23cf6ce6bc26fe094fd5b4dbfe826
+ * Stub hash: ec6306e93fad6d127ff880fc01736ac287619cf7
  * Has decl header: yes */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcntl_fork, 0, 0, IS_LONG, 0)
@@ -31,7 +31,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcntl_signal, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, signal, IS_LONG, 0)
 	ZEND_ARG_INFO(0, handler)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, restart_syscalls, _IS_BOOL, 0, "true")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, restart_syscalls, _IS_BOOL, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_pcntl_signal_get_handler, 0, 0, 1)

--- a/ext/pcntl/pcntl_decl.h
+++ b/ext/pcntl/pcntl_decl.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit pcntl.stub.php instead.
- * Stub hash: 04e7b30c6fb23cf6ce6bc26fe094fd5b4dbfe826 */
+ * Stub hash: ec6306e93fad6d127ff880fc01736ac287619cf7 */
 
-#ifndef ZEND_PCNTL_DECL_04e7b30c6fb23cf6ce6bc26fe094fd5b4dbfe826_H
-#define ZEND_PCNTL_DECL_04e7b30c6fb23cf6ce6bc26fe094fd5b4dbfe826_H
+#ifndef ZEND_PCNTL_DECL_ec6306e93fad6d127ff880fc01736ac287619cf7_H
+#define ZEND_PCNTL_DECL_ec6306e93fad6d127ff880fc01736ac287619cf7_H
 
 typedef enum zend_enum_Pcntl_QosClass {
 	ZEND_ENUM_Pcntl_QosClass_UserInteractive = 1,
@@ -12,4 +12,4 @@ typedef enum zend_enum_Pcntl_QosClass {
 	ZEND_ENUM_Pcntl_QosClass_Background = 5,
 } zend_enum_Pcntl_QosClass;
 
-#endif /* ZEND_PCNTL_DECL_04e7b30c6fb23cf6ce6bc26fe094fd5b4dbfe826_H */
+#endif /* ZEND_PCNTL_DECL_ec6306e93fad6d127ff880fc01736ac287619cf7_H */

--- a/ext/pcntl/tests/pcntl_signal_restart_syscalls.phpt
+++ b/ext/pcntl/tests/pcntl_signal_restart_syscalls.phpt
@@ -1,0 +1,36 @@
+--TEST--
+pcntl_signal(): $restart_syscalls is nullable
+--EXTENSIONS--
+pcntl
+--FILE--
+<?php
+declare(strict_types=1);
+
+$parameter = (new ReflectionFunction('pcntl_signal'))->getParameters()[2];
+var_dump((string) $parameter->getType());
+var_dump($parameter->allowsNull());
+var_dump($parameter->getDefaultValue());
+
+var_dump(pcntl_signal(SIGALRM, SIG_IGN));
+var_dump(pcntl_signal(SIGALRM, SIG_IGN, null));
+var_dump(pcntl_signal(SIGALRM, SIG_IGN, true));
+var_dump(pcntl_signal(SIGALRM, SIG_IGN, false));
+
+try {
+    pcntl_signal(SIGALRM, SIG_IGN, 1);
+} catch (TypeError $exception) {
+    echo $exception->getMessage(), "\n";
+}
+
+var_dump(pcntl_signal(SIGALRM, SIG_DFL));
+?>
+--EXPECT--
+string(5) "?bool"
+bool(true)
+NULL
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+pcntl_signal(): Argument #3 ($restart_syscalls) must be of type ?bool, int given
+bool(true)

--- a/ext/pcntl/tests/pcntl_signal_restart_syscalls.phpt
+++ b/ext/pcntl/tests/pcntl_signal_restart_syscalls.phpt
@@ -18,8 +18,8 @@ var_dump(pcntl_signal(SIGALRM, SIG_IGN, false));
 
 try {
     pcntl_signal(SIGALRM, SIG_IGN, 1);
-} catch (TypeError $exception) {
-    echo $exception->getMessage(), "\n";
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
 }
 
 var_dump(pcntl_signal(SIGALRM, SIG_DFL));
@@ -32,5 +32,5 @@ bool(true)
 bool(true)
 bool(true)
 bool(true)
-pcntl_signal(): Argument #3 ($restart_syscalls) must be of type ?bool, int given
+TypeError: pcntl_signal(): Argument #3 ($restart_syscalls) must be of type ?bool, int given
 bool(true)


### PR DESCRIPTION
`pcntl_signal()` parses its third argument with `Z_PARAM_BOOL_OR_NULL()`, so `null` is accepted, and `null` is also what selects the `SIGALRM` specific default of `false`:

```c
if (restart_syscalls_is_null && signo == SIGALRM) {
    restart_syscalls = 0;
}
```

The stub, however, declared a non-nullable `bool` defaulting to `true`, so Reflection reported a signature the implementation does not honour:

```php
$p = (new ReflectionFunction('pcntl_signal'))->getParameters()[2];

var_dump($p->allowsNull());        // bool(false)
var_dump($p->getDefaultValue());   // bool(true)

pcntl_signal(SIGALRM, fn() => null, null);
echo "null accepted\n";            // no TypeError, no deprecation
```

Every other `Z_PARAM_BOOL_OR_NULL()` user declares a nullable parameter defaulting to `null` — `imageinterlace()`, `json_decode()`, `libxml_use_internal_errors()` and `sapi_windows_vt100_support()`. This aligns `pcntl_signal()` with them.

Runtime behaviour is unchanged: `null` was already accepted, and `null` and an omitted argument already took the same path. What changes is the declared signature, so Reflection now reports `?bool $restart_syscalls = null`.

Fixes #23530
