### PR TITLE
ext/intl: fix build with older ICU

### DIFF
--- a/ext/intl/formatter/formatter_class.cpp
+++ b/ext/intl/formatter/formatter_class.cpp
@@ -71,7 +71,7 @@ U_CFUNC zend_object *NumberFormatter_object_clone(zend_object *object)
 
 	/* clone formatter object. It may fail, the destruction code must handle this case */
 	if (FORMATTER_OBJECT(nfo) != nullptr) {
-		FORMATTER_OBJECT(new_nfo) = FORMATTER_OBJECT(nfo)->clone();
+		FORMATTER_OBJECT(new_nfo) = static_cast<NumberFormat *>(FORMATTER_OBJECT(nfo)->clone());
 		if (FORMATTER_OBJECT(new_nfo) == nullptr) {
 			zend_throw_error(NULL, "Failed to clone NumberFormatter");
 		}

--- a/ext/intl/rangeformatter/rangeformatter_class.h
+++ b/ext/intl/rangeformatter/rangeformatter_class.h
@@ -15,9 +15,8 @@
 #ifndef RANGEFORMATTER_CLASS_H
 #define RANGEFORMATTER_CLASS_H
 
-#include <unicode/numberrangeformatter.h>
-
 #ifdef __cplusplus
+#include <unicode/numberrangeformatter.h>
 using icu::number::LocalizedNumberRangeFormatter;
 #else
 typedef void LocalizedNumberRangeFormatter;


### PR DESCRIPTION
Covariant return types for clone() were only introduced in ICU 65; before that NumberFormat::clone() returns Format*, so cast the result explicitly in NumberFormatter_object_clone().

<unicode/numberrangeformatter.h> is a C++-only header, and older ICU does not wrap it in U_SHOW_CPLUSPLUS_API, so including it from php_intl.c breaks the C compile.  Move it into the __cplusplus branch, next to the using declaration that needs it.