### PR TITLE
ext/intl: report argument #3 ($variant) for an invalid IDNA variant

### DIFF
--- a/ext/intl/idn/idn.cpp
+++ b/ext/intl/idn/idn.cpp
@@ -122,7 +122,7 @@ static void php_intl_idn_handoff(INTERNAL_FUNCTION_PARAMETERS, int mode)
 		RETURN_THROWS();
 	}
 	if (UNEXPECTED(ZSTR_LEN(domain) > INT32_MAX - 1)) {
-		zend_argument_value_error(1, "must be less than " PRId32 " bytes", INT32_MAX);
+		zend_argument_value_error(1, "must be less than %" PRId32 " bytes", INT32_MAX);
 		RETURN_THROWS();
 	}
 	if (variant != INTL_IDN_VARIANT_UTS46) {

--- a/ext/intl/idn/idn.cpp
+++ b/ext/intl/idn/idn.cpp
@@ -126,7 +126,7 @@ static void php_intl_idn_handoff(INTERNAL_FUNCTION_PARAMETERS, int mode)
 		RETURN_THROWS();
 	}
 	if (variant != INTL_IDN_VARIANT_UTS46) {
-		zend_argument_value_error(2, "must be INTL_IDNA_VARIANT_UTS46");
+		zend_argument_value_error(3, "must be INTL_IDNA_VARIANT_UTS46");
 		RETURN_THROWS();
 	}
 	/* don't check options; it wasn't checked before */

--- a/ext/intl/tests/idn_uts46_errors.phpt
+++ b/ext/intl/tests/idn_uts46_errors.phpt
@@ -18,6 +18,13 @@ try {
     echo $e::class, ': ', $e->getMessage(), PHP_EOL;
 }
 
+echo "bad variant, named argument:", "\n";
+try {
+    var_dump(idn_to_utf8("xn--fuball-cta.com", variant: INTL_IDNA_VARIANT_UTS46 + 10));
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
 echo "empty domain:", "\n";
 try {
     var_dump(idn_to_ascii("", 0, INTL_IDNA_VARIANT_UTS46));
@@ -45,7 +52,9 @@ var_dump($foo["errors"]==IDNA_ERROR_CONTEXTJ);
 --EXPECT--
 => PHP level errors
 bad variant:
-ValueError: idn_to_ascii(): Argument #2 ($flags) must be INTL_IDNA_VARIANT_UTS46
+ValueError: idn_to_ascii(): Argument #3 ($variant) must be INTL_IDNA_VARIANT_UTS46
+bad variant, named argument:
+ValueError: idn_to_utf8(): Argument #3 ($variant) must be INTL_IDNA_VARIANT_UTS46
 empty domain:
 ValueError: idn_to_ascii(): Argument #1 ($domain) must not be empty
 with error, but no details arg:


### PR DESCRIPTION
`php_intl_idn_handoff()` parses `$domain`, `$flags`, `$variant`, so the variant check must report argument 3. It hardcodes 2, so `idn_to_ascii()` and `idn_to_utf8()` blame `$flags` for a value that was passed as `$variant`.

Before:
```
ValueError: idn_to_ascii(): Argument #2 ($flags) must be INTL_IDNA_VARIANT_UTS46
```
After:
```
ValueError: idn_to_ascii(): Argument #3 ($variant) must be INTL_IDNA_VARIANT_UTS46
```

Only the error message changes. The existing test is updated and a named-argument case is added, where the wrong number was the most misleading.
