### PR TITLE
ext/openssl: Fix remaining racing tests

### DIFF
--- a/ext/openssl/tests/ServerClientTestCase.inc
+++ b/ext/openssl/tests/ServerClientTestCase.inc
@@ -24,7 +24,7 @@ function phpt_has_sslv3() {
     if (!is_null($result)) {
         return $result;
     }
-    $server = @stream_socket_server('sslv3://127.0.0.1:10013');
+    $server = @stream_socket_server('sslv3://127.0.0.1:0');
     if ($result = !!$server) {
         fclose($server);
     }

--- a/ext/openssl/tests/gh20802.phpt
+++ b/ext/openssl/tests/gh20802.phpt
@@ -26,7 +26,7 @@ $serverCode = <<<'CODE'
 		    ]
 	    ]
     ]);
-    $server = stream_socket_server('tls://127.0.0.1:12443', $errno, $errstr, $flags, $ctx);
+    $server = stream_socket_server('tls://127.0.0.1:0', $errno, $errstr, $flags, $ctx);
     phpt_notify_server_start($server);
     stream_socket_accept($server, 3);
 CODE;
@@ -42,7 +42,7 @@ $ctx = stream_context_create([
 	    'verify_peer'  => false
 	]
     ]);
-    @stream_socket_client("tls://127.0.0.1:12443", $errno, $errstr, 1, $flags, $ctx);
+    @stream_socket_client("tls://{{ ADDR }}", $errno, $errstr, 1, $flags, $ctx);
 CODE;
 
 include 'CertificateGenerator.inc';

--- a/ext/openssl/tests/openssl_error_string_basic_openssl3.phpt
+++ b/ext/openssl/tests/openssl_error_string_basic_openssl3.phpt
@@ -53,7 +53,7 @@ function dump_openssl_errors($name) {
 }
 
 // common output file
-$output_file =  __DIR__ . "/openssl_error_string_basic_output.tmp";
+$output_file =  __DIR__ . "/openssl_error_string_basic_openssl3_output.tmp";
 // invalid file for read is something that does not exist in current directory
 $invalid_file_for_read = __DIR__ . "/invalid_file_for_read_operation.txt";
 // invalid file for is the test dir as writing file to existing dir should always fail
@@ -156,7 +156,7 @@ expect_openssl_errors('openssl_csr_get_subjec pem', [$err_pem_no_start_line]);
 ?>
 --CLEAN--
 <?php
-$output_file =  __DIR__ . "/openssl_error_string_basic_output.tmp";
+$output_file =  __DIR__ . "/openssl_error_string_basic_openssl3_output.tmp";
 if (is_file($output_file)) {
     unlink($output_file);
 }

--- a/ext/openssl/tests/openssl_pkcs12_export_to_file_basic.phpt
+++ b/ext/openssl/tests/openssl_pkcs12_export_to_file_basic.phpt
@@ -4,7 +4,7 @@ openssl_pkcs12_export_to_file() tests
 openssl
 --FILE--
 <?php
-$pkcsfile = __DIR__ . "/openssl_pkcs12_export_to_file__pkcsfile.tmp";
+$pkcsfile = __DIR__ . "/openssl_pkcs12_export_to_file_basic__pkcsfile.tmp";
 
 $cert_file = __DIR__ . "/public.crt";
 $cert = file_get_contents($cert_file);
@@ -38,7 +38,7 @@ try {
 ?>
 --CLEAN--
 <?php
-$pkcsfile = __DIR__ . "/openssl_pkcs12_export_to_file__pkcsfile.tmp";
+$pkcsfile = __DIR__ . "/openssl_pkcs12_export_to_file_basic__pkcsfile.tmp";
 if (file_exists($pkcsfile)) {
     unlink($pkcsfile);
 }

--- a/ext/openssl/tests/openssl_pkcs12_export_to_file_error.phpt
+++ b/ext/openssl/tests/openssl_pkcs12_export_to_file_error.phpt
@@ -4,7 +4,7 @@ openssl_pkcs12_export_to_file() error tests
 openssl
 --FILE--
 <?php
-$pkcsfile = __DIR__ . "/openssl_pkcs12_export_to_file__pkcsfile.tmp";
+$pkcsfile = __DIR__ . "/openssl_pkcs12_export_to_file_error__pkcsfile.tmp";
 
 $cert_file = __DIR__ . "/public.crt";
 $cert = file_get_contents($cert_file);
@@ -21,7 +21,7 @@ var_dump(openssl_pkcs12_export_to_file($cert, '.', $priv, $pass));
 ?>
 --CLEAN--
 <?php
-$pkcsfile = __DIR__ . "/openssl_pkcs12_export_to_file__pkcsfile.tmp";
+$pkcsfile = __DIR__ . "/openssl_pkcs12_export_to_file_error__pkcsfile.tmp";
 if (file_exists($pkcsfile)) {
     unlink($pkcsfile);
 }

--- a/ext/openssl/tests/session_resumption_import_export_session.phpt
+++ b/ext/openssl/tests/session_resumption_import_export_session.phpt
@@ -8,7 +8,7 @@ if (!function_exists("proc_open")) die("skip no proc_open");
 ?>
 --FILE--
 <?php
-$certFile = __DIR__ . DIRECTORY_SEPARATOR . 'session_resumption_serialize.pem.tmp';
+$certFile = __DIR__ . DIRECTORY_SEPARATOR . 'session_resumption_import_export.pem.tmp';
 
 $serverCode = <<<'CODE'
     $flags = STREAM_SERVER_BIND|STREAM_SERVER_LISTEN;
@@ -76,7 +76,7 @@ ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
 ?>
 --CLEAN--
 <?php
-@unlink(__DIR__ . DIRECTORY_SEPARATOR . 'session_resumption_serialize.pem.tmp');
+@unlink(__DIR__ . DIRECTORY_SEPARATOR . 'session_resumption_import_export.pem.tmp');
 ?>
 --EXPECTF--
 string(%d) "-----BEGIN SSL SESSION PARAMETERS-----

--- a/ext/openssl/tests/session_resumption_invalid_session_import.phpt
+++ b/ext/openssl/tests/session_resumption_invalid_session_import.phpt
@@ -15,9 +15,5 @@ try {
     echo $e->getMessage() . "\n";
 }
 ?>
---CLEAN--
-<?php
-@unlink(__DIR__ . DIRECTORY_SEPARATOR . 'session_cache_disabled.pem.tmp');
-?>
 --EXPECT--
 Failed to import session data

--- a/ext/openssl/tests/session_resumption_serialize_session.phpt
+++ b/ext/openssl/tests/session_resumption_serialize_session.phpt
@@ -8,7 +8,7 @@ if (!function_exists("proc_open")) die("skip no proc_open");
 ?>
 --FILE--
 <?php
-$certFile = __DIR__ . DIRECTORY_SEPARATOR . 'session_resumption_serialize.pem.tmp';
+$certFile = __DIR__ . DIRECTORY_SEPARATOR . 'session_resumption_serialize_session.pem.tmp';
 
 $serverCode = <<<'CODE'
     $flags = STREAM_SERVER_BIND|STREAM_SERVER_LISTEN;
@@ -68,7 +68,7 @@ ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
 ?>
 --CLEAN--
 <?php
-@unlink(__DIR__ . DIRECTORY_SEPARATOR . 'session_resumption_serialize.pem.tmp');
+@unlink(__DIR__ . DIRECTORY_SEPARATOR . 'session_resumption_serialize_session.pem.tmp');
 ?>
 --EXPECTF--
 string(%d) "O:15:"Openssl\Session":1:{s:3:"pem";s:%d:"-----BEGIN SSL SESSION PARAMETERS-----

--- a/ext/openssl/tests/session_resumption_server_external_with_context_id.phpt
+++ b/ext/openssl/tests/session_resumption_server_external_with_context_id.phpt
@@ -8,7 +8,7 @@ if (!function_exists("proc_open")) die("skip no proc_open");
 ?>
 --FILE--
 <?php
-$certFile = __DIR__ . DIRECTORY_SEPARATOR . 'session_external_proper.pem.tmp';
+$certFile = __DIR__ . DIRECTORY_SEPARATOR . 'session_external_context_id.pem.tmp';
 
 $serverCode = <<<'CODE'
     $sessionStore = [];
@@ -105,7 +105,7 @@ ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
 ?>
 --CLEAN--
 <?php
-@unlink(__DIR__ . DIRECTORY_SEPARATOR . 'session_external_proper.pem.tmp');
+@unlink(__DIR__ . DIRECTORY_SEPARATOR . 'session_external_context_id.pem.tmp');
 ?>
 --EXPECTF--
 Client first connection resumed: no

--- a/ext/openssl/tests/session_resumption_server_external_with_context_id_tls12.phpt
+++ b/ext/openssl/tests/session_resumption_server_external_with_context_id_tls12.phpt
@@ -8,7 +8,7 @@ if (!function_exists("proc_open")) die("skip no proc_open");
 ?>
 --FILE--
 <?php
-$certFile = __DIR__ . DIRECTORY_SEPARATOR . 'session_external_proper.pem.tmp';
+$certFile = __DIR__ . DIRECTORY_SEPARATOR . 'session_external_context_id_tls12.pem.tmp';
 
 $serverCode = <<<'CODE'
     $sessionStore = [];
@@ -105,7 +105,7 @@ ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
 ?>
 --CLEAN--
 <?php
-@unlink(__DIR__ . DIRECTORY_SEPARATOR . 'session_external_proper.pem.tmp');
+@unlink(__DIR__ . DIRECTORY_SEPARATOR . 'session_external_context_id_tls12.pem.tmp');
 ?>
 --EXPECTF--
 Client first connection resumed: no

--- a/ext/openssl/tests/stream_server_reneg_limit.phpt
+++ b/ext/openssl/tests/stream_server_reneg_limit.phpt
@@ -25,7 +25,7 @@ $certFile = __DIR__ . DIRECTORY_SEPARATOR . 'stream_server_reneg_limit.pem.tmp';
 
 $serverCode = <<<'CODE'
     $printed = false;
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s',
@@ -42,7 +42,7 @@ $serverCode = <<<'CODE'
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify(message: stream_socket_get_name($server, false));
 
     $clients = [];
     while (1) {
@@ -71,9 +71,9 @@ CODE;
 $serverCode = sprintf($serverCode, $certFile);
 
 $clientCode = <<<'CODE'
-    phpt_wait();
+    $serverUri = trim(phpt_wait());
 
-    $cmd = 'openssl s_client -connect 127.0.0.1:64321';
+    $cmd = 'openssl s_client -connect ' . escapeshellarg($serverUri);
     $descriptorSpec = [["pipe", "r"], ["pipe", "w"], ["pipe", "w"]];
     $process = proc_open($cmd, $descriptorSpec, $pipes);
 


### PR DESCRIPTION
Follow-up https://github.com/php/php-src/pull/23559

This PR use unique temporary file names for tests that may run concurrently, and remove a CLEAN section that deletes another test's file, and replace fixed server ports with ephemeral ports.

I hope this can solve the racing issue. If not, let's get the CONFLITS file back :(

e.g. https://github.com/php/php-src/actions/runs/33834514477/job/100904194803