### PR TITLE
ext/session/.../gh23043.phpt: session.save_path can be nonempty

### DIFF
--- a/ext/session/tests/user_session_module/gh23043.phpt
+++ b/ext/session/tests/user_session_module/gh23043.phpt
@@ -27,9 +27,9 @@ string(0) ""
 
 Warning: SessionHandler::write(): Session ID is too long or contains illegal characters. Only the A-Z, a-z, 0-9, "-", and "," characters are allowed in %s on line %d
 
-Warning: session_write_close(): Failed to write session data using user defined save handler. (session.save_path: , handler: a::write) in %s on line %d
+Warning: session_write_close(): Failed to write session data using user defined save handler. (session.save_path: %S, handler: a::write) in %s on line %d
 string(0) ""
 
 Warning: SessionHandler::write(): Session ID is too long or contains illegal characters. Only the A-Z, a-z, 0-9, "-", and "," characters are allowed in Unknown on line 0
 
-Warning: session_write_close(): Failed to write session data using user defined save handler. (session.save_path: , handler: a::write) in Unknown on line 0
+Warning: session_write_close(): Failed to write session data using user defined save handler. (session.save_path: %S, handler: a::write) in Unknown on line 0


### PR DESCRIPTION
Allow `session.save_path` to be nonempty in this test, as the test itself does not empty it, and in automated setups it is common to force all "temporary stuff" to a dedicated location.