### PR TITLE
ext/gd: fix ValueError messages for imagecolormatch() and imagejpeg()

### DIFF
--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -2114,7 +2114,7 @@ PHP_FUNCTION(imagejpeg)
 	}
 
 	if (quality < -1 || quality > 100) {
-		zend_argument_value_error(3, "must be at between -1 and 100");
+		zend_argument_value_error(3, "must be between -1 and 100");
 		ctx->gd_free(ctx);
 		RETURN_THROWS();
 	}

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -785,7 +785,7 @@ PHP_FUNCTION(imagecolormatch)
 			zend_argument_value_error(2, "must be Palette");
 			RETURN_THROWS();
 		case -3:
-			zend_argument_value_error(2, "must be the same size as argument #1 ($im1)");
+			zend_argument_value_error(2, "must be the same size as argument #1 ($image1)");
 			RETURN_THROWS();
 		case -4:
 			zend_argument_value_error(2, "must have at least one color");

--- a/ext/gd/tests/imagecolormatch_error4.phpt
+++ b/ext/gd/tests/imagecolormatch_error4.phpt
@@ -18,6 +18,13 @@ try {
     echo $exception::class, ': ', $exception->getMessage(), "\n";
 }
 
+/* the message names argument #1, so that name has to be the real one */
+foreach ((new ReflectionFunction('imagecolormatch'))->getParameters() as $parameter) {
+    echo '$', $parameter->getName(), "\n";
+}
+
 ?>
 --EXPECT--
-ValueError: imagecolormatch(): Argument #2 ($image2) must be the same size as argument #1 ($im1)
+ValueError: imagecolormatch(): Argument #2 ($image2) must be the same size as argument #1 ($image1)
+$image1
+$image2

--- a/ext/gd/tests/imagejpeg_quality_range.phpt
+++ b/ext/gd/tests/imagejpeg_quality_range.phpt
@@ -14,8 +14,8 @@ $file = __DIR__ . '/imagejpeg_quality_range.jpeg';
 foreach ([-2, -1, 0, 100, 101] as $quality) {
     try {
         var_dump(imagejpeg($image, $file, $quality));
-    } catch (ValueError $e) {
-        echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+    } catch (Throwable $e) {
+        echo $e::class, ': ', $e->getMessage(), "\n";
     }
 }
 ?>

--- a/ext/gd/tests/imagejpeg_quality_range.phpt
+++ b/ext/gd/tests/imagejpeg_quality_range.phpt
@@ -1,0 +1,31 @@
+--TEST--
+imagejpeg(): the accepted range of $quality and the message for values outside it
+--EXTENSIONS--
+gd
+--SKIPIF--
+<?php
+if (!function_exists('imagejpeg')) die('skip jpeg support unavailable');
+?>
+--FILE--
+<?php
+$image = imagecreatetruecolor(8, 8);
+$file = __DIR__ . '/imagejpeg_quality_range.jpeg';
+
+foreach ([-2, -1, 0, 100, 101] as $quality) {
+    try {
+        var_dump(imagejpeg($image, $file, $quality));
+    } catch (ValueError $e) {
+        echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+    }
+}
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/imagejpeg_quality_range.jpeg');
+?>
+--EXPECT--
+ValueError: imagejpeg(): Argument #3 ($quality) must be between -1 and 100
+bool(true)
+bool(true)
+bool(true)
+ValueError: imagejpeg(): Argument #3 ($quality) must be between -1 and 100

--- a/ext/gd/tests/imageresolution_jpeg.phpt
+++ b/ext/gd/tests/imageresolution_jpeg.phpt
@@ -43,7 +43,7 @@ array(2) {
   [1]=>
   int(299)
 }
-ValueError: imagejpeg(): Argument #3 ($quality) must be at between -1 and 100
+ValueError: imagejpeg(): Argument #3 ($quality) must be between -1 and 100
 --CLEAN--
 <?php
 @unlink(__DIR__ . DIRECTORY_SEPARATOR . 'imageresolution_jpeg.jpeg');


### PR DESCRIPTION
Two error messages in `ext/gd/gd.c` that do not say what they mean.

`imagecolormatch()`: the size mismatch message points at "argument #1 ($im1)", a name the function lost in 14a26db3e2 when the ext/gd parameters were renamed for 8.0. Both parameters are `$image1` and `$image2`.

`imagejpeg()`: an out of range `$quality` is rejected with "must be at between -1 and 100". `imageavif()`, a few lines above in the same file, checks the same bounds and words the message without the stray word. The existing expectation is updated and a test pins the accepted range.

Supersedes #23560, which carried the `imagejpeg()` half and is now closed.