### PR TITLE
ext/gd: report $size with the argument number of the function called

### DIFF
--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -3422,14 +3422,16 @@ static void php_imagettftext_common(INTERNAL_FUNCTION_PARAMETERS, int mode)
 		im = php_gd_libgdimageptr_from_zval_p(IM);
 	}
 
+	uint32_t ptsize_arg_num = mode == TTFTEXT_BBOX ? 1 : 2;
+
 	// FT_F26Dot6 is a signed long alias
 	if (ptsize < (double)LONG_MIN / 64 || ptsize > (double)LONG_MAX / 64) {
-		zend_argument_value_error(2, "must be between " ZEND_LONG_FMT " and " ZEND_LONG_FMT, (zend_long)((double)LONG_MIN / 64), (zend_long)((double)LONG_MAX / 64));
+		zend_argument_value_error(ptsize_arg_num, "must be between " ZEND_LONG_FMT " and " ZEND_LONG_FMT, (zend_long)((double)LONG_MIN / 64), (zend_long)((double)LONG_MAX / 64));
 		RETURN_THROWS();
 	}
 
 	if (UNEXPECTED(!zend_finite(ptsize))) {
-		zend_argument_value_error(2, "must be finite");
+		zend_argument_value_error(ptsize_arg_num, "must be finite");
 		RETURN_THROWS();
 	}
 

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -3425,8 +3425,8 @@ static void php_imagettftext_common(INTERNAL_FUNCTION_PARAMETERS, int mode)
 	uint32_t ptsize_arg_num = mode == TTFTEXT_BBOX ? 1 : 2;
 
 	// FT_F26Dot6 is a signed long alias
-	if (ptsize < (double)LONG_MIN / 64 || ptsize > (double)LONG_MAX / 64) {
-		zend_argument_value_error(ptsize_arg_num, "must be between " ZEND_LONG_FMT " and " ZEND_LONG_FMT, (zend_long)((double)LONG_MIN / 64), (zend_long)((double)LONG_MAX / 64));
+	if (ptsize < (double)LONG_MIN / 64 || ptsize >= (double)LONG_MAX / 64) {
+		zend_argument_value_error(ptsize_arg_num, "must be between " ZEND_LONG_FMT " and " ZEND_LONG_FMT, (zend_long)(LONG_MIN / 64), (zend_long)(LONG_MAX / 64));
 		RETURN_THROWS();
 	}
 

--- a/ext/gd/tests/gh18243.phpt
+++ b/ext/gd/tests/gh18243.phpt
@@ -37,8 +37,8 @@ try {
 
 try {
 	imagettftext($im, 144115188075855872.0, 0, 15, 60, 0, $font, "");
-} catch (\ValueError $e) {
-	echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+} catch (Throwable $e) {
+	echo $e::class, ': ', $e->getMessage(), "\n";
 }
 ?>
 --EXPECTF--

--- a/ext/gd/tests/gh18243.phpt
+++ b/ext/gd/tests/gh18243.phpt
@@ -34,9 +34,16 @@ try {
 } catch (\ValueError $e) {
 	echo $e::class, ': ', $e->getMessage(), PHP_EOL;
 }
+
+try {
+	imagettftext($im, 144115188075855872.0, 0, 15, 60, 0, $font, "");
+} catch (\ValueError $e) {
+	echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
 ?>
 --EXPECTF--
 ValueError: imagettftext(): Argument #2 ($size) must be between %i and %d
 ValueError: imagettftext(): Argument #2 ($size) must be between %i and %d
 ValueError: imagettftext(): Argument #2 ($size) must be finite
+ValueError: imagettftext(): Argument #2 ($size) must be between %i and %d
 ValueError: imagettftext(): Argument #2 ($size) must be between %i and %d

--- a/ext/gd/tests/imageftbbox_size_arg_num.phpt
+++ b/ext/gd/tests/imageftbbox_size_arg_num.phpt
@@ -15,13 +15,13 @@ $image = imagecreatetruecolor(100, 80);
 foreach ([NAN, INF, PHP_INT_MAX, PHP_INT_MIN] as $size) {
     try {
         imageftbbox($size, 0.0, $font, 'A');
-    } catch (ValueError $e) {
-        echo $e->getMessage(), "\n";
+    } catch (Throwable $e) {
+        echo $e::class, ': ', $e->getMessage(), "\n";
     }
     try {
         imagettfbbox($size, 0.0, $font, 'A');
-    } catch (ValueError $e) {
-        echo $e->getMessage(), "\n";
+    } catch (Throwable $e) {
+        echo $e::class, ': ', $e->getMessage(), "\n";
     }
 }
 
@@ -29,34 +29,34 @@ foreach ([NAN, INF, PHP_INT_MAX, PHP_INT_MIN] as $size) {
 foreach ([NAN, INF] as $size) {
     try {
         imagefttext($image, $size, 0.0, 15, 60, 0, $font, 'A');
-    } catch (ValueError $e) {
-        echo $e->getMessage(), "\n";
+    } catch (Throwable $e) {
+        echo $e::class, ': ', $e->getMessage(), "\n";
     }
     try {
         imagettftext($image, $size, 0.0, 15, 60, 0, $font, 'A');
-    } catch (ValueError $e) {
-        echo $e->getMessage(), "\n";
+    } catch (Throwable $e) {
+        echo $e::class, ': ', $e->getMessage(), "\n";
     }
 }
 
 /* the type error already agreed with the signature and still does */
 try {
     imageftbbox('x', 0.0, $font, 'A');
-} catch (TypeError $e) {
-    echo $e->getMessage(), "\n";
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
 }
 ?>
 --EXPECTF--
-imageftbbox(): Argument #1 ($size) must be finite
-imagettfbbox(): Argument #1 ($size) must be finite
-imageftbbox(): Argument #1 ($size) must be between %i and %d
-imagettfbbox(): Argument #1 ($size) must be between %i and %d
-imageftbbox(): Argument #1 ($size) must be between %i and %d
-imagettfbbox(): Argument #1 ($size) must be between %i and %d
-imageftbbox(): Argument #1 ($size) must be between %i and %d
-imagettfbbox(): Argument #1 ($size) must be between %i and %d
-imagefttext(): Argument #2 ($size) must be finite
-imagettftext(): Argument #2 ($size) must be finite
-imagefttext(): Argument #2 ($size) must be between %i and %d
-imagettftext(): Argument #2 ($size) must be between %i and %d
-imageftbbox(): Argument #1 ($size) must be of type float, string given
+ValueError: imageftbbox(): Argument #1 ($size) must be finite
+ValueError: imagettfbbox(): Argument #1 ($size) must be finite
+ValueError: imageftbbox(): Argument #1 ($size) must be between %i and %d
+ValueError: imagettfbbox(): Argument #1 ($size) must be between %i and %d
+ValueError: imageftbbox(): Argument #1 ($size) must be between %i and %d
+ValueError: imagettfbbox(): Argument #1 ($size) must be between %i and %d
+ValueError: imageftbbox(): Argument #1 ($size) must be between %i and %d
+ValueError: imagettfbbox(): Argument #1 ($size) must be between %i and %d
+ValueError: imagefttext(): Argument #2 ($size) must be finite
+ValueError: imagettftext(): Argument #2 ($size) must be finite
+ValueError: imagefttext(): Argument #2 ($size) must be between %i and %d
+ValueError: imagettftext(): Argument #2 ($size) must be between %i and %d
+TypeError: imageftbbox(): Argument #1 ($size) must be of type float, string given

--- a/ext/gd/tests/imageftbbox_size_arg_num.phpt
+++ b/ext/gd/tests/imageftbbox_size_arg_num.phpt
@@ -1,0 +1,62 @@
+--TEST--
+The $size errors name the argument of the function that was called
+--EXTENSIONS--
+gd
+--SKIPIF--
+<?php
+if (!function_exists('imageftbbox')) die('skip imageftbbox() not available');
+?>
+--FILE--
+<?php
+$font = __DIR__ . '/Rochester-Regular.otf';
+$image = imagecreatetruecolor(100, 80);
+
+/* $size is argument #1 here */
+foreach ([NAN, INF, PHP_INT_MAX, PHP_INT_MIN] as $size) {
+    try {
+        imageftbbox($size, 0.0, $font, 'A');
+    } catch (ValueError $e) {
+        echo $e->getMessage(), "\n";
+    }
+    try {
+        imagettfbbox($size, 0.0, $font, 'A');
+    } catch (ValueError $e) {
+        echo $e->getMessage(), "\n";
+    }
+}
+
+/* and argument #2 here */
+foreach ([NAN, INF] as $size) {
+    try {
+        imagefttext($image, $size, 0.0, 15, 60, 0, $font, 'A');
+    } catch (ValueError $e) {
+        echo $e->getMessage(), "\n";
+    }
+    try {
+        imagettftext($image, $size, 0.0, 15, 60, 0, $font, 'A');
+    } catch (ValueError $e) {
+        echo $e->getMessage(), "\n";
+    }
+}
+
+/* the type error already agreed with the signature and still does */
+try {
+    imageftbbox('x', 0.0, $font, 'A');
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECTF--
+imageftbbox(): Argument #1 ($size) must be finite
+imagettfbbox(): Argument #1 ($size) must be finite
+imageftbbox(): Argument #1 ($size) must be between %i and %d
+imagettfbbox(): Argument #1 ($size) must be between %i and %d
+imageftbbox(): Argument #1 ($size) must be between %i and %d
+imagettfbbox(): Argument #1 ($size) must be between %i and %d
+imageftbbox(): Argument #1 ($size) must be between %i and %d
+imagettfbbox(): Argument #1 ($size) must be between %i and %d
+imagefttext(): Argument #2 ($size) must be finite
+imagettftext(): Argument #2 ($size) must be finite
+imagefttext(): Argument #2 ($size) must be between %i and %d
+imagettftext(): Argument #2 ($size) must be between %i and %d
+imageftbbox(): Argument #1 ($size) must be of type float, string given


### PR DESCRIPTION
`php_imagettftext_common()` backs four functions with two signatures: `$size` is argument 1 of `imageftbbox()` and `imagettfbbox()`, and 2 of `imagefttext()` and `imagettftext()`, which take the image first. Both size checks hardcode 2, so the bbox pair blames `$angle`:

```php
imageftbbox(NAN, 0.0, $font, 'A');
// ValueError: imageftbbox(): Argument #2 ($angle) must be finite
```

`$angle` was `0.0`. The type error for the same parameter already says #1, since that one comes from the arginfo:

```php
imageftbbox('x', 0.0, $font, 'A');
// TypeError: imageftbbox(): Argument #1 ($size) must be of type float, string given
```

The number is now derived from the mode the helper was called in; the drawing pair keeps 2.

The added test covers all four functions, in the order the checks run: the range test precedes the finite test, so `INF` reports "must be between" while `NAN`, false against both bounds, falls through to "must be finite".

Only the two bbox messages change, so this targets master.


A second commit fixes the upper bound itself. `(double)LONG_MAX` rounds up to 2^63, so `(double)LONG_MAX / 64` is 2^57 and the check let 2^57 through, whose product with 64 is `LONG_MAX + 1`. The bound is now exclusive and the reported values use integer division, so they name the largest size that is actually representable. The lower bound stays inclusive: `(double)LONG_MIN / 64` is exactly -2^57, and -2^57 * 64 is `LONG_MIN`.
