### PR TITLE
Discard buckets abandoned by a filter that returns no output

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -94,6 +94,8 @@ PHP                                                                        NEWS
   . Fixed a memory leak in array_merge_recursive() when the recursive merge of
     an object converted to an array fails. (David Carlier)
   . Fixed read buffer compaction in php_stream_filter_flush(). (crystarm)
+  . Fixed leaked buckets when a stream filter appends output and then returns
+    PSFS_FEED_ME or PSFS_ERR_FATAL. (Ilia Alshanetsky)
 
 - SimpleXML:
   . Fixed writing to a dimension of the object returned by attributes() not

--- a/ext/standard/tests/filters/stream_filter_flush_discard_buckets.phpt
+++ b/ext/standard/tests/filters/stream_filter_flush_discard_buckets.phpt
@@ -1,0 +1,43 @@
+--TEST--
+php_stream_filter_flush() discards buckets a filter left behind on PSFS_FEED_ME / PSFS_ERR_FATAL
+--FILE--
+<?php
+class feed_filter extends php_user_filter
+{
+    public function filter($in, $out, &$consumed, $closing): int
+    {
+        while ($bucket = stream_bucket_make_writeable($in)) {
+            $consumed += strlen($bucket->data);
+        }
+        stream_bucket_append($out, stream_bucket_new($this->stream, 'abandoned'));
+        return PSFS_FEED_ME;
+    }
+}
+
+class fatal_filter extends php_user_filter
+{
+    public function filter($in, $out, &$consumed, $closing): int
+    {
+        stream_bucket_append($out, stream_bucket_new($this->stream, 'abandoned'));
+        return PSFS_ERR_FATAL;
+    }
+}
+
+stream_filter_register('feed', feed_filter::class);
+stream_filter_register('fatal', fatal_filter::class);
+
+foreach (['feed', 'fatal'] as $name) {
+    $fp = fopen('php://memory', 'w+');
+    $filter = stream_filter_append($fp, $name, STREAM_FILTER_WRITE);
+    var_dump(stream_filter_remove($filter));
+    fclose($fp);
+}
+
+echo "done\n";
+?>
+--EXPECTF--
+bool(true)
+
+Warning: stream_filter_remove(): Unable to flush filter, not removing in %s on line %d
+bool(false)
+done

--- a/ext/standard/tests/filters/stream_filter_write_discard_buckets.phpt
+++ b/ext/standard/tests/filters/stream_filter_write_discard_buckets.phpt
@@ -1,0 +1,28 @@
+--TEST--
+php_stream_write_filtered() discards output buckets a filter left behind on PSFS_FEED_ME
+--FILE--
+<?php
+class feed_filter extends php_user_filter
+{
+    public function filter($in, $out, &$consumed, $closing): int
+    {
+        while ($bucket = stream_bucket_make_writeable($in)) {
+            $consumed += strlen($bucket->data);
+        }
+        stream_bucket_append($out, stream_bucket_new($this->stream, 'abandoned'));
+        return PSFS_FEED_ME;
+    }
+}
+
+stream_filter_register('feed', feed_filter::class);
+
+$fp = fopen('php://memory', 'w+');
+stream_filter_append($fp, 'feed', STREAM_FILTER_WRITE);
+var_dump(fwrite($fp, 'one'));
+fclose($fp);
+
+echo "done\n";
+?>
+--EXPECT--
+int(3)
+done

--- a/main/streams/filter.c
+++ b/main/streams/filter.c
@@ -425,6 +425,16 @@ PHPAPI int _php_stream_filter_flush(php_stream_filter *filter, int finish)
 		php_stream_filter_status_t status;
 
 		status = current->fops->filter(stream, current, inp, outp, NULL, flags);
+		if (status == PSFS_FEED_ME || status == PSFS_ERR_FATAL) {
+			while ((bucket = inp->head)) {
+				php_stream_bucket_unlink(bucket);
+				php_stream_bucket_delref(bucket);
+			}
+			while ((bucket = outp->head)) {
+				php_stream_bucket_unlink(bucket);
+				php_stream_bucket_delref(bucket);
+			}
+		}
 		if (status == PSFS_FEED_ME) {
 			/* We've flushed the data far enough */
 			return SUCCESS;

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -1306,6 +1306,11 @@ static ssize_t _php_stream_write_filtered(php_stream *stream, const char *buf, s
 				php_stream_bucket_unlink(bucket);
 				php_stream_bucket_delref(bucket);
 			}
+			while (brig_outp->head) {
+				bucket = brig_outp->head;
+				php_stream_bucket_unlink(bucket);
+				php_stream_bucket_delref(bucket);
+			}
 			break;
 	}
 


### PR DESCRIPTION
A user filter can append buckets to its $out brigade and still answer PSFS_FEED_ME or PSFS_ERR_FATAL. Both brigades live on the caller's stack frame, so whatever is left on them when the caller returns leaks with bucket->brigade dangling, and re-appending such a bucket later writes through that pointer. php_stream_fill_read_buffer() and php_stream_filter_append_ex() already discard leftovers; _php_stream_filter_flush() returned without touching either brigade, and _php_stream_write_filtered() drained only the input one. Smallest case is a filter that appends one bucket to $out, returns PSFS_ERR_FATAL, and is then passed to stream_filter_remove().
