### PR TITLE
simplexml: filter addChild() result by the created element's namespace

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -114,6 +114,9 @@ PHP                                                                        NEWS
 - SimpleXML:
   . Fixed writing to a dimension of the object returned by attributes() not
     creating the attribute. (Ilia Alshanetsky)
+  . Fixed child elements of the element returned by
+    SimpleXMLElement::addChild() not being accessible by property name when
+    namespaces are involved. (Ilia Alshanetsky)
 
 - Zip:
   . Fixed bug GH-23276 (ZipArchive subclass storing its own stream cannot be

--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -1679,6 +1679,7 @@ PHP_METHOD(SimpleXMLElement, addChild)
 	xmlNodePtr      node, newnode;
 	xmlNsPtr        nsptr = NULL;
 	xmlChar        *localname, *prefix = NULL;
+	const xmlChar  *retprefix = NULL;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|s!s!",
 		&qname, &qname_len, &value, &value_len, &nsuri, &nsuri_len) == FAILURE) {
@@ -1727,7 +1728,11 @@ PHP_METHOD(SimpleXMLElement, addChild)
 		}
 	}
 
-	node_as_zval_str(sxe, newnode, return_value, SXE_ITER_NONE, localname, prefix, 0);
+	if ((prefix != NULL || nsuri != NULL) && newnode->ns != NULL) {
+		retprefix = newnode->ns->prefix;
+	}
+
+	node_as_zval_str(sxe, newnode, return_value, SXE_ITER_NONE, localname, retprefix, 1);
 
 	xmlFree(localname);
 	if (prefix != NULL) {

--- a/ext/simplexml/tests/addChild_ns_filter_returned_element.phpt
+++ b/ext/simplexml/tests/addChild_ns_filter_returned_element.phpt
@@ -1,0 +1,56 @@
+--TEST--
+SimpleXMLElement::addChild() wrong namespace filter on returned element
+--EXTENSIONS--
+simplexml
+--FILE--
+<?php
+$x = new SimpleXMLElement('<r xmlns:a="http://example.com"/>');
+$c = $x->addChild('a:kid', null, 'http://example.com');
+$c->addChild('inner', 'v');
+echo trim($x->asXML()), "\n";
+echo (string) $c->inner, "\n";
+var_dump(isset($c->inner));
+
+$y = new SimpleXMLElement('<r xmlns:a="http://example.com"/>');
+$d = $y->addChild('kid', null, 'http://example.com');
+$d->addChild('inner', 'w');
+echo trim($y->asXML()), "\n";
+echo (string) $d->inner, "\n";
+
+$z = new SimpleXMLElement('<r/>');
+$e = $z->addChild('a:kid');
+$e->addChild('inner', 'z');
+echo trim($z->asXML()), "\n";
+echo (string) $e->inner, "\n";
+var_dump(isset($e->inner));
+
+$q = new SimpleXMLElement('<p:r xmlns:p="http://example.com/p"/>');
+$f = $q->addChild('kid');
+$f->addAttribute('id', '7');
+echo trim($q->asXML()), "\n";
+echo (string) $f['id'], "\n";
+
+$m = new SimpleXMLElement('<r xmlns:a="http://example.com"/>');
+$g = $m->addChild('kid', null, 'http://example.com');
+$g->addAttribute('id', '8');
+echo trim($m->asXML()), "\n";
+var_dump(isset($g['id']));
+?>
+--EXPECT--
+<?xml version="1.0"?>
+<r xmlns:a="http://example.com"><a:kid><a:inner>v</a:inner></a:kid></r>
+v
+bool(true)
+<?xml version="1.0"?>
+<r xmlns:a="http://example.com"><a:kid><a:inner>w</a:inner></a:kid></r>
+w
+<?xml version="1.0"?>
+<r><kid><inner>z</inner></kid></r>
+z
+bool(true)
+<?xml version="1.0"?>
+<p:r xmlns:p="http://example.com/p"><p:kid id="7"/></p:r>
+7
+<?xml version="1.0"?>
+<r xmlns:a="http://example.com"><a:kid id="8"/></r>
+bool(false)


### PR DESCRIPTION
`SimpleXMLElement::addChild()` built the returned element with the prefix the caller passed in rather than the one the new node ended up in, so a child added through that returned object was filtered against the wrong namespace and could not be reached by property name. Taking the prefix from `newnode->ns` fixes all three cases: an explicit `a:kid` with a matching uri, a bare `kid` with a uri, and a bare `kid` under a prefixed parent where `xmlNewChild` inherits the parent's prefix.

The filter keys on the prefix rather than the href deliberately. `node_as_zval()` installs no filter at all when the prefix is null or empty, so switching to href matching would start filtering the default-namespace case that currently has none.
