### PR TITLE
ext/ftp: throw an Error when ftp_nb_fget()/ftp_nb_fput() hit a busy connection

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -48,6 +48,12 @@ PHP 8.6 UPGRADE NOTES
     the integer index is greater than INT_MAX instead of overflowing to a
     smaller index.
 
+- FTP:
+  . ftp_nb_fget() and ftp_nb_fput() now throw an Error when the connection is
+    already transferring, instead of emitting a warning and returning false
+    against their declared int return type. ftp_close() already throws on the
+    same condition.
+
 - GD:
   . imagesetstyle(), imagefilter() and imagecrop() filter the types / values of
     their array arguments and raise a TypeError / ValueError accordingly.

--- a/UPGRADING
+++ b/UPGRADING
@@ -49,10 +49,10 @@ PHP 8.6 UPGRADE NOTES
     smaller index.
 
 - FTP:
-  . ftp_nb_fget() and ftp_nb_fput() now throw an Error when the connection is
-    already transferring, instead of emitting a warning and returning false
-    against their declared int return type. ftp_close() already throws on the
-    same condition.
+  . ftp_nb_fget(), ftp_nb_fput(), ftp_nb_get() and ftp_nb_put() now throw an
+    Error when the connection is already transferring, instead of emitting a
+    warning and returning false. ftp_close() already throws on the same
+    condition.
 
 - GD:
   . imagesetstyle(), imagefilter() and imagecrop() filter the types / values of

--- a/ext/ftp/php_ftp.c
+++ b/ext/ftp/php_ftp.c
@@ -656,8 +656,8 @@ PHP_FUNCTION(ftp_nb_fget)
 
 	/* configuration */
 	if (ftp->in_use) {
-		php_error_docref(NULL, E_WARNING, "FTP\\Connection is already in use");
-		RETURN_FALSE;
+		zend_throw_error(NULL, "Cannot start a transfer while another transfer is in progress");
+		RETURN_THROWS();
 	}
 
 	ftp->direction = 0;   /* recv */
@@ -961,8 +961,8 @@ PHP_FUNCTION(ftp_nb_fput)
 
 	/* configuration */
 	if (ftp->in_use) {
-		php_error_docref(NULL, E_WARNING, "FTP\\Connection is already in use");
-		RETURN_FALSE;
+		zend_throw_error(NULL, "Cannot start a transfer while another transfer is in progress");
+		RETURN_THROWS();
 	}
 
 	ftp->direction = true;   /* send */

--- a/ext/ftp/php_ftp.c
+++ b/ext/ftp/php_ftp.c
@@ -771,8 +771,8 @@ PHP_FUNCTION(ftp_nb_get)
 	}
 	GET_FTPBUF(ftp, z_ftp);
 	if (ftp->in_use) {
-		php_error_docref(NULL, E_WARNING, "FTP\\Connection is already in use");
-		RETURN_FALSE;
+		zend_throw_error(NULL, "Cannot start a transfer while another transfer is in progress");
+		RETURN_THROWS();
 	}
 	XTYPE(xtype, mode);
 
@@ -1107,8 +1107,8 @@ PHP_FUNCTION(ftp_nb_put)
 
 	if (ftp->in_use) {
 		php_stream_close(instream);
-		php_error_docref(NULL, E_WARNING, "FTP\\Connection is already in use");
-		RETURN_FALSE;
+		zend_throw_error(NULL, "Cannot start a transfer while another transfer is in progress");
+		RETURN_THROWS();
 	}
 
 	/* configuration */

--- a/ext/ftp/tests/ftp_nb_get_during_nb_transfer.phpt
+++ b/ext/ftp/tests/ftp_nb_get_during_nb_transfer.phpt
@@ -10,11 +10,17 @@ require 'server.inc';
 class NbGetDuringNbGet {
     public $context;
     public static $ftp;
+    public static $error;
     public function stream_open($path, $mode, $options, &$opened_path) {
         return true;
     }
     public function stream_write($data) {
-        @ftp_nb_get(self::$ftp, 'php://memory', 'a story.txt', FTP_BINARY);
+        try {
+            ftp_nb_get(self::$ftp, 'php://memory', 'a story.txt', FTP_BINARY);
+        } catch (Throwable $e) {
+            /* recorded rather than echoed: stream_write() may run more than once */
+            self::$error = $e::class . ': ' . $e->getMessage();
+        }
         return strlen($data);
     }
     public function stream_close() {}
@@ -35,10 +41,13 @@ while ($r == FTP_MOREDATA) {
 }
 var_dump($r === FTP_FINISHED);
 
+var_dump(NbGetDuringNbGet::$error);
+
 ftp_close($ftp);
 echo "closed\n";
 ?>
 --EXPECT--
 bool(true)
 bool(true)
+string(68) "Error: Cannot start a transfer while another transfer is in progress"
 closed

--- a/ext/ftp/tests/ftp_nb_get_during_transfer.phpt
+++ b/ext/ftp/tests/ftp_nb_get_during_transfer.phpt
@@ -10,11 +10,17 @@ require 'server.inc';
 class NbGetDuringGet {
     public $context;
     public static $ftp;
+    public static $error;
     public function stream_open($path, $mode, $options, &$opened_path) {
         return true;
     }
     public function stream_write($data) {
-        @ftp_nb_get(self::$ftp, 'php://memory', 'a story.txt', FTP_BINARY);
+        try {
+            ftp_nb_get(self::$ftp, 'php://memory', 'a story.txt', FTP_BINARY);
+        } catch (Throwable $e) {
+            /* recorded rather than echoed: stream_write() may run more than once */
+            self::$error = $e::class . ': ' . $e->getMessage();
+        }
         return strlen($data);
     }
     public function stream_close() {}
@@ -31,10 +37,13 @@ NbGetDuringGet::$ftp = $ftp;
 
 var_dump(@ftp_get($ftp, 'reentrantget://sink', 'a story.txt', FTP_BINARY));
 
+var_dump(NbGetDuringGet::$error);
+
 ftp_close($ftp);
 echo "closed\n";
 ?>
 --EXPECT--
 bool(true)
 bool(true)
+string(68) "Error: Cannot start a transfer while another transfer is in progress"
 closed

--- a/ext/ftp/tests/ftp_nb_transfer_during_transfer.phpt
+++ b/ext/ftp/tests/ftp_nb_transfer_during_transfer.phpt
@@ -1,0 +1,56 @@
+--TEST--
+ftp_nb_fget() and ftp_nb_fput() throw when a transfer is already in progress
+--EXTENSIONS--
+ftp
+pcntl
+--FILE--
+<?php
+require 'server.inc';
+
+class TransferDuringNbWrite {
+    public $context;
+    public static $ftp;
+    public static $call;
+    public function stream_open($path, $mode, $options, &$opened_path) {
+        return true;
+    }
+    public function stream_write($data) {
+        try {
+            (self::$call)(self::$ftp);
+        } catch (\Error $e) {
+            echo $e::class, ': ', $e->getMessage(), "\n";
+        }
+        return strlen($data);
+    }
+    public function stream_close() {}
+    public function stream_eof() {
+        return true;
+    }
+}
+
+stream_wrapper_register('reentrantnb', TransferDuringNbWrite::class);
+
+$ftp = ftp_connect('127.0.0.1', $port);
+var_dump(ftp_login($ftp, 'user', 'pass'));
+TransferDuringNbWrite::$ftp = $ftp;
+
+$sink = fopen('php://memory', 'w+');
+
+TransferDuringNbWrite::$call = static function ($ftp) use ($sink) {
+    ftp_nb_fget($ftp, $sink, 'a story.txt', FTP_BINARY);
+};
+@ftp_nb_get($ftp, 'reentrantnb://sink', 'a story.txt', FTP_BINARY);
+
+TransferDuringNbWrite::$call = static function ($ftp) use ($sink) {
+    ftp_nb_fput($ftp, 'a story.txt', $sink, FTP_BINARY);
+};
+@ftp_nb_get($ftp, 'reentrantnb://sink', 'a story.txt', FTP_BINARY);
+
+ftp_close($ftp);
+echo "closed\n";
+?>
+--EXPECT--
+bool(true)
+Error: Cannot start a transfer while another transfer is in progress
+Error: Cannot start a transfer while another transfer is in progress
+closed

--- a/ext/ftp/tests/ftp_nb_transfer_during_transfer.phpt
+++ b/ext/ftp/tests/ftp_nb_transfer_during_transfer.phpt
@@ -17,7 +17,7 @@ class TransferDuringNbWrite {
     public function stream_write($data) {
         try {
             (self::$call)(self::$ftp);
-        } catch (\Error $e) {
+        } catch (Throwable $e) {
             echo $e::class, ': ', $e->getMessage(), "\n";
         }
         return strlen($data);

--- a/ext/ftp/tests/ftp_nb_transfer_during_transfer.phpt
+++ b/ext/ftp/tests/ftp_nb_transfer_during_transfer.phpt
@@ -1,5 +1,5 @@
 --TEST--
-ftp_nb_fget() and ftp_nb_fput() throw when a transfer is already in progress
+ftp_nb_fget(), ftp_nb_fput(), ftp_nb_get() and ftp_nb_put() throw when a transfer is already in progress
 --EXTENSIONS--
 ftp
 pcntl
@@ -35,22 +35,33 @@ var_dump(ftp_login($ftp, 'user', 'pass'));
 TransferDuringNbWrite::$ftp = $ftp;
 
 $sink = fopen('php://memory', 'w+');
+/* ftp_nb_put() opens the local file before it reaches the guard, so it has to exist. */
+$local = __DIR__ . '/ftp_nb_transfer_during_transfer.tmp';
+file_put_contents($local, 'payload');
 
-TransferDuringNbWrite::$call = static function ($ftp) use ($sink) {
-    ftp_nb_fget($ftp, $sink, 'a story.txt', FTP_BINARY);
-};
-@ftp_nb_get($ftp, 'reentrantnb://sink', 'a story.txt', FTP_BINARY);
+$calls = [
+    static fn ($ftp) => ftp_nb_fget($ftp, $sink, 'a story.txt', FTP_BINARY),
+    static fn ($ftp) => ftp_nb_fput($ftp, 'a story.txt', $sink, FTP_BINARY),
+    static fn ($ftp) => ftp_nb_get($ftp, $local, 'a story.txt', FTP_BINARY),
+    static fn ($ftp) => ftp_nb_put($ftp, 'a story.txt', $local, FTP_BINARY),
+];
 
-TransferDuringNbWrite::$call = static function ($ftp) use ($sink) {
-    ftp_nb_fput($ftp, 'a story.txt', $sink, FTP_BINARY);
-};
-@ftp_nb_get($ftp, 'reentrantnb://sink', 'a story.txt', FTP_BINARY);
+foreach ($calls as $call) {
+    TransferDuringNbWrite::$call = $call;
+    @ftp_nb_get($ftp, 'reentrantnb://sink', 'a story.txt', FTP_BINARY);
+}
 
 ftp_close($ftp);
 echo "closed\n";
 ?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/ftp_nb_transfer_during_transfer.tmp');
+?>
 --EXPECT--
 bool(true)
+Error: Cannot start a transfer while another transfer is in progress
+Error: Cannot start a transfer while another transfer is in progress
 Error: Cannot start a transfer while another transfer is in progress
 Error: Cannot start a transfer while another transfer is in progress
 closed


### PR DESCRIPTION
Reworked as suggested: all four non-blocking transfer functions now throw the same `Error` on a busy connection, so the whole class is handled consistently. `ftp_nb_get()` and `ftp_nb_put()` keep their `int|false` declaration — `false` is still what they return when the local file cannot be opened — so there are no stub changes.

The guards stay ahead of the `direction`/`closestream` writes, and `ftp_nb_put()` closes the local stream before throwing, so a rejected re-entrant call leaves the running transfer untouched. `ftp_nb_get_during_transfer.phpt` and `ftp_nb_get_during_nb_transfer.phpt` asserted the old warning; they now record the `Error` and still assert that the outer transfer completes.

On the UPGRADING note: the phrase about the declared `int` return type is gone. I kept the entry itself, because the warning-and-false behaviour did ship — the `in_use` guards are in 8.4.24 and 8.5.9 onwards, not master-only. Happy to drop it if you would still rather not carry the entry.