### PR TITLE
Fix GH-23552: keyword class constant name not retagged to T_STRING

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,11 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 8.4.27
 
+- Tokenizer:
+  . Fixed GH-23552 (token_get_all() does not retag a reserved keyword used as a
+    class constant name when the same keyword appears in the initializer).
+    (Ilia Alshanetsky)
+
 
 24 Sep 2026, PHP 8.4.26
 

--- a/ext/tokenizer/tests/gh23552.phpt
+++ b/ext/tokenizer/tests/gh23552.phpt
@@ -1,0 +1,65 @@
+--TEST--
+GH-23552 (keyword class constant name not retagged to T_STRING)
+--EXTENSIONS--
+tokenizer
+--FILE--
+<?php
+$cases = [
+    '<?php class F { const NEW = Bar::NEW; }',
+    '<?php class F { const NEW = [self::NEW]; }',
+    '<?php class F { const NEW = NEW Bar(); }',
+    '<?php class F { const PRINT = X::PRINT; }',
+    "<?php class F { const NEW = <<<EOT\n  a\n  EOT; const PRINT = Bar::PRINT; }",
+];
+
+foreach ($cases as $code) {
+    echo $code, "\n";
+    foreach (token_get_all($code, TOKEN_PARSE) as $token) {
+        if (is_array($token) && in_array(strtolower($token[1]), ['new', 'print'], true)) {
+            echo '  token_get_all: ', token_name($token[0]), ' [', $token[1], "]\n";
+        }
+    }
+    foreach (PhpToken::tokenize($code, TOKEN_PARSE) as $token) {
+        if (in_array(strtolower($token->text), ['new', 'print'], true)) {
+            echo '  PhpToken: ', token_name($token->id), ' [', $token->text, '] at ', $token->pos, "\n";
+        }
+    }
+}
+
+try {
+    token_get_all('<?php class F { const NEW = 1 /* unterminated', TOKEN_PARSE);
+} catch (Throwable $e) {
+    echo 'error path: ', $e::class, ': ', $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+<?php class F { const NEW = Bar::NEW; }
+  token_get_all: T_STRING [NEW]
+  token_get_all: T_STRING [NEW]
+  PhpToken: T_STRING [NEW] at 22
+  PhpToken: T_STRING [NEW] at 33
+<?php class F { const NEW = [self::NEW]; }
+  token_get_all: T_STRING [NEW]
+  token_get_all: T_STRING [NEW]
+  PhpToken: T_STRING [NEW] at 22
+  PhpToken: T_STRING [NEW] at 35
+<?php class F { const NEW = NEW Bar(); }
+  token_get_all: T_STRING [NEW]
+  token_get_all: T_NEW [NEW]
+  PhpToken: T_STRING [NEW] at 22
+  PhpToken: T_NEW [NEW] at 28
+<?php class F { const PRINT = X::PRINT; }
+  token_get_all: T_STRING [PRINT]
+  token_get_all: T_STRING [PRINT]
+  PhpToken: T_STRING [PRINT] at 22
+  PhpToken: T_STRING [PRINT] at 33
+<?php class F { const NEW = <<<EOT
+  a
+  EOT; const PRINT = Bar::PRINT; }
+  token_get_all: T_STRING [NEW]
+  token_get_all: T_STRING [PRINT]
+  token_get_all: T_STRING [PRINT]
+  PhpToken: T_STRING [NEW] at 22
+  PhpToken: T_STRING [PRINT] at 52
+  PhpToken: T_STRING [PRINT] at 65
+error path: ParseError: Unterminated comment starting line 1

--- a/ext/tokenizer/tokenizer.c
+++ b/ext/tokenizer/tokenizer.c
@@ -385,28 +385,26 @@ static bool tokenize(zval *return_value, zend_string *source, zend_class_entry *
 struct event_context {
 	zval *tokens;
 	zend_class_entry *token_class;
+	size_t offset;
 };
 
-static zval *extract_token_id_to_replace(zval *token_zv, const char *text, size_t length) {
-	zval *id_zv, *text_zv;
+static size_t token_source_length(zval *token_zv, zval **id_zv, zend_string **text) {
+	zval *text_zv;
 	ZEND_ASSERT(token_zv);
 	if (Z_TYPE_P(token_zv) == IS_ARRAY) {
-		id_zv = zend_hash_index_find(Z_ARRVAL_P(token_zv), 0);
+		*id_zv = zend_hash_index_find(Z_ARRVAL_P(token_zv), 0);
 		text_zv = zend_hash_index_find(Z_ARRVAL_P(token_zv), 1);
 	} else if (Z_TYPE_P(token_zv) == IS_OBJECT) {
-		id_zv = OBJ_PROP_NUM(Z_OBJ_P(token_zv), 0);
+		*id_zv = OBJ_PROP_NUM(Z_OBJ_P(token_zv), 0);
 		text_zv = OBJ_PROP_NUM(Z_OBJ_P(token_zv), 1);
 	} else {
-		return NULL;
+		*id_zv = NULL;
+		text_zv = token_zv;
 	}
 
-	/* There are multiple candidate tokens to which this feedback may apply,
-	 * check text to make sure this is the right one. */
 	ZEND_ASSERT(Z_TYPE_P(text_zv) == IS_STRING);
-	if (Z_STRLEN_P(text_zv) == length && !memcmp(Z_STRVAL_P(text_zv), text, length)) {
-		return id_zv;
-	}
-	return NULL;
+	*text = Z_STR_P(text_zv);
+	return Z_STRLEN_P(text_zv);
 }
 
 static void on_event(
@@ -426,18 +424,32 @@ static void on_event(
 			}
 			add_token(
 				ctx->tokens, token, (unsigned char *) text, length, line, ctx->token_class, NULL);
+			ctx->offset += length;
 			break;
 		case ON_FEEDBACK: {
 			HashTable *tokens_ht = Z_ARRVAL_P(ctx->tokens);
+			size_t target = (unsigned char *) text - LANG_SCNG(yy_start);
+			size_t offset = ctx->offset;
 			zval *token_zv, *id_zv = NULL;
 			ZEND_HASH_REVERSE_FOREACH_VAL(tokens_ht, token_zv) {
-				id_zv = extract_token_id_to_replace(token_zv, text, length);
-				if (id_zv) {
+				zval *candidate_id;
+				zend_string *candidate_text;
+				size_t candidate_length =
+					token_source_length(token_zv, &candidate_id, &candidate_text);
+				if (offset < candidate_length || offset - candidate_length < target) {
+					break;
+				}
+				offset -= candidate_length;
+				if (offset == target) {
+					ZEND_ASSERT(ZSTR_LEN(candidate_text) == length
+						&& !memcmp(ZSTR_VAL(candidate_text), text, length));
+					id_zv = candidate_id;
 					break;
 				}
 			} ZEND_HASH_FOREACH_END();
-			ZEND_ASSERT(id_zv);
-			ZVAL_LONG(id_zv, token);
+			if (id_zv) {
+				ZVAL_LONG(id_zv, token);
+			}
 			break;
 		}
 		case ON_STOP:
@@ -445,6 +457,7 @@ static void on_event(
 				add_token(ctx->tokens, T_INLINE_HTML, LANG_SCNG(yy_cursor),
 					LANG_SCNG(yy_limit) - LANG_SCNG(yy_cursor), CG(zend_lineno),
 					ctx->token_class, NULL);
+				ctx->offset += LANG_SCNG(yy_limit) - LANG_SCNG(yy_cursor);
 			}
 			break;
 	}
@@ -471,6 +484,7 @@ static bool tokenize_parse(
 
 	ctx.tokens = &token_stream;
 	ctx.token_class = token_class;
+	ctx.offset = 0;
 
 	CG(ast) = NULL;
 	CG(ast_arena) = zend_arena_create(1024 * 32);


### PR DESCRIPTION
`class F { const NEW = Bar::NEW; }` reported `T_NEW` for the declared name under `token_get_all($code, TOKEN_PARSE)`. The tokenizer resolved a parser feedback by searching the collected token list backwards for a matching token text, and since 8.3 typed class constants defer reducing the constant name past the initializer scan, so the declaration's feedback re-found the initializer's token. Matching the ident's source offset instead also corrects `const NEW = NEW Bar();`, where the text search retagged the `NEW` operator and left the declaration alone.

The offset is accumulated as tokens are emitted rather than derived from `LANG_SCNG(yy_cursor)`. The unterminated-comment rule returns `T_ERROR` before recomputing `yyleng`, so the cursor overshoots the emitted length there; the test pins that input.

Fixes #23552