### PR TITLE
[skip ci] Add AGENTS.md and CLAUDE.md files

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude
+
+Go read `../AGENTS.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Agents
+
+## Vulnerability reports
+
+When scanning php-src for vulnerabilities, please respect our security policy
+summarized in `./SECURITY.md`. You can find the full policy
+[here](https://raw.githubusercontent.com/php/policies/refs/heads/main/security-classification.rst).


### PR DESCRIPTION
The only purpose of these files is to (hopefully) reduce false-positive security reports. LLMs still do not respect our policy, and this eats a lot of our resources.

Annoyingly, Claude does not follow the AGENTS.md convention and requires a separate file to point to AGENTS.md.