### PR TITLE
TSRM: roll back id_count when the resource type table cannot grow

### DIFF
--- a/TSRM/TSRM.c
+++ b/TSRM/TSRM.c
@@ -305,6 +305,7 @@ TSRM_API ts_rsrc_id ts_allocate_id(ts_rsrc_id *rsrc_id, size_t size, ts_allocate
 		_tmp = (tsrm_resource_type *) realloc(resource_types_table, sizeof(tsrm_resource_type)*id_count);
 		if (!_tmp) {
 			TSRM_ERROR((TSRM_ERROR_LEVEL_ERROR, "Unable to allocate storage for resource"));
+			id_count--;
 			*rsrc_id = 0;
 			tsrm_mutex_unlock(tsmm_mutex);
 			return 0;
@@ -384,6 +385,7 @@ TSRM_API ts_rsrc_id ts_allocate_fast_id_at(ts_rsrc_id *rsrc_id, size_t *offset, 
 		_tmp = (tsrm_resource_type *) realloc(resource_types_table, sizeof(tsrm_resource_type)*id_count);
 		if (!_tmp) {
 			TSRM_ERROR((TSRM_ERROR_LEVEL_ERROR, "Unable to allocate storage for resource"));
+			id_count--;
 			*rsrc_id = 0;
 			tsrm_mutex_unlock(tsmm_mutex);
 			return 0;
@@ -419,6 +421,7 @@ TSRM_API ts_rsrc_id ts_allocate_tls_id(ts_rsrc_id *rsrc_id, void *(*tls_addr)(vo
 		_tmp = (tsrm_resource_type *) realloc(resource_types_table, sizeof(tsrm_resource_type)*id_count);
 		if (!_tmp) {
 			TSRM_ERROR((TSRM_ERROR_LEVEL_ERROR, "Unable to allocate storage for resource"));
+			id_count--;
 			*rsrc_id = 0;
 			tsrm_mutex_unlock(tsmm_mutex);
 			return 0;


### PR DESCRIPTION
`ts_allocate_id()`, `ts_allocate_fast_id_at()` and `ts_allocate_tls_id()` each do `id_count++` before growing `resource_types_table`. If the realloc fails they return 0 with id_count still counting the new slot, so resource_types_table_size < id_count from then on and `allocate_new_resource()` walks j < id_count over an entry that was never initialized.

This targets master rather than a stable branch because it is unreachable without an allocation failure, and TSRM.c has diverged. The PHP-8.4 shape has only two increment sites and puts one of them in `ts_allocate_fast_id()`, which on master no longer increments at all, so the same diff would be wrong there. No test: the branch needs a failing realloc during ZTS startup, which has no userland surface. Verified against a `--enable-zts` build.
