### PR TITLE
Fix: FPM sendmail_path example

### DIFF
--- a/sapi/fpm/www.conf.in
+++ b/sapi/fpm/www.conf.in
@@ -482,7 +482,7 @@ pm.max_spare_servers = 3
 
 ; Default Value: nothing is defined by default except the values in php.ini and
 ;                specified at startup with the -d argument
-;php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f www@my.domain.com
+;php_admin_value[sendmail_path] = /path/to/sendmail -t -i
 ;php_flag[display_errors] = off
 ;php_admin_value[error_log] = /var/log/fpm-php.www.log
 ;php_admin_flag[log_errors] = on


### PR DESCRIPTION
Fixes #20648.

Remove the `-f` option from the `sendmail_path` example in the FPM config to avoid conflicts with `mail()` parameters.