### PR TITLE
Zend: Fix method inheritance depending on the order of the interfaces

### DIFF
--- a/Zend/tests/inheritance/gh23630.phpt
+++ b/Zend/tests/inheritance/gh23630.phpt
@@ -1,0 +1,40 @@
+--TEST--
+GH-23630: Interface inheritance depends on the order of the parent interfaces
+--FILE--
+<?php
+
+interface A {
+    public function __construct(?string $name = null);
+}
+
+interface B {
+    public function __construct(?string $name = null, ?int $id = null);
+}
+
+interface C extends A, B {
+}
+
+interface D extends B, A {
+}
+
+abstract class E implements A, B {
+}
+
+abstract class F implements B, A {
+}
+
+foreach (['C', 'D', 'E', 'F'] as $inherited) {
+    $method = new ReflectionMethod($inherited, '__construct');
+    var_dump($method->getDeclaringClass()->getName(), $method->getNumberOfParameters());
+}
+
+?>
+--EXPECT--
+string(1) "B"
+int(2)
+string(1) "B"
+int(2)
+string(1) "B"
+int(2)
+string(1) "B"
+int(2)

--- a/Zend/tests/inheritance/gh23630_2.phpt
+++ b/Zend/tests/inheritance/gh23630_2.phpt
@@ -1,0 +1,23 @@
+--TEST--
+GH-23630: Implementation must satisfy the most specific parent interface
+--FILE--
+<?php
+
+interface A {
+    public function __construct(?string $name = null);
+}
+
+interface B {
+    public function __construct(?string $name = null, ?int $id = null);
+}
+
+interface C extends A, B {
+}
+
+class Test implements C {
+    public function __construct(?string $name = null) {}
+}
+
+?>
+--EXPECTF--
+Fatal error: Declaration of Test::__construct(?string $name = null) must be compatible with B::__construct(?string $name = null, ?int $id = null) in %s on line %d

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1241,6 +1241,16 @@ static inheritance_status do_inheritance_check_on_method(
 }
 /* }}} */
 
+static inheritance_status check_interface_method_compatibility(
+		zend_function *child, zend_function *parent, zend_class_entry *ce) /* {{{ */
+{
+	return do_inheritance_check_on_method(
+		child, child->common.scope, parent, parent->common.scope, ce, NULL,
+		ZEND_INHERITANCE_CHECK_PROTO | ZEND_INHERITANCE_CHECK_VISIBILITY
+			| ZEND_INHERITANCE_CHECK_SILENT);
+}
+/* }}} */
+
 static void do_inherit_method(zend_string *key, zend_function *parent, zend_class_entry *ce, bool is_interface, uint32_t flags) /* {{{ */
 {
 	zval *child = zend_hash_find_known_hash(&ce->function_table, key);
@@ -1250,6 +1260,16 @@ static void do_inherit_method(zend_string *key, zend_function *parent, zend_clas
 
 		if (is_interface && UNEXPECTED(func == parent)) {
 			/* The same method in interface may be inherited few times */
+			return;
+		}
+
+		/* Otherwise linking would depend on the order the interfaces are listed in */
+		if (is_interface
+		 && func->common.scope != ce
+		 && (func->common.scope->ce_flags & ZEND_ACC_INTERFACE)
+		 && check_interface_method_compatibility(func, parent, ce) == INHERITANCE_ERROR
+		 && check_interface_method_compatibility(parent, func, ce) == INHERITANCE_SUCCESS) {
+			zend_hash_update_ptr(&ce->function_table, key, zend_duplicate_function(parent, ce));
 			return;
 		}
 


### PR DESCRIPTION
`interface C extends A, B {}` fails while `interface C extends B, A {}` links, as soon as one parent carries a more specific signature than the other:

```php
interface A { public function f(?string $name = null); }
interface B { public function f(?string $name = null, ?int $id = null); }

interface C extends A, B {} // Fatal error: Declaration of A::f() must be compatible with B::f()
interface D extends B, A {} // fine
```

When the child does not declare the method itself, the first parent's declaration is copied into its function table and every later parent is checked against that copy, so linking only works when the interface listed first happens to be the most specific one. Abstract classes are affected the same way.

The inherited method is now replaced when it is definitely not a valid override of a later parent while that parent is a valid override of it, which is the result the opposite order already produces. That is the approach nikic suggested in https://bugs.php.net/bug.php?id=76361. Only a definite error triggers it, so unresolved variance keeps the current behaviour, and signatures that genuinely conflict still fail in both orders.

Fixes #23630
