### PR TITLE
Add `--enable-cli-fpm` to link the FPM SAPI into the CLI binary (`php --fpm`)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,8 @@ PHP                                                                        NEWS
 ?? ??? ????, PHP 8.6.0beta3
 
 - CLI:
+  . Added the --enable-cli-fpm configure option, which links the FPM SAPI into
+    the php binary so that "php --fpm" runs php-fpm. (Matthieu Napoli)
   . Fixed bug GH-23242 (PHP development server does not support Expect
     100-continue flow control). (Sjoerd Langkemper)
 

--- a/UPGRADING
+++ b/UPGRADING
@@ -506,6 +506,9 @@ PHP 8.6 UPGRADE NOTES
 - CLI:
   . The built-in development server now accepts requests using the HTTP QUERY
     method instead of returning 501 Not Implemented.
+  . When PHP is configured with --enable-cli-fpm, the php binary also contains
+    the FPM SAPI: "php --fpm [php-fpm options]" behaves like php-fpm. The flag
+    is only recognized as the first argument. The default build is unchanged.
 
 ========================================
 4. Deprecated Functionality

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -227,6 +227,7 @@ PHP 8.6 INTERNALS UPGRADE NOTES
   . Added zend_string_ends_with() and related variants.
   . Added trait support for internal classes.
   . Added do_php_cli().
+  . Added do_php_fpm(), the former main() of php-fpm.
 
 ========================
 2. Build system changes
@@ -269,6 +270,12 @@ PHP 8.6 INTERNALS UPGRADE NOTES
 - Embed:
   . The CLI SAPI can not be disabled when building the embed SAPI
     (--enable-embed is incompatible with --disable-cli).
+
+- FPM:
+  . The --enable-fpm option moved to sapi/fpm/config0.m4 so that other SAPIs
+    can test $PHP_FPM. The FPM sources other than the main() entry point are
+    now built into PHP_FPM_SHARED_OBJS. The new --enable-cli-fpm option links
+    them into the CLI binary.
 
 ========================
 3. Module changes

--- a/sapi/cli/config.m4
+++ b/sapi/cli/config.m4
@@ -5,6 +5,22 @@ PHP_ARG_ENABLE([cli],
   [yes],
   [no])
 
+PHP_ARG_ENABLE([cli-fpm],
+  [whether to link FPM into the CLI binary],
+  [AS_HELP_STRING([--enable-cli-fpm],
+    [Link the FPM SAPI into the CLI binary, so that "php --fpm" runs php-fpm
+    (requires --enable-fpm)])],
+  [no],
+  [no])
+
+if test "$PHP_CLI_FPM" != "no"; then
+  if test "$PHP_CLI" = "no" || test "$PHP_FPM" = "no"; then
+    AC_MSG_ERROR([--enable-cli-fpm requires both the CLI and the FPM SAPI])
+  fi
+  AC_DEFINE([PHP_CLI_WITH_FPM], [1],
+    [Define to 1 if the FPM SAPI is linked into the CLI binary.])
+fi
+
 dnl The embed SAPI requires the CLI sources for do_php_cli().
 if test "$PHP_EMBED" != "no" -a "$PHP_CLI" = "no"; then
   AC_MSG_ERROR([--enable-embed requires the CLI SAPI, do not use --disable-cli with --enable-embed])
@@ -47,6 +63,8 @@ if test "$PHP_CLI" != "no"; then
     [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1],
     [PHP_CLI_SHARED_OBJS])
   PHP_CLI_OBJS="$PHP_CLI_OBJS $PHP_CLI_SHARED_OBJS"
+  AS_VAR_IF([PHP_CLI_FPM], [no],,
+    [PHP_CLI_OBJS="$PHP_CLI_OBJS \$(PHP_FASTCGI_OBJS) \$(PHP_FPM_SHARED_OBJS)"])
 
   AS_CASE([$host_alias],
     [*aix*], [

--- a/sapi/cli/php.1.in
+++ b/sapi/cli/php.1.in
@@ -365,6 +365,12 @@ Shows configuration for extension
 .TP
 .B \-\-ini
 Show configuration file names
+.TP
+.B \-\-fpm
+Run as
+.BR php\-fpm (8),
+passing the remaining arguments to it. Only available when PHP was configured
+with \-\-enable\-cli\-fpm, and only recognized as the first argument.
 .SH FILES
 .TP 15
 .B php\-cli.ini

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -482,6 +482,9 @@ static void php_cli_usage(char *argv0)
 				"\n"
 				"  --ini            Show configuration file names\n"
 				"  --ini=diff       Show INI entries that differ from the built-in default\n"
+#ifdef PHP_CLI_WITH_FPM
+				"  --fpm            Run as php-fpm, passing the remaining arguments to it\n"
+#endif
 				"\n"
 				"  --rf <name>      Show information about function <name>.\n"
 				"  --rc <name>      Show information about class <name>.\n"

--- a/sapi/cli/tests/cli_fpm.phpt
+++ b/sapi/cli/tests/cli_fpm.phpt
@@ -1,0 +1,24 @@
+--TEST--
+php --fpm runs the FPM SAPI
+--SKIPIF--
+<?php
+include "skipif.inc";
+$php = getenv('TEST_PHP_EXECUTABLE_ESCAPED');
+if (!str_contains((string) shell_exec("$php --fpm -n -v 2>&1"), 'fpm-fcgi')) {
+    die("skip PHP was not built with --enable-cli-fpm");
+}
+?>
+--FILE--
+<?php
+$php = getenv('TEST_PHP_EXECUTABLE_ESCAPED');
+
+// As the first argument, --fpm switches to the FPM SAPI.
+preg_match('/^Server API => .*$/m', shell_exec("$php --fpm -n -i"), $m);
+var_dump($m[0]);
+
+// Anywhere else it is an ordinary argument.
+var_dump(shell_exec("$php -n -r 'echo \$argv[1];' -- --fpm"));
+?>
+--EXPECT--
+string(25) "Server API => FPM/FastCGI"
+string(5) "--fpm"

--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -1,10 +1,3 @@
-PHP_ARG_ENABLE([fpm],
-  [for FPM build],
-  [AS_HELP_STRING([--enable-fpm],
-    [Enable building of the fpm SAPI executable])],
-  [no],
-  [no])
-
 dnl Configure checks.
 AC_DEFUN([PHP_FPM_CLOCK], [
 AC_CHECK_FUNCS([clock_gettime],, [
@@ -473,8 +466,17 @@ if test "$PHP_FPM" != "no"; then
 
   PHP_SELECT_SAPI([fpm],
     [program],
-    [$PHP_FPM_FILES $PHP_FPM_TRACE_FILES $PHP_FPM_SD_FILES],
+    [php_fpm_main.c],
     [-I$abs_srcdir/sapi/fpm -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
+
+  dnl Everything except the main() entry point, so that the CLI binary can link
+  dnl the same objects for do_php_fpm() (--enable-cli-fpm).
+  PHP_ADD_SOURCES_X([sapi/fpm],
+    [$PHP_FPM_FILES $PHP_FPM_TRACE_FILES $PHP_FPM_SD_FILES],
+    [-I$abs_srcdir/sapi/fpm -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1],
+    [PHP_FPM_SHARED_OBJS])
+  PHP_FPM_OBJS="$PHP_FPM_OBJS $PHP_FPM_SHARED_OBJS"
+  PHP_SUBST([PHP_FPM_SHARED_OBJS])
 
   AS_CASE([$host_alias],
     [*aix*], [
@@ -489,4 +491,5 @@ if test "$PHP_FPM" != "no"; then
   PHP_SUBST([SAPI_FPM_PATH])
   PHP_SUBST([BUILD_FPM])
   PHP_SUBST([FPM_EXTRA_LIBS])
+  AS_VAR_IF([PHP_CLI_FPM], [no],, [EXTRA_LIBS="$EXTRA_LIBS $FPM_EXTRA_LIBS"])
 fi

--- a/sapi/fpm/config0.m4
+++ b/sapi/fpm/config0.m4
@@ -1,0 +1,6 @@
+PHP_ARG_ENABLE([fpm],
+  [for FPM build],
+  [AS_HELP_STRING([--enable-fpm],
+    [Enable building of the fpm SAPI executable])],
+  [no],
+  [no])

--- a/sapi/fpm/fpm/fpm.h
+++ b/sapi/fpm/fpm/fpm.h
@@ -41,6 +41,8 @@ enum fpm_init_return_status {
 };
 
 int fpm_run(int *max_requests);
+/* this performs full fpm-SAPI boot: the former main() of php-fpm. */
+int do_php_fpm(int argc, char *argv[]);
 enum fpm_init_return_status fpm_init(int argc, char **argv, char *config, char *prefix, char *pid, int test_conf, int run_as_root, int force_daemon, int force_stderr);
 
 struct fpm_globals_s {

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -131,6 +131,7 @@ static const opt_struct OPTIONS[] = {
 	{'D', 0, "daemonize"},
 	{'F', 0, "nodaemonize"},
 	{'O', 0, "force-stderr"},
+	{20, 0, "fpm"}, /* "php --fpm", see sapi/cli/php_cli_main.c */
 	{'-', 0, NULL} /* end of args */
 };
 
@@ -1495,7 +1496,7 @@ PHP_FUNCTION(fastcgi_finish_request) /* {{{ */
 }
 /* }}} */
 
-PHP_FUNCTION(apache_request_headers) /* {{{ */
+PHP_FUNCTION(fpm_apache_request_headers) /* {{{ */
 {
 	fcgi_request *request;
 
@@ -1531,8 +1532,8 @@ static zend_module_entry cgi_module_entry = {
 	STANDARD_MODULE_PROPERTIES
 };
 
-/* {{{ main */
-int main(int argc, char *argv[])
+/* {{{ do_php_fpm */
+int do_php_fpm(int argc, char *argv[])
 {
 	int exit_status = FPM_EXIT_OK;
 	int c, use_extended_info = 0;
@@ -1666,6 +1667,9 @@ int main(int argc, char *argv[])
 
 			case 'O': /* force stderr even on non tty */
 				force_stderr = 1;
+				break;
+
+			case 20: /* php --fpm */
 				break;
 
 			default:

--- a/sapi/fpm/fpm/fpm_main.stub.php
+++ b/sapi/fpm/fpm/fpm_main.stub.php
@@ -4,9 +4,10 @@
 
 function fastcgi_finish_request(): bool {}
 
+/** @implementation-alias fpm_apache_request_headers */
 function apache_request_headers(): array {}
 
-/** @alias apache_request_headers */
+/** @implementation-alias fpm_apache_request_headers */
 function getallheaders(): array {}
 
 function fpm_get_status(): array|false {}

--- a/sapi/fpm/fpm/fpm_main_arginfo.h
+++ b/sapi/fpm/fpm/fpm_main_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit fpm_main.stub.php instead.
- * Stub hash: b4ac4c0f1d91c354293e21185a2e6d9f99cc9fcc */
+ * Stub hash: 464cd4b4281d68f6368597bd3f890437459e77b7 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_fastcgi_finish_request, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
@@ -13,13 +13,13 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_fpm_get_status, 0, 0, MAY_BE_ARR
 ZEND_END_ARG_INFO()
 
 ZEND_FUNCTION(fastcgi_finish_request);
-ZEND_FUNCTION(apache_request_headers);
+ZEND_FUNCTION(fpm_apache_request_headers);
 ZEND_FUNCTION(fpm_get_status);
 
 static const zend_function_entry ext_functions[] = {
 	ZEND_FE(fastcgi_finish_request, arginfo_fastcgi_finish_request)
-	ZEND_FE(apache_request_headers, arginfo_apache_request_headers)
-	ZEND_RAW_FENTRY("getallheaders", zif_apache_request_headers, arginfo_getallheaders, 0, NULL, NULL)
+	ZEND_RAW_FENTRY("apache_request_headers", zif_fpm_apache_request_headers, arginfo_apache_request_headers, 0, NULL, NULL)
+	ZEND_RAW_FENTRY("getallheaders", zif_fpm_apache_request_headers, arginfo_getallheaders, 0, NULL, NULL)
 	ZEND_FE(fpm_get_status, arginfo_fpm_get_status)
 	ZEND_FE_END
 };

--- a/sapi/fpm/php_fpm_main.c
+++ b/sapi/fpm/php_fpm_main.c
@@ -11,18 +11,9 @@
 */
 
 #include "php.h"
-#include "cli.h"
-#ifdef PHP_CLI_WITH_FPM
-#include "sapi/fpm/fpm/fpm.h"
-#endif
+#include "fpm/fpm.h"
 
 int main(int argc, char *argv[])
 {
-#ifdef PHP_CLI_WITH_FPM
-	/* "php --fpm [args]" runs the FPM SAPI, which ignores the "--fpm" option. */
-	if (argc > 1 && strcmp(argv[1], "--fpm") == 0) {
-		return do_php_fpm(argc, argv);
-	}
-#endif
-	return do_php_cli(argc, argv);
+	return do_php_fpm(argc, argv);
 }


### PR DESCRIPTION
This adds an opt-in configure option, `--enable-cli-fpm`, that links the FPM SAPI into the `php` binary.

The binary behaves exactly like the CLI unless its first argument is `--fpm`, in which case it runs the php-fpm master with the remaining arguments:

```sh
php -v                                     # PHP 8.6.0-dev (cli)
php --fpm -v                               # PHP 8.6.0-dev (fpm-fcgi)
php --fpm --nodaemonize -y /etc/php-fpm.conf
php script.php --fpm                       # "--fpm" is a script argument here (i.e. no changes)
```

The default build is unchanged: without the flag, `php` and `php-fpm` are built exactly as before.

### Goal

In some environments, the size of the runtime matters. Having `php` and `php-fpm` binaries when they are ~99% the same code can be wasteful.

That's the case for example on AWS Lambda with [Bref](https://bref.sh), where a second ~24 MB binary on disk increases the cold start duration (because that's more data to load in the container/micro-VM when it starts).

### Design

This follows the shape of #21385 (`do_php_cli()` / `PHP_CLI_SHARED_OBJS` for embed):

- `sapi/fpm/fpm/fpm_main.c`: `main()` becomes `do_php_fpm()`, declared in `fpm.h`. A new `sapi/fpm/php_fpm_main.c` holds the one-line `main()` for the standalone `php-fpm` binary.
- `sapi/fpm/config.m4`: `PHP_SELECT_SAPI` now only takes `php_fpm_main.c`; all other FPM sources go through `PHP_ADD_SOURCES_X` into `PHP_FPM_SHARED_OBJS`, which is appended to `PHP_FPM_OBJS`. The `BUILD_FPM` link lines are untouched.
- `sapi/fpm/config0.m4` (new): `PHP_ARG_ENABLE([fpm])` moves here so `$PHP_FPM` is set before `sapi/cli/config.m4` runs (same reason embed has a `config0.m4`).
- `sapi/cli/config.m4`: `PHP_ARG_ENABLE([cli-fpm])`, default off; errors out unless both the CLI and FPM SAPIs are enabled; defines `PHP_CLI_WITH_FPM` and appends `$(PHP_FASTCGI_OBJS) $(PHP_FPM_SHARED_OBJS)` to `PHP_CLI_OBJS`. The `BUILD_CLI` lines are untouched. `FPM_EXTRA_LIBS` (systemd, acl, apparmor, selinux) is appended to `EXTRA_LIBS` when the flag is on.
- `sapi/cli/php_cli_main.c`: under `#ifdef PHP_CLI_WITH_FPM`, dispatch to `do_php_fpm(argc, argv)` when `argv[1]` is `--fpm`.
- FPM's option table accepts and ignores `--fpm`, so argv is passed through unchanged. Shifting argv instead breaks FPM's process titles (`fpm_env_init_main` requires the argv strings to be contiguous), which I verified on Linux. Side effect: `php-fpm --fpm` is silently accepted.
- Both SAPIs define `PHP_FUNCTION(apache_request_headers)`, which is a duplicate-symbol link error when linked together. FPM's C symbol is renamed to `fpm_apache_request_headers`; the stub uses `@implementation-alias` on both `apache_request_headers()` and `getallheaders()` and the arginfo header is regenerated. Userland names and behaviour are unchanged.
- `php --help`, `php.1`, NEWS, UPGRADING and UPGRADING.INTERNALS are updated. A new `sapi/cli/tests/cli_fpm.phpt` skips unless the flag is built in.

### Backward compatibility

- Default builds: same binaries. The FPM objects are simply listed in two make variables.
- Internals: `main()` of php-fpm is now `do_php_fpm()`; `--enable-fpm` is declared in `config0.m4`. Both noted in UPGRADING.INTERNALS.
- Windows: untouched (FPM does not build there).

Note: I am new here, so please let me know if I've got things backwards, I've made mistakes, I haven't followed the right workflow, etc. I'm opening this tentatively to get the discussion started.

And the main question I see: does this require a RFC or not?