### PR TITLE
session: close save handler before re-initializing an active session

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,10 @@ PHP                                                                        NEWS
     registrations are freed while still reachable from the cycle collector.
     (Ilia Alshanetsky)
 
+- Session:
+  . Fixed calling SessionHandler::open() twice without an intervening
+    close() when re-initializing an active session. (Ilia Alshanetsky)
+
 
 10 Sep 2026, PHP 8.6.0beta3
 

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -1804,7 +1804,13 @@ static bool php_session_abort(void)
 
 static bool php_session_reset(void)
 {
-	return PS(session_status) == php_session_active && php_session_initialize() == SUCCESS;
+	if (PS(session_status) != php_session_active) {
+		return false;
+	}
+
+	php_session_abort();
+
+	return php_session_initialize() == SUCCESS;
 }
 
 

--- a/ext/session/tests/session_reset_handler_close.phpt
+++ b/ext/session/tests/session_reset_handler_close.phpt
@@ -1,0 +1,74 @@
+--TEST--
+Session reset closes the save handler before reopening it
+--EXTENSIONS--
+session
+--INI--
+session.use_cookies=0
+session.gc_probability=0
+--FILE--
+<?php
+
+class LoggingHandler implements SessionHandlerInterface, SessionIdInterface, SessionUpdateTimestampHandlerInterface
+{
+    public function open(string $path, string $name): bool
+    {
+        $GLOBALS['calls'][] = 'open';
+        return true;
+    }
+    public function close(): bool
+    {
+        $GLOBALS['calls'][] = 'close';
+        return true;
+    }
+    public function read(string $id): string|false
+    {
+        $GLOBALS['calls'][] = 'read';
+        return '';
+    }
+    public function write(string $id, string $data): bool
+    {
+        $GLOBALS['calls'][] = 'write';
+        return true;
+    }
+    public function destroy(string $id): bool
+    {
+        $GLOBALS['calls'][] = 'destroy';
+        return true;
+    }
+    public function gc(int $max_lifetime): int|false
+    {
+        $GLOBALS['calls'][] = 'gc';
+        return 0;
+    }
+    public function create_sid(): string
+    {
+        return 'testsessionid';
+    }
+    public function validateId(string $id): bool
+    {
+        return true;
+    }
+    public function updateTimestamp(string $id, string $data): bool
+    {
+        return true;
+    }
+}
+
+$GLOBALS['calls'] = [];
+session_set_save_handler(new LoggingHandler(), true);
+var_dump(session_start());
+var_dump(session_reset());
+print_r($GLOBALS['calls']);
+
+?>
+--EXPECT--
+bool(true)
+bool(true)
+Array
+(
+    [0] => open
+    [1] => read
+    [2] => close
+    [3] => open
+    [4] => read
+)


### PR DESCRIPTION
`php_session_initialize()` set the status to active and called the save handler's `open()` and `read()` without first closing a session that was already active, so `session_reset()` on an open session issued a second open() with no intervening close(). Aborting the active session first pairs every open() with a close().

The test asserts the handler's own call log, which is `open, read, open, read` before the change and `open, read, close, open, read` after.
