### PR TITLE
Excludes `.git/` from `run-tests.php .`

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -1100,7 +1100,7 @@ function find_files(string $dir, bool $is_ext_dir = false, bool $ignore = false)
     $o = opendir($dir) or error("cannot open directory: $dir");
 
     while (($name = readdir($o)) !== false) {
-        if (is_dir("{$dir}/{$name}") && !in_array($name, ['.', '..', '.svn'])) {
+        if (is_dir("{$dir}/{$name}") && !in_array($name, ['.', '..', '.svn', '.git'])) {
             $skip_ext = ($is_ext_dir && !in_array($name, $exts_to_test));
             if ($skip_ext) {
                 $exts_skipped[] = $name;


### PR DESCRIPTION
When passing `.` to `run-tests.php` the Git directory is unnecessarily included. Not sure whether `.svn` is still relevant for extensions or something, so I left it untouched.