### PR TITLE
ext/hash: report argument #2 ($filename) for null bytes in hash_file()

### DIFF
--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -361,7 +361,7 @@ static void php_hash_do_hash(
 	}
 	if (isfilename) {
 		if (zend_char_has_nul_byte(data, data_len)) {
-			zend_argument_value_error(1, "must not contain any null bytes");
+			zend_argument_value_error(2, "must not contain any null bytes");
 			RETURN_THROWS();
 		}
 		stream = php_stream_open_wrapper_ex(data, "rb", REPORT_ERRORS, NULL, FG(default_context));

--- a/ext/hash/tests/hash_file_error.phpt
+++ b/ext/hash/tests/hash_file_error.phpt
@@ -22,8 +22,8 @@ try {
 echo "\n-- Testing hash_file() function with a null byte in the filename --\n";
 try {
     hash_file('md5', $filename . chr(0) . $filename);
-} catch (ValueError $exception) {
-    echo $exception::class, ': ', $exception->getMessage(), "\n";
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
 }
 
 echo "\n-- Testing hash_file() function with a non-existent file --\n";

--- a/ext/hash/tests/hash_file_error.phpt
+++ b/ext/hash/tests/hash_file_error.phpt
@@ -19,6 +19,13 @@ try {
     echo $exception::class, ': ', $exception->getMessage(), "\n";
 }
 
+echo "\n-- Testing hash_file() function with a null byte in the filename --\n";
+try {
+    hash_file('md5', $filename . chr(0) . $filename);
+} catch (ValueError $exception) {
+    echo $exception::class, ': ', $exception->getMessage(), "\n";
+}
+
 echo "\n-- Testing hash_file() function with a non-existent file --\n";
 var_dump(hash_file('md5', 'nonexistent.txt'));
 
@@ -35,6 +42,9 @@ unlink( $filename );
 
 -- Testing hash_file() function with an unknown algorithm --
 ValueError: hash_file(): Argument #1 ($algo) must be a valid hashing algorithm
+
+-- Testing hash_file() function with a null byte in the filename --
+ValueError: hash_file(): Argument #2 ($filename) must not contain any null bytes
 
 -- Testing hash_file() function with a non-existent file --
 


### PR DESCRIPTION
`php_hash_do_hash()` hardcodes argument index 1 in its `isfilename` branch, so `hash_file()` blames `$algo` for a null byte that was carried by `$filename`. `hash_file()` is the only caller passing `isfilename = 1`, and its filename is argument 2.

Before:
```
ValueError: hash_file(): Argument #1 ($algo) must not contain any null bytes
```
After:
```
ValueError: hash_file(): Argument #2 ($filename) must not contain any null bytes
```

`php_hash_do_hash_hmac()` already reports 2 for the same check, so `hash_hmac_file()` was right and `hash_file()` was the odd one out. Only the error message changes; a test case is added.
