### PR TITLE
ext/session: Truncate session file after successful write

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,10 @@ PHP                                                                        NEWS
     registrations are freed while still reachable from the cycle collector.
     (Ilia Alshanetsky)
 
+- Session:
+  . Fixed session data loss in the files save handler when writing the session
+    file fails after it was already truncated. (Ilia Alshanetsky)
+
 
 24 Sep 2026, PHP 8.4.26
 

--- a/ext/session/mod_files.c
+++ b/ext/session/mod_files.c
@@ -236,11 +236,6 @@ static zend_result ps_files_write(ps_files *data, zend_string *key, zend_string 
 		return FAILURE;
 	}
 
-	/* Truncate file if the amount of new data is smaller than the existing data set. */
-	if (ZSTR_LEN(val) < data->st_size) {
-		php_ignore_value(ftruncate(data->fd, 0));
-	}
-
 #ifdef HAVE_PWRITE
 	n = pwrite(data->fd, ZSTR_VAL(val), ZSTR_LEN(val), 0);
 #else
@@ -272,6 +267,10 @@ static zend_result ps_files_write(ps_files *data, zend_string *key, zend_string 
 			php_error_docref(NULL, E_WARNING, "Write wrote less bytes than requested");
 		}
 		return FAILURE;
+	}
+
+	if (ZSTR_LEN(val) < data->st_size) {
+		php_ignore_value(ftruncate(data->fd, ZSTR_LEN(val)));
 	}
 
 	return SUCCESS;

--- a/ext/session/tests/session_write_failure_keeps_data.phpt
+++ b/ext/session/tests/session_write_failure_keeps_data.phpt
@@ -1,0 +1,58 @@
+--TEST--
+Session files handler must not truncate session file when write fails
+--EXTENSIONS--
+session
+posix
+pcntl
+--INI--
+error_reporting=E_ALL
+display_errors=1
+session.use_strict_mode=0
+--FILE--
+<?php
+$dir = __DIR__ . '/session_write_failure_keeps_data';
+mkdir($dir);
+ini_set('session.save_path', $dir);
+
+$sid = 'apher5sessid12345678901234567890';
+$file = $dir . '/sess_' . $sid;
+
+ob_start();
+
+session_id($sid);
+session_start();
+$_SESSION['data'] = str_repeat('A', 8192);
+session_write_close();
+
+clearstatcache(true);
+$before = file_get_contents($file);
+var_dump(strlen($before));
+
+// A zero file size limit makes the next write fail before any byte lands;
+// SIGXFSZ has to be ignored or the process is killed instead.
+pcntl_signal(SIGXFSZ, SIG_IGN);
+var_dump(posix_setrlimit(POSIX_RLIMIT_FSIZE, 0, POSIX_RLIMIT_INFINITY));
+
+session_start();
+$_SESSION['data'] = str_repeat('B', 4096);
+@session_write_close();
+
+clearstatcache(true);
+var_dump(file_get_contents($file) === $before);
+
+ob_end_flush();
+echo "done\n";
+?>
+--CLEAN--
+<?php
+$dir = __DIR__ . '/session_write_failure_keeps_data';
+foreach (glob($dir . '/sess_*') as $f) {
+    unlink($f);
+}
+rmdir($dir);
+?>
+--EXPECT--
+int(8207)
+bool(true)
+bool(true)
+done


### PR DESCRIPTION
The files session save handler truncated the session file to zero before writing, so a short or failed write returned failure with the previous data already gone. It now writes first and truncates to the new length only after the full buffer lands.
