### PR TITLE
ext/opcache: keep huge page remap inside the reserved range

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -59,6 +59,8 @@ PHP                                                                        NEWS
     (Ilia Alshanetsky)
 
 - Opcache:
+  . Fixed a crash when the huge page SHM remap discarded mappings outside the
+    reserved address range. (Piotr Hałas)
   . Fixed opcache.protect_memory race under ZTS. (realFlowControl)
   . Fixed bug GH-23288 (Crash on restart when opcache.interned_strings_buffer
     is overridden in an individual FPM pool). (David Carlier)

--- a/ext/opcache/shared_alloc_mmap.c
+++ b/ext/opcache/shared_alloc_mmap.c
@@ -245,9 +245,9 @@ static int create_segments(size_t requested_size, zend_shared_segment ***shared_
 		/* to got HUGE PAGES in low 32-bit address we have to reserve address
 		   space and then remap it using MAP_HUGETLB */
 
-		p = mmap(NULL, requested_size, flags, MAP_SHARED|MAP_ANONYMOUS|MAP_32BIT, fd, 0);
+		p = mmap(NULL, requested_size + huge_page_size, flags, MAP_SHARED|MAP_ANONYMOUS|MAP_32BIT, fd, 0);
 		if (p != MAP_FAILED) {
-			munmap(p, requested_size);
+			munmap(p, requested_size + huge_page_size);
 			p = (void*)(ZEND_MM_ALIGNED_SIZE_EX((ptrdiff_t)p, huge_page_size));
 			p = mmap(p, requested_size, flags, MAP_SHARED|MAP_ANONYMOUS|MAP_32BIT|MAP_HUGETLB|MAP_FIXED, -1, 0);
 			if (p != MAP_FAILED) {


### PR DESCRIPTION
Hi, We moved our dev machines from Docker Desktop to Colima and Podman on Apple Silicon. Some of our images are amd64 only, so we turned on Rosetta 2. After that `php-fpm` started to crash: exit 139, one second after start, no log and no error. The same happens on Podman with Rosetta, and on Podman with QEMU.

First I thought this is a Rosetta or Colima problem. It is reported like that here: https://github.com/abiosoft/colima/issues/1452 . But then I saw the same crash with QEMU, so I started to look at PHP.

In `create_segments()` OPcache reserves memory with `MAP_32BIT`, frees it, moves the address up to the 2 MB boundary, and then maps `requested_size` again with `MAP_FIXED`. The address goes up, but the size stays the same. So the new mapping ends up to 2 MB above the memory we reserved, and `MAP_FIXED` deletes what is mapped there.

Other places do this correctly. `zend_mm_chunk_alloc_int()` in `Zend/zend_alloc.c` reserves `size + alignment - REAL_PAGE_SIZE` first, so its aligned address always stays inside its own memory. And `find_prefered_mmap_base()`, in this same file, aligns the address and then checks it: if `last_candidate + requested_size` does not fit any more, it moves one huge page down. Here I do not see either of these.

My patch reserves one huge page more.

I am not sure this is the right fix, or the right place for it. It fixes the crash for us, and on native Linux with huge pages OPcache still gets its 2 MB mapping. Can somebody with more experience please look at this? I have a test script and logs if that is useful.