### PR TITLE
Zend: deprecate ignored case-insensitive constant argument

### DIFF
--- a/Zend/tests/builtin_functions/define_arg_3.phpt
+++ b/Zend/tests/builtin_functions/define_arg_3.phpt
@@ -18,7 +18,7 @@ var_dump(MY_CONSTANT);
 --EXPECTF--
 Deprecated: define(): Argument #3 ($case_insensitive) is ignored and treated as false since declaration of case-insensitive constants is no longer supported, passing the argument explicitly is unnecessary in %s on line %d
 
-Warning: define(): Argument #3 ($case_insensitive) is ignored since declaration of case-insensitive constants is no longer supported, this will be an error in PHP 9.0 in %s on line %d
+Deprecated: define(): Argument #3 ($case_insensitive) is ignored since declaration of case-insensitive constants is no longer supported, this will be an error in PHP 9.0 in %s on line %d
 Error: Undefined constant "MY_CONSTANT"
 
 Deprecated: define(): Argument #3 ($case_insensitive) is ignored and treated as false since declaration of case-insensitive constants is no longer supported, passing the argument explicitly is unnecessary in %s on line %d

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -583,7 +583,7 @@ ZEND_FUNCTION(define)
 	}
 
 	if (non_cs) {
-		zend_error(E_WARNING, "define(): Argument #3 ($case_insensitive) is ignored since declaration of case-insensitive constants is no longer supported, this will be an error in PHP 9.0");
+		zend_error(E_DEPRECATED, "define(): Argument #3 ($case_insensitive) is ignored since declaration of case-insensitive constants is no longer supported, this will be an error in PHP 9.0");
 		if (UNEXPECTED(EG(exception))) {
 			RETURN_THROWS();
 		}


### PR DESCRIPTION
Change the `define()` warning for the ignored `$case_insensitive` argument to `E_DEPRECATED`, as case-insensitive constants are no longer supported and the behavior will become an error in PHP 9.0.

Update the corresponding test to expect a deprecation notice instead of a warning.

ref: https://github.com/php/php-src/pull/23298
