### PR TITLE
ext/sockets: socket_select() silent set truncation on Windows.

### DIFF
--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -542,7 +542,7 @@ static int php_sock_array_to_fd_set(uint32_t arg_num, zval *sock_array, fd_set *
 		num++;
 	} ZEND_HASH_FOREACH_END();
 
-	return num ? 1 : 0;
+	return num;
 }
 /* }}} */
 
@@ -593,7 +593,7 @@ PHP_FUNCTION(socket_select)
 	struct timeval *tv_p = NULL;
 	fd_set			rfds, wfds, efds;
 	PHP_SOCKET		max_fd = 0;
-	int				retval, sets = 0;
+	int				retval, sets = 0, max_set_count = 0;
 	zend_long		sec, usec = 0;
 	bool		sec_is_null = 0;
 
@@ -615,17 +615,26 @@ PHP_FUNCTION(socket_select)
 		if (retval == -1) {
 			RETURN_THROWS();
 		}
+		if (retval > max_set_count) {
+			max_set_count = retval;
+		}
 	}
 	if (w_array != NULL) {
 		sets += retval = php_sock_array_to_fd_set(2, w_array, &wfds, &max_fd);
 		if (retval == -1) {
 			RETURN_THROWS();
 		}
+		if (retval > max_set_count) {
+			max_set_count = retval;
+		}
 	}
 	if (e_array != NULL) {
 		sets += retval = php_sock_array_to_fd_set(3, e_array, &efds, &max_fd);
 		if (retval == -1) {
 			RETURN_THROWS();
+		}
+		if (retval > max_set_count) {
+			max_set_count = retval;
 		}
 	}
 
@@ -634,7 +643,7 @@ PHP_FUNCTION(socket_select)
 		RETURN_THROWS();
 	}
 
-	if (!PHP_SAFE_MAX_FD(max_fd, 0)) {
+	if (!PHP_SAFE_MAX_FD(max_fd, max_set_count)) {
 		RETURN_FALSE;
 	}
 

--- a/ext/sockets/tests/socket_select_fd_setsize_overflow.phpt
+++ b/ext/sockets/tests/socket_select_fd_setsize_overflow.phpt
@@ -1,0 +1,50 @@
+--TEST--
+socket_select() reports an overflowing set instead of silently truncating it
+--EXTENSIONS--
+sockets
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY !== 'Windows') {
+    die('skip Windows only, elsewhere the overflow is caught through max_fd');
+}
+?>
+--FILE--
+<?php
+$sockets = [];
+for ($i = 0; $i < 300; $i++) {
+    $socket = socket_create(AF_INET, SOCK_DGRAM, SOL_UDP);
+    if ($socket === false) {
+        break;
+    }
+    $sockets[] = $socket;
+}
+
+var_dump(count($sockets) > 256);
+
+$read = $sockets;
+$write = $except = null;
+var_dump(socket_select($read, $write, $except, 0));
+
+$write = $sockets;
+$read = $except = null;
+var_dump(socket_select($read, $write, $except, 0));
+
+$except = $sockets;
+$read = $write = null;
+var_dump(socket_select($read, $write, $except, 0));
+
+foreach ($sockets as $socket) {
+    socket_close($socket);
+}
+?>
+--EXPECTF--
+bool(true)
+
+Warning: socket_select(): PHP needs to be recompiled with a larger value of FD_SETSIZE.%A
+bool(false)
+
+Warning: socket_select(): PHP needs to be recompiled with a larger value of FD_SETSIZE.%A
+bool(false)
+
+Warning: socket_select(): PHP needs to be recompiled with a larger value of FD_SETSIZE.%A
+bool(false)


### PR DESCRIPTION
php_sock_array_to_fd_set() returned a flag rather than the socket count, so PHP_SAFE_MAX_FD() got a zero and never fired. Sets larger than FD_SETSIZE were quietly truncated and select() reported on the survivors.