### PR TITLE
Fix race in OpenSSL CMS verification tests

### DIFF
--- a/ext/openssl/tests/openssl_cms_verify_basic.phpt
+++ b/ext/openssl/tests/openssl_cms_verify_basic.phpt
@@ -11,7 +11,7 @@ if ($outfile === false) {
 
 $contentfile = $outfile . ".out";
 
-$pkcsfile = __DIR__ . "/openssl_cms_verify__pkcsfile.tmp";
+$pkcsfile = __DIR__ . "/openssl_cms_verify_basic__pkcsfile.tmp";
 $eml = __DIR__ . "/signed.eml";
 $wrong = "wrong";
 $empty = "";
@@ -38,7 +38,10 @@ if (file_exists($contentfile)) {
 ?>
 --CLEAN--
 <?php
-unlink(__DIR__ . DIRECTORY_SEPARATOR . '/openssl_cms_verify__pkcsfile.tmp');
+$pkcsfile = __DIR__ . DIRECTORY_SEPARATOR . '/openssl_cms_verify_basic__pkcsfile.tmp';
+if (file_exists($pkcsfile)) {
+    unlink($pkcsfile);
+}
 ?>
 --EXPECT--
 bool(false)

--- a/ext/openssl/tests/openssl_cms_verify_der.phpt
+++ b/ext/openssl/tests/openssl_cms_verify_der.phpt
@@ -14,7 +14,7 @@ if ($contentfile === false) {
     die("failed to get a temporary filename!");
 }
 
-$pkcsfile = __DIR__ . "/openssl_cms_verify__pkcsfile.tmp";
+$pkcsfile = __DIR__ . "/openssl_cms_verify_der__pkcsfile.tmp";
 $eml = __DIR__ . "/signed.eml";
 $wrong = "wrong";
 $empty = "";
@@ -45,7 +45,10 @@ if (file_exists($contentfile)) {
 ?>
 --CLEAN--
 <?php
-unlink(__DIR__ . DIRECTORY_SEPARATOR . '/openssl_cms_verify__pkcsfile.tmp');
+$pkcsfile = __DIR__ . DIRECTORY_SEPARATOR . '/openssl_cms_verify_der__pkcsfile.tmp';
+if (file_exists($pkcsfile)) {
+    unlink($pkcsfile);
+}
 ?>
 --EXPECT--
 bool(false)


### PR DESCRIPTION
Follow up to GH-22472.

Fixes the borked test ([Logs](https://github.com/shivammathur/php-windows-builder/actions/runs/33789086089/job/100767489569#step:6:385)), as the two CMS tests try to unlink the same file when run in parallel.