### PR TITLE
[skip ci] Add more rejected examples in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,6 +36,13 @@ are not limited to):
 
 - Malicious `unserialize()` inputs.
 
+- Memory exhaustion from a size the input declares, where `memory_limit`
+  refuses the allocation and only the current request dies.
+
+When creating reports, please **skip** the theatrics. Drop the impact essay,
+send a short reproducer with the few lines that matter, and make each point
+once. This allows us to triage and respond to your report quickly.
+
 # Vulnerability Policy
 
 Our full policy is described at


### PR DESCRIPTION
Some teach backs from the last couple months of advisories triage. We hope that it'll help improve LLM generated reports we get (safe to say _all_ the reports we get) and mitigate a lot of false positives.