### PR TITLE
Fix GH-17626: JIT corrupts opline handler when blacklisting root trace

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -67,6 +67,9 @@ PHP                                                                        NEWS
   . Fixed a tracing JIT crash when compiling a side trace for a method of a
     class that could not be stored in the inheritance cache. (GH-21710)
     (Arnaud, iliaal)
+  . Fixed bug GH-17626 (JIT corrupts an opline handler when blacklisting a
+    root trace at the opcache.jit_max_root_traces limit, causing spurious
+    "Too few arguments" errors and crashes). (RV7PR)
 
 - PDO:
   . Fixed a leak when a persistent connection failed a liveness check

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -8780,7 +8780,7 @@ int ZEND_FASTCALL zend_jit_trace_exit(uint32_t exit_num, zend_jit_registers_buf 
 				SHM_UNPROTECT();
 				zend_jit_unprotect();
 
-				((zend_op*)opline)->handler =
+				((zend_op*)(t->opline))->handler =
 					ZEND_OP_TRACE_INFO(t->opline, jit_extension->offset)->orig_handler;
 
 				ZEND_OP_TRACE_INFO(t->opline, jit_extension->offset)->trace_flags &= ~ZEND_JIT_TRACE_JITED;

--- a/ext/opcache/tests/jit/gh17626.inc
+++ b/ext/opcache/tests/jit/gh17626.inc
@@ -1,0 +1,2 @@
+<?php
+function gh17626_callee(string $s) { return strtoupper($s); }

--- a/ext/opcache/tests/jit/gh17626.phpt
+++ b/ext/opcache/tests/jit/gh17626.phpt
@@ -1,0 +1,41 @@
+--TEST--
+GH-17626: Opline handler corrupted when a root trace is blacklisted at the max_root_traces limit (fails with --repeat 2)
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.file_update_protection=0
+opcache.revalidate_freq=0
+opcache.jit=tracing
+opcache.jit_buffer_size=16M
+opcache.jit_hot_func=2
+opcache.jit_hot_loop=255
+opcache.jit_hot_return=255
+opcache.jit_hot_side_exit=255
+opcache.jit_max_root_traces=2
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+namespace GH17626;
+
+// In --repeat 2 the callee is recompiled after the first run, so the function
+// guard in the trace compiled for caller() fails with ZEND_JIT_EXIT_INVALIDATE.
+
+require __DIR__ . '/gh17626.inc';
+
+function caller(string $s) {
+    return gh17626_callee($s) . $s;
+}
+
+caller('a');
+caller('a');
+caller('a');
+echo caller('a'), "\n";
+echo caller('b'), "\n";
+
+touch(__DIR__ . '/gh17626.inc');
+opcache_invalidate(__DIR__ . '/gh17626.inc', true);
+?>
+--EXPECT--
+Aa
+Bb

--- a/ext/opcache/tests/jit/gh17626_002.inc
+++ b/ext/opcache/tests/jit/gh17626_002.inc
@@ -1,0 +1,2 @@
+<?php
+class GH17626GrandParent {}

--- a/ext/opcache/tests/jit/gh17626_002.phpt
+++ b/ext/opcache/tests/jit/gh17626_002.phpt
@@ -1,0 +1,47 @@
+--TEST--
+GH-17626: Opline handler corrupted when a root trace is blacklisted at the max_root_traces limit
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.file_update_protection=0
+opcache.jit=tracing
+opcache.jit_buffer_size=16M
+opcache.jit_hot_func=2
+opcache.jit_hot_loop=255
+opcache.jit_hot_return=255
+opcache.jit_hot_side_exit=255
+opcache.jit_max_root_traces=2
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+require __DIR__ . '/gh17626_002.inc';
+
+class ParentA extends GH17626GrandParent { public static function m() { return 'A'; } }
+class ParentB extends GH17626GrandParent { public static function m() { return 'B'; } }
+
+trait T {
+    public function run(string $s) {
+        return parent::m() . $s;
+    }
+}
+
+class A extends ParentA { use T; }
+class B extends ParentB { use T; }
+
+$a = new A;
+$b = new B;
+
+$a->run('x');
+$a->run('x');
+$a->run('x');
+echo $a->run('x'), "\n";
+echo $b->run('y'), "\n";
+echo $b->run('y'), "\n";
+echo $a->run('x'), "\n";
+?>
+--EXPECT--
+Ax
+By
+By
+Ax


### PR DESCRIPTION
Fixes #17626

### The bug

`zend_jit_trace_exit()` handles `ZEND_JIT_EXIT_INVALIDATE` by walking up to the root trace `t`. If `ZEND_JIT_TRACE_NUM >= JIT_G(max_root_traces)` it blacklists the root and puts the original VM handler back, but writes it to `opline` (the exit opline of the trace that just exited) instead of `t->opline` (the root's start opline). The sibling `else` branch uses `t->opline`.

The opcodes live in shared memory, so the corruption is process-wide and permanent until restart. That matches the reports: it appears after long uptime (the 1024 root-trace limit has been reached), after deploys / composer updates (a recompiled callee makes an INVALIDATE guard fail), frequently in trait methods on 8.5 (classes using a trait share the opcodes and therefore the trace), and only goes away after restarting FPM / the container.

When the root trace starts at the entry of a function with typed parameters the root opline is `ZEND_RECV`, so the RECV handler ends up on an `INIT_*` opline. It reads `op1.num` as the argument number (2 for `parent::`, the stack size for `INIT_FCALL`, a literal offset for `Foo::bar()`), calls `zend_missing_arg_error()` on a frame that has all its arguments and produces the contradictory "N passed ... and exactly N expected" message from the issue. Other root oplines produce the SIGSEGVs mentioned there.

Introduced by 350af54 (fix for GH-14475); present in PHP-8.3, PHP-8.4, PHP-8.5 and master.

### The fix

Restore the handler on the root trace's opline, `t->opline`, as the other branch already does.

### Tests

Both tests set `opcache.jit_max_root_traces=2` so the limit is reached right after the first root trace, and use a typed function so the root trace starts at a RECV opcode.

- `gh17626.phpt`: namespaced `caller()` calls an unqualified user function from another file (`INIT_NS_FCALL_BY_NAME`, guarded with `ZEND_JIT_EXIT_INVALIDATE` because the callee is immutable). The callee's file is touched and invalidated at the end, so under `--repeat 2` (the CI repeat job; same approach as `gh8591-001.phpt` and `init_fcall_003.phpt`) the second run recompiles the callee and the guard fails. Without the fix: `ArgumentCountError: Too few arguments to function GH17626\caller(), 1 passed ... and exactly 1 expected`. This is the trigger 8.3/8.4 users hit after a deploy or composer update.
- `gh17626_002.phpt`: a typed trait method calling `parent::m()`, used by two classes with different parents (grandparent in another file so `zend_jit_may_be_modified()` keeps the guard). `zend_jit_init_static_method_call()` emits an INVALIDATE guard for this only on PHP-8.5 and master, so this test fails without the fix from 8.5 on without needing `--repeat`. It is the trigger behind the Carbon / trait reports on 8.5.

Verified on macOS arm64: PHP-8.4 unfixed/fixed with and without `--repeat 2`, master unfixed/fixed; full `ext/opcache/tests/jit` passes with the fix (474/0 on 8.4, 487/0 on master).

### Disclaimer

I am the reporter of #17626. The root-cause analysis, the fix, the tests and this write-up were produced with Claude Fable 5.1 (Anthropic) at my direction; I ran the reproductions and test runs on my machine and verified the results, but I cannot review the C myself. I will relay any review questions and apply requested changes.
