### PR TITLE
PHP json_encode(): Check depth range before narrowing

### DIFF
--- a/ext/json/json.c
+++ b/ext/json/json.c
@@ -250,6 +250,11 @@ PHP_FUNCTION(json_encode)
 		Z_PARAM_LONG(depth)
 	ZEND_PARSE_PARAMETERS_END();
 
+	if (ZEND_LONG_EXCEEDS_INT(depth)) {
+		zend_argument_value_error(3, "must be between %d and %d", INT_MIN, INT_MAX);
+		RETURN_THROWS();
+	}
+
 	php_json_encode_init(&encoder);
 	encoder.max_depth = (int)depth;
 	php_json_encode_zval(&buf, parameter, (int)options, &encoder);

--- a/ext/json/tests/json_encode_depth.phpt
+++ b/ext/json/tests/json_encode_depth.phpt
@@ -8,12 +8,12 @@ json_encode() rejects depth values outside the encoder range
 foreach ([2147483648, -2147483649] as $depth) {
     try {
         json_encode([], depth: $depth);
-    } catch (ValueError $e) {
-        echo $e->getMessage(), "\n";
+    } catch (Throwable $e) {
+        echo $e::class, ': ', $e->getMessage(), "\n";
     }
 }
 
 ?>
 --EXPECT--
-json_encode(): Argument #3 ($depth) must be between -2147483648 and 2147483647
-json_encode(): Argument #3 ($depth) must be between -2147483648 and 2147483647
+ValueError: json_encode(): Argument #3 ($depth) must be between -2147483648 and 2147483647
+ValueError: json_encode(): Argument #3 ($depth) must be between -2147483648 and 2147483647

--- a/ext/json/tests/json_encode_depth.phpt
+++ b/ext/json/tests/json_encode_depth.phpt
@@ -1,0 +1,19 @@
+--TEST--
+json_encode() rejects depth values outside the encoder range
+--SKIPIF--
+<?php if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only"); ?>
+--FILE--
+<?php
+
+foreach ([2147483648, -2147483649] as $depth) {
+    try {
+        json_encode([], depth: $depth);
+    } catch (ValueError $e) {
+        echo $e->getMessage(), "\n";
+    }
+}
+
+?>
+--EXPECT--
+json_encode(): Argument #3 ($depth) must be between -2147483648 and 2147483647
+json_encode(): Argument #3 ($depth) must be between -2147483648 and 2147483647


### PR DESCRIPTION
`json_encode()` accepts `$depth` as a `zend_long`, but stores it directly in the encoder's `int max_depth` field.

On 64-bit builds, values outside the range of `int` were silently narrowed before encoding. This could produce platform-dependent behavior.

Check the value with `ZEND_LONG_EXCEEDS_INT()` before assigning it to `encoder.max_depth`, and throw a `ValueError` when it cannot be represented as an `int`.

Values within the existing range, including `depth == 0` and negative values, retain their current behavior.

The regression test covers values above `INT_MAX` and below `INT_MIN`.