### PR TITLE
Fix php://fd/ on platforms without getdtablesize()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -559,6 +559,7 @@ AC_CHECK_FUNCS(m4_normalize([
   funopen
   gai_strerror
   getcwd
+  getdtablesize
   getgrnam_r
   gethostname
   getloadavg

--- a/ext/standard/php_fopen_wrapper.c
+++ b/ext/standard/php_fopen_wrapper.c
@@ -346,7 +346,7 @@ static php_stream * php_stream_url_wrap_php(php_stream_wrapper *wrapper, const c
 			return NULL;
 		}
 
-#ifdef HAVE_UNISTD_H
+#ifdef HAVE_GETDTABLESIZE
 		dtablesize = getdtablesize();
 #else
 		dtablesize = INT_MAX;


### PR DESCRIPTION
HAVE_UNISTD_H does not imply that getdtablesize() exists. Detect the function at configure time.