### PR TITLE
ext/pcntl: fix an off by one bound and a parameter the parser made required

### DIFF
--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -1773,7 +1773,7 @@ PHP_FUNCTION(pcntl_setcpuaffinity)
 		}
 
 		if (cpu < 0 || cpu >= maxcpus) {
-			zend_argument_value_error(2, "cpu id must be between 0 and " ZEND_ULONG_FMT " (" ZEND_LONG_FMT ")", maxcpus, cpu);
+			zend_argument_value_error(2, "cpu id must be between 0 and " ZEND_LONG_FMT " (" ZEND_LONG_FMT ")", maxcpus - 1, cpu);
 			PCNTL_CPU_DESTROY(mask);
 			RETURN_THROWS();
 		}
@@ -1880,9 +1880,10 @@ PHP_FUNCTION(pcntl_getqos_class)
 
 PHP_FUNCTION(pcntl_setqos_class)
 {
-	zend_enum_Pcntl_QosClass qos;
+	zend_enum_Pcntl_QosClass qos = ZEND_ENUM_Pcntl_QosClass_Default;
 
-	ZEND_PARSE_PARAMETERS_START(1, 1)
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
 		Z_PARAM_ENUM(qos, QosClass_ce)
 	ZEND_PARSE_PARAMETERS_END();
 

--- a/ext/pcntl/tests/pcntl_cpuaffinity_bound.phpt
+++ b/ext/pcntl/tests/pcntl_cpuaffinity_bound.phpt
@@ -1,0 +1,46 @@
+--TEST--
+pcntl_setcpuaffinity(): the upper bound the error advertises is itself a valid cpu id
+--EXTENSIONS--
+pcntl
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY === 'Solaris') {
+    die("skip broken pset_create()");
+}
+if (!function_exists("pcntl_setcpuaffinity")) die("skip pcntl_setcpuaffinity is not available");
+?>
+--FILE--
+<?php
+$pid = getmypid();
+$prefix = 'pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) cpu id must be between 0 and ';
+
+/* read the advertised bound out of the message itself */
+try {
+    pcntl_setcpuaffinity($pid, [PHP_INT_MAX]);
+    exit("PHP_INT_MAX was accepted as a cpu id" . PHP_EOL);
+} catch (ValueError $e) {
+    if (!preg_match('/must be between 0 and (\d+) \(/', $e->getMessage(), $m)) {
+        exit("unexpected message: " . $e->getMessage() . PHP_EOL);
+    }
+}
+$bound = (int) $m[1];
+
+/* Every id is range checked before any syscall runs, so pairing the advertised
+   bound with an out of range id shows which of the two the check rejects,
+   without ever changing the process affinity. */
+try {
+    pcntl_setcpuaffinity($pid, [$bound, PHP_INT_MAX]);
+} catch (ValueError $e) {
+    var_dump($e->getMessage() === $prefix . $bound . ' (' . PHP_INT_MAX . ')');
+}
+
+/* and the first id past the bound is rejected, naming itself */
+try {
+    pcntl_setcpuaffinity($pid, [$bound + 1]);
+} catch (ValueError $e) {
+    var_dump($e->getMessage() === $prefix . $bound . ' (' . ($bound + 1) . ')');
+}
+?>
+--EXPECT--
+bool(true)
+bool(true)

--- a/ext/pcntl/tests/pcntl_cpuaffinity_bound.phpt
+++ b/ext/pcntl/tests/pcntl_cpuaffinity_bound.phpt
@@ -18,7 +18,8 @@ $prefix = 'pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) cpu id must be between
 try {
     pcntl_setcpuaffinity($pid, [PHP_INT_MAX]);
     exit("PHP_INT_MAX was accepted as a cpu id" . PHP_EOL);
-} catch (ValueError $e) {
+} catch (Throwable $e) {
+    echo $e::class, "\n";
     if (!preg_match('/must be between 0 and (\d+) \(/', $e->getMessage(), $m)) {
         exit("unexpected message: " . $e->getMessage() . PHP_EOL);
     }
@@ -30,17 +31,22 @@ $bound = (int) $m[1];
    without ever changing the process affinity. */
 try {
     pcntl_setcpuaffinity($pid, [$bound, PHP_INT_MAX]);
-} catch (ValueError $e) {
+} catch (Throwable $e) {
+    echo $e::class, "\n";
     var_dump($e->getMessage() === $prefix . $bound . ' (' . PHP_INT_MAX . ')');
 }
 
 /* and the first id past the bound is rejected, naming itself */
 try {
     pcntl_setcpuaffinity($pid, [$bound + 1]);
-} catch (ValueError $e) {
+} catch (Throwable $e) {
+    echo $e::class, "\n";
     var_dump($e->getMessage() === $prefix . $bound . ' (' . ($bound + 1) . ')');
 }
 ?>
 --EXPECT--
+ValueError
+ValueError
 bool(true)
+ValueError
 bool(true)

--- a/ext/pcntl/tests/pcntl_qosclass.phpt
+++ b/ext/pcntl/tests/pcntl_qosclass.phpt
@@ -13,7 +13,12 @@ pcntl_setqos_class(Pcntl\QosClass::Default);
 var_dump(Pcntl\QosClass::Default === pcntl_getqos_class());
 pcntl_setqos_class(Pcntl\QosClass::Background);
 var_dump(Pcntl\QosClass::Background == pcntl_getqos_class());
+
+/* the parameter is optional, and omitting it applies the declared default */
+pcntl_setqos_class();
+var_dump(Pcntl\QosClass::Default === pcntl_getqos_class());
 ?>
 --EXPECT--
+bool(true)
 bool(true)
 bool(true)


### PR DESCRIPTION
Two unrelated slips in `ext/pcntl/pcntl.c`, together because they touch the same file.

`pcntl_setcpuaffinity()` rejects `cpu >= maxcpus` but advertises `maxcpus` as the inclusive upper bound, so on a 16-CPU host id 16 is refused by a message saying "between 0 and 16". It now prints `maxcpus - 1`. The same line printed `maxcpus`, a `zend_long`, with `ZEND_ULONG_FMT`; corrected to `ZEND_LONG_FMT`, since `sysconf()` can return -1.

`pcntl_setqos_class()` declares `$qos_class` optional with a default of `Pcntl\QosClass::Default`, but its ZPP block was `(1, 1)` and `qos` was left uninitialised, so calling it with no argument raised an `ArgumentCountError` and the declared default was unreachable. It now parses `(0, 1)` with `Z_PARAM_OPTIONAL` and initialises `qos` beforehand, as `bcround()` does for its optional enum parameter. This half is macOS-only and could not be exercised here.

The new test reads the bound out of the message rather than hardcoding a cpu count, then checks that the advertised bound is accepted and the next id refused; it fails on the current code. Master only, as the exception message changes.
