### PR TITLE
sapi/phpdbg: restore the DEFAULT_SLASH check on the module path

### DIFF
--- a/sapi/phpdbg/phpdbg_prompt.c
+++ b/sapi/phpdbg/phpdbg_prompt.c
@@ -1192,7 +1192,7 @@ static const char *phpdbg_load_module_or_extension(zend_string **path, const cha
 		phpdbg_error("extension_dir ini setting contains a nul byte");
 		return NULL;
 	}
-	if (memchr(ZSTR_VAL(*path), '/', ZSTR_LEN(*path)) != NULL || memchr(ZSTR_VAL(*path), '/', ZSTR_LEN(*path)) != NULL) {
+	if (memchr(ZSTR_VAL(*path), '/', ZSTR_LEN(*path)) != NULL || memchr(ZSTR_VAL(*path), DEFAULT_SLASH, ZSTR_LEN(*path)) != NULL) {
 		/* path is fine */
 	} else if (extension_dir && ZSTR_LEN(extension_dir) > 0) {
 		zend_string *libpath;


### PR DESCRIPTION
> Before GH-21578 this guard read `strchr(*path, '/') || strchr(*path, DEFAULT_SLASH)`. The rewrite onto memchr() kept the first half and copied it into the second, so both now look for '/', and the DEFAULT_SLASH half is gone. On Windows that means `ext C:\path\php_foo.dll` is not treated as a path at all, extension_dir gets glued in front of it and the load fails. ext/standard/dl.c still has the pair intact, which is what the phpdbg code was written from. Only master carries this, 8.4 and 8.5 still have the strchr version, and I have not touched the NEWS file since nothing released is affected.

Disclosure per CONTRIBUTING: the paragraph above was drafted with an LLM (Claude Code). The finding came from a static check of my own and I read the code and the history by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
