### PR TITLE
Fix pow(), ** and fpow() losing precision on 32-bit x86

### DIFF
--- a/Zend/tests/pow_fpu_precision.phpt
+++ b/Zend/tests/pow_fpu_precision.phpt
@@ -1,0 +1,73 @@
+--TEST--
+The ** operator must not lose precision when the FPU is clamped to double precision
+--INI--
+serialize_precision=-1
+--FILE--
+<?php
+/* On i386 the x87 FPU is the platform default and zend_init_fpu() clamps it to
+ * double precision (53-bit mantissa) for the whole request. libm's pow()
+ * computes on the x87 unit and relies on the extended range to round correctly
+ * to double, so while that clamp is in place its result is off by one or more
+ * ULP.
+ *
+ * This file covers the ** operator (ZEND_POW). The same cases are covered for
+ * pow() in ext/standard/tests/math/pow_fpu_precision.phpt.
+ *
+ * Every expected value is exactly the correctly rounded double of its decimal
+ * literal, so a build that keeps full precision prints the short literal back
+ * and compares identical to it. */
+
+$ten = 10;
+$five = 5;
+$two = 2;
+
+echo "-- runtime --\n";
+var_dump($ten ** -2);
+var_dump($ten ** -3);
+var_dump($ten ** -4);
+var_dump($five ** -2);
+var_dump($five ** -3);
+var_dump($five ** -4);
+echo "-- compile-time constant folding --\n";
+var_dump(10 ** -2);
+var_dump(10 ** -3);
+var_dump(10 ** -4);
+var_dump(5 ** -2);
+var_dump(5 ** -3);
+var_dump(5 ** -4);
+echo "-- exact powers of two are unaffected --\n";
+var_dump($two ** -1);
+var_dump($two ** -10);
+echo "-- identical to the decimal literal --\n";
+var_dump($ten ** -2 === 0.01);
+var_dump($ten ** -3 === 0.001);
+var_dump($ten ** -4 === 0.0001);
+var_dump($five ** -2 === 0.04);
+var_dump($five ** -3 === 0.008);
+var_dump($five ** -4 === 0.0016);
+?>
+--EXPECT--
+-- runtime --
+float(0.01)
+float(0.001)
+float(0.0001)
+float(0.04)
+float(0.008)
+float(0.0016)
+-- compile-time constant folding --
+float(0.01)
+float(0.001)
+float(0.0001)
+float(0.04)
+float(0.008)
+float(0.0016)
+-- exact powers of two are unaffected --
+float(0.5)
+float(0.0009765625)
+-- identical to the decimal literal --
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/Zend/zend_float.h
+++ b/Zend/zend_float.h
@@ -20,6 +20,8 @@
 
 #include "zend_portability.h"
 
+#include <math.h>
+
 BEGIN_EXTERN_C()
 
 /*
@@ -412,5 +414,23 @@ END_EXTERN_C()
 # define XPFPA_RETURN_DOUBLE_EXTENDED(val)  return (val)
 
 #endif /* FPU CONTROL */
+
+/* zend_init_fpu() clamps the x87 FPU to double precision (53-bit mantissa) for
+ * the whole request. libm's pow() relies on the FPU running at extended
+ * precision internally, so while that clamp is in place its result is off by
+ * one or more ULP compared to platforms whose FPU has no precision control.
+ * Restore extended precision for the call and truncate the result back to
+ * double. Compiles down to a plain pow() everywhere XPFPA_HAVE_CW is 0, which
+ * includes x86-64 and arm64. */
+static zend_always_inline double zend_pow(double base, double exponent)
+{
+#if XPFPA_HAVE_CW
+	XPFPA_DECLARE
+	XPFPA_SWITCH_DOUBLE_EXTENDED();
+	XPFPA_RETURN_DOUBLE(pow(base, exponent));
+#else
+	return pow(base, exponent);
+#endif
+}
 
 #endif

--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -1347,7 +1347,7 @@ static double safe_pow(double base, double exponent)
 		zend_power_base_0_exponent_lt_0_error();
 	}
 
-	return pow(base, exponent);
+	return zend_pow(base, exponent);
 }
 
 static zend_result ZEND_FASTCALL pow_function_base(zval *result, zval *op1, zval *op2) /* {{{ */

--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -1485,7 +1485,7 @@ PHP_FUNCTION(fpow)
 		Z_PARAM_DOUBLE(exponent)
 	ZEND_PARSE_PARAMETERS_END();
 
-	RETURN_DOUBLE(pow(base, exponent));
+	RETURN_DOUBLE(zend_pow(base, exponent));
 }
 /* }}} */
 

--- a/ext/standard/tests/math/fpow_fpu_precision.phpt
+++ b/ext/standard/tests/math/fpow_fpu_precision.phpt
@@ -1,0 +1,75 @@
+--TEST--
+fpow(): results must not lose precision when the FPU is clamped to double precision
+--INI--
+serialize_precision=-1
+--FILE--
+<?php
+/* fpow() calls libm pow() directly instead of going through the ** operator's
+ * safe_pow(), so it needs the same extended-precision handling: on i386 PHP
+ * clamps the x87 FPU to a 53-bit mantissa for the whole request, which costs
+ * pow() one or more ULP. See ext/standard/tests/math/pow_fpu_precision.phpt. */
+
+$ten = 10.0;
+$five = 5.0;
+$two = 2.0;
+
+echo "-- precision --\n";
+var_dump(fpow($ten, -2.0));
+var_dump(fpow($ten, -3.0));
+var_dump(fpow($ten, -4.0));
+var_dump(fpow($five, -2.0));
+var_dump(fpow($five, -3.0));
+var_dump(fpow($five, -4.0));
+
+echo "-- exact powers of two are unaffected --\n";
+var_dump(fpow($two, -1.0));
+var_dump(fpow($two, -10.0));
+
+echo "-- identical to the decimal literal --\n";
+var_dump(fpow($ten, -2.0) === 0.01);
+var_dump(fpow($ten, -3.0) === 0.001);
+var_dump(fpow($ten, -4.0) === 0.0001);
+var_dump(fpow($five, -2.0) === 0.04);
+var_dump(fpow($five, -3.0) === 0.008);
+var_dump(fpow($five, -4.0) === 0.0016);
+
+echo "-- matches the ** operator --\n";
+var_dump(fpow($ten, -2.0) === $ten ** -2);
+var_dump(fpow($five, -4.0) === $five ** -4);
+
+echo "-- IEEE-754 semantics are preserved --\n";
+var_dump(fpow(0.0, -1.0));
+var_dump(fpow(-0.0, -3.0));
+var_dump(fpow(1.0, NAN));
+var_dump(fpow(NAN, 0.0));
+var_dump(fpow(-1.0, INF));
+var_dump(fpow(-8.0, 1 / 3));
+?>
+--EXPECT--
+-- precision --
+float(0.01)
+float(0.001)
+float(0.0001)
+float(0.04)
+float(0.008)
+float(0.0016)
+-- exact powers of two are unaffected --
+float(0.5)
+float(0.0009765625)
+-- identical to the decimal literal --
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+-- matches the ** operator --
+bool(true)
+bool(true)
+-- IEEE-754 semantics are preserved --
+float(INF)
+float(-INF)
+float(1)
+float(1)
+float(1)
+float(NAN)

--- a/ext/standard/tests/math/pow_fpu_precision.phpt
+++ b/ext/standard/tests/math/pow_fpu_precision.phpt
@@ -1,0 +1,73 @@
+--TEST--
+pow() must not lose precision when the FPU is clamped to double precision
+--INI--
+serialize_precision=-1
+--FILE--
+<?php
+/* On i386 the x87 FPU is the platform default and zend_init_fpu() clamps it to
+ * double precision (53-bit mantissa) for the whole request. libm's pow()
+ * computes on the x87 unit and relies on the extended range to round correctly
+ * to double, so while that clamp is in place its result is off by one or more
+ * ULP.
+ *
+ * This file covers the pow() function. The same cases are covered for
+ * the ** operator in Zend/tests/pow_fpu_precision.phpt.
+ *
+ * Every expected value is exactly the correctly rounded double of its decimal
+ * literal, so a build that keeps full precision prints the short literal back
+ * and compares identical to it. */
+
+$ten = 10;
+$five = 5;
+$two = 2;
+
+echo "-- runtime --\n";
+var_dump(pow($ten, -2));
+var_dump(pow($ten, -3));
+var_dump(pow($ten, -4));
+var_dump(pow($five, -2));
+var_dump(pow($five, -3));
+var_dump(pow($five, -4));
+echo "-- compile-time constant folding --\n";
+var_dump(pow(10, -2));
+var_dump(pow(10, -3));
+var_dump(pow(10, -4));
+var_dump(pow(5, -2));
+var_dump(pow(5, -3));
+var_dump(pow(5, -4));
+echo "-- exact powers of two are unaffected --\n";
+var_dump(pow($two, -1));
+var_dump(pow($two, -10));
+echo "-- identical to the decimal literal --\n";
+var_dump(pow($ten, -2) === 0.01);
+var_dump(pow($ten, -3) === 0.001);
+var_dump(pow($ten, -4) === 0.0001);
+var_dump(pow($five, -2) === 0.04);
+var_dump(pow($five, -3) === 0.008);
+var_dump(pow($five, -4) === 0.0016);
+?>
+--EXPECT--
+-- runtime --
+float(0.01)
+float(0.001)
+float(0.0001)
+float(0.04)
+float(0.008)
+float(0.0016)
+-- compile-time constant folding --
+float(0.01)
+float(0.001)
+float(0.0001)
+float(0.04)
+float(0.008)
+float(0.0016)
+-- exact powers of two are unaffected --
+float(0.5)
+float(0.0009765625)
+-- identical to the decimal literal --
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)


### PR DESCRIPTION
### Problem

On 32-bit x86, the `**` operator, `pow()` and `fpow()` return results that are off by one or more ULP compared to every other platform:

```php
var_dump(10 ** -2);          // i386:  float(0.010000000000000002)
                             // other: float(0.01)
var_dump(5 ** -4);           // i386:  float(0.0016000000000000007)
                             // other: float(0.0016)
var_dump(fpow(10.0, -2.0));  // i386:  float(0.010000000000000002)
                             // other: float(0.01)

var_dump(10 ** -2 === 0.01); // i386: false, everywhere else: true
```

The results are not merely different, they are less accurate: measured against a high-precision reference, the i386 values are not correctly rounded while the x86-64 and arm64 ones are. This makes exponentiation silently architecture-dependent, so float comparisons against literals fail, cached or serialized values differ between machines, and the error propagates into anything built on top.

### Cause

`init_executor()` calls `zend_init_fpu()`, which clamps the x87 FPU to double precision (a 53-bit mantissa) for the whole request so that PHP's own `double` arithmetic behaves like IEEE-754 binary64 rather than carrying x87's 64-bit excess precision.

libm's `pow()`, however, computes on that same x87 unit and relies on the extended range internally in order to round correctly to `double`. While the clamp is in place it loses that headroom, so `pow()` inside PHP is less accurate than the very same libm `pow()` is outside PHP.

### Fix

`zend_pow()` in `Zend/zend_float.h` restores extended precision for the duration of the libm call and truncates the result back to `double` on return, using the XPFPA macros already in that header. Both call sites go through it:

- `safe_pow()` in `Zend/zend_operators.c`, which backs the `**` operator and `pow()`
- `PHP_FUNCTION(fpow)` in `ext/standard/math.c`, which called libm `pow()` directly and so did not benefit from a fix to `safe_pow()` alone

Wherever `XPFPA_HAVE_CW` is 0 — x86-64, arm64, and every other target without x87 precision control — `zend_pow()` compiles down to a plain `pow()` call, so no other platform is affected in behaviour or code generation.

The i386 failure is exactly the precision assertions; the reference points and the IEEE-754 cases pass in both states.

### Notes
* I came across this by my work on #19079 where some tests were failing because of these differences
* The failing result of the first phpt-only commit is visible here https://github.com/php/php-src/actions/runs/33944800861/job/101248881797?pr=23578#logs
* This PR is mostly LLM work - I manually verified
* This is the first PR - PRs for `exp`, `expm1` and `sinh` will follow