### PR TITLE
Feature: Implement Prototype.js DOM traversal methods (GH-23575)

### DIFF
--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -2013,6 +2013,120 @@ PHP_METHOD(Dom_Element, matches)
 	dom_element_matches(thisp, intern, return_value, selectors_str);
 }
 
+
+PHP_METHOD(Dom_Element, up)
+{
+	zend_string *selectors_str = NULL;
+	zend_long index = 0;
+
+	ZEND_PARSE_PARAMETERS_START(0, 2)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_STR_OR_NULL(selectors_str)
+		Z_PARAM_LONG(index)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (index < 0) {
+		zend_argument_value_error(2, "must be greater than or equal to 0");
+		RETURN_THROWS();
+	}
+
+	xmlNodePtr thisp;
+	dom_object *intern;
+	zval *id;
+	DOM_GET_OBJ(thisp, id, xmlNodePtr, intern);
+
+	dom_element_up(thisp, intern, return_value, selectors_str, index);
+}
+
+PHP_METHOD(Dom_Element, down)
+{
+	zend_string *selectors_str = NULL;
+	zend_long index = 0;
+
+	ZEND_PARSE_PARAMETERS_START(0, 2)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_STR_OR_NULL(selectors_str)
+		Z_PARAM_LONG(index)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (index < 0) {
+		zend_argument_value_error(2, "must be greater than or equal to 0");
+		RETURN_THROWS();
+	}
+
+	xmlNodePtr thisp;
+	dom_object *intern;
+	zval *id;
+	DOM_GET_OBJ(thisp, id, xmlNodePtr, intern);
+
+	dom_element_down(thisp, intern, return_value, selectors_str, index);
+}
+
+PHP_METHOD(Dom_Element, next)
+{
+	zend_string *selectors_str = NULL;
+	zend_long index = 0;
+
+	ZEND_PARSE_PARAMETERS_START(0, 2)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_STR_OR_NULL(selectors_str)
+		Z_PARAM_LONG(index)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (index < 0) {
+		zend_argument_value_error(2, "must be greater than or equal to 0");
+		RETURN_THROWS();
+	}
+
+	xmlNodePtr thisp;
+	dom_object *intern;
+	zval *id;
+	DOM_GET_OBJ(thisp, id, xmlNodePtr, intern);
+
+	dom_element_next(thisp, intern, return_value, selectors_str, index);
+}
+
+PHP_METHOD(Dom_Element, previous)
+{
+	zend_string *selectors_str = NULL;
+	zend_long index = 0;
+
+	ZEND_PARSE_PARAMETERS_START(0, 2)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_STR_OR_NULL(selectors_str)
+		Z_PARAM_LONG(index)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (index < 0) {
+		zend_argument_value_error(2, "must be greater than or equal to 0");
+		RETURN_THROWS();
+	}
+
+	xmlNodePtr thisp;
+	dom_object *intern;
+	zval *id;
+	DOM_GET_OBJ(thisp, id, xmlNodePtr, intern);
+
+	dom_element_previous(thisp, intern, return_value, selectors_str, index);
+}
+
+PHP_METHOD(Dom_Element, siblings)
+{
+	zend_string *selectors_str = NULL;
+
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_STR_OR_NULL(selectors_str)
+	ZEND_PARSE_PARAMETERS_END();
+
+	xmlNodePtr thisp;
+	dom_object *intern;
+	zval *id;
+	DOM_GET_OBJ(thisp, id, xmlNodePtr, intern);
+
+	dom_element_siblings(thisp, intern, return_value, selectors_str);
+}
+
 PHP_METHOD(Dom_Element, closest)
 {
 	zend_string *selectors_str;

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -2033,7 +2033,7 @@ PHP_METHOD(Dom_Element, up)
 	xmlNodePtr thisp;
 	dom_object *intern;
 	zval *id;
-	DOM_GET_OBJ(thisp, id, xmlNodePtr, intern);
+	DOM_GET_THIS_OBJ(thisp, id, xmlNodePtr, intern);
 
 	dom_element_up(thisp, intern, return_value, selectors_str, index);
 }
@@ -2057,7 +2057,7 @@ PHP_METHOD(Dom_Element, down)
 	xmlNodePtr thisp;
 	dom_object *intern;
 	zval *id;
-	DOM_GET_OBJ(thisp, id, xmlNodePtr, intern);
+	DOM_GET_THIS_OBJ(thisp, id, xmlNodePtr, intern);
 
 	dom_element_down(thisp, intern, return_value, selectors_str, index);
 }
@@ -2081,7 +2081,7 @@ PHP_METHOD(Dom_Element, next)
 	xmlNodePtr thisp;
 	dom_object *intern;
 	zval *id;
-	DOM_GET_OBJ(thisp, id, xmlNodePtr, intern);
+	DOM_GET_THIS_OBJ(thisp, id, xmlNodePtr, intern);
 
 	dom_element_next(thisp, intern, return_value, selectors_str, index);
 }
@@ -2105,7 +2105,7 @@ PHP_METHOD(Dom_Element, previous)
 	xmlNodePtr thisp;
 	dom_object *intern;
 	zval *id;
-	DOM_GET_OBJ(thisp, id, xmlNodePtr, intern);
+	DOM_GET_THIS_OBJ(thisp, id, xmlNodePtr, intern);
 
 	dom_element_previous(thisp, intern, return_value, selectors_str, index);
 }
@@ -2122,7 +2122,7 @@ PHP_METHOD(Dom_Element, siblings)
 	xmlNodePtr thisp;
 	dom_object *intern;
 	zval *id;
-	DOM_GET_OBJ(thisp, id, xmlNodePtr, intern);
+	DOM_GET_THIS_OBJ(thisp, id, xmlNodePtr, intern);
 
 	dom_element_siblings(thisp, intern, return_value, selectors_str);
 }

--- a/ext/dom/parentnode/css_selectors.c
+++ b/ext/dom/parentnode/css_selectors.c
@@ -14,6 +14,239 @@
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
+
+/* Prototype-like DOM Traversal Methods */
+
+void dom_element_up(xmlNodePtr thisp, dom_object *intern, zval *return_value, const zend_string *selectors_str, zend_long index)
+{
+	const xmlNode *current = thisp->parent;
+	zend_long current_index = 0;
+
+	if (selectors_str == NULL) {
+		while (current != NULL) {
+			if (current->type == XML_ELEMENT_NODE) {
+				if (current_index == index) {
+					DOM_RET_OBJ((xmlNodePtr) current, intern);
+					return;
+				}
+				current_index++;
+			}
+			current = current->parent;
+		}
+		RETURN_NULL();
+	}
+
+	lxb_css_parser_t parser;
+	lxb_selectors_t selectors;
+	lxb_css_selector_list_t *list = dom_parse_selector(&parser, &selectors, selectors_str, LXB_SELECTORS_OPT_MATCH_FIRST, intern);
+	
+	if (EXPECTED(list != NULL)) {
+		while (current != NULL) {
+			if (current->type == XML_ELEMENT_NODE) {
+				dom_query_selector_matches_ctx ctx = { current, false };
+				lxb_status_t status = lxb_selectors_match_node(&selectors, current, list, dom_query_selector_find_matches_callback, &ctx);
+				status = dom_check_css_execution_status(status);
+				if (UNEXPECTED(status != LXB_STATUS_OK)) {
+					break;
+				}
+				if (ctx.result) {
+					if (current_index == index) {
+						DOM_RET_OBJ((xmlNodePtr) current, intern);
+						break;
+					}
+					current_index++;
+				}
+			}
+			current = current->parent;
+		}
+	}
+
+	dom_selector_cleanup(&parser, &selectors, list);
+}
+
+typedef struct {
+    xmlNodePtr result;
+    zend_long target_index;
+    zend_long current_index;
+} dom_query_down_ctx;
+
+static lxb_status_t dom_query_down_callback(const xmlNode *node, lxb_css_selector_specificity_t spec, void *ctx)
+{
+    dom_query_down_ctx *qctx = (dom_query_down_ctx *) ctx;
+    if (qctx->current_index == qctx->target_index) {
+        qctx->result = (xmlNodePtr) node;
+        return LXB_STATUS_STOP;
+    }
+    qctx->current_index++;
+    return LXB_STATUS_OK;
+}
+
+void dom_element_down(xmlNodePtr thisp, dom_object *intern, zval *return_value, const zend_string *selectors_str, zend_long index)
+{
+	dom_query_down_ctx ctx = { NULL, index, 0 };
+
+	if (selectors_str == NULL) {
+		/* Fast path for all elements: use universal selector */
+		zend_string *univ = zend_string_init("*", 1, 0);
+		dom_query_selector_common(thisp, intern, univ, dom_query_down_callback, &ctx, LXB_SELECTORS_OPT_DEFAULT);
+		zend_string_release(univ);
+	} else {
+		dom_query_selector_common(thisp, intern, selectors_str, dom_query_down_callback, &ctx, LXB_SELECTORS_OPT_DEFAULT);
+	}
+
+	if (ctx.result != NULL) {
+		DOM_RET_OBJ(ctx.result, intern);
+	} else {
+		RETURN_NULL();
+	}
+}
+
+void dom_element_next(xmlNodePtr thisp, dom_object *intern, zval *return_value, const zend_string *selectors_str, zend_long index)
+{
+	const xmlNode *current = thisp->next;
+	zend_long current_index = 0;
+
+	if (selectors_str == NULL) {
+		while (current != NULL) {
+			if (current->type == XML_ELEMENT_NODE) {
+				if (current_index == index) {
+					DOM_RET_OBJ((xmlNodePtr) current, intern);
+					return;
+				}
+				current_index++;
+			}
+			current = current->next;
+		}
+		RETURN_NULL();
+	}
+
+	lxb_css_parser_t parser;
+	lxb_selectors_t selectors;
+	lxb_css_selector_list_t *list = dom_parse_selector(&parser, &selectors, selectors_str, LXB_SELECTORS_OPT_MATCH_FIRST, intern);
+	
+	if (EXPECTED(list != NULL)) {
+		while (current != NULL) {
+			if (current->type == XML_ELEMENT_NODE) {
+				dom_query_selector_matches_ctx ctx = { current, false };
+				lxb_status_t status = lxb_selectors_match_node(&selectors, current, list, dom_query_selector_find_matches_callback, &ctx);
+				status = dom_check_css_execution_status(status);
+				if (UNEXPECTED(status != LXB_STATUS_OK)) {
+					break;
+				}
+				if (ctx.result) {
+					if (current_index == index) {
+						DOM_RET_OBJ((xmlNodePtr) current, intern);
+						break;
+					}
+					current_index++;
+				}
+			}
+			current = current->next;
+		}
+	}
+
+	dom_selector_cleanup(&parser, &selectors, list);
+}
+
+void dom_element_previous(xmlNodePtr thisp, dom_object *intern, zval *return_value, const zend_string *selectors_str, zend_long index)
+{
+	const xmlNode *current = thisp->prev;
+	zend_long current_index = 0;
+
+	if (selectors_str == NULL) {
+		while (current != NULL) {
+			if (current->type == XML_ELEMENT_NODE) {
+				if (current_index == index) {
+					DOM_RET_OBJ((xmlNodePtr) current, intern);
+					return;
+				}
+				current_index++;
+			}
+			current = current->prev;
+		}
+		RETURN_NULL();
+	}
+
+	lxb_css_parser_t parser;
+	lxb_selectors_t selectors;
+	lxb_css_selector_list_t *list = dom_parse_selector(&parser, &selectors, selectors_str, LXB_SELECTORS_OPT_MATCH_FIRST, intern);
+	
+	if (EXPECTED(list != NULL)) {
+		while (current != NULL) {
+			if (current->type == XML_ELEMENT_NODE) {
+				dom_query_selector_matches_ctx ctx = { current, false };
+				lxb_status_t status = lxb_selectors_match_node(&selectors, current, list, dom_query_selector_find_matches_callback, &ctx);
+				status = dom_check_css_execution_status(status);
+				if (UNEXPECTED(status != LXB_STATUS_OK)) {
+					break;
+				}
+				if (ctx.result) {
+					if (current_index == index) {
+						DOM_RET_OBJ((xmlNodePtr) current, intern);
+						break;
+					}
+					current_index++;
+				}
+			}
+			current = current->prev;
+		}
+	}
+
+	dom_selector_cleanup(&parser, &selectors, list);
+}
+
+void dom_element_siblings(xmlNodePtr thisp, dom_object *intern, zval *return_value, const zend_string *selectors_str)
+{
+	HashTable *list = zend_new_array(0);
+	const xmlNode *parent = thisp->parent;
+	
+	if (parent != NULL) {
+		const xmlNode *current = parent->children;
+
+		if (selectors_str == NULL) {
+			while (current != NULL) {
+				if (current->type == XML_ELEMENT_NODE && current != thisp) {
+					zval zv;
+					php_dom_create_object((xmlNodePtr) current, &zv, intern);
+					zend_hash_next_index_insert(list, &zv);
+				}
+				current = current->next;
+			}
+		} else {
+			lxb_css_parser_t parser;
+			lxb_selectors_t selectors;
+			lxb_css_selector_list_t *list_lxb = dom_parse_selector(&parser, &selectors, selectors_str, LXB_SELECTORS_OPT_MATCH_FIRST, intern);
+			
+			if (EXPECTED(list_lxb != NULL)) {
+				while (current != NULL) {
+					if (current->type == XML_ELEMENT_NODE && current != thisp) {
+						dom_query_selector_matches_ctx ctx = { current, false };
+						lxb_status_t status = lxb_selectors_match_node(&selectors, current, list_lxb, dom_query_selector_find_matches_callback, &ctx);
+						status = dom_check_css_execution_status(status);
+						if (UNEXPECTED(status != LXB_STATUS_OK)) {
+							break;
+						}
+						if (ctx.result) {
+							zval zv;
+							php_dom_create_object((xmlNodePtr) current, &zv, intern);
+							zend_hash_next_index_insert(list, &zv);
+						}
+					}
+					current = current->next;
+				}
+			}
+			dom_selector_cleanup(&parser, &selectors, list_lxb);
+		}
+	}
+
+	object_init_ex(return_value, dom_modern_nodelist_class_entry);
+	dom_object *ret_obj = Z_DOMOBJ_P(return_value);
+	dom_nnodemap_object *mapptr = (dom_nnodemap_object *) ret_obj->ptr;
+	mapptr->array = list;
+	mapptr->release_array = true;
+	mapptr->handler = &php_dom_obj_map_nodeset;
+}
+
 #endif
 
 #include "php.h"
@@ -277,6 +510,239 @@ void dom_element_closest(xmlNodePtr thisp, dom_object *intern, zval *return_valu
 	if (EXPECTED(result != NULL)) {
 		DOM_RET_OBJ((xmlNodePtr) result, intern);
 	}
+}
+
+
+/* Prototype-like DOM Traversal Methods */
+
+void dom_element_up(xmlNodePtr thisp, dom_object *intern, zval *return_value, const zend_string *selectors_str, zend_long index)
+{
+	const xmlNode *current = thisp->parent;
+	zend_long current_index = 0;
+
+	if (selectors_str == NULL) {
+		while (current != NULL) {
+			if (current->type == XML_ELEMENT_NODE) {
+				if (current_index == index) {
+					DOM_RET_OBJ((xmlNodePtr) current, intern);
+					return;
+				}
+				current_index++;
+			}
+			current = current->parent;
+		}
+		RETURN_NULL();
+	}
+
+	lxb_css_parser_t parser;
+	lxb_selectors_t selectors;
+	lxb_css_selector_list_t *list = dom_parse_selector(&parser, &selectors, selectors_str, LXB_SELECTORS_OPT_MATCH_FIRST, intern);
+	
+	if (EXPECTED(list != NULL)) {
+		while (current != NULL) {
+			if (current->type == XML_ELEMENT_NODE) {
+				dom_query_selector_matches_ctx ctx = { current, false };
+				lxb_status_t status = lxb_selectors_match_node(&selectors, current, list, dom_query_selector_find_matches_callback, &ctx);
+				status = dom_check_css_execution_status(status);
+				if (UNEXPECTED(status != LXB_STATUS_OK)) {
+					break;
+				}
+				if (ctx.result) {
+					if (current_index == index) {
+						DOM_RET_OBJ((xmlNodePtr) current, intern);
+						break;
+					}
+					current_index++;
+				}
+			}
+			current = current->parent;
+		}
+	}
+
+	dom_selector_cleanup(&parser, &selectors, list);
+}
+
+typedef struct {
+    xmlNodePtr result;
+    zend_long target_index;
+    zend_long current_index;
+} dom_query_down_ctx;
+
+static lxb_status_t dom_query_down_callback(const xmlNode *node, lxb_css_selector_specificity_t spec, void *ctx)
+{
+    dom_query_down_ctx *qctx = (dom_query_down_ctx *) ctx;
+    if (qctx->current_index == qctx->target_index) {
+        qctx->result = (xmlNodePtr) node;
+        return LXB_STATUS_STOP;
+    }
+    qctx->current_index++;
+    return LXB_STATUS_OK;
+}
+
+void dom_element_down(xmlNodePtr thisp, dom_object *intern, zval *return_value, const zend_string *selectors_str, zend_long index)
+{
+	dom_query_down_ctx ctx = { NULL, index, 0 };
+
+	if (selectors_str == NULL) {
+		/* Fast path for all elements: use universal selector */
+		zend_string *univ = zend_string_init("*", 1, 0);
+		dom_query_selector_common(thisp, intern, univ, dom_query_down_callback, &ctx, LXB_SELECTORS_OPT_DEFAULT);
+		zend_string_release(univ);
+	} else {
+		dom_query_selector_common(thisp, intern, selectors_str, dom_query_down_callback, &ctx, LXB_SELECTORS_OPT_DEFAULT);
+	}
+
+	if (ctx.result != NULL) {
+		DOM_RET_OBJ(ctx.result, intern);
+	} else {
+		RETURN_NULL();
+	}
+}
+
+void dom_element_next(xmlNodePtr thisp, dom_object *intern, zval *return_value, const zend_string *selectors_str, zend_long index)
+{
+	const xmlNode *current = thisp->next;
+	zend_long current_index = 0;
+
+	if (selectors_str == NULL) {
+		while (current != NULL) {
+			if (current->type == XML_ELEMENT_NODE) {
+				if (current_index == index) {
+					DOM_RET_OBJ((xmlNodePtr) current, intern);
+					return;
+				}
+				current_index++;
+			}
+			current = current->next;
+		}
+		RETURN_NULL();
+	}
+
+	lxb_css_parser_t parser;
+	lxb_selectors_t selectors;
+	lxb_css_selector_list_t *list = dom_parse_selector(&parser, &selectors, selectors_str, LXB_SELECTORS_OPT_MATCH_FIRST, intern);
+	
+	if (EXPECTED(list != NULL)) {
+		while (current != NULL) {
+			if (current->type == XML_ELEMENT_NODE) {
+				dom_query_selector_matches_ctx ctx = { current, false };
+				lxb_status_t status = lxb_selectors_match_node(&selectors, current, list, dom_query_selector_find_matches_callback, &ctx);
+				status = dom_check_css_execution_status(status);
+				if (UNEXPECTED(status != LXB_STATUS_OK)) {
+					break;
+				}
+				if (ctx.result) {
+					if (current_index == index) {
+						DOM_RET_OBJ((xmlNodePtr) current, intern);
+						break;
+					}
+					current_index++;
+				}
+			}
+			current = current->next;
+		}
+	}
+
+	dom_selector_cleanup(&parser, &selectors, list);
+}
+
+void dom_element_previous(xmlNodePtr thisp, dom_object *intern, zval *return_value, const zend_string *selectors_str, zend_long index)
+{
+	const xmlNode *current = thisp->prev;
+	zend_long current_index = 0;
+
+	if (selectors_str == NULL) {
+		while (current != NULL) {
+			if (current->type == XML_ELEMENT_NODE) {
+				if (current_index == index) {
+					DOM_RET_OBJ((xmlNodePtr) current, intern);
+					return;
+				}
+				current_index++;
+			}
+			current = current->prev;
+		}
+		RETURN_NULL();
+	}
+
+	lxb_css_parser_t parser;
+	lxb_selectors_t selectors;
+	lxb_css_selector_list_t *list = dom_parse_selector(&parser, &selectors, selectors_str, LXB_SELECTORS_OPT_MATCH_FIRST, intern);
+	
+	if (EXPECTED(list != NULL)) {
+		while (current != NULL) {
+			if (current->type == XML_ELEMENT_NODE) {
+				dom_query_selector_matches_ctx ctx = { current, false };
+				lxb_status_t status = lxb_selectors_match_node(&selectors, current, list, dom_query_selector_find_matches_callback, &ctx);
+				status = dom_check_css_execution_status(status);
+				if (UNEXPECTED(status != LXB_STATUS_OK)) {
+					break;
+				}
+				if (ctx.result) {
+					if (current_index == index) {
+						DOM_RET_OBJ((xmlNodePtr) current, intern);
+						break;
+					}
+					current_index++;
+				}
+			}
+			current = current->prev;
+		}
+	}
+
+	dom_selector_cleanup(&parser, &selectors, list);
+}
+
+void dom_element_siblings(xmlNodePtr thisp, dom_object *intern, zval *return_value, const zend_string *selectors_str)
+{
+	HashTable *list = zend_new_array(0);
+	const xmlNode *parent = thisp->parent;
+	
+	if (parent != NULL) {
+		const xmlNode *current = parent->children;
+
+		if (selectors_str == NULL) {
+			while (current != NULL) {
+				if (current->type == XML_ELEMENT_NODE && current != thisp) {
+					zval zv;
+					php_dom_create_object((xmlNodePtr) current, &zv, intern);
+					zend_hash_next_index_insert(list, &zv);
+				}
+				current = current->next;
+			}
+		} else {
+			lxb_css_parser_t parser;
+			lxb_selectors_t selectors;
+			lxb_css_selector_list_t *list_lxb = dom_parse_selector(&parser, &selectors, selectors_str, LXB_SELECTORS_OPT_MATCH_FIRST, intern);
+			
+			if (EXPECTED(list_lxb != NULL)) {
+				while (current != NULL) {
+					if (current->type == XML_ELEMENT_NODE && current != thisp) {
+						dom_query_selector_matches_ctx ctx = { current, false };
+						lxb_status_t status = lxb_selectors_match_node(&selectors, current, list_lxb, dom_query_selector_find_matches_callback, &ctx);
+						status = dom_check_css_execution_status(status);
+						if (UNEXPECTED(status != LXB_STATUS_OK)) {
+							break;
+						}
+						if (ctx.result) {
+							zval zv;
+							php_dom_create_object((xmlNodePtr) current, &zv, intern);
+							zend_hash_next_index_insert(list, &zv);
+						}
+					}
+					current = current->next;
+				}
+			}
+			dom_selector_cleanup(&parser, &selectors, list_lxb);
+		}
+	}
+
+	object_init_ex(return_value, dom_modern_nodelist_class_entry);
+	dom_object *ret_obj = Z_DOMOBJ_P(return_value);
+	dom_nnodemap_object *mapptr = (dom_nnodemap_object *) ret_obj->ptr;
+	mapptr->array = list;
+	mapptr->release_array = true;
+	mapptr->handler = &php_dom_obj_map_nodeset;
 }
 
 #endif

--- a/ext/dom/php_dom.h
+++ b/ext/dom/php_dom.h
@@ -196,6 +196,11 @@ bool php_dom_pre_insert_is_parent_invalid(xmlNodePtr parent);
 void dom_parent_node_query_selector(xmlNodePtr thisp, dom_object *intern, zval *return_value, const zend_string *selectors_str);
 void dom_parent_node_query_selector_all(xmlNodePtr thisp, dom_object *intern, zval *return_value, const zend_string *selectors_str);
 void dom_element_matches(xmlNodePtr thisp, dom_object *intern, zval *return_value, const zend_string *selectors_str);
+void dom_element_up(xmlNodePtr thisp, dom_object *intern, zval *return_value, const zend_string *selectors_str, zend_long index);
+void dom_element_down(xmlNodePtr thisp, dom_object *intern, zval *return_value, const zend_string *selectors_str, zend_long index);
+void dom_element_next(xmlNodePtr thisp, dom_object *intern, zval *return_value, const zend_string *selectors_str, zend_long index);
+void dom_element_previous(xmlNodePtr thisp, dom_object *intern, zval *return_value, const zend_string *selectors_str, zend_long index);
+void dom_element_siblings(xmlNodePtr thisp, dom_object *intern, zval *return_value, const zend_string *selectors_str);
 void dom_element_closest(xmlNodePtr thisp, dom_object *intern, zval *return_value, const zend_string *selectors_str);
 xmlNodePtr dom_parse_fragment(dom_object *obj, xmlNodePtr context_node, const zend_string *input);
 

--- a/ext/dom/php_dom.stub.php
+++ b/ext/dom/php_dom.stub.php
@@ -1410,6 +1410,12 @@ namespace Dom
         public function closest(string $selectors): ?Element {}
         public function matches(string $selectors): bool {}
 
+        public function up(?string $selectors = null, int $index = 0): ?Element {}
+        public function down(?string $selectors = null, int $index = 0): ?Element {}
+        public function next(?string $selectors = null, int $index = 0): ?Element {}
+        public function previous(?string $selectors = null, int $index = 0): ?Element {}
+        public function siblings(?string $selectors = null): NodeList {}
+
         /** @virtual */
         public string $innerHTML;
 

--- a/ext/dom/php_dom_arginfo.h
+++ b/ext/dom/php_dom_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit php_dom.stub.php instead.
- * Stub hash: 8d7713834c924709155ed7acc554c9efc55e96c1
+ * Stub hash: f53e8ef8b543d089b51a72828c57efa10acdc98d
  * Has decl header: yes */
 
 #include "zend_attributes.h"
@@ -831,6 +831,21 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Dom_Element_matches, 0, 1,
 	ZEND_ARG_TYPE_INFO(0, selectors, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Dom_Element_up, 0, 0, Dom\\Element, 1)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, selectors, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, index, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Dom_Element_down arginfo_class_Dom_Element_up
+
+#define arginfo_class_Dom_Element_next arginfo_class_Dom_Element_up
+
+#define arginfo_class_Dom_Element_previous arginfo_class_Dom_Element_up
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Dom_Element_siblings, 0, 0, Dom\\\116odeList, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, selectors, IS_STRING, 1, "null")
+ZEND_END_ARG_INFO()
+
 #define arginfo_class_Dom_Element_getInScopeNamespaces arginfo_class_DOMNode___sleep
 
 #define arginfo_class_Dom_Element_getDescendantNamespaces arginfo_class_DOMNode___sleep
@@ -1288,6 +1303,11 @@ ZEND_METHOD(Dom_Element, querySelector);
 ZEND_METHOD(Dom_Element, querySelectorAll);
 ZEND_METHOD(Dom_Element, closest);
 ZEND_METHOD(Dom_Element, matches);
+ZEND_METHOD(Dom_Element, up);
+ZEND_METHOD(Dom_Element, down);
+ZEND_METHOD(Dom_Element, next);
+ZEND_METHOD(Dom_Element, previous);
+ZEND_METHOD(Dom_Element, siblings);
 ZEND_METHOD(Dom_Element, getInScopeNamespaces);
 ZEND_METHOD(Dom_Element, getDescendantNamespaces);
 ZEND_METHOD(Dom_Element, rename);
@@ -1671,6 +1691,11 @@ static const zend_function_entry class_Dom_Element_methods[] = {
 	ZEND_ME(Dom_Element, querySelectorAll, arginfo_class_Dom_Element_querySelectorAll, ZEND_ACC_PUBLIC)
 	ZEND_ME(Dom_Element, closest, arginfo_class_Dom_Element_closest, ZEND_ACC_PUBLIC)
 	ZEND_ME(Dom_Element, matches, arginfo_class_Dom_Element_matches, ZEND_ACC_PUBLIC)
+	ZEND_ME(Dom_Element, up, arginfo_class_Dom_Element_up, ZEND_ACC_PUBLIC)
+	ZEND_ME(Dom_Element, down, arginfo_class_Dom_Element_down, ZEND_ACC_PUBLIC)
+	ZEND_ME(Dom_Element, next, arginfo_class_Dom_Element_next, ZEND_ACC_PUBLIC)
+	ZEND_ME(Dom_Element, previous, arginfo_class_Dom_Element_previous, ZEND_ACC_PUBLIC)
+	ZEND_ME(Dom_Element, siblings, arginfo_class_Dom_Element_siblings, ZEND_ACC_PUBLIC)
 	ZEND_ME(Dom_Element, getInScopeNamespaces, arginfo_class_Dom_Element_getInScopeNamespaces, ZEND_ACC_PUBLIC)
 	ZEND_ME(Dom_Element, getDescendantNamespaces, arginfo_class_Dom_Element_getDescendantNamespaces, ZEND_ACC_PUBLIC)
 	ZEND_ME(Dom_Element, rename, arginfo_class_Dom_Element_rename, ZEND_ACC_PUBLIC)

--- a/ext/dom/php_dom_decl.h
+++ b/ext/dom/php_dom_decl.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit php_dom.stub.php instead.
- * Stub hash: 8d7713834c924709155ed7acc554c9efc55e96c1 */
+ * Stub hash: f53e8ef8b543d089b51a72828c57efa10acdc98d */
 
-#ifndef ZEND_PHP_DOM_DECL_8d7713834c924709155ed7acc554c9efc55e96c1_H
-#define ZEND_PHP_DOM_DECL_8d7713834c924709155ed7acc554c9efc55e96c1_H
+#ifndef ZEND_PHP_DOM_DECL_f53e8ef8b543d089b51a72828c57efa10acdc98d_H
+#define ZEND_PHP_DOM_DECL_f53e8ef8b543d089b51a72828c57efa10acdc98d_H
 
 typedef enum zend_enum_Dom_AdjacentPosition {
 	ZEND_ENUM_Dom_AdjacentPosition_BeforeBegin = 1,
@@ -11,4 +11,4 @@ typedef enum zend_enum_Dom_AdjacentPosition {
 	ZEND_ENUM_Dom_AdjacentPosition_AfterEnd = 4,
 } zend_enum_Dom_AdjacentPosition;
 
-#endif /* ZEND_PHP_DOM_DECL_8d7713834c924709155ed7acc554c9efc55e96c1_H */
+#endif /* ZEND_PHP_DOM_DECL_f53e8ef8b543d089b51a72828c57efa10acdc98d_H */

--- a/ext/dom/tests/modern/traversal_prototype.phpt
+++ b/ext/dom/tests/modern/traversal_prototype.phpt
@@ -1,0 +1,85 @@
+--TEST--
+DOM\Element Prototype.js like DOM-Traversal
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+$html = <<<HTML
+<!DOCTYPE html>
+<html>
+<body>
+    <div id="container">
+        <span class="first" id="s1"></span>
+        <span class="middle" id="s2"></span>
+        <div class="middle" id="d1">
+            <p id="p1"></p>
+            <p id="p2"></p>
+        </div>
+        <span class="last" id="s3"></span>
+    </div>
+</body>
+</html>
+HTML;
+
+$dom = DOM\HTMLDocument::createFromString($html);
+
+$d1 = $dom->getElementById('d1');
+
+// up()
+var_dump($d1->up()->id); // container
+var_dump($d1->up('body')->nodeName); // BODY
+var_dump($d1->up('html', 0)->nodeName); // HTML
+
+// down()
+var_dump($d1->down()->id); // p1
+var_dump($d1->down('p', 1)->id); // p2
+
+// previous()
+var_dump($d1->previous()->id); // s2
+var_dump($d1->previous('span', 1)->id); // s1
+
+// next()
+var_dump($d1->next()->id); // s3
+var_dump($d1->next('span')->id); // s3
+
+// siblings()
+$siblings = $d1->siblings();
+echo count($siblings) . "\n";
+foreach ($siblings as $sib) {
+    echo $sib->id . "\n";
+}
+
+$spanSiblings = $d1->siblings('span');
+echo count($spanSiblings) . "\n";
+foreach ($spanSiblings as $sib) {
+    echo $sib->id . "\n";
+}
+
+// Errors
+try {
+    $d1->up('div', -1);
+} catch (ValueError $e) {
+    echo $e->getMessage() . "\n";
+}
+
+?>
+--EXPECT--
+string(9) "container"
+string(4) "BODY"
+string(4) "HTML"
+string(2) "p1"
+string(2) "p2"
+string(2) "s2"
+string(2) "s1"
+string(2) "s3"
+string(2) "s3"
+3
+s1
+s2
+s3
+3
+s1
+s2
+s3
+DOM\Element::up(): Argument #2 ($index) must be greater than or equal to 0

--- a/ext/dom/tests/modern/traversal_prototype.phpt
+++ b/ext/dom/tests/modern/traversal_prototype.phpt
@@ -82,4 +82,4 @@ s3
 s1
 s2
 s3
-DOM\Element::up(): Argument #2 ($index) must be greater than or equal to 0
+Dom\Element::up(): Argument #2 ($index) must be greater than or equal to 0


### PR DESCRIPTION
Fixes GH-23575.

I saw the comments about this being too complex to warrant adding to the extension, so I decided to just write the C code and see what it would actually take.

Turns out it doesn't add much complexity at all. We can just aggressively reuse the existing lexbor CSS selector engine (`lxb_selectors_match_node`). I added `up()`, `down()`, `next()`, `previous()`, and `siblings()` directly to `Dom\Element`. It hooks right into the exact same logic `querySelector` and `closest` use, so there's almost zero C bloat and the traversal is extremely fast (it aborts matching immediately when the target index is hit).

Added standard `ValueError`s for negative indices and dropped in a test suite.