### PR TITLE
dom: report the DOMXPath callback node list to the cycle collector

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -21,6 +21,9 @@ PHP                                                                        NEWS
     the null namespace in spec-following mode. (Ilia Alshanetsky)
   . Fixed stale getElementsByClassName() and other node list caches after
     className/classList writes and attribute removals. (Ilia Alshanetsky)
+  . Fixed reference cycles through DOMXPath and XSLTProcessor php:function
+    callback arguments and return values not being collectable.
+    (Ilia Alshanetsky)
 
 - Hash:
   . Fixed hash_file() reporting argument #1 ($algo) instead of argument #2

--- a/ext/dom/tests/DOMXPath_callback_node_list_gc.phpt
+++ b/ext/dom/tests/DOMXPath_callback_node_list_gc.phpt
@@ -1,0 +1,28 @@
+--TEST--
+DOMXPath callback node list is reported to the cycle collector
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$doc = new DOMDocument();
+$doc->loadXML('<r><a/></r>');
+$xp = new DOMXPath($doc);
+$xp->registerNamespace('php', 'http://php.net/xpath');
+$xp->registerPhpFunctions();
+
+function cb($n) {
+    @$n[0]->back = $GLOBALS['the_xp'];
+    return true;
+}
+
+$GLOBALS['the_xp'] = $xp;
+$wr = WeakReference::create($xp);
+$xp->query('/r/a[php:function("cb", .)]');
+
+unset($xp, $GLOBALS['the_xp']);
+gc_collect_cycles();
+
+var_dump($wr->get() === null);
+?>
+--EXPECT--
+bool(true)

--- a/ext/dom/xpath_callbacks.c
+++ b/ext/dom/xpath_callbacks.c
@@ -53,9 +53,10 @@ PHP_DOM_EXPORT void php_dom_xpath_callbacks_ctor(php_dom_xpath_callbacks *regist
 PHP_DOM_EXPORT void php_dom_xpath_callbacks_clean_node_list(php_dom_xpath_callbacks *registry)
 {
 	if (registry->node_list) {
-		zend_hash_destroy(registry->node_list);
-		FREE_HASHTABLE(registry->node_list);
+		HashTable *node_list = registry->node_list;
 		registry->node_list = NULL;
+		zend_hash_destroy(node_list);
+		FREE_HASHTABLE(node_list);
 	}
 }
 
@@ -100,6 +101,12 @@ static void php_dom_xpath_callback_ns_get_gc(php_dom_xpath_callback_ns *ns, zend
 
 PHP_DOM_EXPORT void php_dom_xpath_callbacks_get_gc(php_dom_xpath_callbacks *registry, zend_get_gc_buffer *gc_buffer)
 {
+	if (registry->node_list) {
+		zval *entry;
+		ZEND_HASH_FOREACH_VAL(registry->node_list, entry) {
+			zend_get_gc_buffer_add_zval(gc_buffer, entry);
+		} ZEND_HASH_FOREACH_END();
+	}
 	if (registry->php_ns) {
 		php_dom_xpath_callback_ns_get_gc(registry->php_ns, gc_buffer);
 	}
@@ -113,7 +120,7 @@ PHP_DOM_EXPORT void php_dom_xpath_callbacks_get_gc(php_dom_xpath_callbacks *regi
 
 PHP_DOM_EXPORT HashTable *php_dom_xpath_callbacks_get_gc_for_whole_object(php_dom_xpath_callbacks *registry, zend_object *object, zval **table, int *n)
 {
-	if (registry->php_ns || registry->namespaces) {
+	if (registry->php_ns || registry->namespaces || registry->node_list) {
 		zend_get_gc_buffer *gc_buffer = zend_get_gc_buffer_create();
 		php_dom_xpath_callbacks_get_gc(registry, gc_buffer);
 		zend_get_gc_buffer_use(gc_buffer, table, n);

--- a/ext/xsl/tests/xsltprocessor_callback_node_list_gc.phpt
+++ b/ext/xsl/tests/xsltprocessor_callback_node_list_gc.phpt
@@ -1,0 +1,50 @@
+--TEST--
+XSLTProcessor callback node list is reported to the cycle collector
+--EXTENSIONS--
+dom
+xsl
+--FILE--
+<?php
+$xml = new DOMDocument();
+$xml->loadXML('<root><a/></root>');
+
+$xsl = new DOMDocument();
+$xsl->loadXML(<<<XSL
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:php="http://php.net/xsl">
+<xsl:template match="/"><out><xsl:value-of select="php:function('hold', /root/a)"/><xsl:value-of select="php:function('pause')"/></out></xsl:template>
+</xsl:stylesheet>
+XSL);
+
+function hold(array $nodes): string {
+    @$nodes[0]->fiber = $GLOBALS['fiber'];
+    return 'h';
+}
+
+function pause(): string {
+    Fiber::suspend();
+    return 'p';
+}
+
+$proc = new XSLTProcessor();
+$proc->registerPHPFunctions();
+$proc->importStylesheet($xsl);
+$wr = WeakReference::create($proc);
+
+/* Suspending inside a callback leaves the transform without reaching the
+   node list cleanup, so the list still holds the node that owns the fiber. */
+$fiber = new Fiber(static function () use ($proc, $xml) {
+    $proc->transformToXml($xml);
+});
+$GLOBALS['fiber'] = $fiber;
+$fiber->start();
+
+var_dump($fiber->isSuspended());
+
+unset($proc, $fiber, $GLOBALS['fiber'], $xml, $xsl);
+gc_collect_cycles();
+
+var_dump($wr->get() === null);
+?>
+--EXPECT--
+bool(true)
+bool(true)

--- a/ext/xsl/tests/xsltprocessor_callback_node_list_gc_teardown.phpt
+++ b/ext/xsl/tests/xsltprocessor_callback_node_list_gc_teardown.phpt
@@ -1,0 +1,50 @@
+--TEST--
+XSLTProcessor: cycle collection triggered while the php:function node list is torn down
+--EXTENSIONS--
+dom
+xsl
+--FILE--
+<?php
+class GcElement extends DOMElement
+{
+    private static int $destroyed = 0;
+
+    public function __destruct()
+    {
+        /* Collect once the node list teardown has already freed some entries. */
+        if (++self::$destroyed === 3) {
+            gc_collect_cycles();
+        }
+    }
+}
+
+$xml = new DOMDocument();
+$xml->loadXML('<root><a/><b/><c/><d/><e/><f/><g/><h/></root>');
+$xml->registerNodeClass(DOMElement::class, GcElement::class);
+
+$xsl = new DOMDocument();
+$xsl->loadXML(<<<XSL
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:php="http://php.net/xsl">
+<xsl:template match="/"><out><xsl:for-each select="/root/*"><xsl:value-of select="php:function('cb', .)"/></xsl:for-each></out></xsl:template>
+</xsl:stylesheet>
+XSL);
+
+function cb(array $nodes): string
+{
+    return $nodes[0]->nodeName;
+}
+
+$proc = new XSLTProcessor();
+$proc->registerPHPFunctions();
+$proc->importStylesheet($xsl);
+
+$root_buffer = $proc;
+unset($root_buffer);
+
+echo $proc->transformToXml($xml);
+echo 'done', PHP_EOL;
+?>
+--EXPECT--
+<?xml version="1.0"?>
+<out xmlns:php="http://php.net/xsl">abcdefgh</out>
+done


### PR DESCRIPTION
`php_dom_xpath_callbacks_get_gc()` traced `php_ns` and `namespaces` but not `node_list`, which holds the nodes passed to and returned from `php:function` callbacks. A cycle from a `DOMXPath` through node_list to a node and back to the same DOMXPath was invisible to the collector, so it was never freed.

node_list is still cleared at object destruction rather than at the end of each evaluation. Clearing it eagerly is not safe, because a callback can run a nested `query()`/`evaluate()` on the same object and the inner call would free wrappers the outer evaluation is still using.
