### PR TITLE
Exclude zend_gdb.c from code coverage

### DIFF
--- a/gcovr.cfg
+++ b/gcovr.cfg
@@ -15,6 +15,7 @@ exclude = ext/pcre/pcre2lib/.*
 exclude = ext/uri/uriparser/.*
 exclude = Zend/Optimizer/ssa_integrity\.c
 exclude = Zend/Optimizer/zend_dump\.c
+exclude = Zend/zend_gdb\.c
 
 # These patterns have implicit ^/$ anchors.
 exclude-lines-by-pattern = .*\b(ZEND_PARSE_PARAMETERS_(START|END|NONE)|Z_PARAM_).*


### PR DESCRIPTION
zend_gdb.c only wires up GDB debugging helpers, so covering it in code coverage reports doesn't add value.

Fixes #23591