### PR TITLE
Zend: Optimize sorting single-element arrays

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -1001,6 +1001,7 @@ PHP 8.6 UPGRADE NOTES
   . Reduced temporary allocations when iterating Phar directories.
 
 - Standard:
+  . Improved performance of sorting single-element arrays.
   . Improved performance of array_fill_keys().
   . Improved performance of array_intersect().
   . Improved performance of array_map() with multiple arrays passed.

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -3005,6 +3005,7 @@ static void zend_hash_sort_internal(HashTable *ht, sort_func_t sort, bucket_comp
 		if (sort == zend_sort && HT_IS_PACKED(ht) && HT_IS_WITHOUT_HOLES(ht)) {
 			/* The single element already has the expected index. */
 			ht->nInternalPointer = 0;
+			ht->nNextFreeElement = 1;
 			return;
 		}
 	}

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -2997,9 +2997,16 @@ static void zend_hash_sort_internal(HashTable *ht, sort_func_t sort, bucket_comp
 
 	IS_CONSISTENT(ht);
 
-	if (!(ht->nNumOfElements>1) && !(renumber && ht->nNumOfElements>0)) {
-		/* Doesn't require sorting */
-		return;
+	if (ht->nNumOfElements <= 1) {
+		if (!renumber || ht->nNumOfElements == 0) {
+			/* Doesn't require sorting */
+			return;
+		}
+		if (sort == zend_sort && HT_IS_PACKED(ht) && HT_IS_WITHOUT_HOLES(ht)) {
+			/* The single element already has the expected index. */
+			ht->nInternalPointer = 0;
+			return;
+		}
 	}
 
 	if (HT_IS_PACKED(ht)) {

--- a/Zend/zend_hash.h
+++ b/Zend/zend_hash.h
@@ -312,7 +312,12 @@ static zend_always_inline void ZEND_FASTCALL zend_hash_sort(HashTable *ht, bucke
  * trigger user code. It will ensure the user code cannot free the array during
  * sorting. */
 static zend_always_inline void zend_array_sort(HashTable *ht, bucket_compare_func_t compare_func, bool renumber) {
-	zend_array_sort_ex(ht, zend_sort, compare_func, renumber);
+	/* zend_sort() cannot invoke the comparator for at most one element. */
+	if (UNEXPECTED(ht->nNumOfElements <= 1)) {
+		zend_hash_sort_ex(ht, zend_sort, compare_func, renumber);
+	} else {
+		zend_array_sort_ex(ht, zend_sort, compare_func, renumber);
+	}
 }
 
 static zend_always_inline uint32_t zend_hash_num_elements(const HashTable *ht) {

--- a/Zend/zend_hash.h
+++ b/Zend/zend_hash.h
@@ -313,7 +313,7 @@ static zend_always_inline void ZEND_FASTCALL zend_hash_sort(HashTable *ht, bucke
  * sorting. */
 static zend_always_inline void zend_array_sort(HashTable *ht, bucket_compare_func_t compare_func, bool renumber) {
 	/* zend_sort() cannot invoke the comparator for at most one element. */
-	if (UNEXPECTED(ht->nNumOfElements <= 1)) {
+	if (ht->nNumOfElements <= 1) {
 		zend_hash_sort_ex(ht, zend_sort, compare_func, renumber);
 	} else {
 		zend_array_sort_ex(ht, zend_sort, compare_func, renumber);

--- a/ext/standard/tests/array/sort/sort_single_element.phpt
+++ b/ext/standard/tests/array/sort/sort_single_element.phpt
@@ -1,0 +1,57 @@
+--TEST--
+Sorting single-element arrays does not invoke the comparison function
+--FILE--
+<?php
+
+$calls = 0;
+$compare = static function ($a, $b) use (&$calls) {
+    $calls++;
+    return $a <=> $b;
+};
+
+$array = [42];
+// Keep the array packed and without holes, but leave the next free index at 11.
+$array[10] = 99;
+unset($array[10]);
+next($array);
+var_dump(usort($array, $compare));
+var_dump($array, key($array));
+$array[] = 43;
+var_dump($array);
+
+$array = ['answer' => 42];
+next($array);
+var_dump(usort($array, $compare));
+var_dump($array, key($array));
+$array[] = 43;
+var_dump($array);
+
+var_dump($calls);
+
+?>
+--EXPECT--
+bool(true)
+array(1) {
+  [0]=>
+  int(42)
+}
+int(0)
+array(2) {
+  [0]=>
+  int(42)
+  [1]=>
+  int(43)
+}
+bool(true)
+array(1) {
+  [0]=>
+  int(42)
+}
+int(0)
+array(2) {
+  [0]=>
+  int(42)
+  [1]=>
+  int(43)
+}
+int(0)


### PR DESCRIPTION
Now, `zend_array_sort()` uses `zend_array_sort_ex()`, which unpacks packed arrays and temporarily increments the array refcount to protect against the comparator freeing the array.

Obviously this is useless for one-element arrays. Here, we can just use `zend_hash_sort_ex` instead for this case.

Some may ask what's the meaning to sort one-element array anyways. This can't be similar to what sorting zero-element array do, which is directly returning the empty array. Because the sorting functions have other things to do rather than just sort the elements. 

```php
<?php
$array = ['key' => 42];
sort($array);

var_dump($array);
// [0 => 42]
```

Here, we remain the original sort behavior for one-element array while making it faster because we are not actually sorting them

benchmark results:

After:  448.923 ms
Before: 905.807 ms
a roughly 50.4% enhancement in this specific case.

script:

```php
<?php

const ITERATIONS = 20_000_000;
const RUNS = 7;

function run(int $iterations): float
{
    $array = [42];

    $start = hrtime(true);
    for ($i = 0; $i < $iterations; $i++) {
        sort($array, SORT_NUMERIC);
    }

    return (hrtime(true) - $start) / 1e6;
}

run(100_000); // Warmup

$times = [];
for ($run = 0; $run < RUNS; $run++) {
    $times[] = run(ITERATIONS);
}

sort($times, SORT_NUMERIC);
$median = $times[intdiv(RUNS, 2)];

printf(
    "single-element sort: %.3f ms (%d iterations, median of %d)\n",
    $median,
    ITERATIONS,
    RUNS,
);
```