### PR TITLE
Fix GH-22214: Honor opcache.dups_fix for duplicate functions

### DIFF
--- a/ext/opcache/tests/gh22214.phpt
+++ b/ext/opcache/tests/gh22214.phpt
@@ -1,0 +1,37 @@
+--TEST--
+GH-22214: opcache.dups_fix is honored for duplicate functions
+--EXTENSIONS--
+opcache
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.file_update_protection=0
+opcache.dups_fix=1
+--FILE--
+<?php
+file_put_contents(__DIR__ . "/gh22214.inc", <<<'PHP'
+<?php
+function test_gh22214() {
+    echo "test_gh22214 called\n";
+}
+class TestGh22214 {
+    public function hello() {
+        echo "TestGh22214 called\n";
+    }
+}
+PHP
+);
+
+include __DIR__ . "/gh22214.inc";
+include __DIR__ . "/gh22214.inc";
+
+test_gh22214();
+(new TestGh22214())->hello();
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . "/gh22214.inc");
+?>
+--EXPECT--
+test_gh22214 called
+TestGh22214 called

--- a/ext/opcache/zend_accelerator_util_funcs.c
+++ b/ext/opcache/zend_accelerator_util_funcs.c
@@ -159,7 +159,13 @@ static zend_always_inline void _zend_accel_function_hash_copy(HashTable *target,
 		ZEND_ASSERT(p->key);
 		t = zend_hash_find_known_hash(target, p->key);
 		if (UNEXPECTED(t != NULL)) {
-			goto failure;
+			if (*ZSTR_VAL(p->key) == '\0') {
+				/* Runtime definition key, keep old value */
+				continue;
+			} else if (!ZCG(accel_directives).ignore_dups) {
+				goto failure;
+			}
+			continue;
 		}
 		_zend_hash_append_ptr_ex(target, p->key, Z_PTR(p->val), 1);
 		if (UNEXPECTED(call_observers) && *ZSTR_VAL(p->key)) { // if not rtd key


### PR DESCRIPTION
Closes GH-22214.

`opcache.dups_fix` was checked when copying the class table in `_zend_accel_class_hash_copy`, but `_zend_accel_function_hash_copy` unconditionally raised a fatal error on duplicate functions without checking `ignore_dups`.

This adds the missing check in `_zend_accel_function_hash_copy` to ignore duplicate functions when `opcache.dups_fix` is enabled, keeping the first definition.