### PR TITLE
ext/opcache: drop the pre-emptive munmap before the huge page remap

### DIFF
--- a/ext/opcache/shared_alloc_mmap.c
+++ b/ext/opcache/shared_alloc_mmap.c
@@ -245,12 +245,18 @@ static int create_segments(size_t requested_size, zend_shared_segment ***shared_
 
 		p = mmap(NULL, requested_size + huge_page_size, flags, MAP_SHARED|MAP_ANONYMOUS|MAP_32BIT, fd, 0);
 		if (p != MAP_FAILED) {
-			munmap(p, requested_size + huge_page_size);
+			void *reserved = p;
 			p = (void*)(ZEND_MM_ALIGNED_SIZE_EX((ptrdiff_t)p, huge_page_size));
 			p = mmap(p, requested_size, flags, MAP_SHARED|MAP_ANONYMOUS|MAP_32BIT|MAP_HUGETLB|MAP_FIXED, -1, 0);
 			if (p != MAP_FAILED) {
+				size_t head = (char*)p - (char*)reserved;
+				if (head != 0) {
+					munmap(reserved, head);
+				}
+				munmap((char*)p + requested_size, huge_page_size - head);
 				goto success;
 			} else {
+				munmap(reserved, requested_size + huge_page_size);
 				p = mmap(NULL, requested_size, flags, MAP_SHARED|MAP_ANONYMOUS|MAP_32BIT, fd, 0);
 				if (p != MAP_FAILED) {
 					goto success;


### PR DESCRIPTION
Follow-up to #23554, suggested by @arnaud-lb: `MAP_FIXED` already replaces the overlapped part of the reservation, so the `munmap()` before it is unnecessary and only opens a window for another thread to take the address.

This keeps the reservation, maps the huge pages into it, and releases only the head and the tail that are left over — they always add up to `huge_page_size`. On failure the whole reservation is released, because a failed `MAP_FIXED` can leave
a hole in it.

As with my last patch, please check this carefully. This part of the code is still new to me.
