### PR TITLE
Fix sinh() losing precision on 32-bit x86

### DIFF
--- a/Zend/zend_float.h
+++ b/Zend/zend_float.h
@@ -20,6 +20,8 @@
 
 #include "zend_portability.h"
 
+#include <math.h>
+
 BEGIN_EXTERN_C()
 
 /*
@@ -412,5 +414,22 @@ END_EXTERN_C()
 # define XPFPA_RETURN_DOUBLE_EXTENDED(val)  return (val)
 
 #endif /* FPU CONTROL */
+
+/* zend_init_fpu() clamps the x87 FPU to double precision (53-bit mantissa) for
+ * the whole request. libm's sinh() computes on the x87 unit and relies on the
+ * extended range to round correctly to double, so while that clamp is in place
+ * its result is off by one or more ULP. Restore extended precision for the call
+ * and truncate the result back to double. Compiles down to a plain sinh()
+ * everywhere XPFPA_HAVE_CW is 0, which includes x86-64 and arm64. */
+static zend_always_inline double zend_sinh(double num)
+{
+#if XPFPA_HAVE_CW
+	XPFPA_DECLARE
+	XPFPA_SWITCH_DOUBLE_EXTENDED();
+	XPFPA_RETURN_DOUBLE(sinh(num));
+#else
+	return sinh(num);
+#endif
+}
 
 #endif

--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -535,7 +535,7 @@ PHP_FUNCTION(sinh)
 	ZEND_PARSE_PARAMETERS_START(1, 1)
 		Z_PARAM_DOUBLE(num)
 	ZEND_PARSE_PARAMETERS_END();
-	RETURN_DOUBLE(sinh(num));
+	RETURN_DOUBLE(zend_sinh(num));
 }
 /* }}} */
 

--- a/ext/standard/tests/math/sinh_fpu_precision.phpt
+++ b/ext/standard/tests/math/sinh_fpu_precision.phpt
@@ -1,0 +1,48 @@
+--TEST--
+sinh(): results must not lose precision when the FPU is clamped to double precision
+--INI--
+serialize_precision=-1
+--FILE--
+<?php
+/* On i386 the x87 FPU is the platform default and zend_init_fpu() clamps it to
+ * double precision (53-bit mantissa) for the whole request. libm's sinh()
+ * computes on the x87 unit and relies on the extended range to round correctly
+ * to double, so while that clamp is in place its result is off by one or more
+ * ULP.
+ *
+ * Every expected value below is the correctly rounded double, verified against
+ * a high-precision reference and written as the shortest decimal that
+ * round-trips back to it. All arguments are exact binary fractions. */
+
+echo "-- reference points already correct on every platform --\n";
+var_dump(sinh(0));
+var_dump(sinh(1));
+var_dump(sinh(17));
+echo "-- inputs the FPU clamp gets wrong --\n";
+var_dump(sinh(3));
+var_dump(sinh(5));
+var_dump(sinh(6));
+var_dump(sinh(7));
+var_dump(sinh(8));
+var_dump(sinh(9));
+var_dump(sinh(10));
+var_dump(sinh(11));
+var_dump(sinh(13));
+var_dump(sinh(14));
+?>
+--EXPECT--
+-- reference points already correct on every platform --
+float(0)
+float(1.1752011936438014)
+float(12077476.376787629)
+-- inputs the FPU clamp gets wrong --
+float(10.017874927409903)
+float(74.20321057778875)
+float(201.71315737027922)
+float(548.3161232732465)
+float(1490.4788257895502)
+float(4051.54190208279)
+float(11013.232874703393)
+float(29937.07084924806)
+float(221206.6960033301)
+float(601302.1420819727)


### PR DESCRIPTION
### Problem

On 32-bit x86, `sinh()` returns results that are off by many ULP compared to other platforms, and that are not correctly rounded:

```php
var_dump(sinh(3));   // i386:  float(10.017874927409904)
                     // other: float(10.017874927409903)
var_dump(sinh(10));  // i386:  float(11013.232874703395)
                     // other: float(11013.232874703393)
```

Measured against (e**x - e**-x) / 2 evaluated to 80 decimal digits and rounded to nearest double, over 720 sampled inputs, the i386 result is correctly rounded in only 75 cases (10.4%).

This makes `sinh()` silently architecture-dependent, so comparisons against precomputed constants fail, cached or serialized values differ between machines, and the error propagates into anything built on `sinh()`.

### Cause

`init_executor()` calls `zend_init_fpu()`, which clamps the x87 FPU to double precision (a 53-bit mantissa) for the whole request so that PHP's own `double` arithmetic behaves like IEEE-754 binary64 rather than carrying x87's 64-bit excess precision.

libm's `sinh()`, however, computes on that same x87 unit and relies on the extended range internally in order to round correctly to `double`. While the clamp is in place it loses that headroom, so `sinh()` inside PHP is markedly less accurate than the very same libm `sinh()` is outside PHP.

### Fix

`zend_sinh()` in `Zend/zend_float.h` restores extended precision for the duration of the libm call and truncates the result back to `double` on return, using the XPFPA macros already in that header. `PHP_FUNCTION(sinh)` calls it.

Wherever `XPFPA_HAVE_CW` is 0 — x86-64, arm64, and every other target without x87 precision control — `zend_sinh()` compiles down to a plain `sinh()` call, so no other platform is affected in behaviour or code generation.

Result on i386, same 720 inputs and same reference:

| build | correctly rounded |
| --- | --- |
| i386, before | 75/720 (10.4%) |
| i386, after | 715/720 (99.3%) |

The accuracy figures are stated against a high-precision reference rather than against another platform, because for `sinh()` no mainstream platform is a correct baseline: glibc on arm64 is itself only correctly rounded for 601/720 (83.5%) of the same inputs. Comparing i386 against arm64 would therefore understate the improvement and mislabel many fixed cases as regressions — against arm64 the change looks like 534 improvements and 26 regressions, whereas against the true value it is 641 improvements and a single regression.

### Known limitations

This is a large improvement, not a guarantee. `sinh(67)` regresses by 1 ULP, because the clamped result there is genuinely the correctly rounded one. It is the only regression in the sample, and the test asserts only inputs that this change fixes.

### Tests

`ext/standard/tests/math/sinh_fpu_precision.phpt`.

All arguments are exact binary fractions and every expected value is the correctly rounded double, written as the shortest decimal that round-trips back to it. Inputs were chosen from the intersection of cases that are wrong on clamped i386, correct on i386 with this change, and correct on x86-64/arm64.

Verified locally with a full `make clean` + `./configure` + `make` per configuration, on i386 and arm64:

| | without fix | with fix |
| --- | --- | --- |
| arm64 | pass | pass |
| i386 | **fail** | pass |

### Relationship to the other XPFPA PRs

This is the same class of bug as the `pow()`/`fpow()`, `exp()` and `expm1()` fixes and adds a helper to the same part of `Zend/zend_float.h`.

### Notes
* This is the same class of bug as #23578, #23579 and #23581 fix and adds a helper to the same part of `Zend/zend_float.h`
* This PR is mostly LLM work - I manually verified
* Failing tests of phpt-only commit is visible here https://github.com/php/php-src/actions/runs/33959211724/job/101288014631
* This is the last PR in the road