### PR TITLE
ext/standard: Do not double the slash when resolving relative redirects

### DIFF
--- a/ext/standard/http_fopen_wrapper.c
+++ b/ext/standard/http_fopen_wrapper.c
@@ -1075,13 +1075,7 @@ finish:
 							}
 						}
 						s[1] = '\0';
-						if (resource->path &&
-							ZSTR_VAL(resource->path)[0] == '/' &&
-							ZSTR_VAL(resource->path)[1] == '\0') {
-							spprintf(&loc_path, 0, "%s%s", ZSTR_VAL(resource->path), header_info.location);
-						} else {
-							spprintf(&loc_path, 0, "%s/%s", ZSTR_VAL(resource->path), header_info.location);
-						}
+						spprintf(&loc_path, 0, "%s%s", ZSTR_VAL(resource->path), header_info.location);
 					} else {
 						spprintf(&loc_path, 0, "/%s", header_info.location);
 					}

--- a/ext/standard/tests/http/http_relative_location_no_double_slash.phpt
+++ b/ext/standard/tests/http/http_relative_location_no_double_slash.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Relative Location header resolves against the request directory without a doubled slash
+--FILE--
+<?php
+$serverCode = <<<'CODE'
+$server = stream_socket_server("tcp://127.0.0.1:0", $errno, $errstr);
+phpt_notify_server_start($server);
+
+for ($n = 0; $n < 2; $n++) {
+    $conn = stream_socket_accept($server, 10);
+    if (!$conn) {
+        break;
+    }
+    $req = fgets($conn);
+    while (trim(fgets($conn)) !== '') {}
+    $uri = explode(' ', $req)[1];
+    if ($n < 1) {
+        fwrite($conn, "HTTP/1.1 302 Found\r\nLocation: xy\r\nContent-Length: 0\r\n\r\n");
+    } else {
+        $body = "uri=$uri";
+        fwrite($conn, "HTTP/1.1 200 OK\r\nContent-Length: " . strlen($body) . "\r\n\r\n$body");
+    }
+    fclose($conn);
+}
+CODE;
+
+$clientCode = <<<'CODE'
+$ctx = stream_context_create(['http' => ['follow_location' => 1]]);
+echo @file_get_contents("http://{{ ADDR }}/a/b", false, $ctx), "\n";
+CODE;
+
+include sprintf("%s/../../../openssl/tests/ServerClientTestCase.inc", __DIR__);
+ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
+?>
+--EXPECT--
+uri=/a/xy


### PR DESCRIPTION
Follow-up to GH-23521. resource->path always ends in a slash by the time the relative Location is appended (s[1] = '\0' truncates it after the last one), so the "%s/%s" format doubles the separator: Location: xy from http://host/a/b redirects to /a//xy instead of /a/xy. "%s%s" fixes that and makes the root-path special case redundant. Single-character locations keep resolving against the host root, as pinned on the stable branches.
