### PR TITLE
ext/gd: fix the wording of the imagejpeg() quality error

### DIFF
--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -2114,7 +2114,7 @@ PHP_FUNCTION(imagejpeg)
 	}
 
 	if (quality < -1 || quality > 100) {
-		zend_argument_value_error(3, "must be at between -1 and 100");
+		zend_argument_value_error(3, "must be between -1 and 100");
 		ctx->gd_free(ctx);
 		RETURN_THROWS();
 	}

--- a/ext/gd/tests/imagejpeg_quality_range.phpt
+++ b/ext/gd/tests/imagejpeg_quality_range.phpt
@@ -1,0 +1,31 @@
+--TEST--
+imagejpeg(): the accepted range of $quality and the message for values outside it
+--EXTENSIONS--
+gd
+--SKIPIF--
+<?php
+if (!function_exists('imagejpeg')) die('skip jpeg support unavailable');
+?>
+--FILE--
+<?php
+$image = imagecreatetruecolor(8, 8);
+$file = __DIR__ . '/imagejpeg_quality_range.jpeg';
+
+foreach ([-2, -1, 0, 100, 101] as $quality) {
+    try {
+        var_dump(imagejpeg($image, $file, $quality));
+    } catch (ValueError $e) {
+        echo $e->getMessage(), "\n";
+    }
+}
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/imagejpeg_quality_range.jpeg');
+?>
+--EXPECT--
+imagejpeg(): Argument #3 ($quality) must be between -1 and 100
+bool(true)
+bool(true)
+bool(true)
+imagejpeg(): Argument #3 ($quality) must be between -1 and 100

--- a/ext/gd/tests/imageresolution_jpeg.phpt
+++ b/ext/gd/tests/imageresolution_jpeg.phpt
@@ -43,7 +43,7 @@ array(2) {
   [1]=>
   int(299)
 }
-ValueError: imagejpeg(): Argument #3 ($quality) must be at between -1 and 100
+ValueError: imagejpeg(): Argument #3 ($quality) must be between -1 and 100
 --CLEAN--
 <?php
 @unlink(__DIR__ . DIRECTORY_SEPARATOR . 'imageresolution_jpeg.jpeg');


### PR DESCRIPTION
`imagejpeg()` rejects an out of range `$quality` with "must be at between -1 and 100". `imageavif()`, a few lines above in the same file, checks the same bounds and words the message without the stray word.

The existing expectation is updated and a test pins the accepted range.
