### PR TITLE
iconv: keep working converter when stream filter seek reset fails

### DIFF
--- a/ext/iconv/iconv.c
+++ b/ext/iconv/iconv.c
@@ -2595,20 +2595,20 @@ static zend_result php_iconv_stream_filter_seek(
 		int whence)
 {
 	php_iconv_stream_filter *self = (php_iconv_stream_filter *)Z_PTR(filter->abstract);
+	iconv_t cd;
 
 	/* Reset stub buffer */
 	self->stub_len = 0;
 
-	/* Reset iconv conversion state by closing and reopening the converter */
-	iconv_close(self->cd);
-
-	self->cd = iconv_open(self->to_charset, self->from_charset);
-	if ((iconv_t)-1 == self->cd) {
+	cd = iconv_open(self->to_charset, self->from_charset);
+	if ((iconv_t)-1 == cd) {
 		php_error_docref(NULL, E_WARNING,
 				"iconv stream filter (\"%s\"=>\"%s\"): failed to reset conversion state",
 				self->from_charset, self->to_charset);
 		return FAILURE;
 	}
+	iconv_close(self->cd);
+	self->cd = cd;
 
 	return SUCCESS;
 }


### PR DESCRIPTION
`php_iconv_stream_filter_seek()` closed the filter's converter before knowing whether a replacement could be opened, then assigned the failed `iconv_open()` result. That left self->cd as (iconv_t)-1 for every subsequent read and write, and the filter dtor then called iconv_close() on it. Opening the replacement first and swapping it in only on success keeps the working converter on failure.

No test: the charsets are fixed when the filter is created and already validated by the iconv_open() there, so a second open of the same pair can only fail on OOM. There is no userland input that reaches the branch.
