### PR TITLE
NEWS: Remove duplicate

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -410,7 +410,6 @@ PHP                                                                        NEWS
     (Girgias)
   . The SORT_LOCALE_STRING constant for the family of sort functions is now
     deprecated, use one of the following functions instead:
-    * Collator::sort()
     * Collator::asort()
     * Collator::sort()
     * Collator::sortWithSortKeys()


### PR DESCRIPTION
Removed duplicate mention of `Collator::sort()` from deprecated functions list.

[`UPGRADING`](https://github.com/php/php-src/blob/1bb25ce0f5887106222ed64dfcc507c94e60a03e/UPGRADING#L648) appears to be correct already.