### PR TITLE
Fix GH-23576: array_keys() on an empty array returns a non-zero next index

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -96,6 +96,8 @@ PHP                                                                        NEWS
   . Fixed a memory leak in array_merge_recursive() when the recursive merge of
     an object converted to an array fails. (David Carlier)
   . Fixed read buffer compaction in php_stream_filter_flush(). (crystarm)
+  . Fixed bug GH-23576 (Next index for array returned from array_keys() is
+    wrong). (Lazizbek Ergashev)
 
 - SimpleXML:
   . Fixed writing to a dimension of the object returned by attributes() not

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -4504,7 +4504,7 @@ PHP_FUNCTION(array_keys)
 
 	/* Base case: empty input */
 	if (!elem_count) {
-		RETURN_COPY(input);
+		RETURN_EMPTY_ARRAY();
 	}
 
 	/* Initialize return array */

--- a/ext/standard/tests/array/gh23576.phpt
+++ b/ext/standard/tests/array/gh23576.phpt
@@ -16,8 +16,34 @@ var_dump($c);
 $d = array_keys($a, 123, true);
 $d[] = 42;
 var_dump($d);
+
+$e = [];
+
+$f = array_keys($e);
+$f[] = 42;
+var_dump($f);
+
+$g = array_keys($e, 123);
+$g[] = 42;
+var_dump($g);
+
+$h = array_keys($e, 123, true);
+$h[] = 42;
+var_dump($h);
 ?>
 --EXPECT--
+array(1) {
+  [0]=>
+  int(42)
+}
+array(1) {
+  [0]=>
+  int(42)
+}
+array(1) {
+  [0]=>
+  int(42)
+}
 array(1) {
   [0]=>
   int(42)

--- a/ext/standard/tests/array/gh23576.phpt
+++ b/ext/standard/tests/array/gh23576.phpt
@@ -1,0 +1,32 @@
+--TEST--
+GH-23576 (Next index for array returned from array_keys() is wrong)
+--FILE--
+<?php
+$a = [123 => 123];
+unset($a[123]);
+
+$b = array_keys($a);
+$b[] = 42;
+var_dump($b);
+
+$c = array_keys($a, 123);
+$c[] = 42;
+var_dump($c);
+
+$d = array_keys($a, 123, true);
+$d[] = 42;
+var_dump($d);
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  int(42)
+}
+array(1) {
+  [0]=>
+  int(42)
+}
+array(1) {
+  [0]=>
+  int(42)
+}


### PR DESCRIPTION
`array_keys()` returns the input array itself when that array is empty. An array that has held elements keeps its next free index, so `array_keys()` on an empty-but-previously-populated array hands back a next index that is not 0, and the first append lands on the old index instead:

```php
$a = [123 => 123];
unset($a[123]);
$b = array_keys($a);
$b[] = 42;      // ends up at key 124, not 0
```

The shortcut has been there since 7.2, but it only became visible in 7.3.17 / 7.4.5, when the fix for bug #79364 made copying an empty array preserve the next free index. `array_keys()` is documented to return a list, so returning the caller's array is wrong regardless of what the copy preserves. Return a fresh empty array instead, which is what `array_values()` right below already does for the same case.

Fixes GH-23576
