### PR TITLE
ext/standard: Use ZVAL_STRINGL_FAST() in php_explode_negative_limit()

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -865,7 +865,7 @@ PHPAPI void php_explode_negative_limit(const zend_string *delim, zend_string *st
 		to_return = limit + found;
 		/* limit is at least -1 therefore no need of bounds checking : i will be always less than found */
 		for (i = 0; i < to_return; i++) { /* this checks also for to_return > 0 */
-			ZVAL_STRINGL(&tmp, positions[i], (positions[i+1] - ZSTR_LEN(delim)) - positions[i]);
+			ZVAL_STRINGL_FAST(&tmp, positions[i], (positions[i+1] - ZSTR_LEN(delim)) - positions[i]);
 			zend_hash_next_index_insert_new(Z_ARRVAL_P(return_value), &tmp);
 		}
 		efree((void *)positions);


### PR DESCRIPTION
Ideally this save a emalloc + memcpy + free.