### PR TITLE
ext/pdo: Reset stale attributes when reusing a persistent connection

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,12 @@ PHP                                                                        NEWS
     registrations are freed while still reachable from the cycle collector.
     (Ilia Alshanetsky)
 
+- PDO:
+  . Reused persistent connections no longer keep stale fetch-related
+    attributes (case conversion, null handling, stringify, default fetch
+    mode) from the previous request. (Ilia Alshanetsky)
+
+
 
 24 Sep 2026, PHP 8.4.26
 

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -424,6 +424,11 @@ PDO_API void php_pdo_internal_construct_driver(INTERNAL_FUNCTION_PARAMETERS, zen
 
 			if (pdbh) {
 				call_factory = 0;
+
+				pdbh->oracle_nulls = PDO_NULL_NATURAL;
+				pdbh->stringify = false;
+				pdbh->desired_case = PDO_CASE_NATURAL;
+				pdbh->default_fetch_type = PDO_FETCH_BOTH;
 			} else {
 				/* need a brand new pdbh */
 				pdbh = pecalloc(1, sizeof(*pdbh), 1);

--- a/ext/pdo/tests/persistent_handle_attribute_reset.phpt
+++ b/ext/pdo/tests/persistent_handle_attribute_reset.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Persistent connection reuse resets PDO attributes to their defaults
+--EXTENSIONS--
+pdo
+pdo_sqlite
+--FILE--
+<?php
+$dsn = 'sqlite::memory:';
+$options = [PDO::ATTR_PERSISTENT => true];
+
+$p1 = new PDO($dsn, null, null, $options);
+$p1->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
+$p1->setAttribute(PDO::ATTR_ORACLE_NULLS, PDO::NULL_EMPTY_STRING);
+$p1->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_NUM);
+$p1->setAttribute(PDO::ATTR_CASE, PDO::CASE_UPPER);
+
+unset($p1);
+
+$p2 = new PDO($dsn, null, null, $options);
+
+var_dump($p2->getAttribute(PDO::ATTR_STRINGIFY_FETCHES));
+var_dump($p2->getAttribute(PDO::ATTR_ORACLE_NULLS) === PDO::NULL_NATURAL);
+var_dump($p2->getAttribute(PDO::ATTR_DEFAULT_FETCH_MODE) === PDO::FETCH_BOTH);
+var_dump($p2->getAttribute(PDO::ATTR_CASE) === PDO::CASE_NATURAL);
+?>
+--EXPECT--
+bool(false)
+bool(true)
+bool(true)
+bool(true)


### PR DESCRIPTION
Reusing a persistent PDO handle only restored auto_commit and error_mode from the new constructor options, so case conversion, oracle nulls, stringify, and the default fetch mode leaked from the previous request. Those four attributes are reset to defaults on reuse before the new options apply.
