### PR TITLE
ext/intl: Preserve PHP-side state when cloning formatters

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,10 @@ PHP                                                                        NEWS
     registrations are freed while still reachable from the cycle collector.
     (Ilia Alshanetsky)
 
+- Intl:
+  . Fixed cloning IntlDateFormatter and MessageFormatter losing PHP-side state
+    such as dateType, timeType, calendar and the message pattern. (Ilia Alshanetsky)
+
 
 24 Sep 2026, PHP 8.4.26
 

--- a/ext/intl/dateformat/dateformat_class.c
+++ b/ext/intl/dateformat/dateformat_class.c
@@ -71,6 +71,13 @@ zend_object *IntlDateFormatter_object_clone(zend_object *object)
 	/* clone standard parts */
 	zend_objects_clone_members(&new_dfo->zo, &dfo->zo);
 
+	new_dfo->date_type = dfo->date_type;
+	new_dfo->time_type = dfo->time_type;
+	new_dfo->calendar = dfo->calendar;
+	if (dfo->requested_locale != NULL) {
+		new_dfo->requested_locale = estrdup(dfo->requested_locale);
+	}
+
 	/* clone formatter object */
 	if (DATE_FORMAT_OBJECT(dfo) != NULL) {
 		UErrorCode error = U_ZERO_ERROR;

--- a/ext/intl/msgformat/msgformat_class.c
+++ b/ext/intl/msgformat/msgformat_class.c
@@ -63,6 +63,12 @@ zend_object *MessageFormatter_object_clone(zend_object *object)
 	/* clone standard parts */
 	zend_objects_clone_members(&new_mfo->zo, &mfo->zo);
 
+	if (mfo->mf_data.orig_format != NULL) {
+		new_mfo->mf_data.orig_format = estrndup(mfo->mf_data.orig_format, mfo->mf_data.orig_format_len);
+		new_mfo->mf_data.orig_format_len = mfo->mf_data.orig_format_len;
+	}
+	new_mfo->mf_data.tz_set = mfo->mf_data.tz_set;
+
 	/* clone formatter object */
 	if (MSG_FORMAT_OBJECT(mfo) != NULL) {
 		UErrorCode error = U_ZERO_ERROR;

--- a/ext/intl/tests/clone_preserves_php_fields.phpt
+++ b/ext/intl/tests/clone_preserves_php_fields.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Cloning IntlDateFormatter and MessageFormatter preserves PHP-side fields
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+$d = new IntlDateFormatter('de_DE', IntlDateFormatter::LONG, IntlDateFormatter::MEDIUM, 'UTC', IntlDateFormatter::GREGORIAN);
+$c = clone $d;
+var_dump($c->getDateType());
+var_dump($c->getTimeType());
+var_dump($c->getCalendar());
+var_dump($c->format(strtotime('2024-01-02 03:04:05 UTC')));
+$c->setCalendar(IntlDateFormatter::GREGORIAN);
+var_dump($c->getPattern());
+
+$m = new MessageFormatter('en_US', '{0, number}');
+$mc = clone $m;
+var_dump($mc->getPattern());
+var_dump($mc->format([1.5]));
+
+date_default_timezone_set('UTC');
+$t = new MessageFormatter('en_US', '{0,time,short}');
+$dt = new DateTimeImmutable('2024-01-02 03:04:05', new DateTimeZone('UTC'));
+$t->format([$dt]);
+$tc = clone $t;
+date_default_timezone_set('America/New_York');
+var_dump($t->format([$dt]) === $tc->format([$dt]));
+?>
+--EXPECT--
+int(1)
+int(2)
+int(1)
+string(26) "2. Januar 2024 um 03:04:05"
+string(23) "d. MMMM y 'um' HH:mm:ss"
+string(11) "{0, number}"
+string(3) "1.5"
+bool(true)


### PR DESCRIPTION
Cloning IntlDateFormatter left dateType, timeType, calendar, and the requested locale at constructor defaults, and cloning MessageFormatter dropped its pattern. The clone handlers now copy those PHP-side fields with the ICU handle.
