### PR TITLE
ext/openssl: Defer pkcs7/cms verify output writes until verification succeeds

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,10 @@ PHP                                                                        NEWS
     registrations are freed while still reachable from the cycle collector.
     (Ilia Alshanetsky)
 
+- OpenSSL:
+  . Fixed openssl_pkcs7_verify() and openssl_cms_verify() truncating output
+    files when verification fails. (Ilia Alshanetsky)
+
 
 24 Sep 2026, PHP 8.4.26
 

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -5763,16 +5763,8 @@ PHP_FUNCTION(openssl_pkcs7_verify)
 		goto clean_exit;
 	}
 	if (datafilename) {
-		dataout = php_openssl_bio_new_file(
-				datafilename, datafilename_len, 6, PHP_OPENSSL_BIO_MODE_W(PKCS7_BINARY));
+		dataout = BIO_new(BIO_s_mem());
 		if (dataout == NULL) {
-			goto clean_exit;
-		}
-	}
-	if (p7bfilename) {
-		p7bout = php_openssl_bio_new_file(
-				p7bfilename, p7bfilename_len, 7, PHP_OPENSSL_BIO_MODE_W(PKCS7_BINARY));
-		if (p7bout == NULL) {
 			goto clean_exit;
 		}
 	}
@@ -5783,6 +5775,24 @@ PHP_FUNCTION(openssl_pkcs7_verify)
 	if (PKCS7_verify(p7, others, store, datain, dataout, (int)flags)) {
 
 		RETVAL_TRUE;
+
+		if (datafilename) {
+			BIO *fileout = php_openssl_bio_new_file(
+					datafilename, datafilename_len, 6, PHP_OPENSSL_BIO_MODE_W(PKCS7_BINARY));
+			if (fileout) {
+				char *buf;
+				long buf_len = BIO_get_mem_data(dataout, &buf);
+				if (buf_len > 0 && BIO_write(fileout, buf, (int)buf_len) != buf_len) {
+					php_openssl_store_errors();
+					RETVAL_LONG(-1);
+					php_error_docref(NULL, E_WARNING, "Failed to write verified data to %s", datafilename);
+				}
+				BIO_free(fileout);
+			} else {
+				php_error_docref(NULL, E_WARNING, "Signature OK, but cannot open %s for writing", datafilename);
+				RETVAL_LONG(-1);
+			}
+		}
 
 		if (signersfilename) {
 			BIO *certout;
@@ -5814,11 +5824,18 @@ PHP_FUNCTION(openssl_pkcs7_verify)
 				RETVAL_LONG(-1);
 			}
 
-			if (p7bout) {
-				if (PEM_write_bio_PKCS7(p7bout, p7) == 0) {
-					php_error_docref(NULL, E_WARNING, "Failed to write PKCS7 to file");
-					php_openssl_store_errors();
-					RETVAL_FALSE;
+			if (p7bfilename) {
+				p7bout = php_openssl_bio_new_file(
+						p7bfilename, p7bfilename_len, 7, PHP_OPENSSL_BIO_MODE_W(PKCS7_BINARY));
+				if (p7bout) {
+					if (PEM_write_bio_PKCS7(p7bout, p7) == 0) {
+						php_error_docref(NULL, E_WARNING, "Failed to write PKCS7 to file");
+						php_openssl_store_errors();
+						RETVAL_FALSE;
+					}
+				} else {
+					php_error_docref(NULL, E_WARNING, "Signature OK, but cannot open %s for writing", p7bfilename);
+					RETVAL_LONG(-1);
 				}
 			}
 		}
@@ -6375,17 +6392,8 @@ PHP_FUNCTION(openssl_cms_verify)
 	}
 
 	if (datafilename) {
-		dataout = php_openssl_bio_new_file(
-				datafilename, datafilename_len, 6, PHP_OPENSSL_BIO_MODE_W(CMS_BINARY));
+		dataout = BIO_new(BIO_s_mem());
 		if (dataout == NULL) {
-			goto clean_exit;
-		}
-	}
-
-	if (p7bfilename) {
-		p7bout = php_openssl_bio_new_file(
-				p7bfilename, p7bfilename_len, 7, PHP_OPENSSL_BIO_MODE_W(CMS_BINARY));
-		if (p7bout == NULL) {
 			goto clean_exit;
 		}
 	}
@@ -6394,6 +6402,24 @@ PHP_FUNCTION(openssl_cms_verify)
 #endif
 	if (CMS_verify(cms, others, store, datain, dataout, (unsigned int)flags)) {
 		RETVAL_TRUE;
+
+		if (datafilename) {
+			BIO *fileout = php_openssl_bio_new_file(
+					datafilename, datafilename_len, 6, PHP_OPENSSL_BIO_MODE_W(CMS_BINARY));
+			if (fileout) {
+				char *buf;
+				long buf_len = BIO_get_mem_data(dataout, &buf);
+				if (buf_len > 0 && BIO_write(fileout, buf, (int)buf_len) != buf_len) {
+					php_openssl_store_errors();
+					RETVAL_FALSE;
+					php_error_docref(NULL, E_WARNING, "Failed to write verified data to %s", datafilename);
+				}
+				BIO_free(fileout);
+			} else {
+				php_error_docref(NULL, E_WARNING, "Signature OK, but cannot open %s for writing", datafilename);
+				RETVAL_FALSE;
+			}
+		}
 
 		if (signersfilename) {
 			certout = php_openssl_bio_new_file(
@@ -6421,10 +6447,17 @@ PHP_FUNCTION(openssl_cms_verify)
 				RETVAL_FALSE;
 			}
 
-			if (p7bout) {
-				if (PEM_write_bio_CMS(p7bout, cms) == 0) {
-					php_error_docref(NULL, E_WARNING, "Failed to write CMS to file");
-					php_openssl_store_errors();
+			if (p7bfilename) {
+				p7bout = php_openssl_bio_new_file(
+						p7bfilename, p7bfilename_len, 7, PHP_OPENSSL_BIO_MODE_W(CMS_BINARY));
+				if (p7bout) {
+					if (PEM_write_bio_CMS(p7bout, cms) == 0) {
+						php_error_docref(NULL, E_WARNING, "Failed to write CMS to file");
+						php_openssl_store_errors();
+						RETVAL_FALSE;
+					}
+				} else {
+					php_error_docref(NULL, E_WARNING, "Signature OK, but cannot open %s for writing", p7bfilename);
 					RETVAL_FALSE;
 				}
 			}

--- a/ext/openssl/tests/openssl_cms_verify_failed_no_truncate.phpt
+++ b/ext/openssl/tests/openssl_cms_verify_failed_no_truncate.phpt
@@ -1,0 +1,70 @@
+--TEST--
+openssl_cms_verify does not truncate output files on verification failure
+--EXTENSIONS--
+openssl
+--FILE--
+<?php
+$dir = __DIR__ . DIRECTORY_SEPARATOR;
+$plain   = $dir . 'cms_verify_nt_plain.tmp';
+$signed  = $dir . 'cms_verify_nt_signed.tmp';
+$aCrt    = $dir . 'cms_verify_nt_a.crt.tmp';
+$aKey    = $dir . 'cms_verify_nt_a.key.tmp';
+$bCrt    = $dir . 'cms_verify_nt_b.crt.tmp';
+$content = $dir . 'cms_verify_nt_content.tmp';
+$p7bout  = $dir . 'cms_verify_nt_p7b.tmp';
+$signers = $dir . 'cms_verify_nt_signers.tmp';
+
+function mkpair(string $cn, string $certFile, string $keyFile): void {
+    $pk = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+    $csr = openssl_csr_new(['commonName' => $cn], $pk);
+    $crt = openssl_csr_sign($csr, null, $pk, 1);
+    openssl_x509_export($crt, $crtPem);
+    openssl_pkey_export($pk, $pkPem);
+    file_put_contents($certFile, $crtPem);
+    file_put_contents($keyFile, $pkPem);
+}
+
+mkpair('signer-A',    $aCrt, $aKey);
+mkpair('untrusted-B', $bCrt, $dir . 'cms_verify_nt_b.key.tmp');
+
+file_put_contents($plain, "hello\n");
+if (!openssl_cms_sign($plain, $signed, "file://$aCrt", "file://$aKey", [])) {
+    echo "sign failed\n";
+    exit(1);
+}
+
+$sentinel = "DO-NOT-OVERWRITE\n";
+file_put_contents($content, $sentinel);
+file_put_contents($p7bout, $sentinel);
+file_put_contents($signers, $sentinel);
+
+// Verify against a CA that does NOT include the signer. Chain validation fails.
+$r = @openssl_cms_verify($signed, 0, $signers, [$bCrt], null, $content, $p7bout);
+
+echo "verify result: " . var_export($r, true) . "\n";
+echo "content sentinel intact?  " . (file_get_contents($content)  === $sentinel ? "YES" : "NO") . "\n";
+echo "p7bout sentinel intact?   " . (file_get_contents($p7bout)   === $sentinel ? "YES" : "NO") . "\n";
+echo "signers sentinel intact?  " . (file_get_contents($signers)  === $sentinel ? "YES" : "NO") . "\n";
+?>
+--CLEAN--
+<?php
+$dir = __DIR__ . DIRECTORY_SEPARATOR;
+foreach ([
+    'cms_verify_nt_plain.tmp',
+    'cms_verify_nt_signed.tmp',
+    'cms_verify_nt_a.crt.tmp',
+    'cms_verify_nt_a.key.tmp',
+    'cms_verify_nt_b.crt.tmp',
+    'cms_verify_nt_b.key.tmp',
+    'cms_verify_nt_content.tmp',
+    'cms_verify_nt_p7b.tmp',
+    'cms_verify_nt_signers.tmp',
+] as $f) {
+    @unlink($dir . $f);
+}
+?>
+--EXPECT--
+verify result: false
+content sentinel intact?  YES
+p7bout sentinel intact?   YES
+signers sentinel intact?  YES

--- a/ext/openssl/tests/openssl_pkcs7_verify_failed_no_truncate.phpt
+++ b/ext/openssl/tests/openssl_pkcs7_verify_failed_no_truncate.phpt
@@ -1,0 +1,70 @@
+--TEST--
+openssl_pkcs7_verify does not truncate output files on verification failure
+--EXTENSIONS--
+openssl
+--FILE--
+<?php
+$dir = __DIR__ . DIRECTORY_SEPARATOR;
+$plain   = $dir . 'pkcs7_verify_nt_plain.tmp';
+$signed  = $dir . 'pkcs7_verify_nt_signed.tmp';
+$aCrt    = $dir . 'pkcs7_verify_nt_a.crt.tmp';
+$aKey    = $dir . 'pkcs7_verify_nt_a.key.tmp';
+$bCrt    = $dir . 'pkcs7_verify_nt_b.crt.tmp';
+$content = $dir . 'pkcs7_verify_nt_content.tmp';
+$p7bout  = $dir . 'pkcs7_verify_nt_p7b.tmp';
+$signers = $dir . 'pkcs7_verify_nt_signers.tmp';
+
+function mkpair(string $cn, string $certFile, string $keyFile): void {
+    $pk = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+    $csr = openssl_csr_new(['commonName' => $cn], $pk);
+    $crt = openssl_csr_sign($csr, null, $pk, 1);
+    openssl_x509_export($crt, $crtPem);
+    openssl_pkey_export($pk, $pkPem);
+    file_put_contents($certFile, $crtPem);
+    file_put_contents($keyFile, $pkPem);
+}
+
+mkpair('signer-A',    $aCrt, $aKey);
+mkpair('untrusted-B', $bCrt, $dir . 'pkcs7_verify_nt_b.key.tmp');
+
+file_put_contents($plain, "hello\n");
+if (!openssl_pkcs7_sign($plain, $signed, "file://$aCrt", "file://$aKey", [], 0)) {
+    echo "sign failed\n";
+    exit(1);
+}
+
+$sentinel = "DO-NOT-OVERWRITE\n";
+file_put_contents($content, $sentinel);
+file_put_contents($p7bout, $sentinel);
+file_put_contents($signers, $sentinel);
+
+// Verify against a CA that does NOT include the signer. Chain validation fails.
+$r = @openssl_pkcs7_verify($signed, 0, $signers, [$bCrt], null, $content, $p7bout);
+
+echo "verify result: " . var_export($r, true) . "\n";
+echo "content sentinel intact?  " . (file_get_contents($content)  === $sentinel ? "YES" : "NO") . "\n";
+echo "p7bout sentinel intact?   " . (file_get_contents($p7bout)   === $sentinel ? "YES" : "NO") . "\n";
+echo "signers sentinel intact?  " . (file_get_contents($signers)  === $sentinel ? "YES" : "NO") . "\n";
+?>
+--CLEAN--
+<?php
+$dir = __DIR__ . DIRECTORY_SEPARATOR;
+foreach ([
+    'pkcs7_verify_nt_plain.tmp',
+    'pkcs7_verify_nt_signed.tmp',
+    'pkcs7_verify_nt_a.crt.tmp',
+    'pkcs7_verify_nt_a.key.tmp',
+    'pkcs7_verify_nt_b.crt.tmp',
+    'pkcs7_verify_nt_b.key.tmp',
+    'pkcs7_verify_nt_content.tmp',
+    'pkcs7_verify_nt_p7b.tmp',
+    'pkcs7_verify_nt_signers.tmp',
+] as $f) {
+    @unlink($dir . $f);
+}
+?>
+--EXPECT--
+verify result: false
+content sentinel intact?  YES
+p7bout sentinel intact?   YES
+signers sentinel intact?  YES


### PR DESCRIPTION
openssl_pkcs7_verify() and openssl_cms_verify() opened the output paths in write mode before verification, emptying existing files on failure. Verified content is buffered in memory and written only on success; the extra PKCS7/CMS output file is created only in that same success branch.
