### PR TITLE
ext/standard: Optimize octal escape generation in addcslashes()

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -1095,6 +1095,7 @@ PHP 8.6 UPGRADE NOTES
   . Reduced temporary allocations when iterating Phar directories.
 
 - Standard:
+  . Improved performance of addcslashes() when generating octal escapes.
   . Improved performance of sorting single-element arrays.
   . Improved performance of array_fill_keys().
   . Improved performance of array_intersect().

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -3904,7 +3904,11 @@ PHPAPI zend_string *php_addcslashes_str(const char *str, size_t len, const char 
 					case '\v': *target++ = 'v'; break;
 					case '\b': *target++ = 'b'; break;
 					case '\f': *target++ = 'f'; break;
-					default: target += snprintf(target, 4, "%03o", (unsigned char) c);
+					default:
+						/* Write the byte as three octal digits, including leading zeros. */
+						*target++ = ((unsigned char) c >> 6) + '0';
+						*target++ = (((unsigned char) c >> 3) & 7) + '0';
+						*target++ = ((unsigned char) c & 7) + '0';
 				}
 				continue;
 			}


### PR DESCRIPTION
This hack is slightly faster than the original one. My local benchmarks show approximately 39% lower runtime for a single NUL byte