### PR TITLE
perf: avoid floating-point formatting in microtime

### DIFF
--- a/ext/standard/microtime.c
+++ b/ext/standard/microtime.c
@@ -75,7 +75,7 @@ static void _php_gettimeofday(INTERNAL_FUNCTION_PARAMETERS, int mode)
 
 		timelib_time_offset_dtor(offset);
 	} else {
-		RETURN_NEW_STR(zend_strpprintf(0, "%.8F %ld", tp.tv_usec / MICRO_IN_SEC, (long)tp.tv_sec));
+		RETURN_NEW_STR(zend_strpprintf(0, "0.%06ld00 %ld", (long)tp.tv_usec, (long)tp.tv_sec));
 	}
 }
 


### PR DESCRIPTION
Convert to long instead of double and save the division. Extra gain because `zend_strpprintf()` takes the cheaper integer formatting path instead of having to call `zend_dtoa()`.

This isn't a bug fix so I guess it should target master? @devnexen 